### PR TITLE
Create test_runner module

### DIFF
--- a/pytest/test_ssh_integration.py
+++ b/pytest/test_ssh_integration.py
@@ -332,7 +332,7 @@ def tunnel_write_and_run(remote_write_fn, remote_cmd_fn):
         tmp_fh.flush()
         remote_tmp_file = '/tmp/' + str(uuid.uuid4())
         remote_write_fn(src=tmp_fh.name, dst=remote_tmp_file)
-        returned_text = remote_cmd_fn(cmd=['cat', remote_tmp_file])
+        returned_text = remote_cmd_fn(cmd=['cat', remote_tmp_file]).decode('utf-8').strip('\n')
         assert returned_text == rando_text
 
 

--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -54,7 +54,7 @@ class SSHTunnel():
         check_call(start_tunnel)
         logger.debug('SSH Tunnel established!')
 
-    def remote_cmd(self, cmd, raw_output=False, timeout=None):
+    def remote_cmd(self, cmd, timeout=None):
         """
         Args:
             cmd: list of strings that will be interpretted in a subprocess
@@ -67,14 +67,11 @@ class SSHTunnel():
         logger.debug('Running socket cmd: ' + ' '.join(run_cmd))
         try:
             output = check_output(run_cmd, timeout=timeout)
-            if raw_output:
-                return output
-            else:
-                return output.decode('utf-8').rstrip('\r\n')
+            return output
         except TimeoutExpired as e:
-            logging.error('{} timed out after {} seconds'.format(cmd, timeout))
+            logging.exception('{} timed out after {} seconds'.format(cmd, timeout))
             logging.debug('Timed out process output:\n' + e.output)
-            raise e
+            raise
 
     def write_to_remote(self, src, dst):
         """

--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -54,7 +54,7 @@ class SSHTunnel():
         check_call(start_tunnel)
         logger.debug('SSH Tunnel established!')
 
-    def remote_cmd(self, cmd, timeout=None):
+    def remote_cmd(self, cmd, raw_output=False, timeout=None):
         """
         Args:
             cmd: list of strings that will be interpretted in a subprocess
@@ -66,11 +66,15 @@ class SSHTunnel():
         run_cmd = self.ssh_cmd + ['-p', str(self.port), self.target] + cmd
         logger.debug('Running socket cmd: ' + ' '.join(run_cmd))
         try:
-            return check_output(run_cmd, timeout=timeout).decode('utf-8').rstrip('\r\n')
+            output = check_output(run_cmd, timeout=timeout)
+            if raw_output:
+                return output
+            else:
+                return output.decode('utf-8').rstrip('\r\n')
         except TimeoutExpired as e:
             logging.error('{} timed out after {} seconds'.format(cmd, timeout))
             logging.debug('Timed out process output:\n' + e.output)
-            raise TimeoutExpired
+            raise e
 
     def write_to_remote(self, src, dst):
         """

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -72,8 +72,8 @@ class AbstractDcosInstaller(metaclass=abc.ABCMeta):
 
     def get_hashed_password(self, password):
         p = self.ssh(["bash", self.installer_path, "--hash-password", password])
-        # password hash is last line output
-        passwd_hash = p.split('\n')[-1]
+        # password hash is last line output but output ends with newline
+        passwd_hash = p.decode('utf-8').split('\n')[-2]
         return passwd_hash
 
     @abc.abstractmethod

--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -35,15 +35,14 @@ CI_FLAGS: string (default=None)
     If provided, this string will be passed directly to py.test as in:
     py.test -vv CI_FLAGS integration_test.py
 """
-import asyncio
-import copy
 import logging
-import multiprocessing
 import os
 import random
 import stat
 import string
 import sys
+from contextlib import closing
+from os import join
 
 import passlib.hash
 import pkg_resources
@@ -51,8 +50,8 @@ from retrying import retry
 
 import test_util.ccm
 import test_util.installer_api_test
-from ssh.ssh_runner import MultiRunner
-from ssh.utils import CommandChain, SyncCmdDelegate
+from ssh.ssh_tunnel import SSHTunnel, TunnelCollection
+from test_util.test_runner import integration_test, setup_integration_test
 
 
 DEFAULT_AWS_REGION = 'us-west-2'
@@ -62,205 +61,24 @@ def pkg_filename(relative_path):
     return pkg_resources.resource_filename(__name__, relative_path)
 
 
-def run_loop(ssh_runner, chain):
-    # TODO: replace with SSH Library Synchronous API
-
-    def function():
-        result = yield from ssh_runner.run_commands_chain_async([chain], block=True)
-        return result
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        result = loop.run_until_complete(function())
-    finally:
-        loop.close()
-    return result
-
-
-def check_results(results, force_print=False):
-    """Loops through iterable results. Only one result dict is produced per
-    command, so when iterating, pop the only dict rather than iterate over it
-
-    Args:
-        results: output of loop.run_until_complete(runner.run_commands_chain_async([cmd_chain]))
-        force_print: print output from loop even if it was successful
-
-    Raises:
-        AssertionError: if any of the commands have non-zero return code
-    """
-    for host_result in results:
-        for command_result in host_result:
-            assert len(command_result.keys()) == 1, 'SSH Library returned unexpected result format'
-            host, data = command_result.popitem()
-            err_msg = "Host {} returned exit code {} after running {}\nSTDOUT: {}\nSTDERR: {}"
-            assert data['returncode'] == 0, err_msg.format(
-                    host, data['returncode'], data['cmd'], '\n'.join(data['stdout']), '\n'.join(data['stderr']))
-            if force_print:
-                print(err_msg.format(
-                    host, data['returncode'], data['cmd'], '\n'.join(data['stdout']), '\n'.join(data['stderr'])))
-
-
-@retry(wait_fixed=1000, stop_max_delay=1000*300)
-def get_local_addresses(ssh_runner, remote_dir):
+def get_local_address(tunnel, remote_dir):
     """Uses checked-in IP detect script to report local IP mapping
