### PR TITLE
Various cleanups allowing straightforward implementation for multiple packages dirs later

### DIFF
--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -477,9 +477,7 @@ def get_tree_package_tuples(package_store, tree_variant):
     return package_tuples
 
 
-def build_tree(packages_dir, mkbootstrap, repository_url, tree_variant):
-    package_store = PackageStore(packages_dir)
-
+def build_tree(package_store, mkbootstrap, repository_url, tree_variant):
     # Check the requires and figure out a feasible build order
     # depth-first traverse the dependency tree, yielding when we reach a
     # leaf or all the dependencies of package have been built. If we get
@@ -564,7 +562,11 @@ def build_tree(packages_dir, mkbootstrap, repository_url, tree_variant):
             package_paths.append(built_packages[name][pkg_variant])
 
         if mkbootstrap:
-            return make_bootstrap_tarball(packages_dir, list(sorted(package_paths)), variant, repository_url)
+            return make_bootstrap_tarball(
+                package_store.packages_dir,
+                list(sorted(package_paths)),
+                variant,
+                repository_url)
 
     # Make sure all treeinfos are satisfied and generate their bootstrap
     # tarballs if requested.

--- a/pkgpanda/build/cli.py
+++ b/pkgpanda/build/cli.py
@@ -28,7 +28,8 @@ def main():
 
         # Make a local repository for build dependencies
         if arguments['tree']:
-            build_tree(getcwd(), arguments['--mkbootstrap'], arguments['--repository-url'], arguments['<variant>'])
+            package_store = PackageStore(getcwd())
+            build_tree(package_store, arguments['--mkbootstrap'], arguments['--repository-url'], arguments['<variant>'])
             sys.exit(0)
 
         # Check for the 'build' file to verify this is a valid package directory.

--- a/pkgpanda/build/cli.py
+++ b/pkgpanda/build/cli.py
@@ -28,8 +28,8 @@ def main():
 
         # Make a local repository for build dependencies
         if arguments['tree']:
-            package_store = PackageStore(getcwd())
-            build_tree(package_store, arguments['--mkbootstrap'], arguments['--repository-url'], arguments['<variant>'])
+            package_store = PackageStore(getcwd(), arguments['--repository-url'])
+            build_tree(package_store, arguments['--mkbootstrap'], arguments['<variant>'])
             sys.exit(0)
 
         # Check for the 'build' file to verify this is a valid package directory.
@@ -45,13 +45,12 @@ def main():
             clean(getcwd())
             sys.exit(0)
 
-        package_store = PackageStore(normpath(getcwd() + '/../'))
+        package_store = PackageStore(normpath(getcwd() + '/../'), arguments['--repository-url'])
 
         # No command -> build package.
         pkg_dict = build_package_variants(
             package_store,
             name,
-            arguments['--repository-url'],
             not arguments['--dont-clean-after-build'])
 
         print("Package variants available as:")

--- a/pkgpanda/build/src_fetchers.py
+++ b/pkgpanda/build/src_fetchers.py
@@ -66,7 +66,7 @@ def get_git_sha1(bare_folder, ref):
                 "git",
                 "--git-dir", bare_folder,
                 "rev-parse", ref + "^{commit}"
-                ]).decode('ascii').strip()
+            ]).decode('ascii').strip()
         except CalledProcessError as ex:
             raise ValidationError(
                 "Unable to find ref '{}' in '{}': {}".format(ref, bare_folder, ex)) from ex

--- a/pkgpanda/build/src_fetchers.py
+++ b/pkgpanda/build/src_fetchers.py
@@ -4,7 +4,7 @@ import shutil
 from subprocess import CalledProcessError, check_call, check_output
 
 from pkgpanda.exceptions import ValidationError
-from pkgpanda.util import download, sha1
+from pkgpanda.util import download_atomic, sha1
 
 
 # Ref must be a git sha-1. We then pass it through get_sha1 to make
@@ -305,7 +305,7 @@ class UrlSrcFetcher(SourceFetcher):
         # Download file to cache if it isn't already there
         if not os.path.exists(self.cache_filename):
             print("Downloading source tarball {}".format(self.url))
-            download(self.cache_filename, self.url, self.package_dir)
+            download_atomic(self.cache_filename, self.url, self.package_dir)
 
         # Validate the sha1 of the source is given and matches the sha1
         file_sha = sha1(self.cache_filename)

