### PR TITLE
Restrict volume permissions for CloudFormation agents

### DIFF
--- a/gen/aws/calc.py
+++ b/gen/aws/calc.py
@@ -3,6 +3,20 @@ import pkg_resources
 import yaml
 
 
+# Use IAM Instance profile for auth and tag volumes with StackId.
+REXRAY_CONFIG = """
+rexray:
+  loglevel: info
+  storageDrivers:
+    - ec2
+  volume:
+    unmount:
+      ignoreusedcount: true
+aws:
+  rexrayTag: { "Ref" : "AWS::StackId" }
+"""
+
+
 def get_spot(name, spot_price):
     if spot_price:
         return '"SpotPrice": "{}",'.format(spot_price)
@@ -45,7 +59,7 @@ entry = {
         'cloud_config': '{{ cloud_config }}',
         'oauth_available': 'true',
         'oauth_enabled': '{ "Ref" : "OAuthEnabled" }',
-        # Use IAM Instance profile for auth
-        'rexray_config_method': 'aws'
+        'rexray_config_method': 'string',
+        'rexray_config_string': REXRAY_CONFIG,
     }
 }

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -139,9 +139,6 @@
                     "ec2:CreateTags",
                     "ec2:DescribeInstances",
                     "ec2:CreateVolume",
-                    "ec2:DeleteVolume",
-                    "ec2:AttachVolume",
-                    "ec2:DetachVolume",
                     "ec2:DescribeVolumes",
                     "ec2:DescribeVolumeStatus",
                     "ec2:DescribeVolumeAttribute",
@@ -152,6 +149,45 @@
                     "ec2:DescribeSnapshotAttribute",
                     "autoscaling:DescribeAutoScalingGroups",
                     "cloudwatch:PutMetricData"
+                  ],
+                  "Effect": "Allow"
+                },
+                {
+                  "Resource": {
+                    "Fn::Join" : [
+                      ":",
+                      [
+                        "arn:aws:ec2",
+                        { "Ref" : "AWS::Region" },
+                        { "Ref" : "AWS::AccountId" },
+                        "volume/*"
+                      ]
+                    ]
+                  },
+                  "Condition": {"StringEquals": {"ec2:ResourceTag/rexraySet": { "Ref" : "AWS::StackId" }}},
+                  "Action": [
+                    "ec2:DeleteVolume",
+                    "ec2:AttachVolume",
+                    "ec2:DetachVolume"
+                  ],
+                  "Effect": "Allow"
+                },
+                {
+                  "Resource": {
+                    "Fn::Join" : [
+                      ":",
+                      [
+                        "arn:aws:ec2",
+                        { "Ref" : "AWS::Region" },
+                        { "Ref" : "AWS::AccountId" },
+                        "instance/*"
+                      ]
+                    ]
+                  },
+                  "Condition": {"StringEquals": {"ec2:ResourceTag/aws:cloudformation:stack-id": { "Ref" : "AWS::StackId" }}},
+                  "Action": [
+                    "ec2:AttachVolume",
+                    "ec2:DetachVolume"
                   ],
                   "Effect": "Allow"
                 }

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -128,9 +128,6 @@
                   "ec2:CreateTags",
                   "ec2:DescribeInstances",
                   "ec2:CreateVolume",
-                  "ec2:DeleteVolume",
-                  "ec2:AttachVolume",
-                  "ec2:DetachVolume",
                   "ec2:DescribeVolumes",
                   "ec2:DescribeVolumeStatus",
                   "ec2:DescribeVolumeAttribute",
@@ -141,6 +138,45 @@
                   "ec2:DescribeSnapshotAttribute",
                   "autoscaling:DescribeAutoScalingGroups",
                   "cloudwatch:PutMetricData"
