### PR TITLE
Update exhibitor to include the latest netflix/exhibitor changes.

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "7d286ac4a5d458ce182bee53445b8883153b88a9",
+      "ref": "ed0374761ec73b46a645142673a9520f73305200",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
See: https://github.com/dcos/exhibitor/pull/2

Biggest things are
 - some tooling fixes
 - Update AWS SDK