### PR TITLE
Move bootstrap to be cached in the cache/ directory

### DIFF
--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -553,9 +553,9 @@ def make_installer_docker(variant, bootstrap_id, installer_bootstrap_id):
 
         subprocess.check_call(['chmod', '+x', dest_path('installer_internal_wrapper')])
 
-        copy_to_build('packages', bootstrap_filename)
-        copy_to_build('packages', installer_bootstrap_filename)
-        copy_to_build('packages', bootstrap_active_filename)
+        copy_to_build('packages/cache/bootstrap', bootstrap_filename)
+        copy_to_build('packages/cache/bootstrap', installer_bootstrap_filename)
+        copy_to_build('packages/cache/bootstrap', bootstrap_active_filename)
 
         # Copy across gen_extra if it exists
         if os.path.exists('gen_extra'):

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,11 +1,6 @@
 #mktarball artifacts
-*.active.json
-*.bootstrap.tar.xz
-bootstrap.latest
-cache/*
+cache/
 
 # Per-pacage artifacts
-*/*.tar.xz
 */result
 */src
-*/cache

--- a/pkgpanda/build/tests/test_build.py
+++ b/pkgpanda/build/tests/test_build.py
@@ -83,8 +83,9 @@ def test_bootstrap(tmpdir):
     with pkg_dir.as_cwd():
         pkg_dir.join("treeinfo.json").write('', ensure=True)
         check_call(["mkpanda", "tree", "--mkbootstrap"])
-        bootstrap_id = open("bootstrap.latest", 'r').read().strip()
-        bootstrap_files = get_tar_contents(bootstrap_id + ".bootstrap.tar.xz")
+        cache_dir = str(pkg_dir.join("cache/bootstrap")) + "/"
+        bootstrap_id = open(cache_dir + "bootstrap.latest", 'r').read().strip()
+        bootstrap_files = get_tar_contents(cache_dir + bootstrap_id + ".bootstrap.tar.xz")
 
         # Seperate files that come from individual packages from those in the root directory
         package_files = dict()

--- a/pytest/test_release.py
+++ b/pytest/test_release.py
@@ -500,14 +500,14 @@ def test_get_package_artifact(tmpdir):
 
 
 def mock_do_build_packages(cache_repository_url):