-    Also functions as a test to verify cluster is up and accessible
-
     Args:
-        ssh_runner: instance of ssh.ssh_runner.MultiRunner
+        tunnel (SSHTunnel): see ssh.ssh_tunnel.SSHTunnel
         remote_dir (str): path on hosts for ip-detect to be copied and run in
 
     Returns:
         dict[public_IP] = local_IP
     """
-
-    def remote(path):
-        return remote_dir + '/' + path
-
     ip_detect_script = pkg_resources.resource_filename('gen', 'ip-detect/aws.sh')
-    ip_map_chain = CommandChain('ip_map')
-    ip_map_chain.add_copy(ip_detect_script, remote('ip-detect.sh'))
-    ip_map_chain.add_execute(['bash', remote('ip-detect.sh')])
-    mapping = {}
-    result = run_loop(ssh_runner, ip_map_chain)
-
-    # Check the running was successful
-    check_results(copy.deepcopy(result))
-
-    # Gather the local IP addresses
-    for host_result in result:
-        host, data = host_result[-1].popitem()  # Grab the last command trigging the script
-        local_ip = data['stdout'][0].rstrip()
-        assert local_ip != '', "Didn't get a valid IP for host {}:\n{}".format(host, data)
-        mapping[host.split(":")[0]] = local_ip
-    return mapping
-
-
-def break_prereqs(ssh_runner):
-    """Performs commands that will cause preflight to fail on a prepared node
-
-    Args:
-        ssh_runner: instance of ssh.ssh_runner.MultiRunner
-    """
-    break_prereq_chain = CommandChain('break_prereqs')
-    break_prereq_chain.add_execute(['sudo', 'groupdel', 'nogroup'])
-
-    check_results(run_loop(ssh_runner, break_prereq_chain))
-
-
-def test_setup(ssh_runner, registry, remote_dir, use_zk_backend):
-    """Transfer resources and issues commands on host to build test app,
-    host it on a docker registry, and prepare the integration_test container
-
-    Args:
-        ssh_runner: instance of ssh.ssh_runner.MultiRunner
-        registry (str): address of registry host that is visible to test nodes
-        remote_dir (str): path to be used for setup and file transfer on host
-
-    Returns:
-        result from async chain that can be checked later for success
-    """
-    test_server_docker = pkg_filename('docker/test_server/Dockerfile')
-    test_server_script = pkg_filename('docker/test_server/test_server.py')
-    pytest_docker = pkg_filename('docker/py.test/Dockerfile')
-    test_script = pkg_filename('integration_test.py')
-    test_setup_chain = CommandChain('test_setup')
-    if use_zk_backend:
-        test_setup_chain.add_execute([
-            'sudo', 'docker', 'run', '-d', '-p', '2181:2181', '-p', '2888:2888',
-            '-p', '3888:3888', 'jplock/zookeeper'])
-
-    def remote(path):
-        return remote_dir + '/' + path
-
-    # Create test application
-    test_setup_chain.add_execute(['mkdir', '-p', remote('test_server')])
-    test_setup_chain.add_copy(test_server_docker, remote('test_server/Dockerfile'))
-    test_setup_chain.add_copy(test_server_script, remote('test_server/test_server.py'))
-    test_setup_chain.add_execute([
-        'docker', 'run', '-d', '-p', '5000:5000', '--restart=always', '--name',
-        'registry', 'registry:2'])
-    test_setup_chain.add_execute([
-        'cd', remote('test_server'), '&&', 'docker', 'build', '-t',
-        '{}:5000/test_server'.format(registry), '.'])
-    test_setup_chain.add_execute(['docker', 'push', "{}:5000/test_server".format(registry)])
-    test_setup_chain.add_execute(['rm', '-rf', remote('test_server')])
-    # Create pytest/integration test instance on remote
-    test_setup_chain.add_execute(['mkdir', '-p', remote('py.test')])
-    test_setup_chain.add_copy(pytest_docker, remote('py.test/Dockerfile'))
-    test_setup_chain.add_copy(test_script, remote('integration_test.py'))
-    test_setup_chain.add_execute([
-        'cd', remote('py.test'), '&&', 'docker', 'build', '-t', 'py.test', '.'])
-    test_setup_chain.add_execute(['rm', '-rf', remote('py.test')])
-
-    check_results(run_loop(ssh_runner, test_setup_chain))
-
-
-def integration_test(
-        ssh_runner, dcos_dns, master_list, agent_list, public_agent_list, region, registry_host,
-        test_dns_search, ci_flags, aws_access_key_id, aws_secret_access_key):
-    """Runs integration test on host
-    Note: check_results() will raise AssertionError if test fails
-
-    Args:
-        ssh_runner: instance of ssh.ssh_runner.MultiRunner
-        dcos_dns: string representing IP of DC/OS DNS host
-        master_list: string of comma separated master addresses
-        region: string indicating AWS region in which cluster is running
-        agent_list: string of comma separated agent addresses
-        registry_host: string for address where marathon can pull test app
-        test_dns_search: if set to True, test for deployed mesos DNS app
-        ci_flags: optional additional string to be passed to test
-
-    """
-    run_test_chain = CommandChain('run_test')
-    dns_search = 'true' if test_dns_search else 'false'
-    test_cmd = [
-        'docker', 'run', '-v', '/home/centos/integration_test.py:/integration_test.py',
-        '-e', 'DCOS_DNS_ADDRESS=http://'+dcos_dns,
-        '-e', 'MASTER_HOSTS='+','.join(master_list),
-        '-e', 'PUBLIC_MASTER_HOSTS='+','.join(master_list),
-        '-e', 'SLAVE_HOSTS='+','.join(agent_list),
-        '-e', 'PUBLIC_SLAVE_HOSTS='+','.join(public_agent_list),
-        '-e', 'REGISTRY_HOST='+registry_host,
-        '-e', 'DCOS_VARIANT=default',
-        '-e', 'DNS_SEARCH='+dns_search,
-        '-e', 'AWS_ACCESS_KEY_ID='+aws_access_key_id,
-        '-e', 'AWS_SECRET_ACCESS_KEY='+aws_secret_access_key,
-        '-e', 'AWS_REGION='+region,
-        '--net=host', 'py.test', 'py.test',
-        '-vv', ci_flags, '/integration_test.py']
-    print("To run this test again, ssh to test node and run:\n{}".format(' '.join(test_cmd)))
-    run_test_chain.add_execute(test_cmd)
-
-    check_results(run_loop(ssh_runner, run_test_chain), force_print=True)
-
-
-def prep_hosts(ssh_runner, registry):
-    """Runs steps so that nodes can pass preflight checks. Nodes are expected
-    to either use the custom AMI or have install-prereqs run on them. Additionally,
-    Note: break_prereqs is run before this always
-
-    Args:
-        ssh_runner: instance of ssh.ssh_runner.MultiRunner
-        registry: string to configure hosts with trusted registry for app deployment
-    """
-    host_prep_chain = CommandChain('host_prep')
-    host_prep_chain.add_execute([
-        'sudo', 'sed', '-i',
-        "'/ExecStart=\/usr\/bin\/docker/ !b; s/$/ --insecure-registry={}:5000/'".format(registry),
-        '/etc/systemd/system/docker.service.d/execstart.conf'])
-    host_prep_chain.add_execute(['sudo', 'systemctl', 'daemon-reload'])
-    host_prep_chain.add_execute(['sudo', 'systemctl', 'restart', 'docker'])
-    host_prep_chain.add_execute(['sudo', 'groupadd', '-g', '65500', 'nogroup'])
-    host_prep_chain.add_execute(['sudo', 'usermod', '-aG', 'docker', 'centos'])
-
-    check_results(run_loop(ssh_runner, host_prep_chain))
+    tunnel.write_to_remote(ip_detect_script, join(remote_dir, 'ip-detect.sh'))
+    local_ip = tunnel.remote_cmd(['bash', join(remote_dir, 'ip-detect.sh')])
+    assert len(local_ip.split('.')) == 4
+    return local_ip
 
 
 def make_vpc(use_bare_os=False):
     """uses CCM to provision a test VPC of minimal size (3).
