### PR TITLE
Adding analytics tracking to installer

### DIFF
--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -1,0 +1,105 @@
+import asyncio
+import logging
+import sys
+
+from dcos_installer import action_lib, backend
+from dcos_installer.util import CONFIG_PATH
+from dcos_installer.installer_analytics import InstallerAnalytics
+from dcos_installer.action_lib.prettyprint import print_header, PrettyPrint
+from ssh.utils import AbstractSSHLibDelegate
+
+
+log = logging.getLogger(__name__)
+
+
+class CliDelegate(AbstractSSHLibDelegate):
+    def on_update(self, future, callback_called):
+        chain_name, result_object, host = future.result()
+        callback_called.set_result(True)
+        log.debug('on_update executed for {}'.format(chain_name))
+
+    def on_done(self, name, result, host_status=None):
+        print_header('STAGE {}'.format(name))
+
+
+def run_loop(action, options):
+    assert callable(action)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    print_header('START {}'.format(action.__name__))
+    try:
+        config = backend.get_config()
+        cli_delegate = CliDelegate()
+        result = loop.run_until_complete(action(config, block=True, async_delegate=cli_delegate, options=options))
+        pp = PrettyPrint(result)
+        pp.stage_name = action.__name__
+        pp.beautify('print_data')
+
+    finally:
+        loop.close()
+    exitcode = 0
+    for host_result in result:
+        for command_result in host_result:
+            for host, process_result in command_result.items():
+                if process_result['returncode'] != 0:
+                    exitcode += 1
+    print_header('ACTION {} COMPLETE'.format(action.__name__))
+    pp.print_summary()
+    return exitcode
+
+
+def tall_enough_to_ride():
+    choices_true = ['yes', 'y']
+    choices_false = ['no', 'n']
+    while True:
+        do_uninstall = input('This will uninstall DC/OS on your cluster. You may need to manually remove '
+                             '/var/lib/zookeeper in some cases after this completes, please see our documentation '
+                             'for details. Are you ABSOLUTELY sure you want to proceed? [ (y)es/(n)o ]: ')
+        if do_uninstall.lower() in choices_true:
+            return
+        elif do_uninstall.lower() in choices_false:
+            sys.exit(1)
+        else:
+            log.error('Choices are [y]es or [n]o. "{}" is not a choice'.format(do_uninstall))
+
+
+def get_new_analytics(config_path=CONFIG_PATH):
+    return InstallerAnalytics(backend.get_config(config_path))
+
+
+def dispatch_action(args):
+    installer_analytics = get_new_analytics()
+
+    def preflight(args):
+        print_header("EXECUTING PREFLIGHT")
+        return action_lib.run_preflight
+
+    def postflight(args):
+        print_header("EXECUTING POSTFLIGHT")
+        return action_lib.run_postflight
+
+    def deploy(args):
+        print_header("EXECUTING DC/OS INSTALLATION")
+        return action_lib.install_dcos
+
+    def uninstall(args):
+        print_header("EXECUTING UNINSTALL")
+        tall_enough_to_ride()
+        return action_lib.uninstall_dcos
+
+    def install_prereqs(args):
+        print_header("EXECUTING INSTALL PREREQUISITES")
+        return action_lib.install_prereqs
+
+    for action in ['deploy', 'preflight', 'postflight', 'uninstall', 'install_prereqs']:
+        if getattr(args, action):
+            errors = run_loop(locals()[action](args), args)
+            if not args.disable_analytics:
+                installer_analytics.send(
+                    action=action,
+                    install_method="cli",
+                    num_errors=errors,
+                )
+            exit_code = 1 if errors > 0 else 0
+            sys.exit(exit_code)

--- a/ext/dcos-installer/dcos_installer/installer_analytics.py
+++ b/ext/dcos-installer/dcos_installer/installer_analytics.py
@@ -1,0 +1,34 @@
+import analytics
+import os
+import uuid
+
+
+class InstallerAnalytics():
+    def __init__(self, config):
+        self.uuid = self.new_uuid()
+        self.bootstrap_version = os.getenv("BOOTSTRAP_ID", "")
+        self.customer_key = config["customer_key"] if 'customer_key' in config else ""
+        self.source = "onprem"  # If you're using the installer you're not in AWS or Azure
+
+    def send(self, action, install_method, num_errors):
+        """Sends analytics track data to segmentIO.
+        variant: string | open or enterprise
+        action: string | preflight, deploy, or postflight
+        install_method: string | gui, cli or advanced
+        """
+        analytics.write_key = "39uhSEOoRHMw6cMR6st9tYXDbAL3JSaP"
+
+        analytics.track(user_id=self.customer_key, anonymous_id=self.uuid, event=action, properties={
+            "install_id": self.uuid,
+            "bootstrap_id": self.bootstrap_version,
+            "provider": self.source,
+            "source": "installer",
+            "install_method": install_method,
+            "stage": action,
+            "errors": num_errors,
+            "customer_key": self.customer_key,
+        })
+        analytics.flush()
+
+    def new_uuid(self):
+        return str(uuid.uuid4())

--- a/ext/dcos-installer/setup.py
+++ b/ext/dcos-installer/setup.py
@@ -16,6 +16,7 @@ setup(
         'aiohttp_jinja2',
         'coloredlogs',
         'passlib',
+        'analytics-python',
         'pyyaml'],
     tests_require=[
         'pytest==2.9.0',

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -4,7 +4,7 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
-for package in aiohttp_jinja2 azure-common azure-nspkg beautifulsoup4 docutils py webob; do
+for package in aiohttp_jinja2 analytics-python azure-common azure-nspkg beautifulsoup4 docutils py webob; do
   pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$package/*.whl
 done
 

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -22,6 +22,11 @@
       "url": "https://pypi.python.org/packages/py3/a/aiohttp_jinja2/aiohttp_jinja2-0.7.0-py3-none-any.whl",
       "sha1": "e5710a2a89210b3b0a804a18f00aa4023498dc38"
     },
+    "analytics-python": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/39/db/ba6ce2c3f13dd046eec3a7767a7d10607c15dc8b23d68bc125ad577f924f/analytics_python-1.2.3-py2.py3-none-any.whl",
+      "sha1": "218ff1fdecb2a0d06499618a6d0e65fcecf50c19"
+    },
     "azure-common": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/sdk/a/azure-common/azure_common-1.0.0-py2.py3-none-any.whl",


### PR DESCRIPTION
@cmaloney @spahl @darkonie

Add analytics tracking to installer CLI (GUI will be next). 

Refactored the CLI a bit to use a dispatcher for the action arguments. This way we can call the tracker once in a clean method. I also moved the dispatcher to a new file cli.py as the groundwork to refactor the __init__.py (future work). 