### PR TITLE
bump concurrent ssh sessions for DC/OS installer

### DIFF
--- a/ext/dcos-installer/dcos_installer/action_lib/utils.py
+++ b/ext/dcos-installer/dcos_installer/action_lib/utils.py
@@ -9,9 +9,12 @@ def get_async_runner(config, hosts, async_delegate=None):
     extra_ssh_options = config.get('extra_ssh_options', '')
     ssh_key_path = config.get('ssh_key_path', '/genconf/ssh_key')
 
+    # if ssh_parallelism is not set, use 20 concurrent ssh sessions by default.
+    parallelism = config.get('ssh_parallelism', 20)
+
     return ssh.ssh_runner.MultiRunner(hosts, ssh_user=config['ssh_user'], ssh_key_path=ssh_key_path,
                                       process_timeout=process_timeout, extra_opts=extra_ssh_options,
-                                      async_delegate=async_delegate)
+                                      async_delegate=async_delegate, parallelism=parallelism)
 
 
 def add_pre_action(chain, ssh_user):

--- a/pytest/test_ssh_unittest.py
+++ b/pytest/test_ssh_unittest.py
@@ -94,3 +94,24 @@ def test_public_agent_list(default_config):
             'agent_list': 'master_list and agent_list cannot contain duplicates 10.10.0.1',
             'public_agent_list': 'master_list and agent_list cannot contain duplicates 10.10.0.1',
             'master_list': 'master_list and agent_list cannot contain duplicates 10.10.0.1'}
+
+
+def test_ssh_parallelism(default_config):
+    with tempfile.NamedTemporaryFile() as tmp:
+        default_config['ssh_key_path'] = tmp.name
+
+        # test ssh_parallelism range, should be ok within 1.100
+        default_config['ssh_parallelism'] = 101
+        assert ssh.validate.validate_config(default_config) == {
+            'ssh_parallelism': 'ssh_parallelism must be within the range 1..100'}
+
+        default_config['ssh_parallelism'] = 0
+        assert ssh.validate.validate_config(default_config) == {
+            'ssh_parallelism': 'ssh_parallelism must be within the range 1..100'}
+
+        default_config['ssh_parallelism'] = 20
+        assert ssh.validate.validate_config(default_config) == {}
+
+        # ssh_parallelism must be integer
+        default_config['ssh_parallelism'] = '20'
+        assert ssh.validate.validate_config(default_config) == {'ssh_parallelism': 'ssh_parallelism must be integer'}

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -96,6 +96,11 @@ def run_validate_config_chunk(key_validate_fn_map, config, keys_required):
     return errors
 
 
+def validate_ssh_parallelism(value):
+    assert isinstance(value, int), 'ssh_parallelism must be integer'
+    assert 0 < value <= 100, 'ssh_parallelism must be within the range 1..100'
+
+
 def validate_config(config):
     assert isinstance(config, dict)
     ssh_keys_checks_map_required = {
@@ -111,7 +116,8 @@ def validate_config(config):
         'agent_list': lambda agent_list: validate_optional_agent(agent_list, config.get('public_agent_list')),
         'public_agent_list': lambda public_agent_list: validate_optional_agent(
             config.get('agent_list'),
-            public_agent_list)
+            public_agent_list),
+        'ssh_parallelism': validate_ssh_parallelism
     }
 
     errors = run_validate_config_chunk(ssh_keys_checks_map_required, config, True)


### PR DESCRIPTION
DCOS-7596
- add optional `ssh_parallelism` option to a config file. The value must be
integer within 1..100 range.

- use default ssh_parallelism of 20 for DC/OS installer.