### PR TITLE
add prepare status json

### DIFF
--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -21,6 +21,9 @@ class CliDelegate(AbstractSSHLibDelegate):
     def on_done(self, name, result, host_status=None):
         print_header('STAGE {}'.format(name))
 
+    def prepare_status(self, name, nodes):
+        pass
+
 
 def run_loop(action, options):
     assert callable(action)

--- a/pytest/test_ssh_integration.py
+++ b/pytest/test_ssh_integration.py
@@ -108,6 +108,9 @@ def test_ssh_async(sshd_manager, loop):
         def on_done(self, *args, **kwargs):
             pass
 
+        def prepare_status(self, name, nodes):
+            pass
+
     with sshd_manager.run(20) as sshd_ports:
         runner = MultiRunner(['127.0.0.1:{}'.format(port) for port in sshd_ports], ssh_user=getpass.getuser(),
                              ssh_key_path=sshd_manager.key_path, async_delegate=DummyAsyncDelegate())

--- a/ssh/ssh_runner.py
+++ b/ssh/ssh_runner.py
@@ -177,6 +177,12 @@ class MultiRunner():
 
     def _run_chain_command(self, chain, host, chain_result):
         assert isinstance(chain, CommandChain)
+
+        # Prepare status json
+        if self.async_delegate is not None:
+            log.debug('Preparing a status json')
+            self.async_delegate.prepare_status(chain.namespace, self.__targets)
+
         host_status = 'hosts_success'
         host_port = '{}:{}'.format(host.ip, host.port)
 

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -193,7 +193,8 @@ class DcosApiInstaller(AbstractDcosInstaller):
             output = self.check_action(action)
             assert output != {}
             host_data = output['hosts']
-            finished_run = all(map(lambda host: host['host_status'] != 'running', host_data.values()))
+            finished_run = all(map(lambda host: host['host_status'] not in ['running', 'unstarted'],
+                                   host_data.values()))
             assert finished_run, 'Action timed out! Last output: {}'.format(output)
             return host_data
 


### PR DESCRIPTION
Add a function to run before any command from a chain start executing. This
allows to prepare status json. For JsonDelegate we want to list all nodes
from a config right away. The status for a node will be changed as installer
proceeds.