### PR TITLE
pkgpanda documentation improvements.

### DIFF
--- a/pkgpanda/README.md
+++ b/pkgpanda/README.md
@@ -1,11 +1,14 @@
 # Pkgpanda
 
-Manages the collection of DC/OS components on the host system.
+`pkgpanda` manages the collection of DC/OS components on the host system.
 
-Most DC/OS components ship inside Docker containers for ease of deployment. Some, however, we need to not ship inside of containers because they are hostile to containers, or because the host OS we are integrating with needs tighter coupling with them (systemd unit files, mesos-{master, slave}, mesos modules, mesos config, java, python, etc).
+Most DC/OS components ship inside Docker containers for ease of deployment. Some, however, need not ship inside of
+containers because they are hostile to containers, or because the host OS we are integrating with needs tighter
+coupling with those components. Examples of those components include `systemd unit files`, `mesos-master`,
+`mesos-slave` modules,` mesos` config,  `java` and `python` language runtime, etc.
 
-Pkgpanda allows for having multiple versions of every component present on a host, and then can select a subset of those
-which are currently active.
+`pkgpanda` allows for having multiple versions of every component present on a host, mark certain versions of those
+components as active, and then select a subset of currently active components.
 
 ## Documentation
 

--- a/pkgpanda/docs/activating.md
+++ b/pkgpanda/docs/activating.md
@@ -1,11 +1,13 @@
-# Activating Packages `pkgpanda activate`
+# Activating Packages
 
-The list if currently active packages is stored in 'active.json' inside of INSTALL_ROOT.
+`pkgpanda activate <id>... [options]` will activate the list of package ids in the command line.
 
-active.json is swapped out when old packages are disabled and new ones are
-enabled.
+The list of currently active packages is stored in `active.json` inside of `INSTALL_ROOT`. The `active.json` is swapped
+out when old packages are disabled and new ones are enabled.
 
