### PR TITLE
Remove Caching Test Server from Signal Test

### DIFF
--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1635,17 +1635,17 @@ def test_signal_service(registry_cluster):
     exp_data = {
         'diagnostics': {
             'event': 'health',
-            'anonymousId': 'test-id',
+            'anonymousId': cluster_id,
             'properties': {}
         },
         'cosmos': {
             'event': 'package_list',
-            'anonymousId': 'test-id',
+            'anonymousId': cluster_id,
             'properties': {}
         },
         'mesos': {
             'event': 'mesos_track',
-            'anonymousId': 'test-id',
+            'anonymousId': cluster_id,
             'properties': {}
         }
     }

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1618,6 +1618,15 @@ def test_signal_service(registry_cluster):
     and pushes the results to the test_server app for easy retrieval
     """
     cluster = registry_cluster
+    dcos_version = os.getenv("DCOS_VERSION", "")
+    signal_config = open('/opt/mesosphere/etc/dcos-signal-config.json', 'r')
+    customer_key = json.loads(signal_config.read())['customer_key']
+    cluster_id_file = open('/var/lib/dcos/cluster-id', 'r')
+    cluster_id = json.loads(cluster_id_file.read())['cluster_id']
+
+    print("Version: ", dcos_version)
+    print("Customer Key: ", customer_key)
+    print("Cluster ID: ", cluster_id)
 
     signal_results = subprocess.check_output(["/opt/mesosphere/bin/dcos-signal", "-test"], universal_newlines=True)
     r_data = json.loads(signal_results)
@@ -1644,9 +1653,9 @@ def test_signal_service(registry_cluster):
     generic_properties = {
         'provider': cluster.provider,
         'source': 'cluster',
-        'clusterId': 'test-id',
-        'customerKey': '',
-        'environmentVersion': '',
+        'clusterId': cluster_id,
+        'customerKey': customer_key,
+        'environmentVersion': dcos_version,
         'variant': 'open'
     }
 

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1611,7 +1611,6 @@ def test_3dt_report(cluster):
         assert len(report_response['Nodes']) > 0
 
 
-@pytest.mark.skipif(os.getenv('TEST_ENV') == 'vagrant', reason="Sometimes vagrant sucks, sometimes.")
 def test_signal_service(registry_cluster):
     """
     signal-service runs on an hourly timer, this test runs it as a one-off

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -5,6 +5,7 @@ import gzip
 import json
 import logging
 import os
+import subprocess
 import tempfile
 import urllib.parse
 import uuid
