### PR TITLE
Signal Service 1.1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+ext/dcos-installer/packages/
 this
 .idea/
 dcos-config--setup*.tar.xz

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -150,6 +150,16 @@ package:
     content: |
       {
         "gen_provider": "{{ provider }}",
+        "diagnostics_urls": [
+          "http://leader.mesos:1050/system/health/v1/report"
+        ],
+        "cosmos_urls": [
+          "http://leader.mesos:7070/package/list"
+        ],
+        "mesos_urls": [
+          "http://leader.mesos:5050/frameworks",
+          "http://leader.mesos:5050/metrics/snapshot"
+        ],
         "enabled": "{{ telemetry_enabled }}"
       }
   - path: /etc/adminrouter.env

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "26bdd0b8a105310fd8913b0fa8df346326406925",
+    "ref": "cdc6473bc6bb10f36ef578f2e411ce927561f2d9",
     "ref_origin": "master"
   },
   "username": "dcos_signal"

--- a/test_util/integration_test.py
+++ b/test_util/integration_test.py
@@ -1267,12 +1267,18 @@ def test_signal_service(cluster):
 
     wait_for_endpoint()
 
-    test_cache_url = "http://{}:{}/signal_test_cache".format(service_points[0].host, service_points[0].port)
+    test_host = service_points[0].host
+    test_port = service_points[0].port
+    test_cache_url = "http://{}:{}/signal_test_cache".format(test_host, test_port)
+
     cmd = """
-data=`/opt/mesosphere/bin/dcos-signal -report-host leader.mesos -test 2> /dev/null`;
-curl -H 'Content-Type: application/json' -X POST -d "$data" {};
+ID_PATH="/${PWD}/test-cluster-id"
+echo 'test-id' > $ID_PATH
+/opt/mesosphere/bin/dcos-signal \
+    -cluster-id-path $ID_PATH \
+    -test-url %s
 sleep 3600
-""".format(test_cache_url)
+""" % test_cache_url
 
     test_uuid = uuid.uuid4().hex
     signal_app_definition = {
@@ -1297,82 +1303,110 @@ sleep 3600
 
     r = requests.get(test_cache_url)
 
+    # Handy for diagnosing strange signal service test behavior, not sure if we should
+    # leave these in for master branch, or remove for the final PR.
+    print('TESTING SIGNAL RETURN:\n{}'.format(r.text))
+    print('CACHE SERVER STATUS:\n{}'.format(r.status_code))
+
     r_data = json.loads(r.json())
 
     cluster.destroy_marathon_app(signal_app_definition['id'])
     cluster.destroy_marathon_app(test_server_app_definition['id'])
 
     exp_data = {
-            'Event': 'health',
-            'UserId': '',
-            'ClusterId': '',
-            'Properties': {
-                'provider': 'onprem',
-                'source': 'cluster',
-                'clusterId': '',
-                'customerKey': '',
-                'environmentVersion': '',
-                'variant': 'open'}
-            }
+        'diagnostics': {
+            'event': 'health',
+            'anonymousId': 'test-id',
+            'properties': {}
+        },
+        'cosmos': {
+            'event': 'package_list',
+            'anonymousId': 'test-id',
+            'properties': {}
+        },
+        'mesos': {
+            'event': 'mesos_track',
+            'anonymousId': 'test-id',
+            'properties': {}
+        }
+    }
 
+    # Generic properties which are the same between all tracks
+    generic_properties = {
+        'provider': 'onprem',
+        'source': 'cluster',
+        'clusterId': 'test-id',
+        'customerKey': '',
+        'environmentVersion': '',
+        'variant': 'open'
+    }
+
+    # Insert the generic property data which is the same between all signal tracks
+    exp_data['diagnostics']['properties'].update(generic_properties)
+    exp_data['cosmos']['properties'].update(generic_properties)
+    exp_data['mesos']['properties'].update(generic_properties)
+
+    # Insert all the diagnostics data programmatically
     master_units = [
-            'adminrouter-reload-service',
-            'adminrouter-reload-timer',
-            'adminrouter-service',
-            'cluster-id-service',
-            'cosmos-service',
-            'exhibitor-service',
-            'history-service-service',
-            'marathon-service',
-            'mesos-dns-service',
-            'mesos-master-service',
-            'signal-service',
-            'logrotate-master-service',
-            'logrotate-master-timer']
+        'adminrouter-reload-service',
+        'adminrouter-reload-timer',
+        'adminrouter-service',
+        'cluster-id-service',
+        'cosmos-service',
+        'exhibitor-service',
+        'history-service-service',
+        'logrotate-master-service',
+        'logrotate-master-timer',
+        'marathon-service',
+        'mesos-dns-service',
+        'mesos-master-service',
+        'signal-service']
     all_node_units = [
-            'ddt-service',
-            'epmd-service',
-            'gen-resolvconf-service',
-            'gen-resolvconf-timer',
-            'minuteman-service',
-            'navstar-service',
-            'signal-timer',
-            'spartan-service',
-            'spartan-watchdog-service',
-            'spartan-watchdog-timer']
+        'ddt-service',
+        'epmd-service',
+        'gen-resolvconf-service',
+        'gen-resolvconf-timer',
+        'minuteman-service',
+        'navstar-service',
+        'signal-timer',
+        'spartan-service',
+        'spartan-watchdog-service',
+        'spartan-watchdog-timer']
     slave_units = [
-            'mesos-slave-service',
-            'vol-discovery-priv-agent-service']
+        'mesos-slave-service',
+        'vol-discovery-priv-agent-service']
     public_slave_units = [
-            'mesos-slave-public-service',
-            'vol-discovery-pub-agent-service']
+        'mesos-slave-public-service',
+        'vol-discovery-pub-agent-service']
     all_slave_units = [
-            'logrotate-agent-service',
-            'logrotate-agent-timer']
+        'logrotate-agent-service',
+        'logrotate-agent-timer']
 
     master_units.append('oauth-service')
 
     for unit in master_units:
-        exp_data['Properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.masters)
-        exp_data['Properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.masters)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in all_node_units:
-        exp_data['Properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.all_slaves+cluster.masters)
-        exp_data['Properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(
+            cluster.all_slaves+cluster.masters)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in slave_units:
-        exp_data['Properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.slaves)
-        exp_data['Properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in public_slave_units:
-        exp_data['Properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.public_slaves)
-        exp_data['Properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.public_slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in all_slave_units:
-        exp_data['Properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.all_slaves)
-        exp_data['Properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.all_slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
 
-    # Cluster ID is uncheckable as this runs on an agent
-    r_data['ClusterId'] = ''
-    r_data['Properties']['clusterId'] = ''
-
-    assert r_data == exp_data
+    # Check the entire hash of diagnostics data
+    assert r_data['diagnostics'] == exp_data['diagnostics']
+    # Check a subset of things regarding Mesos that we can logically check for
+    assert r_data['mesos']['properties']['frameworks'][0]['name'] == 'marathon'
+    # There are no packages installed by default on the integration test, ensure the key exists
+    assert r_data['cosmos']['properties']['package_list'] is None
 
 
 def test_mesos_agent_role_assignment(cluster):


### PR DESCRIPTION
- Updates to tests to POST from signal to test cache server
- Updates for security enhancements 
- Updates to reporters to do asynchronous report queries and multiple, generic reporter types
- Hard fails if cluster-id is not present