### PR TITLE
Restrict AWS public agents to mesos port ranges

### DIFF
--- a/gen/aws/templates/advanced/infra.json
+++ b/gen/aws/templates/advanced/infra.json
@@ -439,7 +439,7 @@
         "GroupId" : { "Ref" : "PublicAgentSecurityGroup" },
         "IpProtocol" : "tcp",
         "FromPort" : "5052",
-        "ToPort" : "65535",
+        "ToPort" : "32000",
         "CidrIp" : "0.0.0.0/0"
         }
     },
@@ -469,7 +469,7 @@
         "GroupId" : { "Ref" : "PublicAgentSecurityGroup" },
         "IpProtocol" : "udp",
         "FromPort" : "5052",
-        "ToPort" : "65535",
+        "ToPort" : "32000",
         "CidrIp" : "0.0.0.0/0"
         }
     }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -944,7 +944,7 @@
         "GroupId" : { "Ref" : "PublicSlaveSecurityGroup" },
         "IpProtocol" : "tcp",
         "FromPort" : "5052",
-        "ToPort" : "65535",
+        "ToPort" : "32000",
         "CidrIp" : "0.0.0.0/0"
         }
     },
@@ -974,7 +974,7 @@
         "GroupId" : { "Ref" : "PublicSlaveSecurityGroup" },
         "IpProtocol" : "udp",
         "FromPort" : "5052",
-        "ToPort" : "65535",
+        "ToPort" : "32000",
         "CidrIp" : "0.0.0.0/0"
         }
     }


### PR DESCRIPTION
AWS public agents were previously allowing traffic to ports up to 65535.
This change adjusts the public agent security group to only allow
traffic to ports controlled by the Mesos agent (ports below 32000).

This fixes a potential security issue, where internal DC/OS services
which listen these high range ports (including minuteman) could be
exposed to the outside world on the public agents.