### PR TITLE
Move mesos_isolation into a gen/calc variable.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -384,6 +384,7 @@ entry = {
         'ui_networking': 'false',
         'ui_organization': 'false',
         'minuteman_forward_metrics': 'false',
+        'mesos_isolation': 'cgroups/cpu,cgroups/mem,disk/du,network/cni,filesystem/linux,docker/runtime,docker/volume'
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -220,7 +220,7 @@ package:
       MESOS_LOG_DIR=/var/log/mesos
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
       MESOS_CONTAINER_LOGGER={{ mesos_container_logger }}
-      MESOS_ISOLATION=cgroups/cpu,cgroups/mem,posix/disk,network/cni,filesystem/linux,docker/runtime,docker/volume
+      MESOS_ISOLATION={{ mesos_isolation }}
       MESOS_DOCKER_VOLUME_CHECKPOINT_DIR=/var/lib/mesos/isolators/docker/volume
       MESOS_IMAGE_PROVIDERS=docker
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni


### PR DESCRIPTION
Move mesos_isolation into a gen/calc variable so downstreams can extend it.
Also dropped the deprecated isolator name 'posix/disk' in favor of the new 'disk/du'.