### PR TITLE
Remove `--skip-build` and simplify `do_build_packages` to help prepare for "upstreams"

### DIFF
--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -213,7 +213,7 @@ def make_bootstrap_tarball(packages_dir, packages, variant, repository_url):
         print("bootstrap: {}".format(bootstrap_name))
         print("active: {}".format(active_name))
         print("latest: {}".format(latest_name))
-        return bootstrap_name
+        return bootstrap_id
 
     if (os.path.exists(bootstrap_name)):
         print("Bootstrap already up to date, not recreating")

--- a/pytest/test_release.py
+++ b/pytest/test_release.py
@@ -490,7 +490,7 @@ def test_get_package_artifact(tmpdir):
     }
 
 
-def mock_do_build_packages(cache_repository_url, skip_build):
+def mock_do_build_packages(cache_repository_url):
     subprocess.check_call(['mkdir', '-p', 'packages'])
     write_string("packages/bootstrap_id.bootstrap.tar.xz", "bootstrap_contents")
     write_json("packages/bootstrap_id.active.json", ['a--b', 'c--d'])
@@ -550,7 +550,7 @@ def test_make_stable_artifacts(monkeypatch, tmpdir):
     monkeypatch.setattr("gen.installer.util.dcos_image_commit", "commit_sha1")
 
     with tmpdir.as_cwd():
-        metadata = release.make_stable_artifacts("http://test", False)
+        metadata = release.make_stable_artifacts("http://test")
         assert metadata == stable_artifacts_metadata
 
 

--- a/pytest/test_release.py
+++ b/pytest/test_release.py
@@ -13,6 +13,8 @@ from pkgpanda.util import variant_prefix, write_json, write_string
 
 @pytest.fixture(scope='module')
 def config():
+    if not os.path.exists('dcos-release.config.yaml'):
+        pytest.skip("Skipping because there is no configuration in dcos-release.config.yaml")
     return release.load_config('dcos-release.config.yaml')
 
 

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -440,9 +440,14 @@ def do_build_packages(cache_repository_url):
     def get_build():
         # TODO(cmaloney): Stop shelling out
         package_dir = os.getcwd() + '/packages'
-        pkgpanda.build.build_tree(package_dir, True, cache_repository_url, None)
+        result = pkgpanda.build.build_tree(package_dir, True, cache_repository_url, None)
+        last_set = pkgpanda.build.get_last_bootstrap_set(package_dir)
+        assert last_set == result, \
+            "Internal error: get_last_bootstrap_set doesn't match the results of build_tree: {} != {}".format(
+                last_set,
+                result)
 
-        return pkgpanda.build.get_last_bootstrap_set(package_dir)
+        return result
 
     return get_build()
 

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -273,7 +273,7 @@ def get_package_artifact(package_id_str):
         'local_path': package_filename}
 
 
-def make_stable_artifacts(cache_repository_url, skip_build):
+def make_stable_artifacts(cache_repository_url):
     metadata = {
         "commit": util.dcos_image_commit,
         "core_artifacts": [],
@@ -282,7 +282,7 @@ def make_stable_artifacts(cache_repository_url, skip_build):
 
     # TODO(cmaloney): Rather than guessing / reverse-engineering all these paths
     # have do_build_packages get them directly from pkgpanda
-    all_bootstraps = do_build_packages(cache_repository_url, skip_build)
+    all_bootstraps = do_build_packages(cache_repository_url)
 
     # The installer is a built bootstrap, but not a DC/OS variant. We use
     # iteration over the bootstrap_dict to enumerate all variants a whole lot,
@@ -398,7 +398,7 @@ def make_abs(path):
     return os.getcwd() + '/' + path
 
 
-def do_build_packages(cache_repository_url, skip_build):
+def do_build_packages(cache_repository_url):
     dockerfile = 'docker/dcos-builder/Dockerfile'
     container_name = 'dcos/dcos-builder:dockerfile-' + pkgpanda.util.sha1(dockerfile)
     print("Attempting to pull dcos-builder docker:", container_name)
@@ -440,8 +440,7 @@ def do_build_packages(cache_repository_url, skip_build):
     def get_build():
         # TODO(cmaloney): Stop shelling out
         package_dir = os.getcwd() + '/packages'
-        if not skip_build:
-            pkgpanda.build.build_tree(package_dir, True, cache_repository_url, None)
+        pkgpanda.build.build_tree(package_dir, True, cache_repository_url, None)
 
         return pkgpanda.build.get_last_bootstrap_set(package_dir)
 
@@ -612,12 +611,12 @@ class ReleaseManager():
 
         return metadata
 
-    def create(self, repository_path, channel, tag, skip_build):
+    def create(self, repository_path, channel, tag):
         assert len(channel) > 0  # channel must be a non-empty string.
 
         # TOOD(cmaloney): Figure out why the cached version hasn't been working right
         # here from the TeamCity agents. For now hardcoding the non-cached s3 download locatoin.
-        metadata = make_stable_artifacts(cloudformation_s3_url + '/' + repository_path, skip_build)
+        metadata = make_stable_artifacts(cloudformation_s3_url + '/' + repository_path)
 
         # Metadata should already have things like bootstrap_id in it.
         assert 'bootstrap_dict' in metadata
@@ -705,7 +704,6 @@ def main():
     # `testing/{channel}`
     create.add_argument('channel')
     create.add_argument('tag')
-    create.add_argument('--skip-build', action='store_true')
 
     # Utility for building just the installers, useful for installer dev work where you don't want
     # to build all of dcos-image locally, and don't care about uploading. Defaults noop to true.
@@ -735,7 +733,7 @@ def main():
     if options.action == 'promote':
         release_manager.promote(options.source_channel, options.destination_repository, options.destination_channel)
     elif options.action == 'create':
-        release_manager.create('testing', options.channel, options.tag, options.skip_build)
+        release_manager.create('testing', options.channel, options.tag)
     elif options.action == 'create-installer':
         release_manager.create_installer(options.src_channel)
     else:


### PR DESCRIPTION
This removes the `--skip-build` option and gets `release create` to use the result of `pkgpanda.build.build_tree` directly rather than calling a helper which scrapes up artifacts.


General shape of the upstream work for pkgpanda:

1. Return structured information about the packages built and place that in the metadata.json
  1. this PR
  1. Returning more dictionaries of exactly what was built from build_tree (all the packages, what variants, what those package ids were, what the bootstrap variants are, what those bootstrap ids are). Broken into a separate step so that we have testing over the return structure change.
2. Add the notion of a "backing" / "upstream" repository. `pkgpanda` can refer to pre-built packages in this "upstream" repository just like it can local filesystem packages. It does not know how to build these packages (does not have access to the `build` and `buildinfo.json` files.