### PR TITLE
Make number of masters configurable in CF template

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -46,6 +46,12 @@
       "Type": "String",
       "Default": "m3.xlarge",
       "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+    },
+    "NumMasters" : {
+      "Type": "Number",
+      "Default": 1,
+      "AllowedValues": [1,3,5,7],
+      "Description": "Number of master nodes to run"
     }
   },
   "Mappings": {
@@ -176,9 +182,9 @@
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
         "LaunchConfigurationName" : { "Ref" : "MasterLaunchConfig" },
-        "MinSize" : {{ num_masters }},
-        "MaxSize" : {{ num_masters }},
-        "DesiredCapacity" : {{ num_masters }},
+        "MinSize" : { "Ref": "NumMasters" },
+        "MaxSize" : { "Ref": "NumMasters" },
+        "DesiredCapacity" : { "Ref": "NumMasters" },
         "LoadBalancerNames" : [ { "Ref" : "ElasticLoadBalancer" }, { "Ref" : "InternalMasterLoadBalancer"} ],
         "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
         "Tags" : [
@@ -192,7 +198,7 @@
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Timeout" : { "Fn::FindInMap" : [ "Parameters", "StackCreationTimeout", "default" ] },
-          "Count" : {{ num_masters }}
+          "Count" : { "Ref": "NumMasters" }
         }
       }
     },

--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -49,6 +49,12 @@
           "Type": "String",
           "Default": "m3.xlarge",
           "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+        },
+        "NumMasters" : {
+          "Type": "Number",
+          "Default": 1,
+          "AllowedValues": [1,3,5,7],
+          "Description": "Number of master nodes to run"
         }
     },
    "Resources": {
@@ -79,7 +85,7 @@
            "DependsOn": ["Infrastructure"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/{{ variant_prefix }}advanced-master-{{ num_masters }}.json",
+               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/{{ variant_prefix }}advanced-master.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"


### PR DESCRIPTION
This is just an idea, so it's not fully fleshed out yet. Mostly for sparking a conversation, but I'm willing to work on it further or hand it off.

The number of masters shouldn't need to be hard coded in various templates if we propagate it properly throughout the CF stack.