### PR TITLE
Output route table ID's from infra.json

### DIFF
--- a/gen/aws/templates/advanced/infra.json
+++ b/gen/aws/templates/advanced/infra.json
@@ -498,6 +498,14 @@
         "ExhibitorS3BucketId": {
           "Value" : { "Ref" : "ExhibitorS3Bucket" },
           "Description": "S3 bucket name for use by Exhibitor"
+        },
+        "PublicRouteTable": {
+          "Value" : { "Ref": "PublicRouteTable" },
+          "Description" : "Route table used by public agent nodes"
+        },
+        "PrivateRouteTable": {
+          "Value" : { "Ref": "PrivateRouteTable" },
+          "Description" : "Route table used by private agent nodes"
         }
     }
 }


### PR DESCRIPTION
It would be nice to have the route table IDs output from the CF template for use in VPN configurations.

Use Case:
 - I have a VPC configured with all of the necessary VPNGateway/CustomerGateway/etc
 - After creating DC/OS subnets and route tables, they are outputted from the CF template
 - I then attach my VPNGateway to these route tables for VPN Route propagation