### PR TITLE
Updated Mesos release to 1.0.0-rc1.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,11 +10,12 @@ Documentation of changes which may break some install environments
  - Make the admin load balancer in all templates do TCP, not HTTP load balancing
  - Switch Ubuntu in Azure to 16.04 LTS final release
  - Teach spartan / DNS to only listen on a local internal address
- - Make the installer preflight actually faile if SELinux is enabled
+ - Make the installer preflight actually fail if SELinux is enabled
  - Took ownership of several sysctl settings for minuteman
     net.netfilter.nf_conntrack_tcp_be_liberal=1
     net.netfilter.ip_conntrack_tcp_be_liberal=1
     net.ipv4.netfilter.ip_conntrack_tcp_be_liberal=1
+ - Mesos updated to 1.0.0-rc1.
 
 1.7-OPEN -- 4/18/2016
  - Open DC/OS Released

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -284,7 +284,18 @@ entry = {
         'ui_banner_header_content': 'null',
         'ui_banner_footer_content': 'null',
         'ui_banner_image_path': 'null',
-        'ui_banner_dismissible': 'null'
+        'ui_banner_dismissible': 'null',
+        'dcos_overlay_enable': "true",
+        'dcos_overlay_network': '{                      \
+            "vtep_subnet": "198.15.0.0/20",             \
+            "vtep_mac_oui": "70:B3:D5:00:00:00",        \
+            "overlays": [                               \
+              {                                         \
+                "name": "overlay-1",                    \
+                "subnet": "44.128.0.0/16",              \
+                "prefix": 24                            \
+              }                                         \
+            ]}'
     },
     'must': {
         'custom_auth': 'false',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -76,14 +76,6 @@ def calculate_gen_resolvconf_search(dns_search):
         return ""
 
 
-def calculate_mesos_slave_modules_json(mesos_slave_modules):
-    # Ensure that this file is readable by humans by including newlines in the output.
-    json_multiline = json.dumps({"libraries": mesos_slave_modules}, indent=2)
-    # Preserve indentation in dcos-config.yaml's template by adding indentation to this content
-    injected_indent = 6 * ' '
-    return json_multiline.replace('\n', '\n' + injected_indent)
-
-
 def validate_telemetry_enabled(telemetry_enabled):
     can_be = ['true', 'false']
     assert telemetry_enabled in can_be, 'Must be one of {}. Got {}.'.format(can_be, telemetry_enabled)
@@ -244,23 +236,7 @@ def validate_os_type(os_type):
 
 
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
-__logrotate_slave_module = {
-    'file': '/opt/mesosphere/lib/liblogrotate_container_logger.so',
-    'modules': [{
-        'name': __logrotate_slave_module_name,
-        'parameters': [
-            {'key': 'launcher_dir', 'value': '/opt/mesosphere/active/mesos/libexec/mesos/'},
-            {'key': 'max_stdout_size', 'value': '2MB'},
-            {'key': 'logrotate_stdout_options', 'value': 'rotate 9'},
-            {'key': 'max_stderr_size', 'value': '2MB'},
-            {'key': 'logrotate_stderr_options', 'value': 'rotate 9'},
-        ]
-    }]
-}
 
-default_mesos_slave_modules = [
-    __logrotate_slave_module,
-]
 
 
 entry = {
@@ -326,8 +302,6 @@ entry = {
         'ui_external_links': 'false',
         'ui_networking': 'false',
         'ui_organization': 'false',
-        'mesos_slave_modules_json': calculate_mesos_slave_modules_json(
-            default_mesos_slave_modules),
         'minuteman_forward_metrics': 'false',
     },
     'conditional': {

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -238,7 +238,6 @@ def validate_os_type(os_type):
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
 
 
-
 entry = {
     'validate': [
         validate_num_masters,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -81,9 +81,82 @@ package:
           ]
         }
       ].
+  - path: /etc/overlay/config/master.json
+    content: |
+      {
+        "zk":
+        {
+          "url": "zk://127.0.0.1:2181/mesos",
+          "quorum": {{ master_quorum }}
+        },
+        "replicated_log_dir":"/var/lib/dcos/mesos/master/",
+        "network": {{ dcos_overlay_network }}
+       }
+  - path: /etc/dcos/network/cni/dummy.cni
+    content: |
+      {
+        "name": "dummy",
+        "type": "bridge"
+      }
+  - path: /etc/overlay/config/agent.json
+    content: |
+      {
+        "master": "zk://leader.mesos:2181/mesos",
+        "cni_dir":"/opt/mesosphere/etc/dcos/network/cni"
+       }
+  - path: /etc/overlay/config/agent-master.json
+    content: |
+      {
+        "master": "zk://127.0.0.1:2181/mesos",
+        "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
+        "network_config" :
+        {
+          "allocate_subnet": true,
+          "mesos_bridge": false,
+          "docker_bridge": true
+        }
+      }
+  {% switch dcos_overlay_enable %}
+  {% case "true" %}
+  - path: /etc/mesos-master-modules/overlay_master_modules.json
+    content: |
+      {
+        "libraries":
+        [
+          {
+            "file": "/opt/mesosphere/active/mesos-overlay/lib/mesos/libmesos_network_overlay.so",
+            "modules":
+              [
+                {
+                  "name": "com_mesosphere_mesos_OverlayMasterManager",
+                  "parameters" :
+                    [
+                      {
+                        "key": "master_config",
+                        "value" : "/opt/mesosphere/etc/overlay/config/master.json"
+                      }
+                    ]
+                },
+                {
+                  "name": "com_mesosphere_mesos_OverlayAgentManager",
+                  "parameters" :
+                    [
+                      {
+                        "key": "agent_config",
+                        "value" : "/opt/mesosphere/etc/overlay/config/agent-master.json"
+                      }
+                    ]
+                }
+              ]
+           }
+        ]
+      }
+  {% case "false" %}
+  {% endswitch %}
   - path: /etc/mesos-master
     content: |
       MESOS_LOG_DIR=/var/lib/dcos/mesos/log
+      MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-master-modules
       MESOS_REGISTRY_STORE_TIMEOUT=60secs
       MESOS_REGISTRY_FETCH_TIMEOUT=60secs
       MESOS_REGISTRY_STRICT=false
@@ -100,6 +173,33 @@ package:
   - path: /etc/mesos-master-provider
     content: |
       MESOS_CLUSTER={{ cluster_name }}
+  {% switch dcos_overlay_enable %}
+  {% case "true" %}
+  - path: /etc/mesos-slave-modules/overlay_slave_modules.json
+    content: |
+      {
+        "libraries":
+        [
+          {
+            "file": "/opt/mesosphere/active/mesos-overlay/lib/mesos/libmesos_network_overlay.so",
+            "modules":
+              [
+                {
+                  "name": "com_mesosphere_mesos_OverlayAgentManager",
+                  "parameters" :
+                    [
+                      {
+                        "key": "agent_config",
+                        "value" : "/opt/mesosphere/etc/overlay/config/agent.json"
+                      }
+                    ]
+                }
+              ]
+           }
+        ]
+      }
+  {% case "false" %}
+  {% endswitch %}
   - path: /etc/mesos-slave-common
     content: |
       MESOS_MASTER=zk://leader.mesos:2181/mesos

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -100,15 +100,12 @@ package:
   - path: /etc/mesos-master-provider
     content: |
       MESOS_CLUSTER={{ cluster_name }}
-  - path: /etc/mesos-slave-modules.json
-    content: |
-      {{ mesos_slave_modules_json }}
   - path: /etc/mesos-slave-common
     content: |
       MESOS_MASTER=zk://leader.mesos:2181/mesos
       MESOS_CONTAINERIZERS=docker,mesos
       MESOS_LOG_DIR=/var/log/mesos
-      MESOS_MODULES=file:///opt/mesosphere/etc/mesos-slave-modules.json
+      MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
       MESOS_CONTAINER_LOGGER={{ mesos_container_logger }}
       MESOS_ISOLATION=cgroups/cpu,cgroups/mem,posix/disk
       MESOS_WORK_DIR=/var/lib/mesos/slave

--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -356,7 +356,7 @@ function check_all() {
     for role in "$ROLES"
     do
         if [ "$role" != "master" -a "$role" != "slave" -a "$role" != "slave_public" -a "$role" != "minuteman" ]; then
-            echo -e "${RED}FAIL Invalid role $role. Role must be one of {master,slave,slave_public}{NORMAL}"
+            echo -e "${RED}FAIL Invalid role $role. Role must be one of {master,slave,slave_public}${NORMAL}"
             (( OVERALL_RC += 1 ))
         fi
     done

--- a/gen/installer/util.py
+++ b/gen/installer/util.py
@@ -33,7 +33,7 @@ def copy_makedirs(src, dest):
     shutil.copy(src, dest)
 
 fetch_pkg_template = """
-mkdir -p dirname {package_path}
+mkdir -p $(dirname {package_path})
 curl -fLsSv --retry 20 -Y 100000 -y 60 -o {package_path} {bootstrap_url}/{package_path}
 """
 

--- a/packages/cni/build
+++ b/packages/cni/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -o nounset -o pipefail
+
+pushd /pkg/src/cni/
+./build
+popd
+
+cp /pkg/src/cni/bin/* $PKG_PATH

--- a/packages/cni/buildinfo.json
+++ b/packages/cni/buildinfo.json
@@ -1,0 +1,9 @@
+{
+    "docker": "golang:1.6",
+    "single_source" : {
+      "kind": "git",
+      "git": "git@github.com:containernetworking/cni.git",
+      "ref" : "b8e92ed030588120f9fda47dd359e17a3234142d",
+      "ref_origin": "master"
+    }
+}

--- a/packages/logrotate/build
+++ b/packages/logrotate/build
@@ -61,7 +61,6 @@ cat <<EOF > "$logrotate_service"
 Description=Logrotate Mesos Master: Rotate Mesos master logs
 [Service]
 Type=simple
-User=dcos_mesos
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/mesos/log/archive
 ExecStart=$PKG_PATH/bin/logrotate $config_file -s /var/lib/dcos/mesos/logrotate_master.status

--- a/packages/logrotate/buildinfo.json
+++ b/packages/logrotate/buildinfo.json
@@ -4,5 +4,4 @@
     "url": "https://fedorahosted.org/releases/l/o/logrotate/logrotate-3.9.1.tar.gz",
     "sha1": "7ba734cd1ffa7198b66edc4bca17a28ea8999386"
   },
-  "username": "dcos_mesos"
 }

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "http://downloads.mesosphere.io/marathon/snaps/876e75d00dd4f3b134e825b83cb1e969dc1cb3a1/marathon.tgz",
-    "sha1": "e517c13c5f795f5e0bf4640f499488ab78bba794"
+    "url": "http://downloads.mesosphere.io/marathon/snaps/d4885134770050331a517cafa6ac4dc53dc67d45/marathon.tgz",
+    "sha1": "59a2ce898681369fe54b4000652f48cf63bbaf61"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "http://downloads.mesosphere.io/marathon/snaps/2deba9bca36f697d9166a97534d689d2a19ee76d/marathon.tgz",
-    "sha1": "81023a238ed512962f84db4430a1917df05818d7"
+    "url": "http://downloads.mesosphere.io/marathon/snaps/876e75d00dd4f3b134e825b83cb1e969dc1cb3a1/marathon.tgz",
+    "sha1": "e517c13c5f795f5e0bf4640f499488ab78bba794"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "http://downloads.mesosphere.io/marathon/v1.1.1/marathon-1.1.1.tgz",
-    "sha1": "36823a2bd74d36932c97a682fb657a5f5e963516"
+    "url": "http://downloads.mesosphere.io/marathon/snaps/2deba9bca36f697d9166a97534d689d2a19ee76d/marathon.tgz",
+    "sha1": "81023a238ed512962f84db4430a1917df05818d7"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos-buildenv/build
+++ b/packages/mesos-buildenv/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -o nounset -o pipefail
-export MAKEFLAGS=-j8
-/pkg/src/mesos-buildenv/make_env $PKG_PATH

--- a/packages/mesos-buildenv/buildinfo.json
+++ b/packages/mesos-buildenv/buildinfo.json
@@ -1,8 +1,0 @@
-{
-  "single_source": {
-    "kind": "git",
-    "git": "https://github.com/dcos/mesos-buildenv.git",
-    "ref": "333a8528f29555b25f5942c4f79665f9e44fc0c1",
-    "ref_origin": "master"
-  }
-}

--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -2,7 +2,7 @@
   "docker": "golang:1.5.3",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/mesosphere/mesos-dns.gith",
+    "git": "https://github.com/mesosphere/mesos-dns.git",
     "ref": "3d42620a12936fccf77435526f5aaee0fb409416",
     "ref_origin": "master"
   },

--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -2,7 +2,7 @@
   "docker": "golang:1.5.3",
   "single_source" : {
     "kind": "git",
-    "git": "git@github.com:mesosphere/mesos-dns.git",
+    "git": "https://github.com/mesosphere/mesos-dns.gith",
     "ref": "3d42620a12936fccf77435526f5aaee0fb409416",
     "ref_origin": "master"
   },

--- a/packages/mesos-overlay/build
+++ b/packages/mesos-overlay/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -o nounset -o pipefail
+
+pushd /pkg/src/mesos-overlay/
+./bootstrap
+popd
+
+export LD_LIBRARY_PATH=/opt/mesosphere/lib
+
+mkdir -p build
+pushd build
+/pkg/src/mesos-overlay/configure \
+     --with-mesos=/opt/mesosphere/active/mesos \
+     --prefix="$PKG_PATH"
+make -j8
+make install
+popd

--- a/packages/mesos-overlay/buildinfo.json
+++ b/packages/mesos-overlay/buildinfo.json
@@ -3,8 +3,8 @@
     "docker": "dcos-builder",
     "single_source" : {
       "kind": "git",
-      "git": "git@github.com:mesosphere/mesos-overlay.git",
-      "ref" : "95f67bdb19f69dc352f64cee92947ca46f87fb8b",
+      "git": "git@github.com:asridharan/mesos-overlay.git",
+      "ref" : "80796b8ac934eeff1e1dec8eac0d597749895a3e",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos-overlay/buildinfo.json
+++ b/packages/mesos-overlay/buildinfo.json
@@ -1,0 +1,10 @@
+{
+  "requires": ["mesos"],
+    "docker": "dcos-builder",
+    "single_source" : {
+      "kind": "git",
+      "git": "git@github.com:mesosphere/mesos-overlay.git",
+      "ref" : "95f67bdb19f69dc352f64cee92947ca46f87fb8b",
+      "ref_origin": "master"
+    }
+}

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -62,6 +62,10 @@ disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
 
+#Create the master modules directory.
+mkdir -p "$PKG_PATH/etc/mesos-master-modules"
+
+
 # Copy the json file describing logrotate module.
 module_json="$PKG_PATH/etc/mesos-slave-modules/logrotate.json"
 mkdir -p "$(dirname "$module_json")"

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -11,6 +11,7 @@ pushd build
 # TODO(cmaloney): DESTDIR builds so we don't have to build as root?
 "/pkg/src/mesos/configure" \
   --prefix="$PKG_PATH" --enable-optimize --disable-python \
+  --enable-install-module-dependencies \
   --with-ssl=/opt/mesosphere/active/openssl \
   --with-libevent=/opt/mesosphere/active/libevent \
   --with-glog=/opt/mesosphere/active/mesos-buildenv \

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -65,7 +65,6 @@ chmod +x "$disk_resource_script"
 #Create the master modules directory.
 mkdir -p "$PKG_PATH/etc/mesos-master-modules"
 
-
 # Copy the json file describing logrotate module.
 module_json="$PKG_PATH/etc/mesos-slave-modules/logrotate.json"
 mkdir -p "$(dirname "$module_json")"

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -61,3 +61,8 @@ envsubst '$PKG_PATH' < /pkg/extra/dcos-vol-discovery-priv-agent.service > "$priv
 disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
+
+# Copy the json file describing logrotate module.
+module_json="$PKG_PATH/etc/mesos-slave-modules/logrotate.json"
+mkdir -p "$(dirname "$module_json")"
+cp /pkg/extra/logrotate.json "$module_json"

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -14,9 +14,6 @@ pushd build
   --enable-install-module-dependencies \
   --with-ssl=/opt/mesosphere/active/openssl \
   --with-libevent=/opt/mesosphere/active/libevent \
-  --with-glog=/opt/mesosphere/active/mesos-buildenv \
-  --with-protobuf=/opt/mesosphere/active/mesos-buildenv \
-  --with-boost=/opt/mesosphere/active/mesos-buildenv \
   --with-curl=/opt/mesosphere/active/curl \
   --sbindir="$PKG_PATH/bin"
 # TODO(cmaloney): -j8 is almost certainly wrong.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,9 +3,9 @@
   "docker": "dcos-builder",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/mesosphere/mesos",
-    "ref": "2c29b84425959538bbccdb6e76a4aad2e93153d9",
-    "ref_origin" : "dcos-pkg-builder-mesos-tag-1.0.0-rc1"
+    "git": "git@github.com:apache/mesos.git",
+    "ref": "408946fffa3b0158258e17561f7a3180549d2dd8",
+    "ref_origin" : "master"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -4,8 +4,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "76c87d55a78e8cbb380fc0c71388ccec53ed1dc8",
-    "ref_origin" : "dcos-1.7"
+    "ref": "dfe62665df67162e4c1064f524d6c0180100a9d2",
+    "ref_origin" : "1.0.0-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -4,8 +4,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "dfe62665df67162e4c1064f524d6c0180100a9d2",
-    "ref_origin" : "1.0.0-rc1"
+    "ref": "2c29b84425959538bbccdb6e76a4aad2e93153d9",
+    "ref_origin" : "dcos-pkg-builder-mesos-tag-1.0.0-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["mesos-buildenv", "openssl", "libevent", "curl"],
+  "requires": ["exhibitor", "openssl", "libevent", "curl"],
   "docker": "dcos-builder",
   "single_source" : {
     "kind": "git",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -11,6 +11,5 @@
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
   },
-  "username": "dcos_mesos",
   "state_directory": true
 }

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Mesos Master: DC/OS Mesos Master Service
 [Service]
-User=dcos_mesos
 Restart=always
 StartLimitInterval=0
 RestartSec=15

--- a/packages/mesos/extra/logrotate.json
+++ b/packages/mesos/extra/logrotate.json
@@ -1,0 +1,34 @@
+{
+  "libraries": [
+    {
+      "file": "/opt/mesosphere/lib/liblogrotate_container_logger.so",
+      "modules": [
+        {
+          "name": "org_apache_mesos_LogrotateContainerLogger",
+          "parameters": [
+            {
+              "key": "launcher_dir",
+              "value": "/opt/mesosphere/active/mesos/libexec/mesos/"
+            },
+            {
+              "key": "max_stdout_size",
+              "value": "2MB"
+            },
+            {
+              "key": "logrotate_stdout_options",
+              "value": "rotate 9"
+            },
+            {
+              "key": "max_stderr_size",
+              "value": "2MB"
+            },
+            {
+              "key": "logrotate_stderr_options",
+              "value": "rotate 9"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Updated Mesos release to 1.0.0-rc1 ([release notes](https://git-wip-us.apache.org/repos/asf?p=mesos.git;a=blob_plain;f=CHANGELOG;hb=1.0.0-rc1)).
* Removed mesos-buildenv package in lieu of `--enable-install-module-dependencies` flag.
* Replaced `--modules` flag for agent with `--modules_dir` (updated gen/calc.py accordingly).
* Update logrotate module to supply a json file for module manifest and install it in `/opt/mesosphere/etc/mesos-slave-modules` directory.