### PR TITLE
Switch to using 9/8 for the subnet to assign agent subnets

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -356,13 +356,13 @@ entry = {
         'dcos_overlay_mtu': '1420',
         'dcos_overlay_enable': "true",
         'dcos_overlay_network': '{                      \
-            "vtep_subnet": "198.18.0.0/20",             \
+            "vtep_subnet": "44.128.0.0/20",             \
             "vtep_mac_oui": "70:B3:D5:00:00:00",        \
             "overlays": [                               \
               {                                         \
                 "name": "dcos",                         \
-                "subnet": "44.128.0.0/16",              \
-                "prefix": 26                            \
+                "subnet": "9.0.0.0/8",                  \
+                "prefix": 24                            \
               }                                         \
             ]}',
         'rexray_config_method': 'empty'


### PR DESCRIPTION
According to this NANOG post, it is unused: https://www.nanog.org/mailinglist/mailarchives/old_archive/2003-04/msg00762.html We're using 9/8 because with the way the overlay works, each agent  takes a fixed sized subnet. We want to be able to run at least 100 Docker container on each machine. The agent takes the aforementioned subnet and splits it in half between Docker and Mesos containes. There is a product requirement to support 100+ containers per machine using this feature. We also want to support 1000+ agents.

Therefore, a reasonable approach is to give the DC/OS cluster a /8 (9/8) that's unlikely to conflict. The middle two octects are per agent, so we can support ~2**16-Masters agents

This is the default, and those doing business in a 9/8 environment can modify the defaults for their needs.