-    subprocess.check_call(['mkdir', '-p', 'packages'])
-    write_string("packages/bootstrap_id.bootstrap.tar.xz", "bootstrap_contents")
-    write_json("packages/bootstrap_id.active.json", ['a--b', 'c--d'])
-    write_string("packages/bootstrap.latest", "bootstrap_id")
-    write_string("packages/installer.bootstrap.latest", "installer_bootstrap_id")
-    write_json("packages/installer_bootstrap_id.active.json", ['c--d', 'e--f'])
-    write_string("packages/ee.installer.bootstrap.latest", "ee_installer_bootstrap_id")
-    write_json("packages/ee_installer_bootstrap_id.active.json", [])
+    subprocess.check_call(['mkdir', '-p', 'packages/cache/bootstrap'])
+    write_string("packages/cache/bootstrap/bootstrap_id.bootstrap.tar.xz", "bootstrap_contents")
+    write_json("packages/cache/bootstrap/bootstrap_id.active.json", ['a--b', 'c--d'])
+    write_string("packages/cache/bootstrap/bootstrap.latest", "bootstrap_id")
+    write_string("packages/cache/bootstrap/installer.bootstrap.latest", "installer_bootstrap_id")
+    write_json("packages/cache/bootstrap/installer_bootstrap_id.active.json", ['c--d', 'e--f'])
+    write_string("packages/cache/bootstrap/ee.installer.bootstrap.latest", "ee_installer_bootstrap_id")
+    write_json("packages/cache/bootstrap/ee_installer_bootstrap_id.active.json", [])
 
     return {
         None: "bootstrap_id",
@@ -519,27 +519,27 @@ def mock_do_build_packages(cache_repository_url):
 stable_artifacts_metadata = {
     'commit': 'commit_sha1',
     'core_artifacts': [
-        {'local_path': 'packages/bootstrap_id.bootstrap.tar.xz',
+        {'local_path': 'packages/cache/bootstrap/bootstrap_id.bootstrap.tar.xz',
             'reproducible_path': 'bootstrap/bootstrap_id.bootstrap.tar.xz'},
-        {'local_path': 'packages/bootstrap_id.active.json',
+        {'local_path': 'packages/cache/bootstrap/bootstrap_id.active.json',
             'reproducible_path': 'bootstrap/bootstrap_id.active.json'},
-        {'local_path': 'packages/bootstrap.latest',
+        {'local_path': 'packages/cache/bootstrap/bootstrap.latest',
             'channel_path': 'bootstrap.latest'},
         {'local_path': 'packages/cache/packages/a/a--b.tar.xz',
             'reproducible_path': 'packages/a/a--b.tar.xz'},
         {'local_path': 'packages/cache/packages/c/c--d.tar.xz',
             'reproducible_path': 'packages/c/c--d.tar.xz'},
-        {'local_path': 'packages/ee_installer_bootstrap_id.bootstrap.tar.xz',
+        {'local_path': 'packages/cache/bootstrap/ee_installer_bootstrap_id.bootstrap.tar.xz',
          'reproducible_path': 'bootstrap/ee_installer_bootstrap_id.bootstrap.tar.xz'},
-        {'local_path': 'packages/ee_installer_bootstrap_id.active.json',
+        {'local_path': 'packages/cache/bootstrap/ee_installer_bootstrap_id.active.json',
          'reproducible_path': 'bootstrap/ee_installer_bootstrap_id.active.json'},
         {'channel_path': 'ee.installer.bootstrap.latest',
-         'local_path': 'packages/ee.installer.bootstrap.latest'},
-        {'local_path': 'packages/installer_bootstrap_id.bootstrap.tar.xz',
+         'local_path': 'packages/cache/bootstrap/ee.installer.bootstrap.latest'},
+        {'local_path': 'packages/cache/bootstrap/installer_bootstrap_id.bootstrap.tar.xz',
             'reproducible_path': 'bootstrap/installer_bootstrap_id.bootstrap.tar.xz'},
-        {'local_path': 'packages/installer_bootstrap_id.active.json',
+        {'local_path': 'packages/cache/bootstrap/installer_bootstrap_id.active.json',
             'reproducible_path': 'bootstrap/installer_bootstrap_id.active.json'},
-        {'local_path': 'packages/installer.bootstrap.latest',
+        {'local_path': 'packages/cache/bootstrap/installer.bootstrap.latest',
             'channel_path': 'installer.bootstrap.latest'},
         {'local_path': 'packages/cache/packages/e/e--f.tar.xz',
             'reproducible_path': 'packages/e/e--f.tar.xz'}

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -116,7 +116,7 @@ def from_json(json_str):
 
 
 def get_bootstrap_packages(bootstrap_id):
-    return set(pkgpanda.util.load_json('packages/{}.active.json'.format(bootstrap_id)))
+    return set(pkgpanda.util.load_json('packages/cache/bootstrap/{}.active.json'.format(bootstrap_id)))
 
 
 def load_providers():
@@ -318,17 +318,17 @@ def make_stable_artifacts(cache_repository_url):
         bootstrap_filename = "{}.bootstrap.tar.xz".format(bootstrap_id)
         add_file({
             'reproducible_path': 'bootstrap/' + bootstrap_filename,
-            'local_path': 'packages/' + bootstrap_filename
+            'local_path': 'packages/cache/bootstrap/' + bootstrap_filename
             })
         active_filename = "{}.active.json".format(bootstrap_id)
         add_file({
             'reproducible_path': 'bootstrap/' + active_filename,
-            'local_path': 'packages/' + active_filename
+            'local_path': 'packages/cache/bootstrap/' + active_filename
             })
         latest_filename = "{}bootstrap.latest".format(pkgpanda.util.variant_prefix(name))
         add_file({
             'channel_path': latest_filename,
-            'local_path': 'packages/' + latest_filename
+            'local_path': 'packages/cache/bootstrap/' + latest_filename
             })
 
         # Add all the packages which haven't been added yet
@@ -583,11 +583,7 @@ class ReleaseManager():
             if 'reproducible_path' in artifact:
                 assert artifact['reproducible_path'][0] != '/'
 
-                local_path = artifact['reproducible_path']
-
-                # `bootstrap/` artifacts should get placed in `packages/`
-                if artifact['reproducible_path'].startswith('bootstrap/'):
-                    local_path = 'packages/' + artifact['reproducible_path'][9:]
+                local_path = "packages/cache/" + artifact['reproducible_path']
 
                 src_path = metadata['repository_path'] + '/' + artifact['reproducible_path']
 


### PR DESCRIPTION
Results in cleaner build directories, less .gitignore being necessary.