-
     Args:
         use_bare_os: if True, vanilla AMI is used. If False, custom AMI is used
             with much faster prereq satisfaction time
@@ -357,34 +175,13 @@ def main():
         host_list = options.host_list
 
     assert os.path.exists('ssh_key'), 'Valid SSH key for hosts must be in working dir!'
-    # key must be chmod 600 for SSH lib to use
+    # key must be chmod 600 for test_runner to use
     os.chmod('ssh_key', stat.S_IREAD | stat.S_IWRITE)
 
     # Create custom SSH Runnner to help orchestrate the test
     ssh_user = 'centos'
     ssh_key_path = 'ssh_key'
     remote_dir = '/home/centos'
-
-    def make_runner(host_list):
-        """process_timeout must be large enough for integration_test.py to run
-        """
-        return MultiRunner(
-                host_list, ssh_user=ssh_user, ssh_key_path=ssh_key_path,
-                process_timeout=1200, async_delegate=SyncCmdDelegate())
-
-    all_host_runner = make_runner(host_list)
-    test_host_runner = make_runner([host_list[0]])
-    dcos_host_runner = make_runner(host_list[1:])
-
-    print('Checking that hosts are accessible')
-    local_ip = get_local_addresses(all_host_runner, remote_dir)
-
-    print("VPC hosts: {}".format(host_list))
-    # use first node as bootstrap node, second node as master, all others as agents
-    registry_host = local_ip[host_list[0]]
-    master_list = [local_ip[_] for _ in host_list[1:2]]
-    agent_list = [local_ip[_] for _ in host_list[2:3]]
-    public_agent_list = [local_ip[_] for _ in host_list[3:]]
 
     if options.use_api:
         installer = test_util.installer_api_test.DcosApiInstaller()
