### PR TITLE
add snapshot size

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -4,7 +4,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "b45a3e838374bfd6ce6a8795adfd83c6347c5818",
+    "ref": "21b1a229900129019f7b2c83b4ecc21ce937a26f",
     "ref_origin": "master"
   },
   "username": "dcos_3dt",

--- a/test_util/integration_test.py
+++ b/test_util/integration_test.py
@@ -1435,7 +1435,7 @@ def _get_snapshot_list(cluster):
     for _, snapshot_list in response.items():
         if snapshot_list is not None and isinstance(snapshot_list, list) and len(snapshot_list) > 0:
             # append snapshots and get just the filename.
-            snapshots += map(lambda s: os.path.basename(s), snapshot_list)
+            snapshots += map(lambda s: os.path.basename(s['file_name']), snapshot_list)
     return snapshots
 
 


### PR DESCRIPTION
API should return snapshot file name along with its size. This will allow
to warn a user if snapshot file is too big.
https://github.com/dcos/3dt/pull/42