### PR TITLE
Add minimum version to the local build git requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All code in this repository is Python 3
     - Docker doesn't have all the features needed on OS X or Windows
     - `tar` needs to be GNU tar for the set of flags used
   1. [tox](https://tox.readthedocs.org/en/latest/)
-  1. git
+  1. git 1.8.5+
   1. Docker
     - [Install Instructions for various distributions](https://docs.docker.com/engine/installation/). Docker needs to be configured so your user can run docker containers. The command `docker run alpine  /bin/echo 'Hello, World!'` when run at a new terminal as your user should just print `"Hello, World!"`. If it says something like "Unable to find image 'alpine:latest' locally" then re-run and the message should go away.
   1. Python 3.4


### PR DESCRIPTION
A local build will end up shelling out with `git -C ...`.
This option is introduced in Git 1.8.5:
https://github.com/git/git/commit/44e1e4d67d5148c245db362cc48c3cc6c2ec82ca

Note: This is relevant because the default git package on CentOS 7 is version 1.8.3.