### PR TITLE
Make cache work for build_local.sh

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -25,7 +25,7 @@ storage:
     path: $HOME/dcos-artifacts
 options:
   preferred: local
-  cloudformation_s3_url: https://change_me_to_use_the_aws_templates_and_webpages/
+  cloudformation_s3_url: https://s3-us-west-2.amazonaws.com/downloads.dcos.io/dcos
 EOF
 fi
 


### PR DESCRIPTION
Without this there is no chance of it working. Note that the docker version must be the same as CI for the package builds to be cached still. With docker 1.11+ that should stop being an issue (the docker image ID format stabilized).