### PR TITLE
Update IAM to allow Cloudwatch stats publishing

### DIFF
--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -149,7 +149,9 @@
                     "ec2:CopySnapshot",
                     "ec2:DeleteSnapshot",
                     "ec2:DescribeSnapshots",
-                    "ec2:DescribeSnapshotAttribute"
+                    "ec2:DescribeSnapshotAttribute",
+                    "autoscaling:DescribeAutoScalingGroups",
+                    "cloudwatch:PutMetricData"
                   ],
                   "Effect": "Allow"
                 }

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -138,7 +138,9 @@
                   "ec2:CopySnapshot",
                   "ec2:DeleteSnapshot",
                   "ec2:DescribeSnapshots",
-                  "ec2:DescribeSnapshotAttribute"
+                  "ec2:DescribeSnapshotAttribute",
+                  "autoscaling:DescribeAutoScalingGroups",
+                  "cloudwatch:PutMetricData"
                 ],
                 "Effect": "Allow"
               }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -519,7 +519,9 @@
                 "ec2:CopySnapshot",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeSnapshotAttribute"
+                "ec2:DescribeSnapshotAttribute",
+                "autoscaling:DescribeAutoScalingGroups",
+                "cloudwatch:PutMetricData"
               ],
               "Effect": "Allow"
             }


### PR DESCRIPTION
These changes make it possible for cloudwatch stats to be published by agents on the cluster. Specifically, allow cloudwatch:PutMetricData and autoscaling:DescribeAutoScalingGroups from the agents.