### PR TITLE
navstar: Cache bouncer users/groups/permissions [WIP]

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -3,9 +3,9 @@
   "sources": {
     "navstar": {
       "kind": "git",
-      "git": "https://github.com/dcos/navstar.git",
-      "ref": "8c308048dc119c149a87ee8f4c63029693495838",
-      "ref_origin": "master"
+      "git": "https://github.com/nlsun/navstar.git",
+      "ref": "5eeb53d5cb86a1dcf00b3b40965ccc89035c2d05",
+      "ref_origin": "bouncer"
     }
   }
 }


### PR DESCRIPTION
The purpose is to raise the availability of bouncer by reducing the
load on the actual bouncer instance and having a local copy at hand
in the event of a network partition.