### PR TITLE
Switch to the `.zk` addresses for finding zookeeper from marathon, metronome, and agents

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -64,7 +64,7 @@ package:
   - path: /etc/mesos-dns.json
     content: |
       {
-        "zk": "zk://127.0.0.1:2181/mesos",
+        "zk": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
         "refreshSeconds": 30,
         "ttl": 60,
         "domain": "mesos",
@@ -113,7 +113,7 @@ package:
   - path: /etc/overlay/config/agent.json
     content: |
       {
-        "master": "zk://leader.mesos:2181/mesos",
+        "master": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181:2181/mesos",
         "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
         "network_config":
         {
@@ -218,7 +218,7 @@ package:
       MESOS_CLUSTER={{ cluster_name }}
   - path: /etc/mesos-slave-common
     content: |
-      MESOS_MASTER=zk://leader.mesos:2181/mesos
+      MESOS_MASTER=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       MESOS_CONTAINERIZERS=docker,mesos
       MESOS_LOG_DIR=/var/log/mesos
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
@@ -381,11 +381,11 @@ package:
       "tracking":{"enabled":{{ telemetry_enabled }}}}}}
   - path: /etc_master/marathon
     content: |
-      MARATHON_ZK=zk://127.0.0.1:2181/marathon
+      MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
   - path: /etc_master/metronome
     content: |
       METRONOME_MESOS_LEADER_UI_URL=http://leader.mesos:5050
-      METRONOME_MESOS_MASTER_URL=zk://@127.0.0.1:2181/mesos
+      METRONOME_MESOS_MASTER_URL=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       METRONOME_PLAY_SERVER_HTTP_PORT=9000
   - path: /etc/user.config.yaml
     content: |

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -30,7 +30,7 @@ ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -jar "$PKG_PATH/usr/marathon.jar" \\
     --zk "\$MARATHON_ZK" \\
-    --master zk://127.0.0.1:2181/mesos \\
+    --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
     --hostname "\$MARATHON_HOSTNAME" \\
     --default_accepted_resource_roles "*" \\
     --mesos_role "slave_public" \\

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -22,6 +22,7 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "5be98261ad2bb39a2222f4f424cf2ff5b50bddbb",
+      "ref": "e207706c1a173887953cf13540aadbff6240d140",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
These were added a bit ago. Helps remove confusion around resolution, what ZK clients do in certain cases. They all resolve statically by spartan, then traffic gets forwarded to the right masters.

Mesos Master can't, because things need it to be up. Since it waits for exhibitor to be up, should always have it's local zookeeper.