### PR TITLE
Pin to latest Ubuntu 16.04 LTS image

### DIFF
--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -154,7 +154,7 @@
     },
     "linuxVersion": {
       "type": "string",
-      "defaultValue": "latest",
+      "defaultValue": "16.04.201606270",
       "metadata": {
         "description": "This is the linux version used by the linux cluster"
       }


### PR DESCRIPTION
Per discussions with Azure, we've agreed to pin to the LTS image
version. Historically these images stick around until Ubuntu EOL's the
release and if we continue to pin to 'latest' there will be a chance
that a new Ubuntu LTS build will break ACS.