@@ -394,110 +191,100 @@ def main():
     else:
         installer = test_util.installer_api_test.DcosCliInstaller()
 
-    # If installer_url is not set, then no downloading occurs
-    installer.setup_remote(
-            tunnel=None,
-            installer_path=remote_dir+'/dcos_generate_config.sh',
-            download_url=options.installer_url,
-            host=host_list[0],
-            ssh_user=ssh_user,
-            ssh_key_path=ssh_key_path)
+    host_list_w_port = [i+':22' for i in host_list]
 
-    if options.do_setup:
-        host_prep_chain = CommandChain('host_prep')
-        host_prep_chain.add_execute([
-            'sudo', 'sed', '-i',
-            "'/ExecStart=\/usr\/bin\/docker/ !b; s/$/ --insecure-registry={}:5000/'".format(registry_host),
-            '/etc/systemd/system/docker.service.d/execstart.conf'])
-        host_prep_chain.add_execute(['sudo', 'systemctl', 'daemon-reload'])
-        host_prep_chain.add_execute(['sudo', 'systemctl', 'restart', 'docker'])
-        host_prep_chain.add_execute(['sudo', 'usermod', '-aG', 'docker', 'centos'])
-        check_results(run_loop(test_host_runner, host_prep_chain))
+    @retry(stop_max_delay=120000)
+    def establish_host_connectivity():
+        """Continually try to recreate the SSH Tunnels to all hosts for 2 minutes
+        """
+        return closing(TunnelCollection(ssh_user, ssh_key_path, host_list_w_port))
 
-    # Retrieve and test the password hash before starting web server
-    test_pass = 'testpassword'
-    hash_passwd = installer.get_hashed_password(test_pass)
-    assert passlib.hash.sha512_crypt.verify(test_pass, hash_passwd), 'Hash does not match password'
+    with establish_host_connectivity() as tunnels:
+        local_ip = {}
+        for tunnel in tunnels.tunnels:
+            local_ip[tunnel.host] = get_local_address(tunnel, remote_dir)
+            if options.do_setup:
+                # Make the default user priveleged to use docker
+                tunnel.remote_cmd(['sudo', 'usermod', '-aG', 'docker', ssh_user])
 
-    if options.do_setup and options.use_api:
-        installer.start_web_server()
+    # use first node as bootstrap node, second node as master, all others as agents
+    test_host = host_list[0]
+    registry_host = local_ip[host_list[0]]
+    master_list = [local_ip[_] for _ in host_list[1:2]]
+    agent_list = [local_ip[_] for _ in host_list[2:]]
 
-    print("Configuring install...")
-    with open(pkg_resources.resource_filename("gen", "ip-detect/aws.sh")) as ip_detect_fh:
-        ip_detect_script = ip_detect_fh.read()
-    with open('ssh_key', 'r') as key_fh:
-        ssh_key = key_fh.read()
-    # Using static exhibitor is the only option in the GUI installer
-    if options.use_api:
-        zk_host = None  # causes genconf to use static exhibitor backend
-    else:
-        zk_host = registry_host + ':2181'
-    # use first node as independent test/bootstrap node, second node as master, all others as slaves
-    installer.genconf(
-            zk_host=zk_host,
-            master_list=master_list,
-            agent_list=agent_list,
-            public_agent_list=public_agent_list,
-            ip_detect_script=ip_detect_script,
-            ssh_user=ssh_user,
-            ssh_key=ssh_key)
+    with closing(SSHTunnel(ssh_user, ssh_key_path, test_host)) as test_host_tunnel:
 
-    # Test install-prereqs. This may take up 15 minutes...
-    if options.test_install_prereqs:
-        installer.install_prereqs()
-        if options.test_install_prereqs_only:
-            if vpc:
-                vpc.delete()
-            sys.exit(0)
+        installer.setup_remote(
+                tunnel=test_host_tunnel,
+                installer_path=remote_dir+'/dcos_generate_config.sh',
+                download_url=options.installer_url)
+        if options.do_setup:
+            # only do on setup so you can rerun this test against a living installer
+            test_pass = 'testpassword'
+            hash_passwd = installer.get_hashed_password(test_pass)
+            assert passlib.hash.sha512_crypt.verify(test_pass, hash_passwd), 'Hash does not match password'
+            if options.use_api:
+                installer.start_web_server()
 
