### PR TITLE
if CI_FLAGS is set, exit with code 0, since the CI should pick up the results and fail that way

### DIFF
--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -304,7 +304,7 @@ def main():
         test_util.test_runner.prepare_test_registry(
                 tunnel=test_host_tunnel,
                 test_dir=remote_dir)
-        test_util.test_runner.integration_test(
+        result = test_util.test_runner.integration_test(
                 tunnel=test_host_tunnel,
                 test_dir=remote_dir,
                 region=vpc.get_region() if vpc else DEFAULT_AWS_REGION,
@@ -323,11 +323,12 @@ def main():
     # TODO(cmaloney): add a `--healthcheck` option which runs dcos-diagnostics
     # on every host to see if they are working.
 
-    log.info("Test successsful!")
-    # Delete the cluster if all was successful to minimize potential costs.
-    # Failed clusters the hosts will continue running
-    if vpc is not None:
-        vpc.delete()
+    if result:
+        log.info("Test successsful!")
+        # Delete the cluster if all was successful to minimize potential costs.
+        # Failed clusters the hosts will continue running
+        if vpc is not None:
+            vpc.delete()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Exiting non-zero causes TeamCity to hard fail, even if the test which failed is muted.

This makes CI_FLAGS interpreted as a sign that we're running in a CI environment which understands
structured test results, and that the CI system will interpret failed test as a failed run.

So the new method is either "basic" environment where a non-zero exit indicates error, or
"everything ran successfully but some tests failed" indicated by test results being reported out and
the process exiting zero.