### PR TITLE
Remove `/etc/environment` from all software

### DIFF
--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -64,7 +64,6 @@ After=dcos-gen-resolvconf.service
 Restart=always
 StartLimitInterval=0
 RestartSec=5
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 Type=forking
 PIDFile=$PKG_PATH/nginx/logs/nginx.pid
@@ -98,7 +97,6 @@ Description=Admin Router Reloader: Reload admin router to get new DNS
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=-$PKG_PATH/nginx/sbin/nginx -s reload
 EOF

--- a/packages/dcos-oauth/extra/dcos-oauth.service
+++ b/packages/dcos-oauth/extra/dcos-oauth.service
@@ -6,7 +6,6 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 ConditionPathExists=/opt/mesosphere/etc/dcos-oauth.env
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-oauth.env
 ExecStartPre=/opt/mesosphere/bin/exhibitor_wait.py

--- a/packages/keepalived/build
+++ b/packages/keepalived/build
@@ -86,7 +86,6 @@ ConditionPathExists=/opt/mesosphere/etc/keepalived
 Restart=always
 StartLimitInterval=0
 RestartSec=5
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/keepalived
 ExecStart=/opt/mesosphere/bin/keepalived-wrapper -n \$KEEPALIVED_OPTIONS

--- a/packages/logrotate/build
+++ b/packages/logrotate/build
@@ -39,7 +39,6 @@ cat <<EOF > "$logrotate_service"
 Description=Logrotate: Rotate various logs on the system
 [Service]
 Type=simple
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/usr/bin/mkdir -p /var/log/mesos/archive
 ExecStart=$PKG_PATH/bin/logrotate $config_file

--- a/packages/mesos-dns/extra/dcos-mesos-dns.service
+++ b/packages/mesos-dns/extra/dcos-mesos-dns.service
@@ -5,6 +5,5 @@ After=dcos-mesos-master.service
 Restart=always
 StartLimitInterval=0
 RestartSec=5
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=/opt/mesosphere/bin/mesos-dns --config=/opt/mesosphere/etc/mesos-dns.json -logtostderr=true

--- a/packages/spartan/extra/dcos-gen-resolvconf.service
+++ b/packages/spartan/extra/dcos-gen-resolvconf.service
@@ -6,7 +6,6 @@ After=dcos-spartan.service
 Type=oneshot
 StandardOutput=journal
 StandardError=journal
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config

--- a/packages/spartan/extra/dcos-spartan-watchdog.service
+++ b/packages/spartan/extra/dcos-spartan-watchdog.service
@@ -6,7 +6,6 @@ After=dcos-spartan.service
 Type=oneshot
 StandardOutput=journal
 StandardError=journal
-EnvironmentFile=/etc/environment
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config


### PR DESCRIPTION
It doesn't exist in many on-prem environments.

Internal JIRA: DCOS-6641