-TODO(cmaloney): Define the requirements for a system image / how things are loaded. Ex:
+*TODO(cmaloney): Define the requirements for a system image / how things are loaded.*
+
+Ex:
 
 ```
 mesos-slave.service must
@@ -16,28 +18,28 @@ EnvironmentFile=/opt/mesosphere/config/mesos-slave-config
 ## Activating new packages
 
 1. Validate new list of packages to activate has no conflicts
-   - No conflicting provides
-   - No conflicting systemd names
-   - No conflicting executable names
-   - No conflicting environment variables
-1. Archive old packages
-   - mv active.json active.json.old
-   - rm -rf INSTALL_ROOT/bin INSTALL_ROOT/systemd INSTALL_ROOT/environment INSTALL_ROOT/config
-1. Write new active manifest to active.json.new
-1. Install new package config
-  - Symlink binaries for every pacakge into INSTALL_ROOT/bin
-  - Symlink config for each package into INSTALL_ROOT/config/{provides}/
-  - Aggregate environment variables to INSTALL_ROOT/environment
-1. Enable everthing in systemd
+    - No conflicting provides
+    - No conflicting `systemd` names
+    - No conflicting executable names
+    - No conflicting environment variables
+2. Archive old packages
+    - `mv active.json active.json.old`
+    - `rm -rf INSTALL_ROOT/bin INSTALL_ROOT/systemd INSTALL_ROOT/environment INSTALL_ROOT/config`
+3. Write new active manifest to `active.json.new`
+4. Install new package config
+    - Symlink binaries for every package into `INSTALL_ROOT/bin`
+    - Symlink config for each package into `INSTALL_ROOT/config/{provides}/`
+    - Aggregate environment variables to `INSTALL_ROOT/environment`
+5. Enable everything in `systemd`
 
 Note: Starting/stopping services is the job of the restart helper or rebooting the machine.
 
-First active.json is moved to active.json.old, then all of the old
-packages have their symlinks removed (INSTALL_ROOT/bin, INSTALL_ROOT/systemd,
-  INSTALL_ROOT/environment, INSTALL_ROOT/config).
+First `active.json` is moved to `active.json.old`, then all of the old packages have their symlinks removed
+in `INSTALL_ROOT/bin`, `INSTALL_ROOT/systemd`, `INSTALL_ROOT/environment` and `INSTALL_ROOT/config`.
 
 
 ## Sample active.json
+
 ```
 [
   "mesos--0.22.0",

--- a/pkgpanda/docs/architecture.md
+++ b/pkgpanda/docs/architecture.md
@@ -1,29 +1,64 @@
 # Architecture of getting dcos bits to machines
 
-*DC/OS CLI*: Issue commands to control the cluster
- - dcos install module
- - dcos upgrade mesos {target-version}
- - dcos slave remove
- - dcos slave add
+**DC/OS CLI**
 
-**Deploy Module**: Perform tasks/call endpoints on every machine, query machine state to determine deployment status. Aggregates status pings from the Restart Helper to monitor rollout progress / provide better insights. Has an endpoint `halt` which can have HTTP requests made to it by any sort of SLA monitoring setup an organization has in order to stop the deploy  module from taking further action without explicit clearing from and admin.
+Issue commands to control the cluster
 
-**Package Manager (CLI + Module)**: Local on every node in the mesos cluster. Coordinates adding/removing state blobs (Packages), Validating state transitions (Always must have one mesos active, one mesos config active, n modules, etc), listing what packages are available/cached locally.  This is a library for managing the packages + file system layout which is well defined. Optionally pings caller on completion. (Can also be scraped to check state).
+* `dcos install module`
+* `dcos upgrade mesos {target-version}`
+* `dcos slave remove`
+* `dcos slave add`
 
-*CLI*: Local command line version of package manager used for bootstrapping / operating when a mesos isn’t running. Localhost only.
+**Deploy Module**
 
-*Module*: Collection of mesos endpoints for fetching / removing packages from the local filesystem. List the current “active” set of modules.
+Performs tasks or calls endpoints on every machine, it used to query machine state to determine deployment status.
+Aggregates status pings from the Restart Helper to monitor progress / provide better insights. Has an endpoint `halt`
+which can have HTTP requests made to it by any sort of SLA monitoring setup an organization has in order to stop the
+deploy module from taking further action without explicit clearing from and admin.
 
-**Package Repository**: Web server serving package tarballs. Accessible from all nodes in the cluster. Could be s3, nginx, etc. Doesn’t matter. I just have to be able to use mesos fetcher, curl, or some equivalent to get data from it.
+**Package Manager (CLI + Module)**
 
-**Restart (Module + Helper)**:
+Local on every node in the mesos cluster. Coordinates adding/removing state blobs (Packages), Validating state
+transitions (Always must have one mesos active, one mesos config active, n modules, etc), listing what packages are
+available/cached locally.  This is a library for managing the packages + file system layout which is well defined.
+Optionally pings caller on completion. (Can also be scraped to check state).
 
-*Module*: Restarts mesos, switching from the running set of packages to the specified set of packages. All packages must be local before restart is called. Uses the Restart Helper to ensure mesos comes up cleanly.
+* **CLI**
 
-*Helper*: Helper binary which lives next to mesos. Stops mesos, then swaps out the active modules using the package cli. Starts up mesos, watching to see if it comes up cleanly. If it doesn’t, tries to roll back. On all events / status changes it pings the Deploy Module so that the deploy module can track the status. If a status ping fails, the deploy module needs.
+    Local command line version of package manager used for bootstrapping / operating when a mesos isn’t running.
+    Localhost only.
+
+* **Module**
+
+    Collection of Mesos endpoints for fetching / removing packages from the local filesystem. List the current
+    “active” set of modules.
+
+**Package Repository**
+
+Web server serving package tarballs. Accessible from all nodes in the cluster. Could be `s3`, `nginx`, etc. It should
+be able to use `Mesos fetcher`, `curl` or an equivalent to get data from it.
+
+**Restart (Module + Helper)**
+
+* **Module**
+
+    Restarts Mesos, switching from the running set of packages to the specified set of packages. All packages must be
+    local before restart is called. Uses the Restart Helper to ensure Mesos comes up cleanly.
+
+* **Helper**
+
+    Helper binary which lives next to Mesos. Stops Mesos, then swaps out the active modules using the package cli.
+    Starts up Mesos, watching to see if it comes up cleanly. If it does not,it tries to roll back. On all
+    events / status changes it pings the Deploy Module so that the deploy module can track the status. If a status ping
+    fails, the deploy module needs.
 
 Helper can also provides “bootstrap”, fetching and activating necessary packages for running
 
-**Provisioning Module (Artemis)**: Provides an api call to decommision_slave, as well as one to add_slave. Must be injected with the necessary configuration to launch a new slave on the current hosting provider (AWS for v1).
+**Provisioning Module**
 
-**Config Generator**: Given a list of enabled modules, and user-specified options (Resources, etc), generate a new config package.
+Provides an api call to `decommission_slave`, as well as one to `add_slave`. Must be injected with the necessary
+configuration to launch a new slave on the current hosting provider (AWS for v1).
+
+**Config Generator**
+
+Given a list of enabled modules, and user-specified options (Resources, etc), generate a new config package.

--- a/pkgpanda/docs/deployer.md
+++ b/pkgpanda/docs/deployer.md
@@ -1,9 +1,13 @@
 # Deployer Module
 
-Perform tasks/call endpoints on every machine, query machine state to determine deployment status. Aggregates status pings from the Restart Helper to monitor rollout progress / provide better insights. Has an endpoint `halt` which can have HTTP requests made to it by any sort of SLA monitoring setup an organization has in order to stop the deploy  module from taking further action without explicit clearing from and admin.
+* Performs tasks/call endpoints on every machine, query machine state to determine deployment status.
+* Aggregates status pings from the Restart Helper to monitor rollout progress / provide better insights.
+* Has an endpoint `halt` which can have HTTP requests made to it by any sort of SLA monitoring setup an organization
+  has in order to stop the deploy module from taking further action without explicit clearing from and admin.
 
 ## Special Powers
- - Wiping out work_dir and all running tasks vs. soft restart of mesos slave
- - halt endpoint
- - Use the maintenance primitives for hard restarts. "soft" maintenance to say "I'm doing things".
- - Rolling deployment / time delay between servers
+
+* Wiping out `work_dir` and all running tasks vs. soft restart of Mesos slave.
+* `halt` endpoint.
+* Use the maintenance primitives for hard restarts. "soft" maintenance to say "I'm doing things".
+* Rolling deployment / time delay between servers.

--- a/pkgpanda/docs/filesystem_layout.md
+++ b/pkgpanda/docs/filesystem_layout.md
@@ -1,49 +1,53 @@
-Host overall filesystem layout:
-```
+# File System Layout
+
+Host overall filesystem layout.
+
+```bash
 /etc/mesosphere/roles/{master,slave}
 /etc/mesosphere/setup-flags/
-	active.json
-	repository-url
+    active.json
+    repository-url
 /etc/systemd/dcos.target.wants/
-	mesos-master.service
+    mesos-master.service
 /opt/mesosphere/
-	bin/
-	lib/
-	etc/
-	environment
-	active/
-		mesos -> /opt/mesosphere/packages/mesos--0.22.0
-		java -> ...
-		zookeeper -> ...
-	packages/
-		mesos-config--123/
-			etc/
-		mesos--0.22.0/
-			bin/
-			lib/
-			libexec/
-			...
-			dcos.target.wants_master/
-				mesos-master.service
-		java--ranodmversionstring/
-			...
-		zookeeper--0.123/
-			...
+    bin/
+    lib/
+    etc/
+    environment
+    active/
+        mesos -> /opt/mesosphere/packages/mesos--0.22.0
+        java -> ...
+        zookeeper -> ...
+    packages/
+    mesos-config--123/
+        etc/
+    mesos--0.22.0/
+        bin/
+        lib/
+        libexec/
+        ...
+        dcos.target.wants_master/
+            mesos-master.service
+    java--ranodmversionstring/
+        ...
+    zookeeper--0.123/
+        ...
 ```
 
 
-Package layout:
-```
-pkginfo.json # json file describing list of dependencies / requires of package either
-	# by name (mesos) or by specific package id (mesos-0.22)
-	# Also lists environment variables to be loaded into the global environment.
+## Package layout
+
+```bash
+pkginfo.json        # json file describing list of dependencies / requires of package either
+                    # by name (mesos) or by specific package id (mesos-0.22)
+                    # Also lists environment variables to be loaded into the global environment.
 etc/
 bin/
 lib/
 dcos.target.wants/
-	foo.service
-	{role}/
-		bar.service
+    foo.service
+    {role}/
+        bar.service
 ```
 
 

--- a/pkgpanda/docs/for_packagers.md
+++ b/pkgpanda/docs/for_packagers.md
@@ -1,109 +1,96 @@
 # Packaging software
 
-Pkgpanda packages are tarballs, containing (optionally) a metadata file `pkginfo.json` as well as several well-known directories. See [Package Concepts](package_concepts.md) for a full listing, as well as descriptions of what each should be used for.
+`pkgpanda packages` are tarballs, containing (optionally) a metadata file `pkginfo.json` as well as several well-known
+directories. See [Package Concepts](package_concepts.md) for a full listing, as well as descriptions of each section.
+should be used for.
 
-They are always extracted and run from a predictable location. The prefix is always `/opt/mesosphere/{name}-{id}/` where name is the package name. This is effectively the PREFIX of the installed package in autotools terms. A package may rely on the absolute path to the package contents remaining constant.
+Packages are always extracted and run from a predictable location. The standard prefix is
+`/opt/mesosphere/{name}-{id}/` where `{name}` is the package name and `{id}`, a id associated with the package . This
+is effectively the `PREFIX` of the installed package in the `autotools` terms. A package may rely on the absolute path
+to the package contents to remaining constant.
 
-Only one package of a given package name may be able to be active on a system at a time. If a package is not active, then there is no guarantee that the package is available on the machine, and files in it should not be referenced.
+Only one package of a given package name may be active on a system at a given time. If a package is not active, then
+there is no guarantee that the package is available on the machine, and files in it should not be referenced.
 
-Pkgpanda operates by swapping out (roughly atomically) one set of active packages for another. If the health-checks of critical components fail after the swapping out, Pkgpanda will attempt to revert (Just another moving of directories), and restart the services again.
-
-There are two
+Pkgpanda operates by swapping out (roughly atomically) one set of active packages for another. If the health-checks of
+critical components fail while swapping out, Pkgpanda will attempt to revert (another move of directories), and restart
+the services again.
 
 ## Package build environment
 
-See: [buildinfo.json](buildinfo.json.md)
+The package build environment is described in [buildinfo.json](buildinfo.json.md). It has
 
- - Environment variables
- - Package directories
- -
-
-# TODO
-LD_LIBRARY_PATH, PATH, roles (bin_slave, bin_master)
+* Environment variables
+* Package directories
 
 # Guiding principles when packaging
 
- - Depend on as tight of a package version as you can, and only share things when necessary.
+* Depend upon a specific version if you can, and only share things when necessary.
 
-# Comon Tasks
+# Common Tasks
 
 ## Providing other packages
 
-If a package can depend on this exact version (mesos-config version x depends on mesos 0.22.0), then there is nothing which needs to be done, and the package can depend on the exact, predictable path of that file when unpacked as part of the package (And specify a dependency on the full package-id).
+If a package can depend upon an exact version like `mesos-config version x` depends on `mesos 0.22.0`, then there is
+nothing which needs to be done, and the package can depend on the exact, predictable path of that file when unpacked as
+part of the package. It can specify the dependency on the full package-id.
 
-If the other packages which will use the file can know about the package name of the package which
+# Depending on other packages
 
-If the file needs to be generally available to other packages which don't know what
+## Adding Multiple versions of the same logical package
 
-## Depending on other packages
+If there is one upstream package which you need, this can be specified explicitly
 
-## Adding
-
-## Multiple versions of the same logical package
-
-If there is one upstream package which you need
-protbuf-2.5.0-1
-
-This works because
+* `protbuf-2.5.0-1`
 
 # Unsupported items
 
 ## Language-specific packages
 
-Currently packagepanda has no clue how, for instance,
+*Not currently implemented*
 
 ## Users
 
-Currently there isn't a good way of reliably adding users on a large number of machines which have had potentially non-identical config applied to them. Pkgpanda in a future release will utilize [Systemd Sysusers](http://www.freedesktop.org/software/systemd/man/systemd-sysusers.html) or something similar to provide the ability to manage users on a machine.
+*Not currently implemented*
 
+There isn't a good way of reliably adding users on a large number of machines which have had potentially non-identical
+config applied to them. Pkgpanda in a future release will utilize [Systemd Sysusers] or something similar to provide
+the ability to manage users on a machine.
 
 ## Fine-grained dependencies
 
-Not currently implemented. Eventually a package will be able to give the list of things it needs in it's operating environment (libraries, executables in path, files on filesystem, users). This is a much more robust way to state dependencies (At the cost of increased complexity, but the computation is still less than a second).
+*Not currently implemented.*
 
+Eventually a package will be able to give the list of things it needs in it's operating environment (libraries,
+executables in path, files on filesystem, users). This is a much more robust way to state dependencies (At the cost of
+increased complexity, but the computation is still less than a second).
 
 ## Depending on other packages
 
