### PR TITLE
Make exhibitor non-root

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ Documentation of changes which may break some install environments
 
 
 1.8-dev
+ - Most software doesn't run as root. Lots of paths that things use for storage
+   or intermediate state changed as a result.
+ - Zookeeper, exhibitor storage paths changed. Prior to upgrade, exhibitor
+   config must be edited to point to new storage locations
+ - Zookeeper should now log to journald
  - dcos-history-serivce was renamed to dcos-history
  - dcos-ddt.service was renamed to dcos-3dt.service
  - Updated to CoreOS Alpha 1053. See https://github.com/dcos/dcos/pull/148 and

--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -35,3 +35,7 @@ chmod +x "$exhibitor_start_wrapper"
 exhibitor_wait="$PKG_PATH/bin/exhibitor_wait.py"
 cp /pkg/extra/exhibitor_wait.py "$exhibitor_wait"
 chmod +x "$exhibitor_wait"
+
+mkdir -p "$PKG_PATH/usr/zookeeper/build/lib/"
+cp /pkg/src/log4j/log4j-systemd-journal-appender-1.3.2.jar "$PKG_PATH/usr/zookeeper/lib/"
+cp /pkg/src/jna/jna-4.2.2.jar "$PKG_PATH/usr/zookeeper/lib/"

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,13 +4,25 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "ed0374761ec73b46a645142673a9520f73305200",
+      "ref": "a04453d14d49e1a3774bef235462b120e1eff3e1",
       "ref_origin": "master"
     },
     "zookeeper": {
       "kind": "url_extract",
       "url": "https://s3.amazonaws.com/downloads.mesosphere.io/zookeeper/zookeeper-3.4.6.tar.gz",
       "sha1": "2a9e53f5990dfe0965834a525fbcad226bf93474"
+    },
+    "log4j": {
+        "kind": "url",
+        "url": "https://repo1.maven.org/maven2/de/bwaldvogel/log4j-systemd-journal-appender/1.3.2/log4j-systemd-journal-appender-1.3.2.jar",
+        "sha1": "4baf482f0de6ed330e0d3ca77e062f6d944039b7"
+    },
+    "jna": {
+        "kind": "url",
+        "url": "https://repo1.maven.org/maven2/net/java/dev/jna/jna/4.2.2/jna-4.2.2.jar",
+        "sha1": "5012450aee579c3118ff09461d5ce210e0cdc2a9"
     }
-  }
+  },
+  "username": "dcos_exhibitor",
+  "state_directory": true
 }

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -2,6 +2,7 @@
 Description=Exhibitor: Zookeeper Supervisor Service
 After=network-online.target
 [Service]
+User=dcos_exhibitor
 StandardOutput=journal
 StandardError=journal
 Restart=always
@@ -13,4 +14,4 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor
 # run in new mount namespace to create custom resolv.conf
-ExecStart=/usr/bin/unshare --mount $PKG_PATH/usr/exhibitor/start_exhibitor.py
+ExecStart=$PKG_PATH/usr/exhibitor/start_exhibitor.py

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["java", "exhibitor"],
+  "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
     "url": "http://downloads.mesosphere.io/marathon/v1.1.1/marathon-1.1.1.tgz",


### PR DESCRIPTION
 - Remove resolv.conf mount, RuntimeDir workaround. Shouldn't be needed with the spartan approach
 - make exhibitor configure ZK use a different config folder than where it's .jar lives
 - Add creating the dir for zoo.cfg to start_exhibitor
 - Update NEWS file
 - Set java preferences di
 - zookeeper is now configured to log to journald
 - Remove marathon's dependency on the exhibitor package. It just needs it at runtime, and we did this recently for the mesos package as well in #239 

TODO before landing:
 - Merge exhibitor patches.