@@ -1616,66 +1617,10 @@ def test_signal_service(registry_cluster):
     signal-service runs on an hourly timer, this test runs it as a one-off
     and pushes the results to the test_server app for easy retrieval
     """
-    cluster = registry_cluster
-    test_server_app_definition, _ = cluster.get_base_testapp_definition()
-    service_points = cluster.deploy_marathon_app(test_server_app_definition)
-
-    @retrying.retry(wait_fixed=1000, stop_max_delay=120*1000)
-    def wait_for_endpoint():
-        """Make sure test server is available before posting to it"""
-        r = requests.get('http://{}:{}/signal_test_cache'.format(
-            service_points[0].host,
-            service_points[0].port))
-        assert r.status_code == 200
-
-    wait_for_endpoint()
-
-    test_host = service_points[0].host
-    test_port = service_points[0].port
-    test_cache_url = "http://{}:{}/signal_test_cache".format(test_host, test_port)
-
-    cmd = """
-ID_PATH="/${PWD}/test-cluster-id"
-echo 'test-id' > $ID_PATH
-/opt/mesosphere/bin/dcos-signal \
-    -cluster-id-path $ID_PATH \
-    -test-url %s
-sleep 3600
-""" % test_cache_url
-
-    print("CMD: {}".format(cmd))
-    test_uuid = uuid.uuid4().hex
-    signal_app_definition = {
-        'id': "/integration-test-signal-service-oneshot-%s" % test_uuid,
-        'cmd': cmd,
-        'cpus': 0.1,
-        'mem': 64,
-        'instances': 1,
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {
-                'value': 'curl {} > tmp; test -s tmp'.format(test_cache_url)
-            },
-            'gracePeriodSeconds': 0,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 1,
-            'ignoreHttp1xx': False}]
-    }
-
-    cluster.deploy_marathon_app(signal_app_definition, ignore_failed_tasks=True)
-
-    r = requests.get(test_cache_url)
-
-    # Handy for diagnosing strange signal service test behavior, not sure if we should
-    # leave these in for master branch, or remove for the final PR.
-    print('TESTING SIGNAL RETURN:\n{}'.format(r.text))
-    print('CACHE SERVER STATUS:\n{}'.format(r.status_code))
-
-    r_data = json.loads(r.json())
-
-    cluster.destroy_marathon_app(signal_app_definition['id'])
-    cluster.destroy_marathon_app(test_server_app_definition['id'])
+# /opt/mesosphere/bin/dcos-signal \
+#    -test
+    subprocess.run(["/opt/mesosphere/bin/dcos-signal", "-test"], stdout=subprocess.PIPE)
+    r_data = json.loads(stdout)
 
     exp_data = {
         'diagnostics': {

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1621,8 +1621,8 @@ def test_signal_service(registry_cluster):
     dcos_version = os.getenv("DCOS_VERSION", "")
     signal_config = open('/opt/mesosphere/etc/dcos-signal-config.json', 'r')
     customer_key = json.loads(signal_config.read())['customer_key']
-    cluster_id_file = open('/var/lib/dcos/cluster-id', 'r')
-    cluster_id = json.loads(cluster_id_file.read())['cluster_id']
+    cluster_id_file = open('/var/lib/dcos/cluster-id')
+    cluster_id = cluster_id_file.read().strip()
 
     print("Version: ", dcos_version)
     print("Customer Key: ", customer_key)

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1620,7 +1620,8 @@ def test_signal_service(registry_cluster):
     cluster = registry_cluster
     dcos_version = os.getenv("DCOS_VERSION", "")
     signal_config = open('/opt/mesosphere/etc/dcos-signal-config.json', 'r')
-    customer_key = json.loads(signal_config.read())['customer_key']
+    signal_config_data = json.loads(signal_config.read())
+    customer_key = signal_config_data.get('customer_key', '')
     cluster_id_file = open('/var/lib/dcos/cluster-id')
     cluster_id = cluster_id_file.read().strip()
 

--- a/packages/dcos-integration-test/extra/integration_test.py
+++ b/packages/dcos-integration-test/extra/integration_test.py
@@ -1617,10 +1617,10 @@ def test_signal_service(registry_cluster):
     signal-service runs on an hourly timer, this test runs it as a one-off
     and pushes the results to the test_server app for easy retrieval
     """
-# /opt/mesosphere/bin/dcos-signal \
-#    -test
-    subprocess.run(["/opt/mesosphere/bin/dcos-signal", "-test"], stdout=subprocess.PIPE)
-    r_data = json.loads(stdout)
+    cluster = registry_cluster
+
+    signal_results = subprocess.check_output(["/opt/mesosphere/bin/dcos-signal", "-test"], universal_newlines=True)
+    r_data = json.loads(signal_results)
 
     exp_data = {
         'diagnostics': {

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -4,7 +4,7 @@
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
     "ref": "d690d78815155c3407413338781643081e3ce7fd",
-    "ref_origin": "1.1.8"
+    "ref_origin": "1.1.9"
   },
   "username": "dcos_signal"
 }

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "d690d78815155c3407413338781643081e3ce7fd",
+    "ref": "7e7cb7a62cb27c175e1864eca98fde173d8267b7",
     "ref_origin": "1.1.9"
   },
   "username": "dcos_signal"

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -93,7 +93,6 @@ export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
 export DNS_SEARCH=true
 export DCOS_AUTH_ENABLED=false
 export DCOS_PROVIDER=onprem
-export TEST_ENV=vagrant
 cd /opt/mesosphere/active/dcos-integration-test
 py.test -vv -s -m "not ccm" ${CI_FLAGS:-}
 EOF


### PR DESCRIPTION
Leverages new test flag which dumps to STDOUT so we can remove the usage of caching server. 