### PR TITLE
Use dedicated storage account for Exhibitor storage

### DIFF
--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -507,6 +507,7 @@
     "agentStoragePublicAccountName": "[concat(variables('storageAccountBaseName'), 'agntpub')]",
     "agentStoragePrivateAccountName": "[concat(variables('storageAccountBaseName'), 'agntpri')]",
     "masterStorageAccountName": "[concat(variables('storageAccountBaseName'), 'mstr0')]",
+    "masterStorageAccountExhibitorName": "[concat(variables('storageAccountBaseName'), 'exhb0')]",
     "omsStorageAccount": "none",
     "omsStorageAccountKey": "none",
     "clusterInstallParameters": "[concat(variables('masterCount'), ' ',variables('masterVMNamePrefix'), ' ',variables('masterFirstAddr'), ' ',variables('swarmEnabled'),' ',variables('marathonEnabled'),' ',variables('chronosEnabled'),' ',variables('omsStorageAccount'),' ',variables('omsStorageAccountKey'),' ', variables('adminUsername'),' ',variables('postInstallScriptURI'))]",
@@ -578,6 +579,18 @@
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('masterStorageAccountExhibitorName')]",
+      "apiVersion": "[variables('apiVersionStorage')]",
+      "location": "[variables('storageLocation')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
+      ],
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('diagnosticsStorageAccountName')]",
       "apiVersion": "[variables('apiVersionStorage')]",
       "location": "[variables('storageLocation')]",
@@ -585,7 +598,7 @@
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
       "properties": {
-        "accountType": "[variables('vmSizesMap')[variables('masterVMSize')].storageAccountType]"
+        "accountType": "Standard_LRS"
       }
     },
     {
@@ -837,6 +850,7 @@
         "[concat('Microsoft.Network/networkInterfaces/', variables('masterVMNamePrefix'), 'nic-', copyIndex())]",
         "[concat('Microsoft.Compute/availabilitySets/',variables('masterAvailabilitySet'))]",
         "[variables('masterStorageAccountName')]",
+        "[variables('masterStorageAccountExhibitorName')]",
         "[variables('diagnosticsStorageAccountName')]"
       ],
       "properties": {

--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -199,9 +199,9 @@ def make_template(num_masters, gen_arguments, varietal, bootstrap_variant_prefix
         dcos_template = gen_templates(args, 'azuredeploy')
     elif varietal == 'acs':
         args['exhibitor_azure_prefix'] = "[[[variables('masterPublicIPAddressName')]]]"
-        args['exhibitor_azure_account_name'] = "[[[variables('masterStorageAccountName')]]]"
+        args['exhibitor_azure_account_name'] = "[[[variables('masterStorageAccountExhibitorName')]]]"
         args['exhibitor_azure_account_key'] = ("[[[listKeys(resourceId('Microsoft.Storage/storageAccounts', "
-                                               "variables('masterStorageAccountName')), '2015-06-15').key1]]]")
+                                               "variables('masterStorageAccountExhibitorName')), '2015-06-15').key1]]]")
         args['cluster_name'] = "[[[variables('masterPublicIPAddressName')]]]"
         dcos_template = gen_templates(args, 'acs')
     else:


### PR DESCRIPTION
This adds a dedicated storage account for Exhibitor coordination state, also making it possible to use Premium LRS for the Agent OS disks. Previously, when a VM with Premium LRS storage was selected, Exhibitor would also be configured to use a Premium LRS account for storing coordination state via block blobs. However, this is not supported use of the Premium LRS service (see [Azure Premium Storage](https://azure.microsoft.com/en-us/documentation/articles/storage-premium-storage/)):

> Currently, Premium Storage does not support Azure Block Blobs, Azure Append Blobs, Azure Files, Azure Tables, or Azure Queues. Any other object placed in a Premium Storage account will be a Page Blob, and it will snap to one of the the supported provisioned sizes. Heance Premium Storage account is not meant for storing tiny blobs.

And the cluster would fail to launch... With this change Exhibitor coordination state will always use Standard LRS and will also be isolated from the Master node storage.
