### PR TITLE
[WIP] Added DC/OS overlay network packages and its dependencies to the installer.

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -71,10 +71,10 @@
         "stable": "ami-05bc0164"
       },
       "us-west-1": {
-        "stable": "ami-27553a47"
+        "stable": "ami-652c5505"
       },
       "us-west-2": {
-        "stable": "ami-00ebfc61"
+        "stable": "ami-f5bc4e95"
       }
     },
     "NATAmi" : {

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-84e0c7ea"
+        "stable": "ami-802dcde1"
       },
       "ap-southeast-1": {
-        "stable": "ami-da67a0b9"
+        "stable": "ami-4c97462f"
       },
       "ap-southeast-2": {
-        "stable": "ami-f35b0590"
+        "stable": "ami-55f6d936"
       },
       "eu-central-1": {
-        "stable": "ami-fdd4c791"
+        "stable": "ami-3b1cf054"
       },
       "eu-west-1": {
-        "stable": "ami-55d20b26"
+        "stable": "ami-2a118659"
       },
       "sa-east-1": {
-        "stable": "ami-154af179"
+        "stable": "ami-ee1b9382"
       },
       "us-east-1": {
-        "stable": "ami-37bdc15d"
+        "stable": "ami-3cf20751"
       },
       "us-gov-west-1": {
-        "stable": "ami-05bc0164"
+        "stable": "ami-9041fef1"
       },
       "us-west-1": {
-        "stable": "ami-652c5505"
+        "stable": "ami-61e99101"
       },
       "us-west-2": {
-        "stable": "ami-f5bc4e95"
+        "stable": "ami-c30af5a3"
       }
     },
     "NATAmi" : {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -74,9 +74,22 @@ package:
       MESOS_MAX_SLAVE_PING_TIMEOUTS=20
       GLOG_drop_log_memory=false
       SASL_PATH=/opt/mesosphere/lib/sasl2
+      {{ mesos_master_modules_env_var }}
   - path: /etc/mesos-master-provider
     content: |
       MESOS_CLUSTER={{ cluster_name }}
+  - path: /etc/mesos-master-modules.json
+    content: |
+      {{ mesos_master_modules_json }}
+  - path: /etc/dcos/network/cni/dummy.cni
+    content: |
+      {
+        "name": "dummy",
+        "type": "bridge"
+      }
+  - path: /etc/dcos/network/overlay
+    content: |
+      {{ dcos_overlay_network }}
   - path: /etc/mesos-slave-modules.json
     content: |
       {{ mesos_slave_modules_json }}
@@ -97,8 +110,11 @@ package:
       MESOS_DOCKER_REMOVE_DELAY={{ docker_remove_delay }}
       MESOS_GC_DELAY={{ gc_delay }}
       MESOS_HOSTNAME_LOOKUP=false
+      MESOS_IMAGE_PROVIDERS=docker
       GLOG_drop_log_memory=false
       {{ mesos_hooks_env_var }}
+      {{ mesos_cni_config_dir_env_var }}
+      {{ mesos_cni_plugins_dir_env_var }}
   - path: /etc/mesos-slave
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]

--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -312,8 +312,7 @@ function check_all() {
             print version
         }
     ')
-    # CoreOS stable as of Aug 2015 has 1.6.2
-    check docker 1.6 "$docker_version"
+    check docker 1.10 "$docker_version"
 
     check curl
     check bash

--- a/packages/cni/build
+++ b/packages/cni/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o nounset -o pipefail
+
+pushd /pkg/src/cni/
+./build
+popd
+
+cp /pkg/src/cni/bin/* $PKG_PATH

--- a/packages/cni/buildinfo.json
+++ b/packages/cni/buildinfo.json
@@ -1,0 +1,9 @@
+{
+    "docker": "golang:1.6",
+    "single_source" : {
+      "kind": "git",
+      "git": "git@github.com:asridharan/cni.git",
+      "ref" : "57b28f3936e60001e4ccd54a8eb74ccf3df7c792",
+      "ref_origin": "master"
+    }
+}

--- a/packages/mesos-overlay/build
+++ b/packages/mesos-overlay/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o nounset -o pipefail
+
+. /opt/mesosphere/active/mesos-buildenv/activate
+
+pushd /pkg/src/mesos-overlay/
+./bootstrap
+popd
+
+export LD_LIBRARY_PATH=/opt/mesosphere/lib
+
+mkdir -p build
+pushd build
+/pkg/src/mesos-overlay/configure \
+     --with-mesos=/opt/mesosphere/active/mesos \
+     --with-protobuf=/opt/mesosphere \
+     --prefix="$PKG_PATH"
+    
+make -j8
+make install
+popd

--- a/packages/mesos-overlay/buildinfo.json
+++ b/packages/mesos-overlay/buildinfo.json
@@ -1,0 +1,10 @@
+{
+  "requires": ["mesos-buildenv", "mesos"],
+    "docker": "dcos-builder",
+    "single_source" : {
+      "kind": "git",
+      "git": "git@github.com:mesosphere/mesos-overlay.git",
+      "ref" : "f328e3c7f4255a92cbbded5e7a3ba7618ae79e51",
+      "ref_origin": "master"
+    }
+}

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,9 +3,9 @@
   "docker": "dcos-builder",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/mesosphere/mesos",
-    "ref": "76c87d55a78e8cbb380fc0c71388ccec53ed1dc8",
-    "ref_origin" : "dcos-1.7"
+    "git": "git@github.com:apache/mesos.git",
+    "ref": "905391ea1c728287ee2b3b23d0fcae6bbafb3e37",
+    "ref_origin" : "master"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Added two packages:
  * mesos-overlay
  * cni

Also made the following modifications to the installer:
  * Introduced user configurable parameters `dcos_overlay_enable` and
   `dcos_overlay_network`.
  * Modified the `dcos-config.yaml` template to enable DC/OS overlay
    specific Mesos modules when the user enables DC/OS overlay by
    setting `dcos_overlay_enable` parameter to "true".
  * Added generation of `overlay_config.json` to specify the overlay
    networks  specified by user using the `dcos_overlay_network`
    parameter.