-    test_setup_handler = None
-    if options.do_setup:
-        print("Making sure prereqs are broken...")
-        break_prereqs(all_host_runner)
-        print('Check that --preflight gives an error')
-        installer.preflight(expect_errors=True)
-        print("Prepping all hosts...")
-        prep_hosts(dcos_host_runner, registry=registry_host)
-        # This will setup the integration test and its resources
-        print('Setting up test node while deploy runs...')
-        # TODO: remove calls to both multiprocessing and asyncio
-        # at time of writing block=False only supported for JSON delegates
-        test_setup_handler = multiprocessing.Process(
-                target=test_setup, args=(test_host_runner, registry_host, remote_dir, not options.use_api))
-        # Wait for this to finish later as it is not required for deploy and preflight
-        test_setup_handler.start()
+        with open(pkg_resources.resource_filename("gen", "ip-detect/aws.sh")) as ip_detect_fh:
+            ip_detect_script = ip_detect_fh.read()
+        with open('ssh_key', 'r') as key_fh:
+            ssh_key = key_fh.read()
+        # Using static exhibitor is the only option in the GUI installer
+        if options.use_api:
+            zk_host = None  # causes genconf to use static exhibitor backend
+        else:
+            zk_host = registry_host + ':2181'
+            zk_cmd = [
+                    'sudo', 'docker', 'run', '-d', '-p', '2181:2181', '-p',
+                    '2888:2888', '-p', '3888:3888', 'jplock/zookeeper']
+            test_host_tunnel.remote_cmd(zk_cmd)
 
-    if not options.test_install_prereqs:
-        # If we ran the prereq install test, then we already used preflight
-        # Avoid running preflight twice in this case
-        print("Running Preflight...")
-        installer.preflight()
+        installer.genconf(
+                zk_host=zk_host,
+                master_list=master_list,
+                agent_list=agent_list,
+                ip_detect_script=ip_detect_script,
+                ssh_user=ssh_user,
+                ssh_key=ssh_key)
 
-    print("Running Deploy...")
-    installer.deploy()
+        if options.test_install_prereqs:
+            # Runs preflight in --web or --install-prereqs for CLI
+            # This may take up 15 minutes...
+            installer.install_prereqs()
+            if options.test_install_prereqs_only:
+                if vpc:
+                    vpc.delete()
+                sys.exit(0)
+        else:
+            # Will not fix errors detected in preflight
+            installer.preflight()
 
-    # If we needed setup, wait for it to finish
-    if test_setup_handler:
-        test_setup_handler.join()
+        installer.deploy()
 
-    print("Running Postflight")
-    installer.postflight()
+        installer.postflight()
 
-    # Runs dcos-image/integration_test.py inside the cluster
-    print("Test host: {}@{}:22".format(ssh_user, host_list[0]))
-    integration_test(
-        test_host_runner,
-        region=vpc.get_region() if vpc else DEFAULT_AWS_REGION,
-        dcos_dns=master_list[0],
-        master_list=master_list,
-        agent_list=agent_list,
-        public_agent_list=public_agent_list,
-        registry_host=registry_host,
-        # Setting dns_search: mesos not currently supported in API
-        test_dns_search=not options.use_api,
-        ci_flags=options.ci_flags,
-        aws_access_key_id=options.aws_access_key_id,
-        aws_secret_access_key=options.aws_secret_access_key)
+        # Runs dcos-image/integration_test.py inside the cluster
+        setup_integration_test(
+                tunnel=test_host_tunnel,
+                test_dir=remote_dir,
+                registry=registry_host,
+                agent_list=agent_list)
+        integration_test(
+                tunnel=test_host_tunnel,
+                test_dir=remote_dir,
+                region=vpc.get_region() if vpc else DEFAULT_AWS_REGION,
+                dcos_dns=master_list[0],
+                master_list=master_list,
+                agent_list=agent_list,
+                registry_host=registry_host,
+                variant=options.variant,
+                # Setting dns_search: mesos not currently supported in API
+                test_dns_search=not options.use_api,
+                ci_flags=options.ci_flags,
+                aws_access_key_id=options.aws_access_key_id,
+                aws_secret_access_key=options.aws_secret_access_key)
 
     # TODO(cmaloney): add a `--healthcheck` option which runs dcos-diagnostics
     # on every host to see if they are working.

--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -75,7 +75,7 @@ def get_local_address(tunnel, remote_dir):
     """
     ip_detect_script = pkg_resources.resource_filename('gen', 'ip-detect/aws.sh')
     tunnel.write_to_remote(ip_detect_script, join(remote_dir, 'ip-detect.sh'))
-    local_ip = tunnel.remote_cmd(['bash', join(remote_dir, 'ip-detect.sh')])
+    local_ip = tunnel.remote_cmd(['bash', join(remote_dir, 'ip-detect.sh')]).decode('utf-8')
     assert len(local_ip.split('.')) == 4
     return local_ip
 

--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -281,9 +281,7 @@ def main():
         # Runs dcos-image/integration_test.py inside the cluster
         setup_integration_test(
                 tunnel=test_host_tunnel,
-                test_dir=remote_dir,
-                registry=registry_host,
-                agent_list=agent_list)
+                test_dir=remote_dir)
         integration_test(
                 tunnel=test_host_tunnel,
                 test_dir=remote_dir,

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -142,7 +142,7 @@ def integration_test(
         raise e
     finally:
         get_logs_cmd = ['docker', 'logs', test_container_name]
-        test_log = tunnel.remote_cmd(get_logs_cmd, raw_output=True)
+        test_log = tunnel.remote_cmd(get_logs_cmd)
         log_file = 'integration_test.log'
         with open(log_file, 'wb') as fh:
             fh.write(test_log)

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -5,6 +5,8 @@ Note: ssh_user must be able to use docker without sudo priveleges
 """
 import logging
 import time