+Every package lives in isolation from other packages, and can be installed/uninstalled atomically.
 
+Packages are unpacked to a metadata file `pkginfo.json`, and Every package has a *Package Name* as well as a *Package
+Id*. Packages are unpacked to predictable locations so they may reference the absolute path to the file.
 
-Often ther
+The `pkginfo.json` contains Packages depending on each other.
 
+**Well Known Directories**
 
+There are several well known directories in the tarball
 
-Every package is ide
-
-Pkgpanda reliably ex
-
-Every package lives in isolation from other packages, and can be installed/uninstalled
-atomically. There is no notion of being able to edit things
-
-
-
-Packages are unpacked to
-
-a metadata file `pkginfo.json`, and
-
-
-Every package has a *Package Name* as well as a *Package Id*. Packages are unpacked
-to predictable locations so they may
-
-The `pkginfo.json` contains
-
-Packages depending on eachother. S
-
-
-There
-are several well known directories in the tarball
-
+```bash
 bin/
 lib/
 etc/
 dcos.target.wants
+```
 
-environment variables, conflicts
+# TODO
 
-Dependencies / requirements
+* `LD_LIBRARY_PATH`
+* `PATH`
+* `roles` - `bin_slave`, `bin_master`
+* Splitting up packages (mesos, master-config, mesos-config, etc)
+* Document package environment variables, conflicts, and dependencies / requirements
 
