### PR TITLE
Remove teamcity-messages from code quality check

### DIFF
--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -684,7 +684,7 @@ def generate(
         if len(templates[key]) > 1 and not key.endswith('.yaml'):
             raise Exception(
                 "Internal Error: Only know how to merge YAML templates at this point in time. "
-                "Can't merge template {} in template_list {}".format(name, template_list))
+                "Can't merge template {} in template_list {}".format(name, templates[key]))
 
     mandatory_parameters = get_parameters(templates)
 

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -23,7 +23,7 @@ import gen.installer.util as util
 import pkgpanda
 import pkgpanda.build
 import pkgpanda.util
-
+import release.storage
 provider_names = ['aws', 'azure', 'bash']
 
 
@@ -433,7 +433,7 @@ def do_build_packages(cache_repository_url):
         # necessary.
         try:
             subprocess.check_call(['docker', 'push', container_name])
-        except CalledProcessError:
+        except subprocess.CalledProcessError:
             print("NOTICE: docker push of dcos-builder failed. This means it will be very difficult "
                   "for this build to be reproduced (others will have a different / non-identical "
                   "base docker for most packages.")
@@ -543,7 +543,7 @@ class ReleaseManager():
 
             # If read only wrap in the read_only proxy
             if read_only:
-                storage = ReadOnlyProxy(storage)
+                storage = release.storage.ReadOnlyProxy(storage)
 
             self.__storage_providers[name] = storage
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,10 @@ testpaths =
 [testenv:py34-syntax]
 deps =
   flake8
-  teamcity-messages
   isort
 
 commands =
-  flake8 --verbose {env:CI_FLAGS:} --exclude="packages/*/src,packages/*/result,packages/cache,.git" ./
+  flake8 --verbose --exclude="packages/*/src,packages/*/result,packages/cache,.git" ./
   isort --recursive --check-only --diff --verbose docker gen packages/dcos-history-service/extra pkgpanda pytest release ssh test_util
 
 [testenv:py34-unittests]


### PR DESCRIPTION
https://github.com/JetBrains/teamcity-messages/issues/103

Hopefully short term. It's nice to have these propogate up to the UI