+from contextlib import contextmanager
+from multiprocessing import Process
 from os.path import join
 from subprocess import CalledProcessError, TimeoutExpired
 
@@ -14,27 +16,37 @@ LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
-TEST_DOCKERD_CONFIG = """[Service]
-Restart=always
-StartLimitInterval=0
-RestartSec=15
-ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay --insecure-registry={}:5000
-"""
+SSH_OPTS = ['-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null']
+
+
+@contextmanager
+def proxy_registry_as_local(tunnel, agent_list):
+    tunnel.write_to_remote(tunnel.ssh_key_path, 'ssh_key')
+    tunnel.remote_cmd(['chmod', '600', 'ssh_key'])
+    cmd_list = ['ssh', '-i', 'ssh_key'] + SSH_OPTS
+    p_list = []
+    for agent in agent_list:
+        target = tunnel.ssh_user + '@' + agent
+        agent_cmd_list = cmd_list + ['-T', '-R', '5000:localhost:5000', target]
+        p = Process(target=tunnel.remote_cmd, args=(agent_cmd_list,))
+        p.start()
+        p_list.append(p)
+    yield
+    for p in p_list:
+        p.terminate()
 
 
 def pkg_filename(relative_path):
     return pkg_resources.resource_filename(__name__, relative_path)
 
 
