### PR TITLE
WIP: Make DC/OS run less software as root

### DIFF
--- a/packages/3dt/build
+++ b/packages/3dt/build
@@ -23,6 +23,7 @@ EnvironmentFile=/opt/mesosphere/environment
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+User=dcos_3dt
 ExecStart=/opt/mesosphere/bin/3dt
 EOF
 
@@ -35,5 +36,6 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 ExecStartPre=/opt/mesosphere/bin/exhibitor_wait.py
+User=dcos_3dt
 ExecStart=/opt/mesosphere/bin/3dt -pull
 EOF

--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -6,5 +6,6 @@
     "git": "https://github.com/dcos/3dt.git",
     "ref": "af89f74746c0df24066ed01bed8e96151ef84bc7",
     "ref_origin": "master"
-  }
+  },
+  "username": "dcos_3dt"
 }

--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -70,6 +70,7 @@ PIDFile=$PKG_PATH/nginx/logs/nginx.pid
 PrivateDevices=yes
 StandardOutput=journal
 StandardError=journal
+User=dcos_adminrouter
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/ping -c1 marathon.mesos
 ExecStartPre=/bin/ping -c1 leader.mesos
@@ -98,6 +99,7 @@ Description=Admin Router Reloader: Reload admin router to get new DNS
 [Service]
 Type=oneshot
 EnvironmentFile=/opt/mesosphere/environment
+User=dcos_adminrouter
 ExecStart=-$PKG_PATH/nginx/sbin/nginx -s reload
 EOF
 

--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -12,5 +12,6 @@
           "ref": "20f08a120fed3ae0e837d7dc2aa102c329c8fd3f",
           "ref_origin": "master"
       }
-  }
+  },
+  "username": "dcos_adminrouter"
 }

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -21,13 +21,10 @@ After=dcos-gen-resolvconf.service
 Restart=always
 StartLimitInterval=0
 RestartSec=15
+User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/var/lib/dcos/environment.proxy
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/exhibitor_wait.py
-## CoreOS
-ExecStartPre=-/usr/bin/mkdir -p /var/lib/cosmos
-## Ubuntu
-ExecStartPre=-/bin/mkdir -p /var/lib/cosmos
-ExecStart=/opt/mesosphere/bin/java -Xmx2G -classpath ${PKG_PATH}/lib/:${PKG_PATH}/usr/cosmos.jar com.simontuffs.onejar.Boot
+ExecStart=/opt/mesosphere/bin/java -Xmx2G -classpath ${PKG_PATH}/lib/:${PKG_PATH}/usr/cosmos.jar com.simontuffs.onejar.Boot -com.mesosphere.cosmos.dataDir=/var/lib/dcos/cosmos
 EOF

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -7,5 +7,7 @@
     "kind": "url",
     "url": "https://downloads.dcos.io/cosmos/0.1.5-3/cosmos-server-0.1.5-3-one-jar.jar",
     "sha1": "8345b8dd2a7ea143c73fc2288ced4d0226d52854"
-  }
+  },
+  "username": "dcos_cosmos",
+  "state_dir": true
 }

--- a/packages/dcos-cluster-id/build
+++ b/packages/dcos-cluster-id/build
@@ -12,9 +12,9 @@ Type=simple
 Restart=always
 RestartSec=20
 EnvironmentFile=/opt/mesosphere/environment
-ExecStartPre=/bin/mkdir -p /var/lib/dcos
+User=dcos_clusterid
 ExecStartPre=/opt/mesosphere/bin/exhibitor_wait.py
-ExecStartPre=/bin/bash -c "python -c 'import uuid; print(uuid.uuid4())' | zk-value-consensus /cluster-id > /var/lib/dcos/cluster-id.tmp"
-ExecStartPre=/usr/bin/test -s /var/lib/dcos/cluster-id.tmp
-ExecStart=/bin/mv /var/lib/dcos/cluster-id.tmp /var/lib/dcos/cluster-id
+ExecStartPre=/bin/bash -c "python -c 'import uuid; print(uuid.uuid4())' | zk-value-consensus /cluster-id > /var/lib/dcos/dcos-cluster-id/cluster-id.tmp"
+ExecStartPre=/usr/bin/test -s /var/lib/dcos/dcos-cluster-id/cluster-id.tmp
+ExecStart=/bin/mv /var/lib/dcos/dcos-cluster-id/cluster-id.tmp /var/lib/dcos/dcos-cluster-id/cluster-id
 EOF

--- a/packages/dcos-cluster-id/buildinfo.json
+++ b/packages/dcos-cluster-id/buildinfo.json
@@ -1,0 +1,4 @@
+{
+  "username": "dcos_clusterid",
+  "state_dir": true
+}

