### PR TITLE
Update from Docker 1.11.0 to 1.11.2

### DIFF
--- a/gen/azure/cloud-config.yaml
+++ b/gen/azure/cloud-config.yaml
@@ -10,8 +10,8 @@ root:
       Environment=DEBIAN_FRONTEND=noninteractive
       StandardOutput=journal+console
       StandardError=journal+console
-      ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/d.deb https://az837203.vo.msecnd.net/dcos-deps/docker-engine_1.11.0-0~xenial_amd64.deb
-      ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /tmp/d.deb || ((try > 5));do echo retry $((try++));sleep 120;done;systemctl --now start docker"
+      ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/d.deb https://az837203.vo.msecnd.net/dcos-deps/docker-engine_1.11.2-0~xenial_amd64.deb
+      ExecStart=/usr/bin/bash -c "try=1;until dpkg -D3 -i /tmp/d.deb || ((try>9));do echo retry $((try++));sleep $((try*try));done;systemctl --now start docker;systemctl restart docker.socket"
   - path: /etc/systemd/system/docker.service.d/execstart.conf
     permissions: "0644"
     content: |
@@ -64,7 +64,8 @@ runcmd:
     - curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/1.deb https://az837203.vo.msecnd.net/dcos-deps/libipset3_6.29-1_amd64.deb
     - curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/2.deb https://az837203.vo.msecnd.net/dcos-deps/ipset_6.29-1_amd64.deb
     - curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/3.deb https://az837203.vo.msecnd.net/dcos-deps/unzip_6.0-20ubuntu1_amd64.deb
-    - bash -c "try=1;until dpkg -i /tmp/{1,2,3}.deb || ((try > 5));do echo retry \$((try++));sleep 120;done"
+    - curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/4.deb https://az837203.vo.msecnd.net/dcos-deps/libltdl7_2.4.6-0.1_amd64.deb
+    - bash -c "try=1;until dpkg -i /tmp/{1,2,3,4}.deb || ((try>9));do echo retry \$((try++));sleep \$((try*try));done"
     - [ cp, -p, /etc/resolv.conf, /tmp/resolv.conf ]
     - [ rm, -f, /etc/resolv.conf ]
     - [ cp, -p, /tmp/resolv.conf, /etc/resolv.conf ]


### PR DESCRIPTION
* Fixes Docker issue with latest Azure Ubuntu 16.04 LTS image
  (16.04.201606100) where the Docker daemon does not successfully start
  during DC/OS boot up, causing Mesos Agents to also fail to start
* Update to Docker 1.11.2 and add new docker dependency: libltdl7
* Various Docker bug fixes, see:
  https://github.com/docker/docker/releases
* Improve install times and protect against edge case of another process
  locking the package database by adding exponential backoff to dpkg
  install wrapper
* Restart docker.socket once docker.service is successfully started (a work around for Docker bug https://github.com/docker/docker/issues/18444)