### PR TITLE
Make the public and private agent definitions listen to the `osImageV…

### DIFF
--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -1136,7 +1136,7 @@
               "publisher": "[variables('osImagePublisher')]",
               "offer": "[variables('osImageOffer')]",
               "sku": "[variables('osImageSKU')]",
-              "version": "latest"
+              "version": "[variables('osImageVersion')]"
             }
           },
           "osProfile": {
@@ -1271,7 +1271,7 @@
               "publisher": "[variables('osImagePublisher')]",
               "offer": "[variables('osImageOffer')]",
               "sku": "[variables('osImageSKU')]",
-              "version": "latest"
+              "version": "[variables('osImageVersion')]"
             }
           },
           "osProfile": {


### PR DESCRIPTION
…ersion` variable

I've been using the azure template generated from this template, and it doesn't allow me to pin the os version for anything but the master.