-Splitting up packages (mesos, master-config, mesos-config, etc)
-
-tar -czf mesos--0.22.0.tar.xz -C mesos--0.22.0 .
+[Systemd Sysusers]: http://www.freedesktop.org/software/systemd/man/systemd-sysusers.html

--- a/pkgpanda/docs/modules.md
+++ b/pkgpanda/docs/modules.md
@@ -1,35 +1,27 @@
 # Module Design
 
-There are several mesos  modules so that we can add slave endpoints which cause
-all of the packaging, provisioning, etc. actions to take place.
+There are several Mesos modules that we can add as slave endpoints which cause all of the packaging, provisioning
+actions to take place.
 
-All of these modules simply add new libprocess processes to mesos. These
-processes will take HTTP requests, and turn them into running a subprocess which
-will perform the actual actions. The command line will be the effective ABI
-between the module and the code performing the actions which is written in
-python currently (although could be any language).
+All of these modules simply add new `libprocess` processes to Mesos. These processes will take HTTP requests, and turn
+them into running a subprocess that perform the actual actions. The command line will be the effective `ABI` between
+the module and the code performing the actions which is written in python currently (although could be any language).
 
 ## Module implementation layout
 
-In progress, point person is Till building a PoC module.
+The modules will be Lifecycle Module inside Mesos. Inside each module we try to keep the C++ code as simple and
+repeatable/predictable as possible.
 
