### PR TITLE
Allow downstream "variants" of DC/OS to include extra bits in gen

### DIFF
--- a/release/__init__.py
+++ b/release/__init__.py
@@ -379,6 +379,11 @@ def make_channel_artifacts(metadata):
                 'bootstrap_variant': pkgpanda.util.variant_prefix(bootstrap_name)
                 })
 
+            # Load additional default variant arguments out of gen_extra
+            if os.path.exists('gen_extra/calc.py'):
+                mod = importlib.machinery.SourceFileLoader('gen_extra.calc', 'gen_extra/calc.py').load_module()
+                variant_arguments[bootstrap_name].update(mod.provider_template_defaults)
+
         # Add templates for the default variant.
         # Use keyword args to make not matching ordering a loud error around changes.
         provider_data = module.do_create(


### PR DESCRIPTION
 - Allow changing defaults which were set in gen/calc.py with a gen_extra/calc.py
 - Allow adding additional content to `gen/{dcos-config.yaml,cloud-config.yaml}` by placing an identically named file in a `gen_extra` folder.

TODO:
 - [x] Hand test to verify this works / gives a full working variant which changes these bits.