### PR TITLE
allow master and slave roles

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -413,7 +413,8 @@ def symlink_tree(src, dest):
             symlink_tree(src_path, dest_path)
         else:
             try:
-                os.symlink(src_path, dest_path)
+                if not os.path.exists(dest_path):
+                    os.symlink(src_path, dest_path)
             except FileNotFoundError as ex:
                 raise ConflictingFile(src_path, dest_path, ex) from ex
 


### PR DESCRIPTION
I'm not sure this is even something you'll want to do, but figured I submit this for clarification just the same.

When I run the install script, passing both master and slave as roles (multiple roles seems to be supported based on the script) I get the following error:

`sh /root/genconf/serve/dcos_install.sh master slave -d`

```
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: symlink_all(role_dir, new)
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/__init__.py", line 522, in symlink_all
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: symlink_tree(src, dest)
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: File "/opt/mesosphere/lib/python3.4/site-packages/pkgpanda/__init__.py", line 397, in symlink_tree
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: os.symlink(src_path, dest_path)
Jun 20 13:23:04 n7-z01-0a2a2202 pkgpanda[11654]: FileExistsError: [Errno 17] File exists: '/opt/mesosphere/packages/3dt--c3970af261c1e9ed9014904a6408617dafd41e6c/dcos.target.wants_master/dcos-ddt.service' -> '/etc/systemd/system/dcos.target.wants.new/dcos-ddt.service'
```

With this change, it avoids the error, and seems to allow both roles to be run. I'm super green to dcos, so I don't know how to validate this 100% just yet, but so far seems ok on my setup.