### PR TITLE
do not restart docker on install [WIP]

### DIFF
--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -1,8 +1,5 @@
 - name: systemd-journald.service
   command: restart
-# Restart docker to make it recover from a SIGPIPE it recieves when systemd-journald dies.
-- name: docker.service
-  command: restart
 - name: dcos-link-env.service
   command: start
   content: |


### PR DESCRIPTION
Currently on prem installer is being run from a docker container. We cannot
restart the container because this will break the installer.