### PR TITLE
DCOS-4

### DIFF
--- a/ext/dcos-installer/dcos_installer/__init__.py
+++ b/ext/dcos-installer/dcos_installer/__init__.py
@@ -121,13 +121,14 @@ class DcosInstaller:
         # If no args are passed to the class, then we're calling this
         # class from another library or code so we shouldn't execute
         # parser or anything else
-        make_default_dir()
         if args:
             options = self.parse_args(args)
             if len(options.hash_password) > 0:
                 print_header("HASHING PASSWORD TO SHA512")
                 backend.hash_password(options.hash_password)
                 sys.exit(0)
+
+            make_default_dir()
 
             if options.web:
                 print_header("Starting DC/OS installer in web mode")


### PR DESCRIPTION
https://dcosjira.atlassian.net/browse/DCOS-4

This PR fixes the `__init__.py` for the installer to ensure we do not execute make_default_dir() when importing the installer library. This fixes the issue of tox requiring root access to run as well as the requirement to have /genconf available at test time. 

We refactored the installer in a way which required /genconf to exist if you import installer lib. Because of that directory requirement, tox needed to be root to run, and it should not. This fixes the code to ensure you don’t need /genconf to exist to import the lib fixes that.