### PR TITLE
Increase log rotation threshold for /var/log/mesos

### DIFF
--- a/packages/logrotate/build
+++ b/packages/logrotate/build
@@ -43,7 +43,7 @@ nomail
 
 /var/log/mesos/* {
     olddir /var/log/mesos/archive
-    maxsize 2000k
+    maxsize 256M
     daily
     rotate 7
     copytruncate


### PR DESCRIPTION
The default log rotation is way to small by mistake. This bumps it from 7*2000k to 7*256M