### PR TITLE
Use curl instead of wget

### DIFF
--- a/gen/installer/bash/Dockerfile.in
+++ b/gen/installer/bash/Dockerfile.in
@@ -2,7 +2,7 @@ FROM alpine:3.3
 MAINTAINER help@dcos.io
 
 RUN apk add --update curl ca-certificates git openssh tar xz zlib && rm -rf /var/cache/apk/*
-RUN wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.22-r5/glibc-2.22-r5.apk && apk --allow-untrusted add glibc-2.22-r5.apk && rm glibc-2.22-r5.apk && rm -rf /var/cache/apk/*
+RUN curl -fLsS --retry 20 -Y 100000 -y 60 -o glibc-2.22-r5.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.22-r5/glibc-2.22-r5.apk && apk --allow-untrusted add glibc-2.22-r5.apk && rm glibc-2.22-r5.apk && rm -rf /var/cache/apk/*
 VOLUME ["/genconf"]
 
 EXPOSE 9000


### PR DESCRIPTION
Fixes issue with installer failing to build with the following:

```
wget: error getting response: Connection reset by peer
The command '/bin/sh -c wget
https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.22-r5/glibc-2.22-r5.apk
&& apk --allow-untrusted add glibc-2.22-r5.apk && rm glibc-2.22-r5.apk
&& rm -rf /var/cache/apk/*' returned a non-zero code: 1
```

This is due to busybox wget in Alpine not supporting https. Use the installed curl instead.