### PR TITLE
Get proxy settings for OAuth service

### DIFF
--- a/packages/dcos-oauth/extra/dcos-oauth.service
+++ b/packages/dcos-oauth/extra/dcos-oauth.service
@@ -7,6 +7,7 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=-/var/lib/dcos/environment.proxy
 EnvironmentFile=/opt/mesosphere/etc/dcos-oauth.env
 ExecStartPre=/opt/mesosphere/bin/exhibitor_wait.py
 ExecStartPre=/opt/mesosphere/bin/dcos-oauth-setup.py


### PR DESCRIPTION
Cosmos service already uses `/var/lib/dcos/environment.proxy` for proxy settings. It would be good to use that for OAuth service as well instead of users having to edit other environment files