### PR TITLE
Added disk free check for /var/lib to check_all() function

### DIFF
--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -266,6 +266,17 @@ function check_all() {
     check_selinux
     check_sort_capability
 
+     # Check to see that the /var/lib partition has enough space
+    varFree=$(( $( df /var/lib | tail -1 | awk '{print $4}')/1024/1024 ))
+    varFreeInt=${varFree%.*}
+    if [ $varFreeInt -ge 20 ]; then
+        varFreeStatus="PASS"
+    else
+        varFreeStatus="FAIL"
+    fi
+    echo "/var has" $varFree "GB available" 
+    echo $varFreeStatus
+
     local docker_version=$(command -v docker >/dev/null 2>&1 && docker version 2>/dev/null | awk '
         BEGIN {
             version = 0


### PR DESCRIPTION
Added DF check for /var/lib to make sure that Agents have enough space to hold Docker images and Mesos Sandbox components. Note sure what the best number was to check for so I used relatively low (20 GB) but show the user what they have available.