-The modules will be Lifecycle Modules inside of Mesos. Inside each module we try
-to keep the C++ as simple and repeatable/predictable as possible.
-
-The module will define a new libprocess Process and its routes. It will then
-execute subprocesses to carry out the actions of the different routes.
-
-If the module needs to communicate out, it should write information to stdout to
-be returned to the caller.
-
-If it needs to make API calls to remote services, it should do them itself using
-an HTTP library.
+The module will define a new `libprocess` process and its routes. It will then execute `subprocess` to carry out the
+actions of the different routes. If the module needs to communicate out, it should write information to stdout to be
+returned to the caller. If it needs to make API calls to remote services, it should do them itself using an HTTP
+library.
 
 ## Example
 
-Note: This code is incorrect, doesn't compile, etc. It is just a sample of how
-the modules are structured. Till should hopefully have a complete sample module
-soon.
+Note: This code is incorrect, doesn't compile, etc. It is just a sample of how the modules are structured.
+
+```cpp
 
 class PackagerProcess : public Process<PackagerProcess>
 {
@@ -63,5 +55,5 @@ class PackagerProcess : public Process<PackagerProcess>
 
 }
 
+```
 
-class Module

--- a/pkgpanda/docs/package_concepts.md
+++ b/pkgpanda/docs/package_concepts.md
@@ -1,42 +1,64 @@
 # Package concepts
 
