### PR TITLE
Instead of pyvenv command, invoke it as a module.

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 # Create a python virtual environment to install the DC/OS tools to
-pyvenv /tmp/dcos_build_venv
+python3 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools


### PR DESCRIPTION
Details of the bug are given here: DCOS-7837

The binary `pyvenv` is deprecated and  Python3.5 does not ship pyvenv. The correct way to use the module seems to be like `python -m venv`.

I installed Ubuntu 16.04, and it came with python3.5 by default, and it did not have the pyvenv command installed.

```
skumaran@hamming:~/workspace/dcos/dcos$ sudo ./build_local.sh 
+ set -o errexit -o pipefail
+ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+ rm -rf /tmp/dcos_build_venv
+ export PYTHONUNBUFFERED=notemtpy
+ PYTHONUNBUFFERED=notemtpy
+ '[' '!' -f dcos-release.config.yaml ']'
+ cat
+ pyvenv /tmp/dcos_build_venv
./build_local.sh: line 33: pyvenv: command not found
skumaran@hamming:~/workspace/dcos/dcos$ py
py3clean          pyclean           pydoc3            pygettext3        python2.7         python3.5         pyversions
py3compile        pycompile         pydoc3.5          pygettext3.5      python2.7-config  python3.5m        
py3versions       pydoc             pygettext         python            python2-config    python3m          
pybuild           pydoc2.7          pygettext2.7      python2           python3           python-config     
```


To show that `pyvenv` is equivalent to `python3 -m venv`, here is a simple demo.

```
skumaran@hamming:~/workspace/dcos/dcos$ python3 -m venv something
skumaran@hamming:~/workspace/dcos/dcos$ pwd
/home/skumaran/workspace/dcos/dcos
skumaran@hamming:~/workspace/dcos/dcos$ python3
Python 3.4.5rc1 (default, Jun 20 2016, 17:13:05) 
[GCC 5.3.1 20160413] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
skumaran@hamming:~/workspace/dcos/dcos$ cd something/
skumaran@hamming:~/workspace/dcos/dcos/something$ ls -a
.  ..  bin  include  lib  lib64  pyvenv.cfg
```

And [docs mention](https://docs.python.org/3/using/scripts.html) about their equivalence too