### PR TITLE
Genericize CoreOS specific cloud-config

### DIFF
--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -35,7 +35,7 @@ role_names = {"master", "slave", "slave_public"}
 role_template = '/etc/mesosphere/roles/{}'
 
 CLOUDCONFIG_KEYS = {'coreos', 'runcmd', 'apt_sources', 'root', 'mounts', 'disk_setup', 'fs_setup', 'bootcmd'}
-PACKAGE_KEYS = {'package', 'root'}
+PACKAGE_KEYS = {'package', 'root', 'runcmd'}
 
 
 def add_roles(cloudconfig, roles):
@@ -49,7 +49,7 @@ def add_roles(cloudconfig, roles):
 
 
 def add_units(cloudconfig, services):
-    cloudconfig['coreos']['units'] += services
+    cloudconfig['write_files'] += services
     return cloudconfig
 
 
@@ -675,7 +675,7 @@ def generate(
     # (likely indicates a misspelling)
     for name, template in rendered_templates.items():
         if name == 'dcos-services.yaml':  # yaml list of the service files
-            assert isinstance(template, list)
+            assert isinstance(template, dict)
         elif name == 'cloud-config.yaml':
             assert template.keys() <= CLOUDCONFIG_KEYS, template.keys()
         elif isinstance(template, str):  # Not a yaml template

--- a/gen/aws/dcos-docker-services.yaml
+++ b/gen/aws/dcos-docker-services.yaml
@@ -1,0 +1,37 @@
+root:
+  - path: /etc/systemd/system/dcos-docker-install.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      After=network-online.target
+      Wants=network-online.target
+      [Service]
+      Type=oneshot
+      Environment=DEBIAN_FRONTEND=noninteractive
+      StandardOutput=journal+console
+      StandardError=journal+console
+      ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/d.deb https://az837203.vo.msecnd.net/dcos-deps/docker-engine_1.11.0-0~xenial_amd64.deb
+      ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /tmp/d.deb || ((try > 5));do echo retry $((try++));sleep 120;done;systemctl --now start docker"
+  - path: /etc/systemd/system/docker.service.d/execstart.conf
+    permissions: "0644"
+    content: |
+      [Service]
+      Restart=always
+      StartLimitInterval=0
+      RestartSec=15
+      ExecStart=
+      ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay
+  - path: /etc/systemd/system/docker.socket
+    permissions: "0644"
+    content: |
+      [Unit]
+      PartOf=docker.service
+      [Socket]
+      ListenStream=/var/run/docker.sock
+      SocketMode=0660
+      SocketUser=root
+      SocketGroup=docker
+      ListenStream=2375
+      BindIPv6Only=both
+      [Install]
+      WantedBy=sockets.target

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -1,49 +1,61 @@
-- name: systemd-journald.service
-  command: restart
-# Restart docker to make it recover from a SIGPIPE it recieves when systemd-journald dies.
-- name: docker.service
-  command: restart
-- name: dcos-link-env.service
-  command: start
-  content: |
-    [Unit]
-    Before=dcos.target
-    [Service]
-    Type=oneshot
-    StandardOutput=journal+console
-    StandardError=journal+console
-    ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
-    ExecStart=/usr/bin/ln -sf /opt/mesosphere/environment.export /etc/profile.d/dcos.sh
-- name: dcos-download.service
-  content: |
-    [Unit]
-    Description=Pkgpanda: Download DC/OS to this host.
-    After=network-online.target
-    Wants=network-online.target
-    ConditionPathExists=!/opt/mesosphere/
-    [Service]
-    EnvironmentFile=/etc/mesosphere/setup-flags/bootstrap-id
-    Type=oneshot
-    StandardOutput=journal+console
-    StandardError=journal+console
-    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
-    ExecStartPre=/usr/bin/mkdir -p /opt/mesosphere
-    ExecStart=/usr/bin/tar -axf /tmp/bootstrap.tar.xz -C /opt/mesosphere
-    ExecStartPost=-/usr/bin/rm -f /tmp/bootstrap.tar.xz
-- name: dcos-setup.service
-  command: start
-  no_block: true
-  enable: true
-  content: |
-    [Unit]
-    Description=Pkgpanda: Specialize DC/OS for this host.
-    Requires=dcos-download.service
-    After=dcos-download.service
-    [Service]
-    Type=oneshot
-    StandardOutput=journal+console
-    StandardError=journal+console
-    EnvironmentFile=/opt/mesosphere/environment
-    ExecStart=/opt/mesosphere/bin/pkgpanda setup --no-block-systemd
-    [Install]
-    WantedBy=multi-user.target
+root:
+  - path: /etc/systemd/system/dcos-link-env.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Before=dcos.target
+      [Service]
+      Type=oneshot
+      StandardOutput=journal+console
+      StandardError=journal+console
+      ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
+      ExecStart=/usr/bin/ln -sf /opt/mesosphere/environment.export /etc/profile.d/dcos.sh
+  - path: /etc/systemd/system/dcos-download.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      After=network-online.target
+      Wants=network-online.target
+      ConditionPathExists=!/opt/mesosphere/
+      [Service]
+      EnvironmentFile=/etc/mesosphere/setup-flags/bootstrap-id
+      Type=oneshot
+      StandardOutput=journal+console
+      StandardError=journal+console
+      ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
+      ExecStartPre=/usr/bin/mkdir -p /opt/mesosphere
+      ExecStart=/usr/bin/tar -axf /tmp/bootstrap.tar.xz -C /opt/mesosphere
+      ExecStartPost=-/usr/bin/rm -f /tmp/bootstrap.tar.xz
+  - path: /etc/systemd/system/dcos-setup.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Requires=dcos-download.service
+      After=dcos-download.service
+      [Service]
+      Type=oneshot
+      StandardOutput=journal+console
+      StandardError=journal+console
+      EnvironmentFile=/opt/mesosphere/environment
+      ExecStart=/opt/mesosphere/bin/pkgpanda setup --no-block-systemd
+      [Install]
+      WantedBy=multi-user.target
+  - path: /etc/systemd/system/dcos-config-writer.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Requires=dcos-setup.service
+      After=dcos-setup.service
+      [Service]
+      Type=oneshot
+      EnvironmentFile=/etc/environment
+      EnvironmentFile=/opt/mesosphere/environment
+      ExecStart=/usr/bin/bash -c "echo $(detect_ip) $(hostname) > /etc/hosts"
+runcmd:
+    - [ systemctl, stop, resolvconf.service ]
+    - [ systemctl, disable, resolvconf.service ]
+    - [ systemctl, start, dcos-docker-install.service ]
+    - [ systemctl, start, dcos-link-env.service ]
+    - [ systemctl, start, dcos-download.service ]
+    - [ systemctl, start, dcos-setup.service ]
+    - [ systemctl, start, dcos-config-writer.service ]

--- a/gen/installer/aws.py
+++ b/gen/installer/aws.py
@@ -219,7 +219,7 @@ def gen_supporting_template():
         })
 
 
-extra_templates = ['aws/dcos-config.yaml', 'coreos-aws/cloud-config.yaml', 'coreos/cloud-config.yaml']
+extra_templates = ['aws/dcos-config.yaml', 'aws/dcos-docker-services.yaml']
 
 
 def make_advanced_bunch(variant_args, template_name, cc_params):

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
             'dcos-metadata.yaml',
             'dcos-services.yaml',
             'aws/dcos-config.yaml',
+            'aws/dcos-docker-services.yaml',
             'aws/templates/aws.html',
             'aws/templates/cloudformation.json',
             'azure/cloud-config.yaml',


### PR DESCRIPTION
Instead of using CoreOS specific cloud-config `units` use a more generic
pattern of `write_files` and `runcmds`, which will work with all
cloud-init implementations.