+**Package Name**
 
-*Package Name*: The name which other packages will know this package by, used so that. Package names must be valid linux folder names, are case insensitive / always lower case. Valid characters are [a-zA-Z0-9@._+-]. They may not start with a hyphen or a dot. Must be at least 1 character long. A package name may not contain '--'.
+The name which other packages will know this package by and use. Package names must be valid Linux folder names, should
+be case insensitive most often lower case only. Valid characters are [a-zA-Z0-9@._+-]. They may not start with a hyphen
+or a dot. Must be at least one character long. A package name may not contain '--'.
 
-*Package ID*: `name--id` Combination package name + arbitrary other information (likely some sort of version indicator). The packaging system just cares that it can extract the package name from a package id, as well as can fetch the package from. The package id may not contain a '-'. Valid characters are [a-zA-Z0-9@._+-]. A package-id may not contain '--'. Once a package-id is used, that package-id should never be re-used with different package contents.
+**Package ID**
 
-*pkginfo.json*: Metadata file containing the requrements of the package (either package names or package ids), as well as the environment variables provided by the package.
+`name--id` combination package name + arbitrary information (most often a version indicator). The packaging system
+needs to extract the package name from a package id. Valid characters are [a-zA-Z0-9@._+-]. A package-id may not
+contain '-' or '--'. Once a package-id is utilized, it should never be re-used with different package contents.
 
-*Well-known directories*  Every pkgpanda package may put items in several well-known directories to have them available to other packages.
+**pkginfo.json**
 
+Metadata file containing the requirements of the package (either package names or package ids), as well as the
+environment variables provided by the package.
 
+**Well-known directories**
 
+Every pkgpanda package may put items in several well-known directories to have them available to other packages.
 
-
-lib, bin, etc, dcos.target.wants
-
+```bash
+lib
+bin
+etc
+dcos.target.wants
+```
 
 ## Install directories
 
-The packaging system makes use of some *well-known directories*. Well-known directories are used so that packages can find information from other packages without having to know the exact package version some piece is coming from.
+The packaging system makes use of some *well-known directories*. Well-known directories are used so that packages can
+find information from other packages without having to know the exact package version some piece is coming from.
 
 ## Package
 
-Well-known directories which packages can depend upon. All other filesystem directories should be assumed to not exist.
+Different things want to rely on finding individual packages at certain locations. When we unbundle packages, there are
+often multiple components which are shipped independently (So, we can update Java without having to re-ship
+everything).
 
