### PR TITLE
Update exhibitor_wait to not print an error on connection failure in requests

### DIFF
--- a/packages/exhibitor/extra/exhibitor_wait.py
+++ b/packages/exhibitor/extra/exhibitor_wait.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import requests
-
+import requests.exceptions
 
 EXHIBITOR_STATUS_URL = 'http://127.0.0.1:8181/exhibitor/v1/cluster/status'
 
@@ -17,7 +17,11 @@ os.environ.pop('no_proxy', None)
 
 cluster_size = int(open('/opt/mesosphere/etc/master_count').read().strip())
 
-resp = requests.get(EXHIBITOR_STATUS_URL)
+try:
+    resp = requests.get(EXHIBITOR_STATUS_URL)
+except requests.exceptions.ConnectionError as ex:
+    print('Could not connect to exhibitor: {}'.format(ex), file=sys.stderr)
+    sys.exit(1)
 if resp.status_code != 200:
     print('Could not get exhibitor status: {}, Status code: {}'.format(
           EXHIBITOR_STATUS_URL, resp.status_code), file=sys.stderr)


### PR DESCRIPTION

There was a 60+ line traceback looking something like:
```
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: Traceback (most recent call last):
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/connection.py", line 142, in _new_conn
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: (self.host, self.port), self.timeout, **extra_kw)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/util/connection.py", line 91, in create_connection
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: raise err
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/util/connection.py", line 81, in create_connection
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: sock.connect(sa)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: ConnectionRefusedError: [Errno 111] Connection refused
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: During handling of the above exception, another exception occurred:
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: Traceback (most recent call last):
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 578, in urlopen
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: chunked=chunked)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 362, in _make_request
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: conn.request(method, url, **httplib_request_kw)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/packages/python--3920e1de5657905ec0429744ea7cafdf7ca0a6b4/lib/python3.4/http/client.py", line 1090, in request
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self._send_request(method, url, body, headers)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/packages/python--3920e1de5657905ec0429744ea7cafdf7ca0a6b4/lib/python3.4/http/client.py", line 1128, in _send_request
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self.endheaders(body)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/packages/python--3920e1de5657905ec0429744ea7cafdf7ca0a6b4/lib/python3.4/http/client.py", line 1086, in endheaders
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self._send_output(message_body)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/packages/python--3920e1de5657905ec0429744ea7cafdf7ca0a6b4/lib/python3.4/http/client.py", line 924, in _send_output
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self.send(msg)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/packages/python--3920e1de5657905ec0429744ea7cafdf7ca0a6b4/lib/python3.4/http/client.py", line 859, in send
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self.connect()
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/connection.py", line 167, in connect
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: conn = self._new_conn()
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: File "/opt/mesosphere/lib/python3.4/site-packages/requests/packages/urllib3/connection.py", line 151, in _new_conn
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: self, "Failed to establish a new connection: %s" % e)
Jun 08 03:21:40 ip-10-10-0-126 exhibitor_wait.py[2928]: requests.packages.urllib3.exceptions.NewConnectionError: <requests.packages.urllib3.connection.HTTPConnection object at 0x7efc449b96d8>: Failed to establish a new connection: [Errno
```