### PR TITLE
Test fixes

### DIFF
--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1102,6 +1102,7 @@ def test_if_minuteman_routes_to_vip(cluster, timeout=125):
 def test_ip_per_container(registry_cluster):
     """Test if we are able to connect to a task with ip-per-container mode
     """
+    cluster = registry_cluster
     # Launch the test_server in ip-per-container mode
 
     app_definition, test_uuid = cluster.get_base_testapp_definition(ip_per_container=True)

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -369,6 +369,9 @@ class Cluster:
         return requests.head(self.dcos_uri + path, headers=hdrs)
 
     def get_base_testapp_definition(self, docker_network_bridge=True, ip_per_container=False):
+        """The test_server app used here is only guaranteed to exist if
+        the registry_cluster pytest fixture is used
+        """
         test_uuid = uuid.uuid4().hex
         base_app = {
             'id': TEST_APP_NAME_FMT.format(test_uuid),
@@ -1096,7 +1099,7 @@ def test_if_minuteman_routes_to_vip(cluster, timeout=125):
     _ensure_routable()
 
 
-def test_ip_per_container(cluster):
+def test_ip_per_container(registry_cluster):
     """Test if we are able to connect to a task with ip-per-container mode
     """
     # Launch the test_server in ip-per-container mode

--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -117,12 +117,12 @@ class TunnelCollection():
             tunnel.close()
 
 
-def run_ssh_cmd(ssh_user, ssh_key_path, host, cmd, port=22):
+def run_ssh_cmd(ssh_user, ssh_key_path, host, cmd, port=22, timeout=None):
     """Convenience function to do a one-off SSH command
     """
     assert isinstance(cmd, list)
     with closing(SSHTunnel(ssh_user, ssh_key_path, host, port=port)) as tunnel:
-        return tunnel.remote_cmd(cmd)
+        return tunnel.remote_cmd(cmd, timeout=timeout)
 
 
 def run_scp_cmd(ssh_user, ssh_key_path, host, src, dst, port=22):


### PR DESCRIPTION
-tests that use base_marathon_app need to be apart of registry_cluster fixture
-timeout must be settable in environment for installer API
-Suppressing error codes in test make it very hard to distinguish if the test failed or if the setup of the test failed. Rather, do the suppression  in TC (there is a specific option just for this case)