### PR TITLE
CoreOS Stable 1068.8.0 + Spartan fix-bind-ips

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,7 @@ Documentation of changes which may break some install environments
  - Zookeeper should now log to journald
  - dcos-history-serivce was renamed to dcos-history
  - dcos-ddt.service was renamed to dcos-3dt.service
- - Updated to CoreOS Beta 1068.
+ - Updated to CoreOS Stable 1068.8.0
  - Make the admin load balancer in all templates do TCP, not HTTP load balancing
  - Switch Ubuntu in Azure to 16.04 LTS final release
  - Teach spartan / DNS to only listen on a local internal address

--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -71,43 +71,43 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-fcd9209d",
         "el7": "ami-b8d831d9"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-9b00dcf8",
         "el7": "ami-133eee70"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-e8e4ce8b",
         "el7": "ami-f57d5496"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-7b7a8f14",
         "el7": "ami-2e6f8141"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-cbb5d5b8",
         "el7": "ami-20af3253"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-ef43d783",
         "el7": "ami-89179ce5"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-368c0321",
         "el7": "ami-7848b115"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-1d66d87c",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-bc2465dc",
         "el7": "ami-a891ebc8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-cfef22af",
         "el7": "ami-1e22d97e"
       }
     },

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -254,43 +254,43 @@
     },
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-fcd9209d",
         "el7": "ami-b8d831d9"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-9b00dcf8",
         "el7": "ami-133eee70"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-e8e4ce8b",
         "el7": "ami-f57d5496"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-7b7a8f14",
         "el7": "ami-2e6f8141"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-cbb5d5b8",
         "el7": "ami-20af3253"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-ef43d783",
         "el7": "ami-89179ce5"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-368c0321",
         "el7": "ami-7848b115"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-1d66d87c",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-bc2465dc",
         "el7": "ami-a891ebc8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-cfef22af",
         "el7": "ami-1e22d97e"
       }
     }

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -246,43 +246,43 @@
     },
     "RegionToAmi": {
       "ap-northeast-1": {
-        "coreos": "ami-bebc4ddf",
+        "coreos": "ami-fcd9209d",
         "el7": "ami-b8d831d9"
       },
       "ap-southeast-1": {
-        "coreos": "ami-3602d055",
+        "coreos": "ami-9b00dcf8",
         "el7": "ami-133eee70"
       },
       "ap-southeast-2": {
-        "coreos": "ami-07be9664",
+        "coreos": "ami-e8e4ce8b",
         "el7": "ami-f57d5496"
       },
       "eu-central-1": {
-        "coreos": "ami-8d8d66e2",
+        "coreos": "ami-7b7a8f14",
         "el7": "ami-2e6f8141"
       },
       "eu-west-1": {
-        "coreos": "ami-0d68f37e",
+        "coreos": "ami-cbb5d5b8",
         "el7": "ami-20af3253"
       },
       "sa-east-1": {
-        "coreos": "ami-18a23774",
+        "coreos": "ami-ef43d783",
         "el7": "ami-89179ce5"
       },
       "us-east-1": {
-        "coreos": "ami-153af578",
+        "coreos": "ami-368c0321",
         "el7": "ami-7848b115"
       },
       "us-gov-west-1": {
-        "coreos": "ami-96b50bf7",
+        "coreos": "ami-1d66d87c",
         "el7": ""
       },
       "us-west-1": {
-        "coreos": "ami-8befabeb",
+        "coreos": "ami-bc2465dc",
         "el7": "ami-a891ebc8"
       },
       "us-west-2": {
-        "coreos": "ami-02bf7962",
+        "coreos": "ami-cfef22af",
         "el7": "ami-1e22d97e"
       }
     }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-bebc4ddf"
+        "stable": "ami-fcd9209d"
       },
       "ap-southeast-1": {
-        "stable": "ami-3602d055"
+        "stable": "ami-9b00dcf8"
       },
       "ap-southeast-2": {
-        "stable": "ami-07be9664"
+        "stable": "ami-e8e4ce8b"
       },
       "eu-central-1": {
-        "stable": "ami-8d8d66e2"
+        "stable": "ami-7b7a8f14"
       },
       "eu-west-1": {
-        "stable": "ami-0d68f37e"
+        "stable": "ami-cbb5d5b8"
       },
       "sa-east-1": {
-        "stable": "ami-18a23774"
+        "stable": "ami-ef43d783"
       },
       "us-east-1": {
-        "stable": "ami-153af578"
+        "stable": "ami-368c0321"
       },
       "us-gov-west-1": {
-        "stable": "ami-96b50bf7"
+        "stable": "ami-1d66d87c"
       },
       "us-west-1": {
-        "stable": "ami-8befabeb"
+        "stable": "ami-bc2465dc"
       },
       "us-west-2": {
-        "stable": "ami-02bf7962"
+        "stable": "ami-cfef22af"
       }
     },
     "NATAmi" : {

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,8 +4,8 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "a615a611b514648a5a1abae93a96f1b7544ec4db",
-      "ref_origin": "master"
+      "ref": "a577b56c6357498d4f913ecaadcdf5b93c749c35",
+      "ref_origin": "fix-bind-ips"
     }
   }
 }


### PR DESCRIPTION
CoreOS 1068.8.0 includes:
* kernel: 4.6.3
* rkt: 1.7.0
* docker: 1.10.3
* etcd: 0.4.9, 2.3.2
* fleet: 0.11.7
* systemd: 229

See: https://coreos.com/releases/#1068.8.0 for full release notes.