### PR TITLE
Revert "Remove teamcity-messages from code quality check"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,11 @@ testpaths =
 [testenv:py34-syntax]
 deps =
   flake8
+  teamcity-messages
   isort
 
 commands =
-  flake8 --verbose --exclude="packages/*/src,packages/*/result,packages/cache,.git" ./
+  flake8 --verbose {env:CI_FLAGS:} --exclude="packages/*/src,packages/*/result,packages/cache,.git" ./
   isort --recursive --check-only --diff --verbose docker gen packages/dcos-history/extra pkgpanda pytest release ssh test_util
 
 [testenv:py34-unittests]


### PR DESCRIPTION
This reverts commit 1db7c13d56be01031dae7ed5cfff320165841cb3.

Should work now that https://github.com/JetBrains/teamcity-messages/pull/104 has landed.