-Different things want to rely on finding certain packages at certain locations. When we unbundle things, there are often multiple components which are shipped independently (So we can update java without having to re-ship everything). In order for all the java packages to find the "current java" we need to make java at a well known location.
+In order, for all the java packages to find the "current Java" we need to make Java at a well-known location. There are
+well-known directories which packages can depend on upon. All other filesystem directories should be assumed not to
+exist.
+
+### Why /opt/mesosphere/etc, etc.
+
+Not all packages know what is going to provide bits of environment. Mesos shouldn't need to know for instance what is
+the name of the package which provides `HDFS`, it just cares if `HDFS` is available.
+
+This goes for config as well, we may want a specific monolithic `mesos-config` package name, or a bunch of small
+`mesos-slave-config`, `mesos-master-config` packages. Either way Mesos needs to find the config.
+
+### Special install files and directories
+
+All the environment variables to be used when running Mesos are available at `/opt/mesosphere/environment`. Compiled
+from a `environment` section in `pkginfo.json` of every active package, as well as a generated `PATH` and
+`LD_LIBRARY_PATH` containing the `/opt/mesosphere/bin` and `/opt/mesosphere/lib` respectively.
 
 
-# Why /opt/mesosphere/etc, etc.
-
- Not all packages know what is going to provide bits of environment. Mesos shouldn't need to know for instance what is the name of the package which provides hdfs, it just cares if hdfs is available.
-
- This goes for config as well, I might want to have a monolithic mesos-config package name, or a bunch of small {mesos-slave-config, mesos-master-config} packages. Either way mesos needs to be able to find the config.
-
-## Special install files + directories
-`/opt/mesosphere/environment`
-  - All the environment variables to be used when running mesos. Compiled from a `environment` section in `pkginfo.json` of every active package, as well as a generated PATH and LD_LIBRARY_PATH containing the /opt/mesosphere/bin and /opt/mesosphere/lib respectively.
-```
+```bash
 /opt/mesosphere/bin/
 /opt/mesosphere/lib/
 /opt/mesosphere/etc/
@@ -46,24 +68,29 @@ Different things want to rely on finding certain packages at certain locations. 
 ```
 
 ### Assumed system files
+
 `/etc/systemd/system/multi-user.target/dcos.target`
 
+### Reasoning
 
-## Reasoning
-Why don't we do /{name}/current
+**Why don't we do /{name}/current ?**
+
   - Then we can't atomically swap things into place, easier to get partial updates.
 
-Why not make /{name}/{id_without_name}
+**Why not make /{name}/{id_without_name} ?**
+
   - Who cleans up /{name}/?
   - Lots more logic to get wrong, coordination required.
 
-When things go wrong, how to recover
-1) Dump the host and load a new one, simplest safest
-2) `pkgpanda setup` the host.
-3) pkgpanda activate {list of packages}
+**When things go wrong, how to recover**
+
+1. Dump the host and load a new one, simplest safest
+2. `pkgpanda setup` the host.
+3. pkgpanda activate {list of packages}
     - Fix problems if they happen
 
 NOTE: Packager should always overwrite / remove / replace .new when that is given.
 
+### TODO
 
-TODO: Doc how we support upgrading things in light of security problems.
+*Doc how we support upgrading things in light of security problems.*

--- a/pkgpanda/docs/readme.md
+++ b/pkgpanda/docs/readme.md
@@ -1,24 +1,28 @@
-# Pkgpanda: The DC/OS Package manager
+# Pkgpanda: The DC/OS Package Manager
 
-While most things can run in containers on top of mesos, using whatever fetching mechanism
+Most packages run in containers on top of Mesos, using its native mechanism. There are requirements to install and run
+packages on top of the host system.
+
+`pkgpanda` allows for having multiple versions of every component present on a host and selecting one of them to
+be active at a given time.
 
 # Major features
 
 1. Ability to have multiple versions of a package ready for use simultaneously on a host.
-2. No notion of modifying existing state. A package is either active (all its state alive), or not.
+2. No notion of modifying existing state. A package is either active (all it's is state alive), or not.
 
 # Documentation
 
-[For Packagers](for_packagers.md)
-[Package Concepts](package_concepts.md)
-
+* [For Packagers](for_packagers.md)
+* [Package Concepts](package_concepts.md)
 
 # Internals
-[Filesystem Layout](filesystem_layout.md)
-[Activating Packages](activating.md)
+
+* [Filesystem Layout](filesystem_layout.md)
+* [Activating Packages](activating.md)
 
 # WIP / long term design
 
-[Architecture for Cluster Upgrades](architecture.md)
-[Deployer component](deployer.md)
-[Modules](modueles.md)
+* [Architecture for Cluster Upgrades](architecture.md)
+* [Deployer component](deployer.md)
+* [Modules](modules.md)


### PR DESCRIPTION
* Fixed typos.
* Fixed grammatical errors.
* Fixed formatting strings.
* Ensured that long lines break at `120` char and don't overflow the screen. (This is helpful as we improve the docs and `diff` will be legible).

I will iterate on this further as I gain more ground in understanding `pkgpanda`.

Please review @cmaloney and @spahl . 