### PR TITLE
Allow to delete Exhibitor S3 bucket after the fact

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -988,6 +988,10 @@
     "PublicSlaveDnsAddress" : {
       "Description" : "Public slaves",
       "Value" : { "Fn::GetAtt" : [ "PublicSlaveLoadBalancer", "DNSName" ]}
+    },
+    "ExhibitorS3Bucket" : {
+      "Description" : "Exhibitor S3 bucket name",
+      "Value" : { "Ref" : "ExhibitorS3Bucket" }
     }
   }
 }


### PR DESCRIPTION
By adding its resource ID to the outputs of the CloudFormation stack.

The bucket is created with a "Retain" deletion policy, which means that destroying the stack won't delete the bucket. This change makes it possible to still delete the bucket in an automated way (figuring out the bucket name without the stack output [is much more complicated](https://github.com/dcos-labs/dcos-bootstrap/blob/1ec418ca52590199576a7d5999fad6e3d0545747/destroy.yml#L5-L9)).