### PR TITLE
pkgpanda: check dest_path for symlink_tree

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -393,7 +393,7 @@ def symlink_tree(src, dest):
 
             # Recuse into the directory symlinking everything so long as the directory isn't
             symlink_tree(src_path, dest_path)
-        else:
+        elif not os.path.exists(dest_path):
             os.symlink(src_path, dest_path)
 
 


### PR DESCRIPTION
 * ensure that dest_path for symlink doesn't exist

Have error during installation on slave node. Source isn't directory and target is exists

```
Apr 26 16:13:11 tpad systemd[1]: Starting Pkgpanda: Specialize DC/OS for this host....
Apr 26 16:13:12 tpad pkgpanda[12353]: Calculated active packages from bootstrap tarball
Apr 26 16:13:12 tpad pkgpanda[12353]: Checking for cluster packages in: /etc/mesosphere/setup-flags/cluster-packages.json
Apr 26 16:13:12 tpad pkgpanda[12353]: Loading cluster-packages: ['dcos-config--setup_18dfd6e1a126b9f660610bf10d7721cb4ff5ab51', 'dcos-metadata--setup_18dfd6e1a126b9f660610bf10d7721cb4ff5ab51']
Apr 26 16:13:12 tpad pkgpanda[12353]: Activating packages
Apr 26 16:13:12 tpad pkgpanda[12353]: Traceback (most recent call last):
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/bin/pkgpanda", line 9, in <module>
Apr 26 16:13:12 tpad pkgpanda[12353]:     load_entry_point('dcos-image==0.1', 'console_scripts', 'pkgpanda')()
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/cli.py", line 309, in main
Apr 26 16:13:12 tpad pkgpanda[12353]:     setup(install, repository)
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/cli.py", line 192, in setup
Apr 26 16:13:12 tpad pkgpanda[12353]:     do_bootstrap(install, repository)
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/cli.py", line 161, in do_bootstrap
Apr 26 16:13:12 tpad pkgpanda[12353]:     install.activate(repository.load_packages(to_activate))
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/__init__.py", line 549, in activate
Apr 26 16:13:12 tpad pkgpanda[12353]:     symlink_all(role_dir, new)
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/__init__.py", line 522, in symlink_all
Apr 26 16:13:12 tpad pkgpanda[12353]:     symlink_tree(src, dest)
Apr 26 16:13:12 tpad pkgpanda[12353]:   File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/__init__.py", line 397, in symlink_tree
Apr 26 16:13:12 tpad pkgpanda[12353]:     os.symlink(src_path, dest_path)
Apr 26 16:13:12 tpad pkgpanda[12353]: FileExistsError: [Errno 17] File exists: '/opt/mesosphere/packages/3dt--c3970af261c1e9ed9014904a6408617dafd41e6c/dcos.target.wants_master/dcos-ddt.service' -> '/etc/systemd/system/dcos.target.wa
Apr 26 16:13:12 tpad systemd[1]: dcos-setup.service: Main process exited, code=exited, status=1/FAILURE
```