### PR TITLE
Use hash instead of r_user@host:port for ctrl path

### DIFF
--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -40,7 +40,7 @@ class SSHTunnel():
             '/usr/bin/ssh',
             '-oConnectTimeout=10',
             '-oControlMaster=auto',
-            '-oControlPath={}/%r@%h:%p'.format(self.socket_dir),
+            '-oControlPath={}/%C'.format(self.socket_dir),
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
             '-oBatchMode=yes',


### PR DESCRIPTION
Otherwise path name will be too long for a unix socket