### PR TITLE
Fix REX-Ray default config

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -24,6 +24,14 @@ rexray:
       ignoreusedcount: true
 """
 
+DEFAULT_REXRAY_CONFIG = """
+rexray:
+  loglevel: info
+  modules:
+    default-docker:
+      disabled: true
+"""
+
 
 def calculate_bootstrap_variant():
     variant = os.getenv('BOOTSTRAP_VARIANT')
@@ -411,7 +419,7 @@ entry = {
                 'must': {'rexray_config_contents': yaml.dump(AWS_REXRAY_CONFIG)},
             },
             'empty': {
-                'must': {'rexray_config_contents': yaml.dump('')},
+                'must': {'rexray_config_contents': yaml.dump(DEFAULT_REXRAY_CONFIG)},
             },
         }
     }


### PR DESCRIPTION
[REX-Ray will fail with an empty config file](https://teamcity.mesosphere.io/viewLog.html?buildId=341742&buildTypeId=DcosIo_Dcos_VagrantIntegrationTests_ProvisioningTestGenconfBashPr&tab=buildLog#_focus=1615). This PR adds a new config that [disables the default Docker module](http://rexray.readthedocs.io/en/v0.3.3/user-guide/config/#disabling-modules). This config will allow REX-Ray to start, and cause dvdcli to fail with `Unable to locate plugin: rexray`.