### PR TITLE
Build docker images locally

### DIFF
--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -79,7 +79,7 @@ class SSHTunnel():
             src: (str) local path representing source data
             dst: (str) destination for path
         """
-        cmd = self.ssh_cmd + ['-p', str(self.port), self.target, 'cat>'+dst]
+        cmd = self.ssh_cmd + ['-C', '-p', str(self.port), self.target, 'cat>'+dst]
         logger.debug('Running socket write: ' + ' '.join(cmd))
         with open(src, 'r') as fh:
             check_call(cmd, stdin=fh)

--- a/test_util/docker/py.test/Dockerfile
+++ b/test_util/docker/py.test/Dockerfile
@@ -8,3 +8,6 @@ RUN pip install \
     requests \
     retrying \
     teamcity-messages
+ADD integration_test.py /integration_test.py
+ADD test_wrapper.sh /test_wrapper.sh
+CMD bash /test_wrapper.sh

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -85,7 +85,26 @@ vagrant up m1 m2 m3 a1 a2 p1 boot
 # with DC/OS assembling itself to save some time.
 # Build a docker container for running py.test inside of.
 echo "Building py.test container"
-docker build -t py.test - < ../docker/py.test/Dockerfile
+mkdir tmp_build_dir_for_pytest
+pushd tmp_build_dir_for_pytest
+cat <<EOF > test_wrapper.sh
+#!/bin/bash
+export DCOS_DNS_ADDRESS=$DCOS_DNS_ADDRESS
+export MASTER_HOSTS=$MASTER_HOSTS
+export PUBLIC_MASTER_HOSTS=$MASTER_HOSTS
+export SLAVE_HOSTS=192.168.65.111,192.168.65.121
+export PUBLIC_SLAVE_HOSTS=192.168.65.60
+export REGISTRY_HOST=boot.dcos
+export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
+export DNS_SEARCH=true
+export DCOS_AUTH_ENABLED=false
+py.test -vv -s ${CI_FLAGS:-} /integration_test.py
+EOF
+cp $PWD/../../integration_test.py .
+cp $PWD/../../docker/py.test/Dockerfile .
+docker build -t py.test .
+popd
+rm -rf tmp_build_dir_for_pytest
 
 # Build and push test server to local registry:
 echo "Building&pushing test_server container"
@@ -97,21 +116,9 @@ vagrant ssh boot -- -N -L 5000:192.168.65.50:5000 -f && docker push 127.0.0.1:50
 
 echo "Running integration test"
 set +e # So we can potentially capture the logs
-
-docker run -v $PWD/../integration_test.py:/integration_test.py \
-    -e DCOS_DNS_ADDRESS=$DCOS_DNS_ADDRESS \
-    -e MASTER_HOSTS=$MASTER_HOSTS \
-    -e PUBLIC_MASTER_HOSTS=$MASTER_HOSTS \
-    -e SLAVE_HOSTS="192.168.65.111,192.168.65.121" \
-    -e PUBLIC_SLAVE_HOSTS="192.168.65.60" \
-    -e REGISTRY_HOST="boot.dcos" \
-    -e "TEAMCITY_VERSION=${TEAMCITY_VERSION:-}" \
-    -e "DNS_SEARCH=true" \
-    -e "DCOS_AUTH_ENABLED=false" \
-    --net=host py.test py.test -vv -s -m "not minuteman and not ccm" ${CI_FLAGS:-} /integration_test.py
+docker run --net=host py.test
 RET=$?
 
-mkdir -p $WORKDIR/test/vagrant-logs
 if [ $RET -ne 0 ]; then
   echo "TEST FAILED"
   echo "Attempting to gather logs"

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -3,13 +3,16 @@
 Note: ssh_user must be able to use docker without sudo priveleges
 """
 import logging
+import tempfile
 import time
 from contextlib import contextmanager
 from multiprocessing import Process
 from os.path import join
-from subprocess import CalledProcessError, TimeoutExpired
+from subprocess import CalledProcessError, TimeoutExpired, check_call
 
 import pkg_resources
+
+from pkgpanda.util import write_string
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
@@ -65,9 +68,7 @@ def prepare_test_registry(tunnel, test_dir):
     """
     test_server_docker = pkg_filename('docker/test_server/Dockerfile')
     test_server_script = pkg_filename('docker/test_server/test_server.py')
-    pytest_docker = pkg_filename('docker/py.test/Dockerfile')
     log.info('Setting up integration_test.py to run on ' + tunnel.host)
-    tunnel.remote_cmd(['mkdir', '-p', test_dir])
 
     tunnel.remote_cmd(['mkdir', '-p', join(test_dir, 'test_server')])
     tunnel.write_to_remote(test_server_docker, join(test_dir, 'test_server/Dockerfile'))
@@ -90,12 +91,6 @@ def prepare_test_registry(tunnel, test_dir):
     tunnel.remote_cmd(['docker', 'push', '127.0.0.1:5000/test_server'])
     log.debug('Cleaning up test_server files')
     tunnel.remote_cmd(['rm', '-rf', join(test_dir, 'test_server')])
-    log.info('Building base integration_test.py container on test host')
-    tunnel.remote_cmd(['mkdir', '-p', join(test_dir, 'py.test')])
-    tunnel.write_to_remote(pytest_docker, join(test_dir, 'py.test/Dockerfile'))
-    tunnel.remote_cmd([
-        'cd', join(test_dir, 'py.test'), '&&', 'docker', 'build', '-t', 'py.test', '.'])
-    tunnel.remote_cmd(['rm', '-rf', join(test_dir, 'py.test')])
 
 
 def integration_test(
@@ -120,38 +115,60 @@ def integration_test(
         add_env: a python dict with any number of key=value assignments to be passed to
             the test environment
     """
