### PR TITLE
Add detect_ip_public script, default to detect_ip script.

### DIFF
--- a/gen/aws/calc.py
+++ b/gen/aws/calc.py
@@ -31,6 +31,8 @@ entry = {
             lambda slave_public_spot_price: get_spot('slave_public', slave_public_spot_price),
         'aws_region': '{ "Ref" : "AWS::Region" }',
         'ip_detect_contents': yaml.dump(pkg_resources.resource_string('gen', 'ip-detect/aws.sh').decode()),
+        'ip_detect_public_contents':
+            yaml.dump(pkg_resources.resource_string('gen', 'ip-detect/aws_public.sh').decode()),
         'exhibitor_explicit_keys': 'false',
         'cluster_name': '{ "Ref" : "AWS::StackName" }',
         'master_discovery': 'master_http_loadbalancer',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -65,6 +65,10 @@ def calculate_ip_detect_contents(ip_detect_filename):
     return yaml.dump(open(ip_detect_filename, encoding='utf-8').read())
 
 
+def calculate_ip_detect_public_contents(ip_detect_contents):
+    return ip_detect_contents
+
+
 def calculate_gen_resolvconf_search(dns_search):
     if len(dns_search) > 0:
         return "SEARCH=" + dns_search
@@ -279,6 +283,7 @@ entry = {
         'docker_remove_delay': '1hrs',
         'gc_delay': '2days',
         'ip_detect_contents': calculate_ip_detect_contents,
+        'ip_detect_public_contents': calculate_ip_detect_public_contents,
         'dns_search': '',
         'auth_cookie_secure_flag': 'false',
         'master_dns_bindall': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -10,6 +10,9 @@ package:
   - path: /bin/detect_ip
     permissions: "0755"
     content: {{ ip_detect_contents }}
+  - path: /bin/detect_ip_public
+    permissions: "0755"
+    content: {{ ip_detect_public_contents }}
   - path: /check/check_ip
     permissions: "0755"
     content: |

--- a/gen/ip-detect/aws_public.sh
+++ b/gen/ip-detect/aws_public.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -o nounset -o errexit
+
+curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4

--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -9,7 +9,7 @@
       "adminrouter": {
           "kind": "git",
           "git": "https://github.com/dcos/adminrouter.git",
-          "ref": "20f08a120fed3ae0e837d7dc2aa102c329c8fd3f",
+          "ref": "9bafbe37097b8bc329eb89552075185620da1267",
           "ref_origin": "master"
       }
   }

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
     package_data={
         'gen': [
             'ip-detect/aws.sh',
+            'ip-detect/aws_public.sh',
             'ip-detect/azure.sh',
             'ip-detect/vagrant.sh',
             'cloud-config.yaml',


### PR DESCRIPTION
In AWS, add an alternate implementation to get the instance Public IP from the metadata service.

# TODO
 - Update adminrouter to run `/opt/mesosphere/bin/detect_ip_public` still

cc @sargun 