### PR TITLE
WIP: `dcos launch`, GCE backed integration test clusters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+deployment: cody-test
+project: inbound-bee-664
+num_agent: 1
+num_agent_public: 1

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'botocore',
         'coloredlogs',
         'docopt',
+        'google-api-python-client',
         'passlib',
         'pyyaml',
         'requests',
@@ -52,6 +53,7 @@ setup(
     entry_points={
         'console_scripts': [
             'release=release:main',
+            'dcos-launch=test_util.launch:main',
             'ccm-deploy-test=test_util.test_installer_ccm:main',
             'pkgpanda=pkgpanda.cli:main',
             'mkpanda=pkgpanda.build.cli:main',

--- a/test_util/gce/__init__.py
+++ b/test_util/gce/__init__.py
@@ -1,0 +1,121 @@
+import logging
+import pkg_resources
+
+from oauth2client.service_account import ServiceAccountCredentials
+from googleapiclient import discovery
+from retrying import retry
+
+from test_util.installer_runner import Host
+
+log = logging.getLogger(__name__)
+
+
+def get_deployment_imports():
+    imports = []
+    for filename in ['centos7_cluster.jinja', 'centos7_cluster.jinja.schema']:
+        imports.append({
+            "content": pkg_resources.resource_string('test_util', 'gce/' + filename).decode(),
+            "name": filename})
+
+    return imports
+
+
+# NOTE: this actually condenses a "launcher" and "cluster state" mechanism into one class. They should
+# be two.
+class GceVpc():
+    def __init__(self, deployment, description, project, zone, credentials_filename):
+        self.deployment = deployment
+        self.description = description
+        self.project = project
+        self.zone = zone
+        self.credentials = ServiceAccountCredentials.from_json_keyfile_name(
+            credentials_filename,
+            scopes='https://www.googleapis.com/auth/cloud-platform')
+        self._compute = discovery.build('compute', 'v1', credentials=self.credentials)
+        self._dm = discovery.build('deploymentmanager', 'v2', credentials=self.credentials)
+
+    def get_state(self):
+        return self._dm.deployments().get(project=self.project, deployment=self.deployment).execute()
+
+    def launch(self, instance_count):
+        deployment_api = self._dm.deployments()
+        deployment_api.insert(
+            project=self.project,
+            body={
+                'name': self.deployment,
+                'description': self.description,
+                'target': {
+                    'imports': get_deployment_imports(),
+                    'config': {
+                        'content': pkg_resources.resource_string('test_util', 'gce/config.yaml').decode().format(
+                            instance_count=instance_count)
+                    }
+                }
+            }).execute()
+
+    def delete(self):
+        return self._dm.deployments().delete(project=self.project, deployment=self.deployment).execute()
+
+    def wait_for_done(self):
+        # Poll every 5 seconds
+        @retry(wait_fixed=5000, retry_on_result=lambda x: x is False, retry_on_exception=lambda _: False)
+        def poller():
+            state = self.get_state()
+            logging.info('Waiting for up. current status: %s, progress %s',
+                         state['operation']['status'], state['operation']['progress'])
+            return state['operation']['status'] == 'DONE'
+
+        poller()
+
+    def get_ips(self):
+        resource_list = self._dm.resources().list(project=self.project, deployment=self.deployment).execute()
+
+        # Get the instance group
+        instance_group = None
+        for resource in resource_list['resources']:
+            if resource['type'] == 'compute.v1.instanceGroupManager':
+                instance_group = resource
+                break
+
+        # Get the instance IPs
+        instances = self._compute.instanceGroupManagers().listManagedInstances(
+            project=self.project,
+            zone=self.zone,
+            instanceGroupManager=instance_group['name']).execute()
+
+        hosts = []
+        ci_api = self._compute.instances()
+        for instance in instances['managedInstances']:
+            # Because Google doesn't give direct access to the instance name from a managed group...
+            name = instance['instance'].rsplit('/', 1)[1]
+            instance = ci_api.get(project=self.project, zone=self.zone, instance=name).execute()
+            assert len(instance['networkInterfaces']) == 1
+            interface = instance['networkInterfaces'][0]
+            internal_ip = interface['networkIP']
+            assert len(interface['accessConfigs']) == 1
+            external_ip = interface['accessConfigs'][0]['natIP']
+            hosts.append(Host(internal_ip, external_ip))
+
+        return hosts
+
+    def hosts(self):
+        return self.get_ips()
+
+
+def make_vpc(unique_cluster_id, use_bare_os):
+    assert use_bare_os is True, "use_bare_os True is the only supported option currently."
+
+    log.info("Spinning up GCE VPC via Google Deployment Manager with ID: %s", unique_cluster_id)
+
+    vpc = GceVpc(
+        deployment=unique_cluster_id,
+        description='VPC based Integration Test',
+        project='inbound-bee-664',
+        zone='us-central-1b',
+        credentials_filename='gce-credentials.json')
+    vpc.launch(5)  # 1 bootstrap, 1 master, 2 agents, 1 public agent
+
+    return {
+        'ssh_user': 'ops_shared',
+        'ssh_key_path': 'ssh_key'
+    }, vpc

--- a/test_util/gce/centos7_cluster.jinja
+++ b/test_util/gce/centos7_cluster.jinja
@@ -1,0 +1,80 @@
+# Make a network / VPC which contains the set of instances. All instances are
+# inside one instance group for this template (raw host installs)
+{% set NETWORK = env["deployment"] + "-network" %}
+{% set INSTANCE_TEMPLATE = env["deployment"] + "-instance-template" %}
+resources:
+# Network
+# - Allows Mesosphere office inbound
+# - Allows all internal traffic
+# - Doesn't allow general internet to access
+- name: {{ NETWORK }}
+  type: compute.v1.network
+  properties:
+    IPv4Range: "10.240.0.0/16"
+- name: {{ NETWORK }}-allow-office
+  type: compute.v1.firewall
+  properties:
+    network: $(ref.{{ NETWORK }}.selfLink)
+    allowed:
+     - IPProtocol: tcp
+       ports:
+        - 22
+        - 80
+        - 443
+     # - IPProtocol: udp
+     # - IPProtocol: icmp
+    sourceRanges:
+     - 0.0.0.0/0
+     # - 12.161.175.2/32
+     # - 199.116.75.18/32
+     # - 212.53.142.20/32
+     # - 192.195.82.206/32
+     # TODO / TEMP: Cody's home IP
+     # - 67.180.197.95/32
+- name: {{ NETWORK }}-internal
+  type: compute.v1.firewall
+  properties:
+    network: $(ref.{{ NETWORK }}.selfLink)
+    allowed:
+     - IPProtocol: tcp
+     - IPProtocol: udp
+     - IPProtocol: icmp
+    sourceRanges:
+     - 10.240.0.0/16
+
+# VMs
+# One pool of machines, all reasonable sized
+- name: {{ INSTANCE_TEMPLATE }}
+  type: compute.v1.instanceTemplate
+  properties:
+    zone: us-central1-b
+    properties:
+      machineType: n1-standard-4
+      networkInterfaces:
+        - network: $(ref.{{ NETWORK }}.selfLink)
+          # Make instances accessible without `gcloud ssh`
+          accessConfigs:
+           - name: external-nat
+             type: ONE_TO_ONE_NAT
+      scheduling:
+        onHostMaintenance: MIGRATE
+      serviceAccounts:
+        - scopes:
+          - https://www.googleapis.com/auth/devstorage.read_only
+          - https://www.googleapis.com/auth/logging.write
+      disks:
+        - deviceName: boot
+          type: PERSISTENT
+          boot: true
+          autoDelete: true
+          initializeParams:
+            sourceImage: https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160606
+            diskSizeGb: 128
+            diskType: pd-standard
+- name: {{ env["deployment"] + "-instance-group" }}
+  type: compute.v1.instanceGroupManager
+  properties:
+    baseInstanceName: {{ env["deployment"] }}-vms
+    instanceTemplate: $(ref.{{ INSTANCE_TEMPLATE }}.selfLink)
+    targetSize: {{ properties['instanceCount'] }}
+    zone: us-central1-b

--- a/test_util/gce/centos7_cluster.jinja.schema
+++ b/test_util/gce/centos7_cluster.jinja.schema
@@ -1,0 +1,14 @@
+info:
+  title: CentOS 7 installed in a isolated network with public and private IPs
+  author: Cody Maloney
+  version: 0.1
+imports:
+ - path: centos7_cluster.jinja
+required:
+  - instanceCount
+properties:
+  instanceCount:
+    type: integer
+    default: 5
+    description: Number of machines to launch
+    minimum: 1

--- a/test_util/gce/config.yaml
+++ b/test_util/gce/config.yaml
@@ -1,0 +1,8 @@
+imports:
+  - path: centos7_cluster.jinja
+
+resources:
+  - type: centos7_cluster.jinja
+    name: centos-7-cluster
+    properties:
+      instanceCount: {instance_count}

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -1,0 +1,98 @@
+"""Launch a cluster of hosts
+
+Usage:
+    dcos-launch [--config=config.yaml]
+    # gce <num_hosts> <path_to_dcos_generate_config>
+    # dcos-launch aws
+    #     vpc
+    # dcos-launch ccm vpc
+    # dcos-launch vpc {ccm,aws,gce,vagrant} {num_hosts}
+    # dcos-launch cloudformation
+    # dcos-launch
+    # dcos-launch connect <config.yaml> # {ccm,aws,gce,vagrant}
+    # dcos-launch <aws> <vpc>
+    # dcos-launch <vpc> <aws>
+    # Build up an index of "launchables"?
+    # - Can then compose into things which take that API shape?
+"""
+import argparse
+import sys
+
+import yaml
+
+from test_util.gce import GceVpc
+from test_util.installer_runner import do_install
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Launches a DC/OS cluster using the specified config')
+    parser.add_argument('--config', default='config.yaml')
+
+    arguments = parser.parse_args()
+
+    with open(arguments.config, 'r') as config_file:
+        config = yaml.load(config_file)
+
+    vpc = GceVpc(
+        deployment=config['deployment'],
+        description=config.get('description', 'DC/OS Dev Testing'),
+        project=config['project'],
+        zone=config.get('zone', 'us-central1-b'),
+        credentials_filename=config.get('credentials_filename', 'gce-credentials.json'))
+
+    num_master = config.get('num_master', 1)
+    num_agent = config.get('num_agent', 3)
+    num_agent_public = config.get('num_agent_public', 1)
+
+    # Test host + all other hosts
+    host_count = 1 + num_master + num_agent + num_agent_public
+    vpc.launch(host_count)
+    vpc.wait_for_done()
+
+    hosts = vpc.get_ips()
+    test_host = hosts.pop()
+    master_list = [hosts.pop() for i in range(num_master)]
+    agent_list = [hosts.pop() for i in range(num_agent)]
+    public_agent_list = [hosts.pop() for i in range(num_agent_public)]
+
+    try:
+        do_install(
+            installer_url=config.get('installer_url', 'https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh'),
+            ssh_user='ops_shared',
+            ssh_key_path='/Users/codymaloney/.ssh/mesosphere_shared',
+            test_host=test_host,
+            master_list=master_list,
+            agent_list=agent_list,
+            public_agent_list=public_agent_list,
+            method='ssh',  # TODO(cmaloney): MAke configurable
+            install_prereqs=True,
+            do_setup=True,
+            remote_dir='/home/centos',
+            add_config_path=None,
+            stop_after_prereqs=False,
+            run_test=True,
+            aws_region=None,
+            dcos_variant='',
+            provider='onprem',
+            ci_flags=None,
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            add_env={})
+    except Exception as ex:
+        print("ERROR: {}".format(ex))
+        try:
+            while True:
+                choice = input("Delete cluster [yes/No]:").lower()
+                if 'yes'.startswith(choice):
+                    vpc.delete()
+                    break
+                if 'no'.startswith(choice) or choice == '':
+                    break
+        except KeyboardInterrupt as ex:
+            pass
+        except Exception as ex:
+            print("ERROR while getting input: {}".format(ex))
+        sys.exit(1)
+
+    sys.exit(0)
+


### PR DESCRIPTION
This is _very_ in progress. 

Adds a `dcos launch` command which (in theory) can launch a isolated network / VPC with hosts in it inside GCE using Deployment Manager.

That same bit of functionality is also applied to the integration tests, which are now able to (hopefully) be launched on top of GCE (With lots of TeamCity tweaks to make everything happy).

Likely the bits that aren't `dcos launch` which are a core for running the integration tests on a GCE VPC will be pulled out and landed as one bit, enabling quite a bit faster integration tests in GCE (Instances just start a whole lot quicker).