--- a/packages/dcos-oauth/buildinfo.json
+++ b/packages/dcos-oauth/buildinfo.json
@@ -5,5 +5,6 @@
     "git": "https://github.com/dcos/dcos-oauth.git",
     "ref": "5780c204b87bfb5a23e209b3856d45d1f4624f4b",
     "ref_origin": "master"
-  }
+  },
+  "username": "dcos_oauth"
 }

--- a/packages/dcos-oauth/extra/dcos-oauth.service
+++ b/packages/dcos-oauth/extra/dcos-oauth.service
@@ -2,6 +2,7 @@
 Description=OAuth: OAuth Authentication Service
 
 [Service]
+User=dcos_oauth
 Restart=always
 StartLimitInterval=0
 RestartSec=5

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -5,5 +5,6 @@
     "git": "https://github.com/dcos/dcos-signal.git",
     "ref": "26bdd0b8a105310fd8913b0fa8df346326406925",
     "ref_origin": "master"
-  }
+  },
+  "username": "dcos_signal"
 }

--- a/packages/dcos-signal/extra/dcos-signal.service
+++ b/packages/dcos-signal/extra/dcos-signal.service
@@ -5,6 +5,7 @@ After=dcos-mesos-master.service
 Type=simple
 Restart=on-failure
 RestartSec=20
+User=dcos_signal
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/opt/mesosphere/etc/cfn_signal_metadata
 ExecStartPre=/bin/bash -c '[ -f /var/lib/dcos/cluster-id ] || exit 1'

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -18,6 +18,7 @@ cat <<EOF > $service
 Description=Erlang Port Mapping Daemon: DC/OS Erlang Port Mapping Daemon
 
 [Service]
+User=dcos_epmd
 Restart=always
 StartLimitInterval=0
 RestartSec=5

--- a/packages/erlang/buildinfo.json
+++ b/packages/erlang/buildinfo.json
@@ -6,5 +6,6 @@
       "url": "https://downloads.mesosphere.com/pkgpanda-artifact-cache/otp_src_18.3.tar.gz",
       "sha1": "efc229b75e0b0614a187efe858faf33027bcf3d1"
     }
-  }
+  },
+  "username": "dcos_epmd"
 }

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -12,5 +12,7 @@
       "url": "https://s3.amazonaws.com/downloads.mesosphere.io/zookeeper/zookeeper-3.4.6.tar.gz",
       "sha1": "2a9e53f5990dfe0965834a525fbcad226bf93474"
     }
-  }
+  },
+  "username": "dcos_exhibitor",
+  "state_dir": true
 }

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -2,6 +2,7 @@
 Description=Exhibitor: Zookeeper Supervisor Service
 After=network-online.target
 [Service]
+User=dcos_exhibitor
 StandardOutput=journal
 StandardError=journal
 Restart=always

--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -5,5 +5,6 @@
       "url": "https://github.com/mesosphere/mesos-dns/releases/download/v0.5.2/mesos-dns-v0.5.2-linux-amd64",
       "sha1": "e731deba705f6599fb6c20bf760e72480b895b82"
     }
-  }
+  },
+  "user": "dcos_mesos_dns"
 }

--- a/packages/mesos-dns/extra/dcos-mesos-dns.service
+++ b/packages/mesos-dns/extra/dcos-mesos-dns.service
@@ -2,6 +2,7 @@
 Description=Mesos DNS: DNS based Service Discovery
 After=dcos-mesos-master.service
 [Service]
+User=dcos_mesos_dns
 Restart=always
 StartLimitInterval=0
 RestartSec=5

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,5 +10,6 @@
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
-  }
+  },
+  "user": "dcos_mesos"
 }

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mesos Master: DC/OS Mesos Master Service
 [Service]
+User=dcos_mesos
 Restart=always
 StartLimitInterval=0
 RestartSec=15


### PR DESCRIPTION
# TODO
 - dcos_cfn_signal / the AWS CFN Signal service (Might just opt out)
 -  packages/dcos-cluster-id/build
    - Find all references to
 - Add a test to ensure more non-root things aren't added / only the services in exceptions are allowed to be root.

# In Review

# Done
packages/dcos-oauth/extra/dcos-oauth.service
packages/exhibitor/extra/dcos-exhibitor.service
packages/marathon/build
packages/3dt/build
packages/adminrouter/build
packages/cosmos/build
packages/erlang/build
packages/keepalived/build
packages/mesos-dns/extra/dcos-mesos-dns.service

# Root Exceptions
packages/logrotate/build
  - Must rotate the logs written by mesos-slave (which is root)
packages/minuteman/build
  - Requires special privileges to use certain kernel APIs

packages/mesos/build
 - Mesos Slave
 - Logrotate for mesos slave
 - Mesos master with navstar module?

packages/spartan/build:
  - Needs special privileges for binding among other things.