### PR TITLE
Move extra module configuration into a separate EnvironmentFile

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -72,12 +72,6 @@ def calculate_gen_resolvconf_search(dns_search):
         return ""
 
 
-def calculate_mesos_hooks_env_var(mesos_hooks):
-    if mesos_hooks == '':
-        return ''
-    return 'MESOS_HOOKS=' + mesos_hooks
-
-
 def calculate_mesos_slave_modules_json(mesos_slave_modules):
     # Ensure that this file is readable by humans by including newlines in the output.
     json_multiline = json.dumps({"libraries": mesos_slave_modules}, indent=2)
@@ -254,12 +248,6 @@ default_mesos_slave_modules = [
     __logrotate_slave_module,
 ]
 
-default_isolation_modules = [
-    'cgroups/cpu',
-    'cgroups/mem',
-    'posix/disk',
-]
-
 
 entry = {
     'validate': [
@@ -314,14 +302,11 @@ entry = {
         'curly_pound': '{#',
         'cluster_packages': calculate_cluster_packages,
         'config_id': calculate_config_id,
-        'mesos_hooks_env_var': calculate_mesos_hooks_env_var,
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,
         'ui_branding': 'false',
         'ui_external_links': 'false',
         'ui_networking': 'false',
         'ui_organization': 'false',
-        'mesos_isolation_modules': ','.join(default_isolation_modules),
-        'mesos_hooks': '',
         'mesos_slave_modules_json': calculate_mesos_slave_modules_json(
             default_mesos_slave_modules),
         'minuteman_forward_metrics': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -87,7 +87,7 @@ package:
       MESOS_LOG_DIR=/var/log/mesos
       MESOS_MODULES=file:///opt/mesosphere/etc/mesos-slave-modules.json
       MESOS_CONTAINER_LOGGER={{ mesos_container_logger }}
-      MESOS_ISOLATION={{ mesos_isolation_modules }}
+      MESOS_ISOLATION=cgroups/cpu,cgroups/mem,posix/disk
       MESOS_WORK_DIR=/var/lib/mesos/slave
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
@@ -98,7 +98,6 @@ package:
       MESOS_GC_DELAY={{ gc_delay }}
       MESOS_HOSTNAME_LOOKUP=false
       GLOG_drop_log_memory=false
-      {{ mesos_hooks_env_var }}
   - path: /etc/mesos-slave
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -10,6 +10,7 @@ Delegate=true
 LimitNOFILE=infinity
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
+EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-public
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=/var/lib/dcos/mesos-resources

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -10,6 +10,7 @@ Delegate=true
 LimitNOFILE=infinity
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
+EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=/var/lib/dcos/mesos-resources


### PR DESCRIPTION
This removes some assumptions relating to custom hook and isolator modules, which aren't currently being used in Open DC/OS. With this change, a separate config file* is designated for use by downstream builds. This allows keeping unused configuration logic out of Open DC/OS while making downstream changes a bit more flexible.

* `/opt/mesosphere/etc/mesos-slave-common-extras`