-    log.info('Transfering integration_test.py')
     test_script = pkg_filename('integration_test.py')
-    tunnel.remote_cmd(['mkdir', '-p', test_dir])
-    tunnel.write_to_remote(test_script, test_dir+'/integration_test.py')
+    pytest_docker = pkg_filename('docker/py.test/Dockerfile')
 
-    test_container_name = 'int_test_' + str(int(time.time()))
     dns_search = 'true' if test_dns_search else 'false'
-    test_cmd = [
-        'docker', 'run', '-v', test_dir+'/integration_test.py:/integration_test.py',
-        '--net=host', '--name='+test_container_name]
-    test_cmd.extend([
-        '-e', 'DCOS_DNS_ADDRESS=http://'+dcos_dns,
-        '-e', 'MASTER_HOSTS='+','.join(master_list),
-        '-e', 'PUBLIC_MASTER_HOSTS='+','.join(master_list),
-        '-e', 'SLAVE_HOSTS='+','.join(agent_list),
-        '-e', 'PUBLIC_SLAVE_HOSTS='+','.join(public_agent_list),
-        '-e', 'REGISTRY_HOST=127.0.0.1',
-        '-e', 'DCOS_VARIANT='+variant,
-        '-e', 'DNS_SEARCH='+dns_search,
-        '-e', 'AWS_ACCESS_KEY_ID='+aws_access_key_id,
-        '-e', 'AWS_SECRET_ACCESS_KEY='+aws_secret_access_key,
-        '-e', 'AWS_REGION='+region])
+    test_env = [
+        'DCOS_DNS_ADDRESS=http://'+dcos_dns,
+        'MASTER_HOSTS='+','.join(master_list),
+        'PUBLIC_MASTER_HOSTS='+','.join(master_list),
+        'SLAVE_HOSTS='+','.join(agent_list),
+        'PUBLIC_SLAVE_HOSTS='+','.join(public_agent_list),
+        'REGISTRY_HOST=127.0.0.1',
+        'DCOS_VARIANT='+variant,
+        'DNS_SEARCH='+dns_search,
+        'AWS_ACCESS_KEY_ID='+aws_access_key_id,
+        'AWS_SECRET_ACCESS_KEY='+aws_secret_access_key,
+        'AWS_REGION='+region]
     if add_env:
         for key, value in add_env.items():
-            extra_env = ['-e', key+'='+value]
-            test_cmd.extend(extra_env)
-    test_cmd.extend(['py.test', 'py.test', '-vv', ci_flags, '/integration_test.py'])
+            extra_env = key + '=' + value
+            test_env.append(extra_env)
+    test_env = ['export '+e+'\n' for e in test_env]
+    test_env = ''.join(test_env)
+    test_cmd = 'py.test -vv ' + ci_flags + ' /integration_test.py'
+
+    log.info('Building py.test image')
+    # Make a clean docker context
+    temp_dir = tempfile.mkdtemp()
+    cmd_script = """
+#!/bin/bash
+set -euo pipefail; set -x
+{test_env}
+{test_cmd}
+""".format(test_env=test_env, test_cmd=test_cmd)
+    write_string(join(temp_dir, 'test_wrapper.sh'), cmd_script)
+    check_call(['cp', test_script, join(temp_dir, 'integration_test.py')])
+    check_call(['cp', pytest_docker, join(temp_dir, 'Dockerfile')])
+    check_call(['docker', 'build', '-t', 'py.test', temp_dir])
+
+    log.info('Exporting py.test image')
+    pytest_image_tar = 'DCOS_integration_test.tar'
+    check_call(['docker', 'save', '-o', join(temp_dir, pytest_image_tar), 'py.test'])
+
+    log.info('Transferring py.test image')
+    tunnel.write_to_remote(join(temp_dir, pytest_image_tar), join(test_dir, pytest_image_tar))
+    log.info('Loading py.test image on remote host')
+    tunnel.remote_cmd(['docker', 'load', '-i', join(test_dir, pytest_image_tar)])
+
+    test_container_name = 'int_test_' + str(int(time.time()))
+    docker_cmd = ['docker', 'run', '--net=host', '--name='+test_container_name, 'py.test']
     try:
         with remote_port_forwarding(tunnel, agent_list+public_agent_list, join(test_dir, 'ssh_key')):
             log.info('Running integration test...')
             try:
-                tunnel.remote_cmd(test_cmd, timeout=timeout)
+                tunnel.remote_cmd(docker_cmd, timeout=timeout)
             except CalledProcessError:
                 log.exception('Test failed!')
                 if ci_flags:


### PR DESCRIPTION
Refactors how VPC intgration tests are run
-creates pluggable python module for setting up and running
tests on bare remote hosts (or mesos masters)
-Adds CLI for running on arbitrary clusters as a tool
-bakes arguments and integration test into docker image
before every test => custom depdencies can be used in integration +
huge string of arguments does not need to be copied to rerun test