### PR TITLE
Update DCOS to include latest Mesos 1.0.0 (pre-rc2)

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -76,14 +76,6 @@ def calculate_gen_resolvconf_search(dns_search):
         return ""
 
 
-def calculate_mesos_slave_modules_json(mesos_slave_modules):
-    # Ensure that this file is readable by humans by including newlines in the output.
-    json_multiline = json.dumps({"libraries": mesos_slave_modules}, indent=2)
-    # Preserve indentation in dcos-config.yaml's template by adding indentation to this content
-    injected_indent = 6 * ' '
-    return json_multiline.replace('\n', '\n' + injected_indent)
-
-
 def validate_telemetry_enabled(telemetry_enabled):
     can_be = ['true', 'false']
     assert telemetry_enabled in can_be, 'Must be one of {}. Got {}.'.format(can_be, telemetry_enabled)
@@ -244,23 +236,6 @@ def validate_os_type(os_type):
 
 
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
-__logrotate_slave_module = {
-    'file': '/opt/mesosphere/lib/liblogrotate_container_logger.so',
-    'modules': [{
-        'name': __logrotate_slave_module_name,
-        'parameters': [
-            {'key': 'launcher_dir', 'value': '/opt/mesosphere/active/mesos/libexec/mesos/'},
-            {'key': 'max_stdout_size', 'value': '2MB'},
-            {'key': 'logrotate_stdout_options', 'value': 'rotate 9'},
-            {'key': 'max_stderr_size', 'value': '2MB'},
-            {'key': 'logrotate_stderr_options', 'value': 'rotate 9'},
-        ]
-    }]
-}
-
-default_mesos_slave_modules = [
-    __logrotate_slave_module,
-]
 
 
 entry = {
@@ -326,8 +301,6 @@ entry = {
         'ui_external_links': 'false',
         'ui_networking': 'false',
         'ui_organization': 'false',
-        'mesos_slave_modules_json': calculate_mesos_slave_modules_json(
-            default_mesos_slave_modules),
         'minuteman_forward_metrics': 'false',
     },
     'conditional': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -100,15 +100,12 @@ package:
   - path: /etc/mesos-master-provider
     content: |
       MESOS_CLUSTER={{ cluster_name }}
-  - path: /etc/mesos-slave-modules.json
-    content: |
-      {{ mesos_slave_modules_json }}
   - path: /etc/mesos-slave-common
     content: |
       MESOS_MASTER=zk://leader.mesos:2181/mesos
       MESOS_CONTAINERIZERS=docker,mesos
       MESOS_LOG_DIR=/var/log/mesos
-      MESOS_MODULES=file:///opt/mesosphere/etc/mesos-slave-modules.json
+      MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
       MESOS_CONTAINER_LOGGER={{ mesos_container_logger }}
       MESOS_ISOLATION=cgroups/cpu,cgroups/mem,posix/disk
       MESOS_WORK_DIR=/var/lib/mesos/slave

--- a/packages/mesos-buildenv/build
+++ b/packages/mesos-buildenv/build
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -o nounset -o pipefail
-export MAKEFLAGS=-j8
-/pkg/src/mesos-buildenv/make_env $PKG_PATH

--- a/packages/mesos-buildenv/buildinfo.json
+++ b/packages/mesos-buildenv/buildinfo.json
@@ -1,8 +1,0 @@
-{
-  "single_source": {
-    "kind": "git",
-    "git": "https://github.com/dcos/mesos-buildenv.git",
-    "ref": "333a8528f29555b25f5942c4f79665f9e44fc0c1",
-    "ref_origin": "master"
-  }
-}

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -11,6 +11,7 @@ pushd build
 # TODO(cmaloney): DESTDIR builds so we don't have to build as root?
 "/pkg/src/mesos/configure" \
   --prefix="$PKG_PATH" --enable-optimize --disable-python \
+  --enable-install-module-dependencies \
   --with-ssl=/opt/mesosphere/active/openssl \
   --with-libevent=/opt/mesosphere/active/libevent \
   --with-glog=/opt/mesosphere/active/mesos-buildenv \

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -61,3 +61,8 @@ envsubst '$PKG_PATH' < /pkg/extra/dcos-vol-discovery-priv-agent.service > "$priv
 disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
+
+# Copy the json file describing logrotate module.
+module_json="$PKG_PATH/etc/mesos-slave-modules/logrotate.json"
+mkdir -p "$(dirname "$module_json")"
+cp /pkg/extra/logrotate.json "$module_json"

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -14,9 +14,6 @@ pushd build
   --enable-install-module-dependencies \
   --with-ssl=/opt/mesosphere/active/openssl \
   --with-libevent=/opt/mesosphere/active/libevent \
-  --with-glog=/opt/mesosphere/active/mesos-buildenv \
-  --with-protobuf=/opt/mesosphere/active/mesos-buildenv \
-  --with-boost=/opt/mesosphere/active/mesos-buildenv \
   --with-curl=/opt/mesosphere/active/curl \
   --sbindir="$PKG_PATH/bin"
 # TODO(cmaloney): -j8 is almost certainly wrong.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -4,8 +4,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "76c87d55a78e8cbb380fc0c71388ccec53ed1dc8",
-    "ref_origin" : "dcos-1.7"
+    "ref": "6aae23e9562ea98c815e92baa2a44f911cc0129c",
+    "ref_origin" : "dcos-mesos-1.0.0-master-455b6cd"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["mesos-buildenv", "openssl", "libevent", "curl"],
+  "requires": ["exhibitor", "openssl", "libevent", "curl"],
   "docker": "dcos-builder",
   "single_source" : {
     "kind": "git",

--- a/packages/mesos/extra/logrotate.json
+++ b/packages/mesos/extra/logrotate.json
@@ -1,0 +1,34 @@
+{
+  "libraries": [
+    {
+      "file": "/opt/mesosphere/lib/liblogrotate_container_logger.so",
+      "modules": [
+        {
+          "name": "org_apache_mesos_LogrotateContainerLogger",
+          "parameters": [
+            {
+              "key": "launcher_dir",
+              "value": "/opt/mesosphere/active/mesos/libexec/mesos/"
+            },
+            {
+              "key": "max_stdout_size",
+              "value": "2MB"
+            },
+            {
+              "key": "logrotate_stdout_options",
+              "value": "rotate 9"
+            },
+            {
+              "key": "max_stderr_size",
+              "value": "2MB"
+            },
+            {
+              "key": "logrotate_stderr_options",
+              "value": "rotate 9"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Also includes other Mesos-related changes
- Remove mesos-buildenv
- Use new modules_dir strategy