-def setup_integration_test(tunnel, test_dir, registry=None, agent_list=None):
+def setup_integration_test(tunnel, test_dir):
     """Transfer resources and issues commands on host to build test app,
     host it on a docker registry, and prepare the integration_test container
     Note: we perform configuration of the nodes via a single establish tunnel
         so that the test may run through a load balance (i.e. Azure tests)
 
     Args:
-        registry (str): address of registry host that is visible to test nodes (DCOS local IP of test_host)
         test_dir (str): path to be used for setup and file transfer on host
 
     Returns:
@@ -45,42 +57,6 @@ def setup_integration_test(tunnel, test_dir, registry=None, agent_list=None):
     pytest_docker = pkg_filename('docker/py.test/Dockerfile')
     log.info('Setting up integration_test.py to run on ' + tunnel.host)
     tunnel.remote_cmd(['mkdir', '-p', test_dir])
-
-    if not registry:
-        log.warning('No registry provided; using test host as registry')
-        log.warning('Assuming that test host is a node in DCOS')
-        log.info('Finding IP local of test host')
-        registry = tunnel.remote_cmd(['/opt/mesosphere/bin/detect_ip'])
-
-    log.info('Setting up SSH key on test host for daisy-chain-ing')
-    remote_key_path = join(test_dir, 'test_ssh_key')
-    tunnel.write_to_remote(tunnel.ssh_key_path, remote_key_path)
-    tunnel.remote_cmd(['chmod', '600', remote_key_path])
-
-    log.info('Reconfiguring all dockerd to trust insecurity registry: ' + registry)
-    with open('execstart.conf', 'w') as conf_fh:
-        conf_fh.write(TEST_DOCKERD_CONFIG.format(registry))
-    conf_transfer_path = join(test_dir, 'execstart.conf')
-    docker_conf_chain = (
-        ['docker', 'version'],  # checks that docker is available w/o sudo
-        ['sudo', 'cp', conf_transfer_path, '/etc/systemd/system/docker.service.d/execstart.conf'],
-        ['sudo', 'systemctl', 'daemon-reload'],
-        ['sudo', 'systemctl', 'restart', 'docker'])
-    log.info('Reconfiguring dockerd on test host')
-    tunnel.write_to_remote('execstart.conf', conf_transfer_path)
-    for cmd in docker_conf_chain:
-        tunnel.remote_cmd(cmd)
-    for agent in agent_list:
-        log.info('Reconfiguring dockerd on ' + agent)
-        target = "{}@{}".format(tunnel.ssh_user, agent)
-        target_scp = "{}:{}".format(target, conf_transfer_path)
-        ssh_opts = ['-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null']
-        scp_cmd = ['/usr/bin/scp', '-i', remote_key_path] + ssh_opts
-        remote_scp = scp_cmd + [conf_transfer_path, target_scp]
-        tunnel.remote_cmd(remote_scp)
-        chain_prefix = ['/usr/bin/ssh', '-tt', '-i', remote_key_path] + ssh_opts + [target]
-        for cmd in docker_conf_chain:
-            tunnel.remote_cmd(chain_prefix+cmd)
 
     tunnel.remote_cmd(['mkdir', '-p', join(test_dir, 'test_server')])
     tunnel.write_to_remote(test_server_docker, join(test_dir, 'test_server/Dockerfile'))
@@ -98,9 +74,9 @@ def setup_integration_test(tunnel, test_dir, registry=None, agent_list=None):
     log.info('Building test_server Docker image on test host')
     tunnel.remote_cmd([
         'cd', join(test_dir, 'test_server'), '&&', 'docker', 'build', '-t',
-        '{}:5000/test_server'.format(registry), '.'])
+        'localhost:5000/test_server', '.'])
     log.info('Pushing built test server to insecure registry')
-    tunnel.remote_cmd(['docker', 'push', "{}:5000/test_server".format(registry)])
+    tunnel.remote_cmd(['docker', 'push', 'localhost:5000/test_server'])
     log.debug('Cleaning up test_server files')
     tunnel.remote_cmd(['rm', '-rf', join(test_dir, 'test_server')])
     log.info('Building base integration_test.py container on test host')
@@ -145,7 +121,7 @@ def integration_test(
         '-e', 'MASTER_HOSTS='+','.join(master_list),
         '-e', 'PUBLIC_MASTER_HOSTS='+','.join(master_list),
         '-e', 'SLAVE_HOSTS='+','.join(agent_list),
-        '-e', 'REGISTRY_HOST='+registry_host,
+        '-e', 'REGISTRY_HOST=localhost',
         '-e', 'DCOS_VARIANT='+variant,
         '-e', 'DNS_SEARCH='+dns_search,
         '-e', 'AWS_ACCESS_KEY_ID='+aws_access_key_id,
@@ -155,7 +131,8 @@ def integration_test(
         '-vv', ci_flags, '/integration_test.py']
     log.info('Running integration test...')
     try:
-        tunnel.remote_cmd(test_cmd, timeout=timeout)
+        with proxy_registry_as_local(tunnel, agent_list):
+            tunnel.remote_cmd(test_cmd, timeout=timeout)
         log.info('Successful test run!')
     except TimeoutExpired as e:
         log.error('Test failed due to timing out after {} seconds'.format(timeout))

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Module for running integration_test.py inside of a remote cluster
+Parameters for integration_test.py are passed via the same environment variables
+Note: ssh_user must be able to use docker without sudo priveleges
+"""
+import logging
+import time
+from os.path import join
+from subprocess import CalledProcessError, TimeoutExpired
+
+import pkg_resources
+
+LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
+logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+TEST_DOCKERD_CONFIG = """[Service]
+Restart=always
+StartLimitInterval=0
+RestartSec=15
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay --insecure-registry={}:5000
+"""
+
+
+def pkg_filename(relative_path):
+    return pkg_resources.resource_filename(__name__, relative_path)
+
+
+def setup_integration_test(tunnel, test_dir, registry=None, agent_list=None):
+    """Transfer resources and issues commands on host to build test app,
+    host it on a docker registry, and prepare the integration_test container
+    Note: we perform configuration of the nodes via a single establish tunnel
+        so that the test may run through a load balance (i.e. Azure tests)
+
+    Args:
+        registry (str): address of registry host that is visible to test nodes (DCOS local IP of test_host)
+        test_dir (str): path to be used for setup and file transfer on host
+
+    Returns:
+        result from async chain that can be checked later for success
+    """
+    test_server_docker = pkg_filename('docker/test_server/Dockerfile')
+    test_server_script = pkg_filename('docker/test_server/test_server.py')
+    pytest_docker = pkg_filename('docker/py.test/Dockerfile')
+    log.info('Setting up integration_test.py to run on ' + tunnel.host)
+    tunnel.remote_cmd(['mkdir', '-p', test_dir])
+
+    if not registry:
+        log.warning('No registry provided; using test host as registry')
+        log.warning('Assuming that test host is a node in DCOS')
+        log.info('Finding IP local of test host')
+        registry = tunnel.remote_cmd(['/opt/mesosphere/bin/detect_ip'])
+
+    log.info('Setting up SSH key on test host for daisy-chain-ing')
+    remote_key_path = join(test_dir, 'test_ssh_key')
+    tunnel.write_to_remote(tunnel.ssh_key_path, remote_key_path)
+    tunnel.remote_cmd(['chmod', '600', remote_key_path])
+
+    log.info('Reconfiguring all dockerd to trust insecurity registry: ' + registry)
+    with open('execstart.conf', 'w') as conf_fh:
+        conf_fh.write(TEST_DOCKERD_CONFIG.format(registry))
+    conf_transfer_path = join(test_dir, 'execstart.conf')
+    docker_conf_chain = (
+        ['docker', 'version'],  # checks that docker is available w/o sudo
+        ['sudo', 'cp', conf_transfer_path, '/etc/systemd/system/docker.service.d/execstart.conf'],
+        ['sudo', 'systemctl', 'daemon-reload'],
+        ['sudo', 'systemctl', 'restart', 'docker'])
+    log.info('Reconfiguring dockerd on test host')
+    tunnel.write_to_remote('execstart.conf', conf_transfer_path)
+    for cmd in docker_conf_chain:
+        tunnel.remote_cmd(cmd)
+    for agent in agent_list:
+        log.info('Reconfiguring dockerd on ' + agent)
+        target = "{}@{}".format(tunnel.ssh_user, agent)
+        target_scp = "{}:{}".format(target, conf_transfer_path)
+        ssh_opts = ['-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null']
+        scp_cmd = ['/usr/bin/scp', '-i', remote_key_path] + ssh_opts
+        remote_scp = scp_cmd + [conf_transfer_path, target_scp]
+        tunnel.remote_cmd(remote_scp)
+        chain_prefix = ['/usr/bin/ssh', '-tt', '-i', remote_key_path] + ssh_opts + [target]
+        for cmd in docker_conf_chain:
+            tunnel.remote_cmd(chain_prefix+cmd)
+
+    tunnel.remote_cmd(['mkdir', '-p', join(test_dir, 'test_server')])
+    tunnel.write_to_remote(test_server_docker, join(test_dir, 'test_server/Dockerfile'))
+    tunnel.write_to_remote(test_server_script, join(test_dir, 'test_server/test_server.py'))
+    log.info('Starting insecure registry on test host')
+    try:
+        log.debug('Attempt to replace a previously setup registry')
+        tunnel.remote_cmd(['docker', 'kill', 'registry'])
+        tunnel.remote_cmd(['docker', 'rm', 'registry'])
+    except CalledProcessError:
+        log.debug('No previous registry to kill or delete')
+    tunnel.remote_cmd([
+        'docker', 'run', '-d', '-p', '5000:5000', '--restart=always', '--name',
+        'registry', 'registry:2'])
+    log.info('Building test_server Docker image on test host')
+    tunnel.remote_cmd([
+        'cd', join(test_dir, 'test_server'), '&&', 'docker', 'build', '-t',
+        '{}:5000/test_server'.format(registry), '.'])
+    log.info('Pushing built test server to insecure registry')
+    tunnel.remote_cmd(['docker', 'push', "{}:5000/test_server".format(registry)])
+    log.debug('Cleaning up test_server files')
+    tunnel.remote_cmd(['rm', '-rf', join(test_dir, 'test_server')])
+    log.info('Building base integration_test.py container on test host')
+    tunnel.remote_cmd(['mkdir', '-p', join(test_dir, 'py.test')])
+    tunnel.write_to_remote(pytest_docker, join(test_dir, 'py.test/Dockerfile'))
+    tunnel.remote_cmd([
+        'cd', join(test_dir, 'py.test'), '&&', 'docker', 'build', '-t', 'py.test', '.'])
+    tunnel.remote_cmd(['rm', '-rf', join(test_dir, 'py.test')])
+
+
+def integration_test(
+        tunnel, test_dir,
+        dcos_dns, master_list, agent_list, registry_host,
+        variant, test_dns_search, ci_flags, timeout=None,
+        aws_access_key_id='', aws_secret_access_key='', region=''):
+    """Runs integration test on host
+
+    Args:
+        test_dir: string representing host where integration_test.py exists on test_host
+        dcos_dns: string representing IP of DCOS DNS host
+        master_list: string of comma separated master addresses
+        agent_list: string of comma separated agent addresses
+        registry_host: string for address where marathon can pull test app
+        variant: 'ee' or 'default'
+        test_dns_search: if set to True, test for deployed mesos DNS app
+        ci_flags: optional additional string to be passed to test
+        # The following variables correspond to currently disabled tests
+        aws_access_key_id: needed for REXRAY tests
+        aws_secret_access_key: needed for REXRAY tests
+        region: string indicating AWS region in which cluster is running
+    """
+    log.info('Transfering integration_test.py')
+    test_script = pkg_filename('integration_test.py')
+    tunnel.remote_cmd(['mkdir', '-p', test_dir])
+    tunnel.write_to_remote(test_script, test_dir+'/integration_test.py')
+
+    test_container_name = 'int_test_' + str(int(time.time()))
+    dns_search = 'true' if test_dns_search else 'false'
+    test_cmd = [
+        'docker', 'run', '-v', test_dir+'/integration_test.py:/integration_test.py',
+        '-e', 'DCOS_DNS_ADDRESS=http://'+dcos_dns,
+        '-e', 'MASTER_HOSTS='+','.join(master_list),
+        '-e', 'PUBLIC_MASTER_HOSTS='+','.join(master_list),
+        '-e', 'SLAVE_HOSTS='+','.join(agent_list),
+        '-e', 'REGISTRY_HOST='+registry_host,
+        '-e', 'DCOS_VARIANT='+variant,
+        '-e', 'DNS_SEARCH='+dns_search,
+        '-e', 'AWS_ACCESS_KEY_ID='+aws_access_key_id,
+        '-e', 'AWS_SECRET_ACCESS_KEY='+aws_secret_access_key,
+        '-e', 'AWS_REGION='+region,
+        '--net=host', '--name='+test_container_name, 'py.test', 'py.test',
+        '-vv', ci_flags, '/integration_test.py']
+    log.info('Running integration test...')
+    try:
+        tunnel.remote_cmd(test_cmd, timeout=timeout)
+        log.info('Successful test run!')
+    except TimeoutExpired as e:
+        log.error('Test failed due to timing out after {} seconds'.format(timeout))
+        raise e
+    except CalledProcessError as e:
+        log.error('Test failed!')
+        raise e
+    finally:
+        get_logs_cmd = ['docker', 'logs', test_container_name]
+        test_log = tunnel.remote_cmd(get_logs_cmd, raw_output=True)
+        log_file = 'integration_test.log'
+        with open(log_file, 'wb') as fh:
+            fh.write(test_log)
+        log.info('Logs from test container can be found in '+log_file)


### PR DESCRIPTION
-transfers generic test-orchestration code from test_installer_ccm
-switches from awkward synchronous async ssh usage to sync ssh
-configures agents via single control node for easy compatibility
  with clusters behind load balancers