### PR TITLE
Hard fail if master count file doesn't exist.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -262,7 +262,7 @@ package:
       GLOG_drop_log_memory=false
 {% switch use_mesos_hooks %}
 {% case "true" %}
-      MESOS_HOOKS={{ mesos_hooks }} 
+      MESOS_HOOKS={{ mesos_hooks }}
 {% case "false" %}
 {% endswitch %}
   - path: /etc/mesos-slave

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -62,6 +62,10 @@ bootstrappers = {
 }
 
 
+def get_roles():
+    return os.listdir('/opt/mesosphere/etc/roles')
+
+
 def main():
     opts = parse_args()
 
@@ -73,7 +77,8 @@ def main():
         os.environ.pop(name, None)
         os.environ.pop(name.lower(), None)
 
-    exhibitor.wait(opts.master_count)
+    if 'master' in get_roles():
+        exhibitor.wait(opts.master_count)
 
     b = bootstrap.Bootstrapper(opts.zk)
 
@@ -101,9 +106,8 @@ def get_zookeeper_address_agent():
 
 
 def get_zookeeper_address():
-    roles = os.listdir('/opt/mesosphere/etc/roles')
-
     # Masters use a special zk address since spartan and the like aren't up yet.
+    roles = get_roles()
     if 'master' in roles:
         return '127.0.0.1:2181'
 

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -71,8 +71,8 @@ def wait(master_count_filename):
     log.info('Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize')
 
     if not os.path.exists(master_count_filename):
-        log.info("master_count file doesn't exist, not waiting")
-        return
+        log.info("master_count file doesn't exist when it should. Hard failing.")
+        sys.exit(1)
 
     cluster_size = int(utils.read_file_line(master_count_filename))
     log.info('Expected cluster size: {}'.format(cluster_size))


### PR DESCRIPTION
In tests we can point it to a file which does exist. It is a parameter.