### PR TITLE
Allow setting provider in integration_test.py

### DIFF
--- a/test_util/integration_test.py
+++ b/test_util/integration_test.py
@@ -41,9 +41,12 @@ def cluster():
     assert 'SLAVE_HOSTS' in os.environ
     assert 'PUBLIC_SLAVE_HOSTS' in os.environ
     assert 'DNS_SEARCH' in os.environ
+    assert 'DCOS_PROVIDER' in os.environ
 
     # dns_search must be true or false (prevents misspellings)
     assert os.environ['DNS_SEARCH'] in ['true', 'false']
+
+    assert os.environ['DCOS_PROVIDER'] in ['onprem', 'aws', 'azure']
 
     _setup_logging()
 
@@ -53,7 +56,8 @@ def cluster():
                    slaves=os.environ['SLAVE_HOSTS'].split(','),
                    public_slaves=os.environ['PUBLIC_SLAVE_HOSTS'].split(','),
                    registry=os.environ['REGISTRY_HOST'],
-                   dns_search_set=os.environ['DNS_SEARCH'])
+                   dns_search_set=os.environ['DNS_SEARCH'],
+                   provider=os.environ['DCOS_PROVIDER'])
 
 
 @pytest.fixture(scope='module')
@@ -228,7 +232,7 @@ class Cluster:
         self.superuser_auth_cookie = r.cookies[
             'dcos-acs-auth-cookie']
 
-    def __init__(self, dcos_uri, masters, public_masters, slaves, public_slaves, registry, dns_search_set):
+    def __init__(self, dcos_uri, masters, public_masters, slaves, public_slaves, registry, dns_search_set, provider):
         """Proxy class for DC/OS clusters.
 
         Args:
@@ -240,6 +244,7 @@ class Cluster:
             registry: hostname or IP address of a private Docker registry.
             dns_search_set: string indicating that a DNS search domain is
                 configured if its value is "true".
+            provider: onprem, azure, or aws
         """
         self.masters = sorted(masters)
         self.public_masters = sorted(public_masters)
@@ -249,6 +254,7 @@ class Cluster:
         self.zk_hostports = ','.join(':'.join([host, '2181']) for host in self.public_masters)
         self.registry = registry
         self.dns_search_set = dns_search_set == 'true'
+        self.provider = provider
 
         assert len(self.masters) == len(self.public_masters)
 
@@ -1333,7 +1339,7 @@ sleep 3600
 
     # Generic properties which are the same between all tracks
     generic_properties = {
-        'provider': 'onprem',
+        'provider': cluster.provider,
         'source': 'cluster',
         'clusterId': 'test-id',
         'customerKey': '',

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -98,6 +98,7 @@ export REGISTRY_HOST=boot.dcos
 export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
 export DNS_SEARCH=true
 export DCOS_AUTH_ENABLED=false
+export DCOS_PROVIDER=onprem
 py.test -vv -s ${CI_FLAGS:-} /integration_test.py
 EOF
 cp $PWD/../../integration_test.py .

--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -313,6 +313,7 @@ def main():
                 agent_list=agent_list,
                 public_agent_list=public_agent_list,
                 variant=options.variant,
+                provider='onprem',
                 # Setting dns_search: mesos not currently supported in API
                 test_dns_search=not options.use_api,
                 ci_flags=options.ci_flags,

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -96,7 +96,7 @@ def prepare_test_registry(tunnel, test_dir):
 def integration_test(
         tunnel, test_dir,
         dcos_dns, master_list, agent_list, public_agent_list,
-        variant, test_dns_search, ci_flags, timeout=None,
+        variant, test_dns_search, provider, ci_flags, timeout=None,
         aws_access_key_id='', aws_secret_access_key='', region='', add_env=None):
     """Runs integration test on host
 
@@ -108,6 +108,7 @@ def integration_test(
         variant: 'ee' or 'default'
         test_dns_search: if set to True, test for deployed mesos DNS app
         ci_flags: optional additional string to be passed to test
+        provider: (str) either onprem, aws, or azure
         # The following variables correspond to currently disabled tests
         aws_access_key_id: needed for REXRAY tests
         aws_secret_access_key: needed for REXRAY tests
@@ -127,6 +128,7 @@ def integration_test(
         'PUBLIC_SLAVE_HOSTS='+','.join(public_agent_list),
         'REGISTRY_HOST=127.0.0.1',
         'DCOS_VARIANT='+variant,
+        'DCOS_PROVIDER='+provider,
         'DNS_SEARCH='+dns_search,
         'AWS_ACCESS_KEY_ID='+aws_access_key_id,
         'AWS_SECRET_ACCESS_KEY='+aws_secret_access_key,


### PR DESCRIPTION
Required for activating AWS and Azure integration testing