--- a/pkgpanda/build/tests/test_build.py
+++ b/pkgpanda/build/tests/test_build.py
@@ -23,8 +23,8 @@ def package(resource_dir, name, tmpdir):
     # Build once using programmatic interface
     pkg_dir_2 = str(tmpdir.join("api-build/" + name))
     copytree(resource_dir, pkg_dir_2)
-    package_store = pkgpanda.build.PackageStore(str(tmpdir.join("api-build")))
-    pkgpanda.build.build_package_variants(package_store, name, None, True)
+    package_store = pkgpanda.build.PackageStore(str(tmpdir.join("api-build")), None)
+    pkgpanda.build.build_package_variants(package_store, name, True)
 
 
 def test_build(tmpdir):

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -33,6 +33,7 @@ def variant_prefix(variant):
 
 
 def download(out_filename, url, work_dir):
+    assert os.path.isabs(out_filename)
     assert os.path.isabs(work_dir)
     work_dir = work_dir.rstrip('/')
 
@@ -72,6 +73,7 @@ def download(out_filename, url, work_dir):
 
 
 def download_atomic(out_filename, url, work_dir):
+    assert os.path.isabs(out_filename)
     tmp_filename = out_filename + '.tmp'
     try:
         download(tmp_filename, url, work_dir)

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -71,6 +71,19 @@ def download(out_filename, url, work_dir):
         raise FetchError(url, out_filename, fetch_exception, rm_passed) from fetch_exception
 
 
+def download_atomic(out_filename, url, work_dir):
+    tmp_filename = out_filename + '.tmp'
+    try:
+        download(tmp_filename, url, work_dir)
+        os.rename(tmp_filename, out_filename)
+    except FetchError:
+        try:
+            os.remove(tmp_filename)
+        except:
+            pass
+        raise
+
+
 def extract_tarball(path, target):
     """Extract the tarball into target.
 

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -439,9 +439,9 @@ def do_build_packages(cache_repository_url):
 
     def get_build():
         # TODO(cmaloney): Stop shelling out
-        package_store = pkgpanda.build.PackageStore(os.getcwd() + '/packages')
-        result = pkgpanda.build.build_tree(package_store, True, cache_repository_url, None)
-        last_set = pkgpanda.build.get_last_bootstrap_set(package_dir)
+        package_store = pkgpanda.build.PackageStore(os.getcwd() + '/packages', cache_repository_url)
+        result = pkgpanda.build.build_tree(package_store, True, None)
+        last_set = package_store.get_last_bootstrap_set()
         assert last_set == result, \
             "Internal error: get_last_bootstrap_set doesn't match the results of build_tree: {} != {}".format(
                 last_set,

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -439,8 +439,8 @@ def do_build_packages(cache_repository_url):
 
     def get_build():
         # TODO(cmaloney): Stop shelling out
-        package_dir = os.getcwd() + '/packages'
-        result = pkgpanda.build.build_tree(package_dir, True, cache_repository_url, None)
+        package_store = pkgpanda.build.PackageStore(os.getcwd() + '/packages')
+        result = pkgpanda.build.build_tree(package_store, True, cache_repository_url, None)
         last_set = pkgpanda.build.get_last_bootstrap_set(package_dir)
         assert last_set == result, \
             "Internal error: get_last_bootstrap_set doesn't match the results of build_tree: {} != {}".format(

--- a/release/storage/local.py
+++ b/release/storage/local.py
@@ -65,7 +65,7 @@ class LocalStorageProvider(AbstractStorageProvider):
         final_filenames = set()
         for dirpath, _, filenames in os.walk(self.__full_path(path)):
             assert dirpath.startswith(self.__storage_path)
-            dirpath_no_prefix = dirpath[len(self.__storage_path)+1:]
+            dirpath_no_prefix = dirpath[len(self.__storage_path) + 1:]
             for filename in filenames:
                 final_filenames.add(dirpath_no_prefix + '/' + filename)
 


### PR DESCRIPTION
 - Fix some code style nits
 - Add a download_atomic to remove redundant code
 - Always use PackageStore to get / ask about a package, whether that is from cache or local disk
 - pass PackageStore to `build_tree()` and `make_bootstrap_tarball()` as an argument, simplifying the call signatures and making them in line with `build()`
 - pass PackageStore to build_tree, make_bootstrap like it is