### PR TITLE
Replace registry_cluster fixture

### DIFF
--- a/test_util/docker/test_registry/Dockerfile
+++ b/test_util/docker/test_registry/Dockerfile
@@ -1,4 +1,8 @@
 FROM registry:2
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
 ADD client.key /client.key
 ADD client.cert /client.cert
 ENV REGISTRY_HTTP_TLS_CERTIFICATE=/client.cert


### PR DESCRIPTION
marathon apps should be calling docker CLI by default. This way is a bit more sensible and instead requires that the user running the test do the docker build