### PR TITLE
use latest 3dt

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -4,7 +4,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "af89f74746c0df24066ed01bed8e96151ef84bc7",
+    "ref": "6a227d01fed4c2d6621e323501e8d18c16f3daec",
     "ref_origin": "master"
   },
   "username": "dcos_3dt"


### PR DESCRIPTION
if systemd exposes socket, 3dt will be using it and do not bind to tcp port
https://github.com/dcos/3dt/pull/30

add plugable http request interface
https://github.com/dcos/3dt/pull/31

if 3dt finds CA cert it will be used to validate https connection
https://github.com/dcos/3dt/pull/32

fix for public agent role, 3dt will display agent or public agent correctly
https://github.com/dcos/3dt/pull/33