### PR TITLE
Make argument parsing be more direct / rely less on python run-time introspection

### DIFF
--- a/ext/dcos-installer/dcos_installer/action_lib/__init__.py
+++ b/ext/dcos-installer/dcos_installer/action_lib/__init__.py
@@ -61,7 +61,7 @@ def run_preflight(config, pf_script_path='/genconf/serve/dcos_install.sh', block
 
     preflight_chain = ssh.utils.CommandChain('preflight')
     # In web mode run if no --offline flag used.
-    if options.web:
+    if options.action == 'web':
         if options.offline:
             log.debug('Offline mode used. Do not install prerequisites on CentOS7, RHEL7 in web mode')
         else:

--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -50,7 +50,7 @@ def parse_args(args):
 Install Mesosophere's Data Center Operating System
 
 dcos_installer [-h] [-f LOG_FILE] [--hash-password HASH_PASSWORD] [-v]
-[--web | --genconf | --preflight | --deploy | --postflight | --uninstall | --validate-config]
+[--web | --genconf | --preflight | --deploy | --postflight | --uninstall | --validate-config | --version]
 
 Environment Settings:
 

--- a/ext/dcos-installer/dcos_installer/cli_dispatcher.py
+++ b/ext/dcos-installer/dcos_installer/cli_dispatcher.py
@@ -1,8 +1,11 @@
 import asyncio
 import coloredlogs
+import json
 import logging
+import os
 import sys
 
+import gen.calc
 from dcos_installer import async_server, action_lib, backend
 from dcos_installer.action_lib.prettyprint import print_header, PrettyPrint
 from dcos_installer.installer_analytics import InstallerAnalytics
@@ -100,9 +103,19 @@ def validate_ssh_config_or_exit():
         sys.exit(1)
 
 
+def do_version(args):
+    print(json.dumps(
+        {
+            'version': gen.calc.entry['must']['dcos_version'],
+            'variant': os.environ['BOOTSTRAP_VARIANT']},
+        indent=2, sort_keys=True))
+    return 0
+
+
 def do_web(args):
     print_header("Starting DC/OS installer in web mode")
     async_server.start(args)
+    return 0
 
 
 def do_validate_config(args):
@@ -150,6 +163,7 @@ def do_uninstall(args):
 
 
 dispatch_dict_simple = {
+    'version': (do_version, 'Print the DC/OS version'),
     'web': (do_web, 'Run the web interface'),
     'genconf': (do_genconf, 'Execute the configuration generation (genconf).'),
     'validate-config': (

--- a/pytest/test_installer_backend.py
+++ b/pytest/test_installer_backend.py
@@ -19,6 +19,15 @@ def test_password_hash():
     assert passlib.hash.sha512_crypt.verify(password, hash_pw), 'Hash does not match password'
 
 
+def test_version(monkeypatch):
+    monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
+    version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
+    assert json.loads(version_data) == {
+        'version': '1.8-dev',
+        'variant': 'some-variant'
+    }
+
+
 def test_good_create_config_from_post(tmpdir):
     """
     Test that it creates the config

--- a/pytest/test_installer_init.py
+++ b/pytest/test_installer_init.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dcos_installer import cli
 
 
@@ -5,14 +7,7 @@ def test_default_arg_parser():
     parser = cli.parse_args([])
     assert parser.verbose is False
     assert parser.port == 9000
-    assert parser.web is False
-    assert parser.genconf is False
-    assert parser.preflight is False
-    assert parser.deploy is False
-    assert parser.postflight is False
-    assert parser.validate_config is False
-    assert parser.test is False
-    assert parser.uninstall is False
+    assert parser.action is None
 
 
 def test_set_arg_parser():
@@ -20,18 +15,23 @@ def test_set_arg_parser():
     assert parser.verbose is True
     assert parser.port == 12345
     parser = cli.parse_args(['--web'])
-    assert parser.web is True
+    assert parser.action == 'web'
     parser = cli.parse_args(['--genconf'])
-    assert parser.genconf is True
+    assert parser.action == 'genconf'
     parser = cli.parse_args(['--preflight'])
-    assert parser.preflight is True
+    assert parser.action == 'preflight'
     parser = cli.parse_args(['--postflight'])
-    assert parser.postflight is True
+    assert parser.action == 'postflight'
     parser = cli.parse_args(['--deploy'])
-    assert parser.deploy is True
+    assert parser.action == 'deploy'
     parser = cli.parse_args(['--validate-config'])
-    assert parser.validate_config is True
-    parser = cli.parse_args(['--test'])
-    assert parser.test is True
+    assert parser.action == 'validate-config'
     parser = cli.parse_args(['--uninstall'])
-    assert parser.uninstall is True
+    assert parser.action == 'uninstall'
+    parser = cli.parse_args(['--hash-password', 'foo'])
+    assert parser.hash_password == 'foo'
+    assert parser.action is None
+
+    # Can't do two at once
+    with pytest.raises(SystemExit):
+        cli.parse_args(['--validate', '--hash-password', 'foo'])


### PR DESCRIPTION
Rather than do getattr() to see if the particular flag we want was set, followed by a dispatch into the local scope whatever has that name, instead add the argparse arguments, having them all set a '.action' ot the name of the option.

This fixes a couple things
 - Remove unimplemented `--test` flag
 - Remove default=False from store_true arguments
   `store_true` and `store_false` both default appropriately.
   See: https://docs.python.org/3/library/argparse.html
 - Write a single dispatch which does a simple dictionary lookup to figure out which to run.
 - Make it so that argparse building and dispatch can't get out of sync
 - Add a `--version` mode / flag