### PR TITLE
Teach waiting for exhibitor to "shortcut" if the local zookeeper is k…

### DIFF
--- a/packages/bootstrap/buildinfo.json
+++ b/packages/bootstrap/buildinfo.json
@@ -4,5 +4,6 @@
     "python-kazoo",
     "python-requests"
   ],
-  "docker": "dcos-builder"
+  "docker": "dcos-builder",
+  "state_directory": true
 }

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor/__init__.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor/__init__.py
@@ -4,6 +4,7 @@ import sys
 
 import requests
 
+from pkgpanda.util import load_string, write_string
 from .. import utils
 
 log = logging.getLogger(__name__)
@@ -11,8 +12,64 @@ log = logging.getLogger(__name__)
 
 EXHIBITOR_STATUS_URL = 'http://127.0.0.1:8181/exhibitor/v1/cluster/status'
 
+zk_pid_path = "/var/lib/dcos/exhibitor/zk.pid"
+stash_zk_pid_stat_mtime_path = "/var/lib/dcos/bootstrap/exhibitor_pid_stat"
+
+
+def get_zk_pid_mtime():
+    return os.stat(zk_pid_path).st_mtime_ns
+
+
+def get_zk_pid():
+    return load_string(zk_pid_path)
+
+
+def try_shortcut():
+    try:
+        # pid stat file exists, read the value out of it
+        stashed_pid_stat = load_string(stash_zk_pid_stat_mtime_path)
+    except FileNotFoundError:
+        log.info('No zk.pid last mtime found at %s', stash_zk_pid_stat_mtime_path)
+        return False
+
+    # Make sure that the pid hasn't been written anew
+    cur_pid_stat = get_zk_pid_mtime()
+
+    if stashed_pid_stat != cur_pid_stat:
+        return False
+
+    # Check that the PID has a zk running at it currently.
+    zk_pid = get_zk_pid()
+    cmdline_path = '/proc/{}/cmdline'.format(zk_pid)
+    try:
+        # Custom because the command line is ascii with `\0` as separator.
+        with open(cmdline_path, 'rb') as f:
+            cmd_line = f.read().split(b'\0')
+    except FileNotFoundError:
+        log.info('Process no longer running (couldn\'t read the cmdline at: %s)', zk_pid)
+        return False
+
+    log.info('PID %s has command line %s', zk_pid, cmd_line)
+
+    if len(cmd_line) < 3:
+        log.info("Command line too short to be zookeeper started by exhibitor")
+        return False
+
+    if cmd_line[-1] != '/var/lib/dcos/exhibitor/conf/zoo.cfg' \
+            or cmd_line[0] != '/opt/mesosphere/active/java/usr/java/bin/java':
+        log.info("command line doesn't start with java and end with zookeeper.cfg")
+        return False
+
+    log.info("PID file hasn't been modified. ZK still seems to be at that PID.")
+    return True
+
 
 def wait(master_count_filename):
+    if try_shortcut():
+        log.info("Shortcut succeeeded, assuming local zk is in good config state, not waiting for quorum.")
+        return
+    log.info('Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize')
+
     if not os.path.exists(master_count_filename):
         log.info("master_count file doesn't exist, not waiting")
         return
@@ -44,3 +101,9 @@ def wait(master_count_filename):
     if serving != cluster_size or leaders != 1:
         msg = 'Expected {} servers and 1 leader, got {} servers and {} leaders'.format(cluster_size, serving, leaders)
         raise Exception(msg)
+
+    # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
+    # there is a restart we can come up quickly without requiring a new zookeeper quorum.
+    zk_pid_mtime = str(get_zk_pid_mtime())
+    log.info('Stashing zk.pid mtime %s to %s', zk_pid_mtime, stash_zk_pid_stat_mtime_path)
+    write_string(stash_zk_pid_stat_mtime_path, zk_pid_mtime)


### PR DESCRIPTION
…nown to be running with a good config

Previously whenever a service, such as a mesos master restarted, it would have
to wait until all zookeeper instances in the cluster were started and stable.
This meant that if one master was gone, gone, no other master could be restarted
(it would never come back up until the gone node was replaced).

This changes that logic a bit, making it so that if the exact same zookeeper
process which was running when the mesos master (or friends) comes up is still
running then the master can start up instantly. This should be safe beause that
zookeeper had to have been started with a full quorum config by exhibitor, which
means it should be up, running, with a valid state of the cluster overall,
rather than this node belonging to a subset / partition which hasn't reached
overall cluster status.