### PR TITLE
Set the temp directory crated for docker operations to /tmp.

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -270,7 +270,7 @@ def requests_fetcher(base_url, id_str, target, work_dir):
     url = base_url + "/packages/{0}/{1}.tar.xz".format(id.name, id_str)
     # TODO(cmaloney): Use a private tmp directory so there is no chance of a user
     # intercepting the tarball + other validation data locally.
-    with tempfile.NamedTemporaryFile(suffix=".tar.xz") as file:
+    with tempfile.NamedTemporaryFile(suffix=".tar.xz", dir="/tmp") as file:
         download(file.name, url, work_dir)
         extract_tarball(file.name, target)
 

--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -511,7 +511,7 @@ def make_bootstrap_tarball(package_store, packages, variant):
 
     print("Creating bootstrap tarball for variant {}".format(variant))
 
-    work_dir = tempfile.mkdtemp(prefix='mkpanda_bootstrap_tmp')
+    work_dir = tempfile.mkdtemp(prefix='mkpanda_bootstrap_tmp', dir="/tmp")
 
     def make_abs(path):
         return os.path.join(work_dir, path)
@@ -744,7 +744,7 @@ class IdBuilder():
 def build(package_store, name, variant, clean_after_build, recursive=False):
     assert isinstance(package_store, PackageStore)
     print("Building package {} variant {}".format(name, pkgpanda.util.variant_str(variant)))
-    tmpdir = tempfile.TemporaryDirectory(prefix="pkgpanda_repo")
+    tmpdir = tempfile.TemporaryDirectory(prefix="pkgpanda_repo", dir="/tmp")
     repository = Repository(tmpdir.name)
 
     package_dir = package_store.get_package_folder(name)
@@ -861,7 +861,7 @@ def build(package_store, name, variant, clean_after_build, recursive=False):
     # Packages need directories inside the fake install root (otherwise docker
     # will try making the directories on a readonly filesystem), so build the
     # install root now, and make the package directories in it as we go.
-    install_dir = tempfile.mkdtemp(prefix="pkgpanda-")
+    install_dir = tempfile.mkdtemp(prefix="pkgpanda-", dir="/tmp")
 
     active_packages = list()
     active_package_ids = set()


### PR DESCRIPTION
This achieves consistent behavior of pkgpanda on Mac and Linux.

On Mac,  the `TMPDIR` is set to

```
$ echo $TMPDIR
/var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/
```

Further more `/var` is symlinked to `/private/var`

```
$ ls -l /var
lrwxr-xr-x@ 1 root  wheel  11 Mar 12 01:38 /var -> private/var
```

This causes docker to deny the mount (a docker bug perhaps).

```
docker: Error response from daemon: Mounts denied: 738ee8ff668072 and /var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/pkgpanda-ya69uyz8 and /var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/pkgpanda_reposqojoha_/openssl--50c0a47f950e7793e340b45f701150af83fb42bb and /var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00.
```

The easy workaround is have temporary directories shared for docker operations to `/tmp`  as it is in the case of linux. 

Please review and include this, @spahl and @cmaloney 
