### PR TITLE
Fixing RHEL7 --install-prereqs

### DIFF
--- a/ext/dcos-installer/dcos_installer/action_lib/__init__.py
+++ b/ext/dcos-installer/dcos_installer/action_lib/__init__.py
@@ -330,7 +330,7 @@ sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
 sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
 [dockerrepo]
 name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/$releasever/
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
 enabled=1
 gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg


### PR DESCRIPTION
Solution here is to statically assign the path for CentOS and RHEL servers that are version 7. I have also tested if this will break CentOS and It works well.

Docker explicitly mentions this as well in their installation instructions for RHEL here: https://docs.docker.com/engine/installation/linux/rhel/.

Second confirmation. $releasever is equal to '7' on CentOS and $releasever is equal to '7Server' on RHEL. Our fixes solves this problem during this point in time.
```
[centos@ip-172-31-4-230 ~]$ python -c 'import yum, pprint; yb = yum.YumBase(); pprint.pprint(yb.conf.yumvar, width=1)'
Loaded plugins: fastestmirror
{'arch': 'ia32e',
 'basearch': 'x86_64',
 'infra': 'genclo',
 'releasever': '7',
 'uuid': 'c6243c4d-d2b4-4ff0-9f6f-2ad3caa48c27'}
[centos@ip-172-31-4-230 ~]$ 
```
```
[ec2-user@ip-172-31-3-212 ~]$ python -c 'import yum, pprint; yb = yum.YumBase(); pprint.pprint(yb.conf.yumvar, width=1)'
Loaded plugins: amazon-id, rhui-lb
Repo rhui-REGION-client-config-server-7 forced skip_if_unavailable=True due to: /etc/pki/rhui/cdn.redhat.com-chain.crt
Repo rhui-REGION-client-config-server-7 forced skip_if_unavailable=True due to: /etc/pki/rhui/product/rhui-client-config-server-7.crt
Repo rhui-REGION-client-config-server-7 forced skip_if_unavailable=True due to: /etc/pki/rhui/rhui-client-config-server-7.key
Repo rhui-REGION-rhel-server-releases forced skip_if_unavailable=True due to: /etc/pki/rhui/cdn.redhat.com-chain.crt
Repo rhui-REGION-rhel-server-releases forced skip_if_unavailable=True due to: /etc/pki/rhui/product/content-rhel7.crt
Repo rhui-REGION-rhel-server-releases forced skip_if_unavailable=True due to: /etc/pki/rhui/content-rhel7.key
Repo rhui-REGION-rhel-server-rh-common forced skip_if_unavailable=True due to: /etc/pki/rhui/cdn.redhat.com-chain.crt
Repo rhui-REGION-rhel-server-rh-common forced skip_if_unavailable=True due to: /etc/pki/rhui/product/content-rhel7.crt
Repo rhui-REGION-rhel-server-rh-common forced skip_if_unavailable=True due to: /etc/pki/rhui/content-rhel7.key
{'arch': 'ia32e',
 'basearch': 'x86_64',
 'releasever': '7Server',
 'uuid': '954a077e-bfc0-4fd8-8f80-764724f51d67'}
[ec2-user@ip-172-31-3-212 ~]$ ```