### PR TITLE
No JSON for --version

### DIFF
--- a/ext/dcos-installer/dcos_installer/cli_dispatcher.py
+++ b/ext/dcos-installer/dcos_installer/cli_dispatcher.py
@@ -104,11 +104,8 @@ def validate_ssh_config_or_exit():
 
 
 def do_version(args):
-    print(json.dumps(
-        {
-            'version': gen.calc.entry['must']['dcos_version'],
-            'variant': os.environ['BOOTSTRAP_VARIANT']},
-        indent=2, sort_keys=True))
+    print("version: ", gen.calc.entry['must']['dcos_version'])
+    print("variant: ", os.environ['BOOTSTRAP_VARIANT']})
     return 0
 
 

--- a/ext/dcos-installer/dcos_installer/cli_dispatcher.py
+++ b/ext/dcos-installer/dcos_installer/cli_dispatcher.py
@@ -104,8 +104,8 @@ def validate_ssh_config_or_exit():
 
 
 def do_version(args):
-    print("version: ", gen.calc.entry['must']['dcos_version'])
-    print("variant: ", "open" if os.environ['BOOTSTRAP_VARIANT'] is None else os.environ['BOOTSTRAP_VARIANT'])
+    print("Version: ", gen.calc.entry['must']['dcos_version'])
+    print("Distro: ", "open" if os.environ['BOOTSTRAP_VARIANT'] is None else 'enterprise')
     return 0
 
 

--- a/ext/dcos-installer/dcos_installer/cli_dispatcher.py
+++ b/ext/dcos-installer/dcos_installer/cli_dispatcher.py
@@ -105,7 +105,7 @@ def validate_ssh_config_or_exit():
 
 def do_version(args):
     print("version: ", gen.calc.entry['must']['dcos_version'])
-    print("variant: ", os.environ['BOOTSTRAP_VARIANT']})
+    print("variant: ", "open" if os.environ['BOOTSTRAP_VARIANT'] is None else os.environ['BOOTSTRAP_VARIANT'])
     return 0
 
 


### PR DESCRIPTION
Do not use JSON output for a utility whose primary purpose is to print to STDOUT. This makes it difficult to parse in the shell.