### PR TITLE
Remove `ec2:DeleteVolume` permission from agents

### DIFF
--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -139,7 +139,6 @@
                     "ec2:CreateTags",
                     "ec2:DescribeInstances",
                     "ec2:CreateVolume",
-                    "ec2:DeleteVolume",
                     "ec2:AttachVolume",
                     "ec2:DetachVolume",
                     "ec2:DescribeVolumes",

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -128,7 +128,6 @@
                   "ec2:CreateTags",
                   "ec2:DescribeInstances",
                   "ec2:CreateVolume",
-                  "ec2:DeleteVolume",
                   "ec2:AttachVolume",
                   "ec2:DetachVolume",
                   "ec2:DescribeVolumes",

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -509,7 +509,6 @@
                 "ec2:CreateTags",
                 "ec2:DescribeInstances",
                 "ec2:CreateVolume",
-                "ec2:DeleteVolume",
                 "ec2:AttachVolume",
                 "ec2:DetachVolume",
                 "ec2:DescribeVolumes",


### PR DESCRIPTION
Neither Marathon nore the Mesos docker/volume isolator will delete a
volume, so this permission is unnecessary.