### PR TITLE
Revert "Remove unused dnspython and boost-system packages"

### DIFF
--- a/packages/boost-system/build
+++ b/packages/boost-system/build
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export CPPFLAGS=-I/opt/mesosphere/include
+export LDFLAGS="-L/opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
+export LD_LIBRARY_PATH=/opt/mesosphere/lib
+
+# Use same version of boost as provided by mesos-buildenv
+pushd /pkg/src/boost-system
+./bootstrap.sh
+# Only build the 'system' library, used by ASIO
+# TODO: have mesos-buildenv build this library, instead of having this separate pkg?
+./b2 --with-system
+# Move lib dir into pkg
+mv -v stage/lib $PKG_PATH
+popd

--- a/packages/boost-system/buildinfo.json
+++ b/packages/boost-system/buildinfo.json
@@ -1,0 +1,7 @@
+{
+  "single_source": {
+    "kind": "url_extract",
+    "url": "https://downloads.mesosphere.com/pkgpanda-artifact-cache/boost_1_53_0.tar.gz",
+    "sha1": "0e4ef26cc7780c6bbc63987ef2f29be920e2395b"
+  }
+}

--- a/packages/dcos-signal/extra/dcos-signal-ee.timer
+++ b/packages/dcos-signal/extra/dcos-signal-ee.timer
@@ -1,0 +1,5 @@
+[Unit]
+Description=Signal Timer: Timer for DC/OS Signal Service
+[Timer]
+Unit=dcos-signal.service
+OnCalendar=*:0/5

--- a/packages/dnspython/build
+++ b/packages/dnspython/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/dnspython/buildinfo.json
+++ b/packages/dnspython/buildinfo.json
@@ -1,0 +1,9 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/rthalley/dnspython.git",
+    "ref": "f9597eefe62c1bcda08c1a89140248060a07c73c",
+    "ref_origin": "v1.12.0-py3"
+  }
+}


### PR DESCRIPTION
Reverts dcos/dcos#19

Turns out the DNS is actually used