### PR TITLE
Work on making it so pkgpanda packages can have their software run as non-root

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -15,11 +15,12 @@ envrionment variables from the package.
 import json
 import os
 import os.path
+import pwd
 import re
 import shutil
 import tempfile
 from itertools import chain
-from subprocess import CalledProcessError, check_call
+from subprocess import CalledProcessError, check_call, check_output
 
 from pkgpanda.constants import RESERVED_UNIT_NAMES
 from pkgpanda.exceptions import InstallError, PackageError, ValidationError
@@ -39,6 +40,7 @@ export PATH="{0}/bin:$PATH"\n\n"""
 
 name_regex = "^[a-zA-Z0-9@_+][a-zA-Z0-9@._+\-]*$"
 version_regex = "^[a-zA-Z0-9@_+:.]+$"
+username_regex = "^dcos_[a-z_]+$"
 
 
 # Manage starting/stopping all systemd services inside a folder.
@@ -165,6 +167,10 @@ class Package:
     @property
     def state_directory(self):
         return self.__pkginfo.get('state_directory', False)
+
+    @property
+    def username(self):
+        return self.__pkginfo.get('username', None)
 
     def __repr__(self):
         return str(self.__id)
@@ -412,6 +418,72 @@ def symlink_tree(src, dest):
                 raise ConflictingFile(src_path, dest_path, ex) from ex
 
 
+# Manages a systemd-sysusers user set.
+# Can have users
+class UserManagement:
+    """Manages a systemd-sysusers configuration file / user set
+
+    add_user() can be called until `ensure_users_exist` is called.
+    get_uid() can only be called once `ensure_users_exist` is called.
+
+    This helps enforce the code pattern which is needed to build one big sysusers configuration file
+    and then create all the users / validate they all exist once. After that the users can be
+    referenced / used.
+    """
+
+    def __init__(self, manage_users, add_users):
+        assert isinstance(manage_users, bool)
+        self._manage_users = manage_users
+        self._add_users = add_users
+        self._users = set()
+
+    @staticmethod
+    def validate_username(username):
+        if not re.match(username_regex, username):
+            raise ValidationError("Username must begin with `dcos_` and only have a-z and underscore after that")
+
+    def add_user(self, username):
+        UserManagement.validate_username(username)
+
+        if not self._manage_users:
+            return
+
+        # Check if hte user already exists and exit.
+        try:
+            pwd.getpwnam(username)
+            self._users.add(username)
+            return
+        except KeyError as ex:
+            # Doesn't exist, fall through
+            pass
+
+        # If we're not allowed to manage users, error
+        if not self._add_users:
+            raise ValidationError("User {} doesn't exist but is required by a DC/OS Component, and "
+                                  "automatic user addition is disabled".format(username))
+
+        # Add the user:
+        try:
+            check_output([
+                'useradd',
+                '--system',
+                '--home-dir', '/opt/mesosphere',
+                '--shell', '/sbin/nologin',
+                '-c', 'DCOS System User',
+                username])
+            self._users.add(username)
+        except CalledProcessError as ex:
+            raise ValidationError("User {} doesn't exist and couldn't be created because of: {}"
+                                  .format(username, ex.output))
+
+    def get_uid(self, username):
+        # Code should have already asserted all users exist, and be passing us
+        # a user we know about. This method only works for package users.
+        assert username in self._users
+
+        return pwd.getpwnam(username).pw_uid
+
+
 # A rooted instal lgtree.
 # Inside the install tree there will be all the well known folders and files as
 # described in `docs/package_concepts.md`
@@ -428,7 +500,10 @@ class Install:
             manage_systemd,
             block_systemd,
             fake_path=False,
-            skip_systemd_dirs=False):
+            skip_systemd_dirs=False,
+            manage_users=False,
+            add_users=False,
+            manage_state_dir=False):
         assert type(rooted_systemd) == bool
         assert type(fake_path) == bool
         self.__root = os.path.abspath(root)
@@ -454,6 +529,9 @@ class Install:
 
         self.__fake_path = fake_path
         self.__skip_systemd_dirs = skip_systemd_dirs
+        self.__manage_users = manage_users
+        self.__add_users = add_users
+        self.__manage_state_dir = manage_state_dir
 
     def get_active_dir(self):
         return os.path.join(self.__root, "active")
@@ -542,6 +620,9 @@ class Install:
 
         active_buildinfo_full = {}
 
+        # Building up the set of users
+        sysusers = UserManagement(self.__manage_users, self.__add_users)
+
         # Add the folders, config in each package.
         for package in packages:
             # Package folders
@@ -595,10 +676,24 @@ class Install:
                 # setup-packages to add a buildinfo.full for those packages
                 active_buildinfo_full[package.name] = None
 
+            # NOTE: It is critical the state dir, the package name and the user name are all the
+            # same. Otherwise on upgrades we might remove access to a files by changing their chown
+            # to something incompatible. We survive the first upgrade because everything goes from
+            # root to specific users, and root can access all user files.
+            if package.username is not None:
+                sysusers.add_user(package.username)
+
             # Ensure the state directory in `/var/lib/dcos` exists
             # TODO(cmaloney): On upgrade take a snapshot?
-            if package.state_directory:
-                check_call(['mkdir', '-p', '/var/lib/dcos/{}'.format(package.name)])
+            if self.__manage_state_dir:
+                state_dir_path = '/var/lib/dcos/{}'.format(package.name)
+                if package.state_directory:
+                    check_call(['mkdir', '-p', state_dir_path])
+
+                if package.username:
+                    state_dir_path = '/var/lib/dcos/{}'.format(package.name)
+                    uid = sysusers.get_uid(package.username)
+                    check_call(['chown', '-R', str(uid), state_dir_path])
 
         # Write out the new environment file.
         new_env = self._make_abs("environment.new")

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -162,6 +162,10 @@ class Package:
     def version(self):
         return self.__id.version
 
+    @property
+    def state_directory(self):
+        return self.__pkginfo.get('state_directory', False)
+
     def __repr__(self):
         return str(self.__id)
 
@@ -590,6 +594,11 @@ class Install:
                 # TODO(cmaloney): These only come from setup-packages. Should update
                 # setup-packages to add a buildinfo.full for those packages
                 active_buildinfo_full[package.name] = None
+
+            # Ensure the state directory in `/var/lib/dcos` exists
+            # TODO(cmaloney): On upgrade take a snapshot?
+            if package.state_directory:
+                check_call(['mkdir', '-p', '/var/lib/dcos/{}'.format(package.name)])
 
         # Write out the new environment file.
         new_env = self._make_abs("environment.new")

--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -964,6 +964,11 @@ def build(package_store, name, variant, clean_after_build, recursive=False):
     # Copy over environment settings
     pkginfo['environment'] = buildinfo['environment']
 
+    # Whether pkgpanda should on the host make sure a `/var/lib` state directory is available
+    pkginfo['state_directory'] = buildinfo.get('state_directory', False)
+    if pkginfo['state_directory'] not in [True, False]:
+        raise BuildError("state_directory in buildinfo.json must be a boolean `true` or `false`")
+
     # Activate the packages so that we have a proper path, environment
     # variables.
     # TODO(cmaloney): RAII type thing for temproary directory so if we

--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -411,7 +411,16 @@ def make_bootstrap_tarball(package_store, packages, variant):
     # Activate the packages inside the repository.
     # Do generate dcos.target.wants inside the root so that we don't
     # try messing with /etc/systemd/system.
-    install = Install(pkgpanda_root, None, True, False, True, True, True)
+    install = Install(
+        root=pkgpanda_root,
+        config_dir=None,
+        rooted_systemd=True,
+        manage_systemd=False,
+        block_systemd=True,
+        fake_path=True,
+        skip_systemd_dirs=True,
+        manage_users=False,
+        manage_state_dir=False)
     install.activate(repository.load_packages(pkg_ids))
 
     # Mark the tarball as a bootstrap tarball/filesystem so that
@@ -969,11 +978,30 @@ def build(package_store, name, variant, clean_after_build, recursive=False):
     if pkginfo['state_directory'] not in [True, False]:
         raise BuildError("state_directory in buildinfo.json must be a boolean `true` or `false`")
 
+    username = buildinfo.get('username')
+    if not (username is None or isinstance(username, str)):
+        raise BuildError("username in buildinfo.json must be either not set (no user for this"
+                         " package), or a user name string")
+    if username:
+        try:
+            pkgpanda.UserManagement.validate_username(username)
+        except ValidationError as ex:
+            raise BuildError("username in buildinfo.json didn't meet the validation rules. {}".format(ex))
+    pkginfo['username'] = username
+
     # Activate the packages so that we have a proper path, environment
     # variables.
     # TODO(cmaloney): RAII type thing for temproary directory so if we
     # don't get all the way through things will be cleaned up?
-    install = Install(install_dir, None, True, False, True, True)
+    install = Install(
+        root=install_dir,
+        config_dir=None,
+        rooted_systemd=True,
+        manage_systemd=False,
+        block_systemd=True,
+        fake_path=True,
+        manage_users=False,
+        manage_state_dir=False)
     install.activate(active_packages)
     # Rewrite all the symlinks inside the active path because we will
     # be mounting the folder into a docker container, and the absolute

--- a/pkgpanda/cli.py
+++ b/pkgpanda/cli.py
@@ -132,7 +132,11 @@ def main():
         os.path.abspath(arguments['--root']),
         os.path.abspath(arguments['--config-dir']),
         arguments['--rooted-systemd'],
-        not arguments['--no-systemd'], not arguments['--no-block-systemd'])
+        not arguments['--no-systemd'],
+        not arguments['--no-block-systemd'],
+        manage_users=True,
+        add_users=not os.path.exists('/etc/mesosphere/manual_host_users'),
+        manage_state_dir=True)
     repository = Repository(os.path.abspath(arguments['--repository']))
 
     try:

--- a/pkgpanda/tests/test_util.py
+++ b/pkgpanda/tests/test_util.py
@@ -1,4 +1,8 @@
+import pytest
+
 import pkgpanda.util
+from pkgpanda import UserManagement
+from pkgpanda.exceptions import ValidationError
 
 
 def test_variant_variations():
@@ -10,3 +14,28 @@ def test_variant_variations():
 
     assert pkgpanda.util.variant_prefix(None) == ''
     assert pkgpanda.util.variant_prefix('test') == 'test.'
+
+
+def test_validate_username():
+
+    def good(name):
+        UserManagement.validate_username(name)
+
+    def bad(name):
+        with pytest.raises(ValidationError):
+            UserManagement.validate_username(name)
+
+    good('dcos_mesos')
+    good('dcos_a')
+    good('dcos__')
+    good('dcos_a_b_c')
+
+    bad('dcos')
+    bad('d')
+    bad('d_a')
+    bad('dcos_a1')
+    bad('dcos_1')
+    bad('foobar_asdf')
+    bad('dcos_***')
+    bad('dc/os_foobar')
+    bad('dcos_foo:bar')


### PR DESCRIPTION
 - By default we'll use systemd-sysusers to add users to the host (You can opt to manually add users instead). RPM, Deb, and Arch packaging all automatically have packages add users
 - All DC/OS software users begin with `dcos_` to make them easy to find / distinguish.
 

# TODO
 - [x] Test by hand
 - [x] Write unittest for username validation
 - [x] Move `mkpanda --recursive` into a separate PR

# Followup
 - [ ] Move dcos-history-service changes to another PR (And get 3dt updated)
 - [ ] Write an integration test for software running non-root
 - [ ] Add tooling to make it so that we can enforce that all systemd services except a couple exceptions have `User=` lines
