### PR TITLE
Update AWS templates to CoreOS Stable 1068.9.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,7 @@ Documentation of changes which may break some install environments
  - Zookeeper should now log to journald
  - dcos-history-serivce was renamed to dcos-history
  - dcos-ddt.service was renamed to dcos-3dt.service
- - Updated to CoreOS Beta 1068.
+ - Updated to CoreOS Stable 1068.9.0
  - Make the admin load balancer in all templates do TCP, not HTTP load balancing
  - Switch Ubuntu in Azure to 16.04 LTS final release
  - Teach spartan / DNS to only listen on a local internal address

--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -71,43 +71,43 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-965899f7",
         "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-3120fe52",
         "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-b1291dd2",
         "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-3ae31555",
         "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-b7cba3c4",
         "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-61e3750d",
         "el7": "ami-ac980ec0"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-6d138f7a",
         "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-b712acd6",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-ee57148e",
         "el7": "ami-a883c0c8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-dc6ba3bc",
         "el7": "ami-a4dd16c4"
       }
     },

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -254,43 +254,43 @@
     },
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-965899f7",
         "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-3120fe52",
         "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-b1291dd2",
         "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-3ae31555",
         "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-b7cba3c4",
         "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-61e3750d",
         "el7": "ami-ac980ec0"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-6d138f7a",
         "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-b712acd6",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-ee57148e",
         "el7": "ami-a883c0c8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-dc6ba3bc",
         "el7": "ami-a4dd16c4"
       }
     }

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -246,43 +246,43 @@
     },
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-965899f7",
         "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-3120fe52",
         "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-b1291dd2",
         "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-3ae31555",
         "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-b7cba3c4",
         "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-61e3750d",
         "el7": "ami-ac980ec0"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-6d138f7a",
         "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-b712acd6",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-ee57148e",
         "el7": "ami-a883c0c8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-dc6ba3bc",
         "el7": "ami-a4dd16c4"
       }
     }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-bebc4ddf"
+        "stable": "ami-965899f7"
       },
       "ap-southeast-1": {
-        "stable": "ami-3602d055"
+        "stable": "ami-3120fe52"
       },
       "ap-southeast-2": {
-        "stable": "ami-07be9664"
+        "stable": "ami-b1291dd2"
       },
       "eu-central-1": {
-        "stable": "ami-8d8d66e2"
+        "stable": "ami-3ae31555"
       },
       "eu-west-1": {
-        "stable": "ami-0d68f37e"
+        "stable": "ami-b7cba3c4"
       },
       "sa-east-1": {
-        "stable": "ami-18a23774"
+        "stable": "ami-61e3750d"
       },
       "us-east-1": {
-        "stable": "ami-153af578"
+        "stable": "ami-6d138f7a"
       },
       "us-gov-west-1": {
-        "stable": "ami-96b50bf7"
+        "stable": "ami-b712acd6"
       },
       "us-west-1": {
-        "stable": "ami-8befabeb"
+        "stable": "ami-ee57148e"
       },
       "us-west-2": {
-        "stable": "ami-02bf7962"
+        "stable": "ami-dc6ba3bc"
       }
     },
     "NATAmi" : {


### PR DESCRIPTION
CoreOS 1068.9.0 includes:
* kernel: 4.6.3
* rkt: 1.7.0
* docker: 1.10.3
* etcd: 0.4.9, 2.3.2
* fleet: 0.11.7
* systemd: 229

See: https://coreos.com/releases/#1068.9.0 for full release notes.