### PR TITLE
Generate AWS Advanced Templates directly with gen library

### DIFF
--- a/ext/dcos-installer/dcos_installer/backend.py
+++ b/ext/dcos-installer/dcos_installer/backend.py
@@ -5,13 +5,27 @@ libraries to support the dcos installer.
 import logging
 import os
 
+import boto3
+import botocore.exceptions
+import yaml
+
 import gen
+import gen.calc
+import gen.installer.aws
+import release
+import release.storage.aws
+import release.storage.local
 import ssh.validate
 from dcos_installer import config_util
-from dcos_installer.config import DCOSConfig
+from dcos_installer.config import DCOSConfig, stringify_configuration
 from dcos_installer.constants import CONFIG_PATH, IP_DETECT_PATH, SSH_KEY_PATH
 
 log = logging.getLogger()
+
+
+def print_messages(messages):
+    for key, error in messages.items():
+        log.error('{}: {}'.format(key, error))
 
 
 def do_configure(config_path=CONFIG_PATH):
@@ -20,15 +34,247 @@ def do_configure(config_path=CONFIG_PATH):
     :param config_path: path to config.yaml
     :type config_path: string | CONFIG_PATH (genconf/config.yaml)
     """
-    validate_gen = do_validate_config(config_path, include_ssh=False)
-    if len(validate_gen) > 0:
-        for key, error in validate_gen.items():
-            log.error('{}: {}'.format(key, error))
+    messages = do_validate_config(config_path, include_ssh=False)
+    if messages:
+        print_messages(messages)
         return 1
     else:
         config = DCOSConfig(config_path=config_path)
         config_util.do_configure(config.stringify_configuration())
         return 0
+
+
+# Taken from: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+# In the same order as that document.
+region_to_endpoint = {
+    'us-east-1': 's3.amazonaws.com',
+    'us-west-1': 's3-us-west-1.amazonaws.com',
+    'us-west-2': 's3-us-west-2.amazonaws.com',
+    'ap-south-1': 's3.ap-south-1.amazonaws.com',
+    'ap-northeast-2': 's3.ap-northeast-2.amazonaws.com',
+    'ap-southeast-1': 's3-ap-southeast-1.amazonaws.com',
+    'ap-southeast-2': 's3-ap-southeast-2.amazonaws.com',
+    'ap-northeast-1': 's3-ap-northeast-1.amazonaws.com',
+    'eu-central-1': 's3.eu-central-1.amazonaws.com',
+    'eu-west-1': 's3-eu-west-1.amazonaws.com',
+    'sa-east-1': 's3-sa-east-1.amazonaws.com'
+}
+
+
+def validate_aws_template_storage_region_name(aws_template_storage_region_name):
+    assert aws_template_storage_region_name in region_to_endpoint, \
+        "Unsupported AWS region {}. Only {} are supported".format(
+            aws_template_storage_region_name,
+            region_to_endpoint.keys())
+
+
+def validate_aws_bucket_access(aws_template_storage_region_name,
+                               aws_template_storage_access_key_id,
+                               aws_template_storage_secret_access_key,
+                               aws_template_storage_bucket,
+                               aws_template_storage_bucket_path,
+                               aws_template_storage_bucket_path_autocreate):
+
+    session = boto3.session.Session(
+        aws_access_key_id=aws_template_storage_access_key_id,
+        aws_secret_access_key=aws_template_storage_secret_access_key,
+        region_name=aws_template_storage_region_name)
+
+    bucket = session.resource('s3').Bucket(aws_template_storage_bucket)
+
+    try:
+        bucket.load()
+    except botocore.exceptions.ClientError as ex:
+        if ex.response['Error']['Code'] == '404':
+            raise AssertionError("s3 bucket {} does not exist".format(aws_template_storage_bucket)) from ex
+        raise AssertionError("Unable to access s3 bucket {} in region {}: {}".format(
+            aws_template_storage_bucket, aws_template_storage_region_name, ex)) from ex
+
+    # If autocreate is on, then skip ensuring the path exists
+    if not aws_template_storage_bucket_path_autocreate:
+        try:
+            bucket.Object(aws_template_storage_bucket_path).load()
+        except botocore.exceptions.ClientError as ex:
+            if ex.response['Error']['Code'] == '404':
+                raise AssertionError(
+                    "path `{}` in bucket `{}` does not exist. Create it or set "
+                    "aws_template_storage_bucket_path_autocreate to true".format(
+                        aws_template_storage_bucket_path, aws_template_storage_bucket))
+            raise AssertionError("Unable to access s3 path {} in bucket {}: {}".format(
+                aws_template_storage_bucket_path, aws_template_storage_bucket, ex)) from ex
+
+
+def calculate_reproducible_artifact_path(config_id):
+    return 'config_id/{}'.format(config_id)
+
+
+def calculate_base_repository_url(
+        aws_template_storage_region_name,
+        aws_template_storage_bucket,
+        aws_template_storage_bucket_path):
+    return 'https://{domain}/{bucket}/{path}'.format(
+        domain=region_to_endpoint[aws_template_storage_region_name],
+        bucket=aws_template_storage_bucket,
+        path=aws_template_storage_bucket_path)
+
+
+# Figure out the s3 bucket url from region + bucket + path
+# TODO(cmaloney): Allow using a CDN rather than the raw S3 url, which will allow
+# us to use this same logic for both the internal / do_create version and the
+# user dcos_generate_config.sh option.
+def calculate_cloudformation_s3_url(bootstrap_url, aws_template_storage_bucket_path, config_id):
+    return '{}/{}/config_id/{}'.format(bootstrap_url, aws_template_storage_bucket_path, config_id)
+
+aws_advanced_entry = {
+    # TOOD(cmaloney): Add parameter validation for AWS Advanced template output.
+    'validate': [
+        lambda aws_template_upload: gen.calc.validate_true_false(aws_template_upload),
+        lambda aws_template_storage_bucket_path_autocreate:
+            gen.calc.validate_true_false(aws_template_storage_bucket_path_autocreate),
+        validate_aws_template_storage_region_name,
+        validate_aws_bucket_access
+    ],
+    'default': {
+        'num_masters': '5',
+        'aws_template_upload': 'true',
+        'aws_template_storage_bucket_path_autocreate': 'true',
+        'bootstrap_id': lambda: gen.calc.calculate_environment_variable('BOOTSTRAP_ID')
+        # TODO(cmaloney): Add defaults for getting AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY from the
+        # environment to set as keys. Not doing for now since they would need to be passed through
+        # the `docker run` inside dcos_generate_config.sh
+    },
+    'must': gen.merge_dictionaries({
+        'provider': 'aws',
+        'cloudformation_s3_url': calculate_cloudformation_s3_url,
+        'bootstrap_url': calculate_base_repository_url,
+        'reproducible_artifact_path': calculate_reproducible_artifact_path
+    }, gen.installer.aws.groups['master'][1])
+}
+
+
+aws_advanced_parameters = {
+    'variables': {
+        # TODO(cmaloney): Namespacing would be really handy here...
+        'aws_template_storage_bucket',
+        'aws_template_storage_bucket_path',
+        'aws_template_upload',
+        'aws_template_storage_bucket_path_autocreate',
+        'cloudformation_s3_url',
+        'provider',
+        'bootstrap_url',
+        'bootstrap_variant',
+        'reproducible_artifact_path'
+    },
+    'sub_scopes': {
+        'aws_template_upload': {
+            'true': {
+                'variables': {
+                    'aws_template_storage_access_key_id',
+                    'aws_template_storage_secret_access_key',
+                    'aws_template_storage_region_name'
+                }
+            },
+            'false': {}
+        }
+    }
+}
+
+
+# TODO(cmaloney): Make it so validation happens using the provided AWS credentials.
+def do_aws_cf_configure():
+    """Returns error code
+
+    Generates AWS templates using a custom config.yaml
+    """
+
+    # TODO(cmaloney): Move to Config class introduced in https://github.com/dcos/dcos/pull/623
+    with open(CONFIG_PATH, 'r') as f:
+        config = yaml.load(f)
+
+    aws_config_target = gen.ConfigTarget(aws_advanced_parameters)
+    aws_config_target.add_entry(aws_advanced_entry, False)
+
+    gen_config = stringify_configuration(config)
+    config_targets = [
+        gen.get_dcosconfig_target_and_templates(gen_config, [])[0],
+        aws_config_target]
+
+    messages = gen.validate_config_for_targets(config_targets, gen_config)
+    # TODO(cmaloney): kill this function and make the API return the structured
+    # results api as was always intended rather than the flattened / lossy other
+    # format. This will be an  API incompatible change. The messages format was
+    # specifically so that there wouldn't be this sort of API incompatibility.
+    messages = normalize_config_validation(messages)
+    if messages:
+        print_messages(messages)
+        return 1
+
+    # TODO(cmaloney): This is really hacky but a lot simpler than merging all the config flows into
+    # one currently.
+    # Get out the calculated arguments and manually move critical calculated ones to the gen_config
+    # object.
+    # NOTE: the copying across, as well as validation is guaranteed to succeed because we've already
+    # done a validation run.
+    full_config = gen.calculate_config_for_targets(config_targets, gen_config)
+    gen_config['bootstrap_url'] = full_config['bootstrap_url']
+    gen_config['provider'] = full_config['provider']
+    gen_config['bootstrap_id'] = full_config['bootstrap_id']
+    gen_config['cloudformation_s3_url'] = full_config['cloudformation_s3_url']
+
+    # Convert the bootstrap_Variant string we have back to a bootstrap_id as used internally by all
+    # the tooling (never has empty string, uses None to say "no variant")
+    bootstrap_variant = full_config['bootstrap_variant'] if full_config['bootstrap_variant'] else None
+
+    artifacts = list()
+    for built_resource in list(gen.installer.aws.do_create(
+            tag='dcos_generate_config.sh --aws-cloudformation',
+            build_name='Custom',
+            reproducible_artifact_path=full_config['reproducible_artifact_path'],
+            variant_arguments={bootstrap_variant: gen_config},
+            commit=full_config['dcos_image_commit'],
+            all_bootstraps=None)):
+        artifacts += release.built_resource_to_artifacts(built_resource)
+
+    artifacts += list(release.make_bootstrap_artifacts(full_config['bootstrap_id'], bootstrap_variant, 'artifacts'))
+
+    # Upload all the artifacts to the config-id path and then print out what
+    # the path that should be used is, as well as saving a local json file for
+    # easy machine access / processing.
+    repository = release.Repository(
+        full_config['aws_template_storage_bucket_path'],
+        None,
+        'config_id/' + full_config['config_id'])
+
+    storage_commands = repository.make_commands({'core_artifacts': [], 'channel_artifacts': artifacts})
+
+    log.warning("Writing local copies to genconf/cloudformation")
+    storage_provider = release.storage.local.LocalStorageProvider('genconf/cloudformation')
+    release.apply_storage_commands({'local': storage_provider}, storage_commands)
+
+    log.warning(
+        "Generated templates locally available at %s",
+        "genconf/cloudformation/" + full_config["reproducible_artifact_path"])
+    # TODO(cmaloney): Print where the user can find the files locally
+
+    if full_config['aws_template_upload'] == 'false':
+        return 0
+
+    storage_provider = release.storage.aws.S3StorageProvider(
+        bucket=full_config['aws_template_storage_bucket'],
+        object_prefix=None,
+        download_url=full_config['cloudformation_s3_url'],
+        region_name=full_config['aws_template_storage_region_name'],
+        access_key_id=full_config['aws_template_storage_access_key_id'],
+        secret_access_key=full_config['aws_template_storage_secret_access_key'])
+
+    log.warning("Uploading to AWS")
+    release.apply_storage_commands({'aws': storage_provider}, storage_commands)
+    log.warning("AWS CloudFormation templates now available at: {}".format(
+        full_config['cloudformation_s3_url']))
+
+    # TODO(cmaloney): Print where the user can find the files in AWS
+    # TODO(cmaloney): Dump out a JSON with machine paths to make scripting easier.
+    return 1
 
 
 def write_external_config(data, path, mode=0o644):
@@ -128,7 +374,9 @@ def _do_validate_config(config, include_ssh):
 
 def do_validate_config(config_path=CONFIG_PATH, include_ssh=True):
     """Returns complete validation messages from both SSH and Gen libraries."""
-    return _do_validate_config(DCOSConfig(config_path=config_path), include_ssh)
+    return _do_validate_config(
+        DCOSConfig(config_path=config_path),
+        include_ssh=include_ssh)
 
 
 def remap_post_data_keys(post_data):

--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -156,7 +156,11 @@ dispatch_dict_simple = {
     'validate-config': (
         do_validate_config,
         'VALIDATING CONFIGURATION',
-        'Validate the configuration for executing --genconf and deploy arguments in config.yaml')
+        'Validate the configuration for executing --genconf and deploy arguments in config.yaml'),
+    'aws-cloudformation': (
+        lambda args: backend.do_aws_cf_configure(),
+        'EXECUTING AWS CLOUD FORMATION TEMPLATE GENERATION',
+        'Generate AWS Advanced AWS CloudFormation templates using the provided config')
 }
 
 dispatch_dict_aio = {

--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -81,7 +81,7 @@
        "Infrastructure": {
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/infra.json",
+               "TemplateURL": "{{ cloudformation_full_s3_url }}/infra.json",
                "TimeoutInMinutes": "60",
                "Parameters": {
                     "KeyName": {
@@ -109,7 +109,7 @@
            "DependsOn": ["Infrastructure"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
+               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -160,7 +160,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
+               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -199,7 +199,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
+               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"

--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -563,6 +563,8 @@ def make_installer_docker(variant, bootstrap_id, installer_bootstrap_id):
     bootstrap_filename = bootstrap_id + ".bootstrap.tar.xz"
     bootstrap_active_filename = bootstrap_id + ".active.json"
     installer_bootstrap_filename = installer_bootstrap_id + '.bootstrap.tar.xz'
+    bootstrap_latest_filename = pkgpanda.util.variant_prefix(variant) + 'bootstrap.latest'
+    latest_complete_filename = pkgpanda.util.variant_prefix(variant) + 'complete.latest.json'
     docker_image_name = 'mesosphere/dcos-genconf:' + image_version
 
     # TODO(cmaloney): All of this should use package_resources
@@ -585,7 +587,9 @@ def make_installer_docker(variant, bootstrap_id, installer_bootstrap_id):
         fill_template('Dockerfile', {
             'installer_bootstrap_filename': installer_bootstrap_filename,
             'bootstrap_filename': bootstrap_filename,
-            'bootstrap_active_filename': bootstrap_active_filename})
+            'bootstrap_active_filename': bootstrap_active_filename,
+            'bootstrap_latest_filename': bootstrap_latest_filename,
+            'latest_complete_filename': latest_complete_filename})
 
         fill_template('installer_internal_wrapper', {
             'variant': pkgpanda.util.variant_str(variant),
@@ -594,9 +598,13 @@ def make_installer_docker(variant, bootstrap_id, installer_bootstrap_id):
 
         subprocess.check_call(['chmod', '+x', dest_path('installer_internal_wrapper')])
 
+        # TODO(cmaloney) make this use make_bootstrap_artifacts / that set
+        # rather than manually keeping everything in sync
         copy_to_build('packages/cache/bootstrap', bootstrap_filename)
         copy_to_build('packages/cache/bootstrap', installer_bootstrap_filename)
         copy_to_build('packages/cache/bootstrap', bootstrap_active_filename)
+        copy_to_build('packages/cache/bootstrap', bootstrap_latest_filename)
+        copy_to_build('packages/cache/complete', latest_complete_filename)
 
         # Copy across gen_extra if it exists
         if os.path.exists('gen_extra'):

--- a/gen/installer/bash/Dockerfile.in
+++ b/gen/installer/bash/Dockerfile.in
@@ -9,10 +9,12 @@ VOLUME ["/genconf"]
 EXPOSE 9000
 ENTRYPOINT ["/installer_internal_wrapper"]
 
-# Add the mutable artifacts last to increase caching, starting with the common
-# one
+# Add the mutable artifacts last to increase caching, starting with the common one
 ADD {installer_bootstrap_filename} /opt/mesosphere/
 COPY installer_internal_wrapper /installer_internal_wrapper
-COPY {bootstrap_filename} /artifacts/{bootstrap_filename}
-COPY {bootstrap_active_filename} /artifacts/{bootstrap_active_filename}
+# TODO(cmaloney): Switch to copying across a whole artifacts directory
+COPY {bootstrap_filename} /artifacts/bootstrap/{bootstrap_filename}
+COPY {bootstrap_active_filename} /artifacts/bootstrap/{bootstrap_active_filename}
+COPY {bootstrap_latest_filename} /artifacts/bootstrap/{bootstrap_latest_filename}
+COPY {latest_complete_filename} /artifacts/complete/{latest_complete_filename}
 COPY gen_extra/ /gen_extra

--- a/release/storage/aws.py
+++ b/release/storage/aws.py
@@ -26,16 +26,23 @@ class S3StorageProvider(AbstractStorageProvider):
 
     def __init__(self, bucket, object_prefix, download_url, boto3_profile=None, region_name=None,
                  access_key_id=None, secret_access_key=None):
-        assert not object_prefix.startswith('/')
-        assert not object_prefix.endswith('/')
+        if object_prefix is not None:
+            assert object_prefix and not object_prefix.startswith('/') and not object_prefix.endswith('/')
 
         self.__session = get_session(boto3_profile, region_name, access_key_id, secret_access_key)
         self.__bucket = self.__session.resource('s3').Bucket(bucket)
         self.__object_prefix = object_prefix
         self.__url = download_url
 
+    @property
+    def object_prefix(self):
+        if self.__object_prefix is None:
+            return ''
+        return self.__object_prefix + '/'
+
     def _get_path(self, name):
-        return self.__object_prefix + '/' + name
+
+        return self.object_prefix + name
 
     def _get_objects_with_prefix(self, prefix):
         return self.__bucket.objects.filter(Prefix=self._get_path(prefix))
@@ -95,7 +102,7 @@ class S3StorageProvider(AbstractStorageProvider):
             return False
 
     def list_recursive(self, path):
-        prefix_len = len(self.__object_prefix + '/')
+        prefix_len = len(self.object_prefix)
         names = set()
         for object_summary in self._get_objects_with_prefix(path):
             name = object_summary.key

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -428,16 +428,16 @@ def exercise_make_commands(repository):
 def test_repository():
     # Must specify a repository path
     with pytest.raises(ValueError):
-        release.Repository("", None, "testing_commit")
+        release.Repository("", None, "commit/testing_commit")
 
     # For an empty channel name, use None
     with pytest.raises(AssertionError):
-        release.Repository("foo", "", "testing_commit")
+        release.Repository("foo", "", "commit/testing_commit")
 
     # Repository path with no channel (Like we'd do for a stable or EA release).
     no_channel = release.Repository("stable", None, "commit/testing_commit_2")
     assert no_channel.channel_prefix == ''
-    assert no_channel.path_channel_commit_prefix + 'foo' == 'stable/commit/testing_commit_2/foo'
+    assert no_channel.reproducible_artifact_path + 'foo' == 'stable/commit/testing_commit_2/foo'
     assert no_channel.path_channel_prefix + 'bar' == 'stable/bar'
     assert no_channel.path_prefix + "a/baz--foo.tar.xz" == 'stable/a/baz--foo.tar.xz'
     exercise_make_commands(no_channel)
@@ -445,7 +445,7 @@ def test_repository():
     # Repository path with a channel (Like we do for PRs)
     with_channel = release.Repository("testing", "pull/283", "commit/testing_commit_3")
     assert with_channel.channel_prefix == 'pull/283/'
-    assert with_channel.path_channel_commit_prefix + "foo" == 'testing/pull/283/commit/testing_commit_3/foo'
+    assert with_channel.reproducible_artifact_path + "foo" == 'testing/pull/283/commit/testing_commit_3/foo'
     assert with_channel.path_channel_prefix + "bar" == 'testing/pull/283/bar'
     assert with_channel.path_prefix + "a/baz--foo.tar.xz" == 'testing/a/baz--foo.tar.xz'
     # TODO(cmaloney): Exercise make_commands with a channel.


### PR DESCRIPTION
Initial support for creating AWS templates with `dcos_generate_config.sh` using the argument `--aws-cloudformation` and a limited subset of `config.yaml` options.

Known bugs:
 - [x] Setting `aws_template_upload: true` doesn't make aws_template_storage_access_key_id and friends mandatory / validate
 - [x] Need to tell user about `config_id` folder + path information
 - [x] bootstrap_url is set wrong (Shouldn't contain the unique config_id path)
 - [x] repository_url is set wrong (Shouldn't contain the unique config_id path)

Sample config.yaml:
```
---
aws_template_storage_bucket: cody-test-advanced
aws_template_storage_bucket_path: some/path
aws_template_storage_region_name: us-west-2
aws_template_upload: true
aws_template_storage_access_key_id: <your_access_key_id>
aws_template_storage_secret_access_key: <your_secret_access_key>
```

Includes: #656