### PR TITLE
Teach packaging about "upstream" packages

### DIFF
--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -2,6 +2,7 @@
 *.active.json
 *.bootstrap.tar.xz
 bootstrap.latest
+cache/*
 
 # Per-pacage artifacts
 */*.tar.xz

--- a/pkgpanda/build/cli.py
+++ b/pkgpanda/build/cli.py
@@ -17,8 +17,8 @@ from os.path import basename, exists, normpath
 from docopt import docopt
 
 import pkgpanda.build.constants
-from pkgpanda.build import (BuildError, PackageStore, build_package_variants, build_tree,
-                            clean)
+from pkgpanda.build import (BuildError, PackageStore, build_package_variants,
+                            build_tree)
 
 
 def main():
@@ -40,11 +40,7 @@ def main():
         # Package name is the folder name.
         name = basename(getcwd())
 
-        # Only clean in valid build locations (Why this is after buildinfo.json)
-        if arguments['clean']:
-            clean(getcwd())
-            sys.exit(0)
-
+        # Package store is always the parent directory
         package_store = PackageStore(normpath(getcwd() + '/../'), arguments['--repository-url'])
 
         # No command -> build package.

--- a/pkgpanda/build/tests/test_build.py
+++ b/pkgpanda/build/tests/test_build.py
@@ -1,3 +1,4 @@
+import os
 from shutil import copytree
 from subprocess import CalledProcessError, check_call, check_output
 
@@ -18,7 +19,6 @@ def package(resource_dir, name, tmpdir):
     copytree(resource_dir, str(pkg_dir))
     with pkg_dir.as_cwd():
         check_call(["mkpanda"])
-        check_call(["mkpanda", "clean"])
 
     # Build once using programmatic interface
     pkg_dir_2 = str(tmpdir.join("api-build/" + name))
@@ -47,7 +47,13 @@ def test_url_extract_zip(tmpdir):
 def test_single_source_with_extra(tmpdir):
     package("resources/single_source_extra", "single_source_extra", tmpdir)
 
