### PR TITLE
Include localhost entry on Azure clusters

### DIFF
--- a/gen/azure/cloud-config.yaml
+++ b/gen/azure/cloud-config.yaml
@@ -45,7 +45,7 @@ root:
       Type=oneshot
       EnvironmentFile=/etc/environment
       EnvironmentFile=/opt/mesosphere/environment
-      ExecStart=/usr/bin/bash -c "echo $(detect_ip) $(hostname) > /etc/hosts"
+      ExecStart=/usr/bin/bash -c "echo -e 127.0.0.1 localhost\\\n$(detect_ip) $(hostname) > /etc/hosts"
 runcmd:
     - [ ln, -s, /bin/rm, /usr/bin/rm ]
     - [ ln, -s, /bin/mkdir, /usr/bin/mkdir ]


### PR DESCRIPTION
Fixes an issue currently impacting Azure regions in Australia and North
Europe, where the Azure DNS servers are no longer responding with an
entry for `localhost`. The startup service currently overwrites the
default /etc/hosts file so that it is an idempotent operation and can be
run multiple times if the $(detect_ip) value changes.