### PR TITLE
add group to make 3dt read journal

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -8,5 +8,6 @@
     "ref_origin": "master"
   },
   "username": "dcos_3dt",
+  "group": "systemd-journal",
   "state_directory": true
 }

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1,4 +1,5 @@
 import collections
+import gzip
 import json
 import logging
 import os
@@ -1725,6 +1726,16 @@ def test_3dt_bundle_create(cluster):
     assert bundles[0] == response['extra']['bundle_name']
 
 
+def verify_unit_response(zip_ext_file):
+    assert isinstance(zip_ext_file, zipfile.ZipExtFile)
+    unit_output = gzip.decompress(zip_ext_file.read())
+
+    # TODO: This seems like a really fragile string to be searching for. This might need to be changed for
+    # different localizations.
+    assert 'Hint: You are currently not seeing messages from other users and the system' not in str(unit_output), (
+        '3dt does not have permission to run `journalctl`')
+
+
 def test_3dt_bundle_download_and_extract(cluster):
     """
     test bundle download and validate zip file
@@ -1769,6 +1780,10 @@ def test_3dt_bundle_download_and_extract(cluster):
                 assert 'ip' in health_report
                 assert health_report['ip'] == master_ip
 
+                # make sure systemd unit output is correct and does not contain error message
+                gzipped_unit_output = z.open(master_folder + 'dcos-mesos-master.service.gz')
+                verify_unit_response(gzipped_unit_output)
+
                 for expected_master_file in expected_master_files:
                     expected_file = master_folder + expected_master_file
                     assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
@@ -1782,6 +1797,10 @@ def test_3dt_bundle_download_and_extract(cluster):
                 assert 'ip' in health_report
                 assert health_report['ip'] == slave_ip
 
+                # make sure systemd unit output is correct and does not contain error message
+                gzipped_unit_output = z.open(agent_folder + 'dcos-mesos-slave.service.gz')
+                verify_unit_response(gzipped_unit_output)
+
                 for expected_agent_file in expected_agent_files:
                     expected_file = agent_folder + expected_agent_file
                     assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
@@ -1794,6 +1813,10 @@ def test_3dt_bundle_download_and_extract(cluster):
                 health_report = json.loads(z.read(agent_public_folder + '3dt-health.json').decode())
                 assert 'ip' in health_report
                 assert health_report['ip'] == public_slave_ip
+
+                # make sure systemd unit output is correct and does not contain error message
+                gzipped_unit_output = z.open(agent_public_folder + 'dcos-mesos-slave-public.service.gz')
+                verify_unit_response(gzipped_unit_output)
 
                 for expected_public_agent_file in expected_public_agent_files:
                     expected_file = agent_public_folder + expected_public_agent_file

--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -858,6 +858,18 @@ def build(package_store, name, variant, clean_after_build, recursive=False):
             raise BuildError("username in buildinfo.json didn't meet the validation rules. {}".format(ex))
         pkginfo['username'] = username
 
+    group = None
+    if builder.has('group'):
+        group = builder.take('group')
+        if not isinstance(group, str):
+            raise BuildError("group in buildinfo.json must be either not set (use default group for this user)"
+                             ", or group must be a string")
+        try:
+            pkgpanda.UserManagement.validate_group_name(group)
+        except ValidationError as ex:
+            raise BuildError("group in buildinfo.json didn't meet the validation rules. {}".format(ex))
+        pkginfo['group'] = group
+
     # Packages need directories inside the fake install root (otherwise docker
     # will try making the directories on a readonly filesystem), so build the
     # install root now, and make the package directories in it as we go.

--- a/pkgpanda/tests/test_util.py
+++ b/pkgpanda/tests/test_util.py
@@ -42,3 +42,11 @@ def test_validate_username():
     bad('dcos_foo:bar')
     bad('3dcos_foobar')
     bad('dcos3_foobar')
+
+
+def test_validate_group():
+    # assuming linux distributions have `root` group.
+    UserManagement.validate_group('root')
+
+    with pytest.raises(ValidationError):
+        UserManagement.validate_group('group-should-not-exist')


### PR DESCRIPTION
3dt needs to read the journal. In order to do that it needs to be in
systemd-journal group. The issue is that coreos uses several backends for
users and groups. One is a regular /etc/passwd, /etc/groups and the other is
located under /usr/share/baselayout. If we try to append dcos_3dt user with
flag -G this will not work. (Tested on CoreOS beta (1068.3.0))
This seems to be a long running issue with CoreOS
https://github.com/coreos/bugs/issues/312
However if we try to change a user's primary group with -g flag all works
as expected.