-    expect_fs(str(tmpdir.join("single_source_extra/cache")), {
+    # remove the built package tarball because that has a variable filename
+    cache_dir = tmpdir.join("cache/packages/single_source_extra/")
+    packages = [str(x) for x in cache_dir.visit(fil="single_source_extra*.tar.xz")]
+    assert len(packages) == 1, "should have built exactly one package: {}".format(packages)
+    os.remove(packages[0])
+
+    expect_fs(str(cache_dir), {
         "latest": None,
         "single_source_extra": ["foo"]})
 
@@ -68,8 +74,7 @@ def test_single_source_corrupt(tmpdir):
         package("resources-nonbootstrapable/single_source_corrupt", "single_source", tmpdir)
 
     # Check the corrupt file got moved to the right place
-    expect_fs(str(tmpdir.join("single_source/cache")), {
-        "single_source": ["foo.corrupt"]})
+    expect_fs(str(tmpdir.join("cache/packages/single_source/single_source")), ["foo.corrupt"])
 
 
 def test_bootstrap(tmpdir):

--- a/pkgpanda/build/tests/test_build.py
+++ b/pkgpanda/build/tests/test_build.py
@@ -47,7 +47,9 @@ def test_url_extract_zip(tmpdir):
 def test_single_source_with_extra(tmpdir):
     package("resources/single_source_extra", "single_source_extra", tmpdir)
 
-    expect_fs(str(tmpdir.join("single_source_extra/cache")), ["latest", "foo"])
+    expect_fs(str(tmpdir.join("single_source_extra/cache")), {
+        "latest": None,
+        "single_source_extra": ["foo"]})
 
 
 # TODO(cmaloney): Re-enable once we build a dcos-builder docker as part of this test. Currently the
@@ -66,7 +68,8 @@ def test_single_source_corrupt(tmpdir):
         package("resources-nonbootstrapable/single_source_corrupt", "single_source", tmpdir)
 
     # Check the corrupt file got moved to the right place
-    expect_fs(str(tmpdir.join("single_source/cache")), ["foo.corrupt"])
+    expect_fs(str(tmpdir.join("single_source/cache")), {
+        "single_source": ["foo.corrupt"]})
 
 
 def test_bootstrap(tmpdir):

--- a/pytest/test_release.py
+++ b/pytest/test_release.py
@@ -485,10 +485,17 @@ def test_repository():
     # TODO(cmaloney): Exercise make_commands with a channel.
 
 
+def test_get_gen_package_artifact(tmpdir):
+    assert release.get_gen_package_artifact('foo--test') == {
+        'reproducible_path': 'packages/foo/foo--test.tar.xz',
+        'local_path': 'packages/foo/foo--test.tar.xz'
+    }
+
+
 def test_get_package_artifact(tmpdir):
     assert release.get_package_artifact('foo--test') == {
         'reproducible_path': 'packages/foo/foo--test.tar.xz',
-        'local_path': 'packages/foo/foo--test.tar.xz'
+        'local_path': 'packages/cache/packages/foo/foo--test.tar.xz'
     }
 
 
@@ -518,9 +525,9 @@ stable_artifacts_metadata = {
             'reproducible_path': 'bootstrap/bootstrap_id.active.json'},
         {'local_path': 'packages/bootstrap.latest',
             'channel_path': 'bootstrap.latest'},
-        {'local_path': 'packages/a/a--b.tar.xz',
+        {'local_path': 'packages/cache/packages/a/a--b.tar.xz',
             'reproducible_path': 'packages/a/a--b.tar.xz'},
-        {'local_path': 'packages/c/c--d.tar.xz',
+        {'local_path': 'packages/cache/packages/c/c--d.tar.xz',
             'reproducible_path': 'packages/c/c--d.tar.xz'},
         {'local_path': 'packages/ee_installer_bootstrap_id.bootstrap.tar.xz',
          'reproducible_path': 'bootstrap/ee_installer_bootstrap_id.bootstrap.tar.xz'},
@@ -534,7 +541,7 @@ stable_artifacts_metadata = {
             'reproducible_path': 'bootstrap/installer_bootstrap_id.active.json'},
         {'local_path': 'packages/installer.bootstrap.latest',
             'channel_path': 'installer.bootstrap.latest'},
-        {'local_path': 'packages/e/e--f.tar.xz',
+        {'local_path': 'packages/cache/packages/e/e--f.tar.xz',
             'reproducible_path': 'packages/e/e--f.tar.xz'}
     ],
     'packages': ['a--b', 'c--d', 'e--f'],

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -270,6 +270,14 @@ def get_package_artifact(package_id_str):
     package_filename = 'packages/{}/{}.tar.xz'.format(package_id.name, package_id_str)
     return {
         'reproducible_path': package_filename,
+        'local_path': 'packages/cache/' + package_filename}
+
+
+def get_gen_package_artifact(package_id_str):
+    package_id = pkgpanda.PackageId(package_id_str)
+    package_filename = 'packages/{}/{}.tar.xz'.format(package_id.name, package_id_str)
+    return {
+        'reproducible_path': package_filename,
         'local_path': package_filename}
 
 
@@ -384,7 +392,7 @@ def make_channel_artifacts(metadata):
         assert provider_data.keys() <= {'packages', 'artifacts'}
 
         for package in provider_data.get('packages', set()):
-            artifacts.append(get_package_artifact(package))
+            artifacts.append(get_gen_package_artifact(package))
 
         # TODO(cmaloney): Check the provider artifacts adhere to the artifact template.
         artifacts += provider_data.get('artifacts', list())


### PR DESCRIPTION
This is useful for being able to have a distributon of DC/OS derived from the
open source DC/OS.

The distribution of DC/OS could do things like
  - Add new DC/OS system packages which should be installed on every host
  - Replace DC/OS components with alternate implementations

In another patch set the ability to have gen spit out more configuration files
will be added.

TODO: 
 - [x] Write a test that upstreams work at all
 - [ ] Write documentation on how to build a derivative of DC/OS
 - [ ] Write code to allow adding new configuration parameters, changing configuration defaults / values in the gen library
 - [ ] Make `release create` work (this makes `mkpanda tree` work)