### PR TITLE
Bumped `mesos-overlay-modules`

### DIFF
--- a/packages/mesos-overlay-modules/buildinfo.json
+++ b/packages/mesos-overlay-modules/buildinfo.json
@@ -4,7 +4,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/mesos-overlay-modules.git",
-      "ref": "9ea9dab6cbb117ce244524bfb6d119e96b5289a8",
+      "ref": "bc54123f6f90b4fdf9347a8d3a25d45efcf8e32c",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
* Added unit-test cases for `mesos-overlay-modules`. We can run `make
check`.
* Re-factored Agent and Master modules for the unit-test.
* Fixed a discrepancy in the information exposed in the
overlay-master/state` endpoint and the `overlay-agent/overlay` endpoint.
* Ensuring that `DOCKER-ISOLATION` bypass iptable rules are installed
only if the `docker-bridge` is enabled in the Agent module.