+                ],
+                "Effect": "Allow"
+              },
+              {
+                "Resource": {
+                  "Fn::Join" : [
+                    ":",
+                    [
+                      "arn:aws:ec2",
+                      { "Ref" : "AWS::Region" },
+                      { "Ref" : "AWS::AccountId" },
+                      "volume/*"
+                    ]
+                  ]
+                },
+                "Condition": {"StringEquals": {"ec2:ResourceTag/rexraySet": { "Ref" : "AWS::StackId" }}},
+                "Action": [
+                  "ec2:DeleteVolume",
+                  "ec2:AttachVolume",
+                  "ec2:DetachVolume"
+                ],
+                "Effect": "Allow"
+              },
+              {
+                "Resource": {
+                  "Fn::Join" : [
+                    ":",
+                    [
+                      "arn:aws:ec2",
+                      { "Ref" : "AWS::Region" },
+                      { "Ref" : "AWS::AccountId" },
+                      "instance/*"
+                    ]
+                  ]
+                },
+                "Condition": {"StringEquals": {"ec2:ResourceTag/aws:cloudformation:stack-id": { "Ref" : "AWS::StackId" }}},
+                "Action": [
+                  "ec2:AttachVolume",
+                  "ec2:DetachVolume"
                 ],
                 "Effect": "Allow"
               }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -509,9 +509,6 @@
                 "ec2:CreateTags",
                 "ec2:DescribeInstances",
                 "ec2:CreateVolume",
-                "ec2:DeleteVolume",
-                "ec2:AttachVolume",
-                "ec2:DetachVolume",
                 "ec2:DescribeVolumes",
                 "ec2:DescribeVolumeStatus",
                 "ec2:DescribeVolumeAttribute",
@@ -524,8 +521,46 @@
                 "cloudwatch:PutMetricData"
               ],
               "Effect": "Allow"
-            }
-            ]
+            },
+            {
+              "Resource": {
+                "Fn::Join" : [
+                  ":",
+                  [
+                    "arn:aws:ec2",
+                    { "Ref" : "AWS::Region" },
+                    { "Ref" : "AWS::AccountId" },
+                    "volume/*"
+                  ]
+                ]
+              },
+              "Action": [
+                "ec2:DeleteVolume",
+                "ec2:AttachVolume",
+                "ec2:DetachVolume"
+              ],
+              "Condition": {"StringEquals": {"ec2:ResourceTag/rexraySet": { "Ref" : "AWS::StackId" }}},
+              "Effect": "Allow"
+            },
+            {
+              "Resource": {
+                "Fn::Join" : [
+                  ":",
+                  [
+                    "arn:aws:ec2",
+                    { "Ref" : "AWS::Region" },
+                    { "Ref" : "AWS::AccountId" },
+                    "instance/*"
+                  ]
+                ]
+              },
+              "Action": [
+                "ec2:AttachVolume",
+                "ec2:DetachVolume"
+              ],
+              "Condition": {"StringEquals": {"ec2:ResourceTag/aws:cloudformation:stack-id": { "Ref" : "AWS::StackId" }}},
+              "Effect": "Allow"
+            } ]
           }
         } ]
       }

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -90,12 +90,16 @@ def calculate_ip_detect_public_contents(ip_detect_contents):
     return ip_detect_contents
 
 
-def calculate_rexray_config_contents(rexray_config_filename):
+def calculate_rexray_config_from_file(rexray_config_filename):
     try:
         with open(rexray_config_filename, encoding='utf-8') as f:
             return yaml.dump(f.read())
     except IOError as err:
         raise Exception('REX-Ray config file {}: {}'.format(rexray_config_filename, err)) from err
+
+
+def calculate_rexray_config_from_string(rexray_config_string):
+    return yaml.dump(rexray_config_string)
 
 
 def calculate_gen_resolvconf_search(dns_search):
@@ -421,7 +425,10 @@ entry = {
         },
         'rexray_config_method': {
             'file': {
-                'must': {'rexray_config_contents': calculate_rexray_config_contents},
+                'must': {'rexray_config_contents': calculate_rexray_config_from_file},
+            },
+            'string': {
+                'must': {'rexray_config_contents': calculate_rexray_config_from_string},
             },
             'aws': {
                 'must': {'rexray_config_contents': yaml.dump(AWS_REXRAY_CONFIG)},


### PR DESCRIPTION
* DeleteVolume, AttachVolume, DetachVolume restricted to volumes with
  tag rexraySet = AWS::StackId
* AttachVolume, DetachVolume restricted to instances with the
  tag aws:cloudformation:stack-id = AWS::StackId

This has the happy side effect of [restricting a CloudFormation cluster's REX-Ray to viewing only the volumes created by that cluster](https://github.com/dcos/rexray/blob/v0.3.3-dcos/drivers/storage/ec2/ec2.go#L678).