### PR TITLE
Fix Metronome startup issues

### DIFF
--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -19,6 +19,7 @@ RestartSec=15
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/metronome
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metronome
+ExecStartPre=/bin/bash -c 'mkdir -p /run/dcos/etc/metronome'
 ExecStartPre=/bin/bash -c 'echo "METRONOME_LEADER_ELECTION_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /run/dcos/etc/metronome/service.env'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /run/dcos/etc/metronome/service.env'
 ExecStartPre=-/usr/bin/env rm -f /opt/mesosphere/active/metronome/RUNNING_PID

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -18,6 +18,7 @@ StartLimitInterval=0
 RestartSec=15
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/metronome
+EnvironmentFile=-/run/dcos/etc/metronome/service.env
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metronome
 ExecStartPre=/bin/bash -c 'mkdir -p /run/dcos/etc/metronome'
 ExecStartPre=/bin/bash -c 'echo "METRONOME_LEADER_ELECTION_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /run/dcos/etc/metronome/service.env'


### PR DESCRIPTION
Metronome service fails to start on Azure with:

```
Jul 13 20:41:09 dcos-master-01234567-0 systemd[1]: Starting Jobs Service: DC/OS Metronome...
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Clearing proxy environment variables
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Expected cluster size: 1
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Waiting for ZooKeeper cluster to stabilize
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Starting new HTTP connection (1): 127.0.0.1
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Connecting to 127.0.0.1:2181
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [INFO] Zookeeper connection established, state: CONNECTED
Jul 13 20:41:09 dcos-master-01234567-0 bootstrap[24433]: [DEBUG] bootstrapping dcos-metronome
Jul 13 20:41:09 dcos-master-01234567-0 bash[24445]: /bin/bash: /run/dcos/etc/metronome/service.env: No such file or directory
```

Fix by ensuring the run state directory always exists.