### PR TITLE
Add a pkgpanda package that will say what roles are active

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -101,10 +101,16 @@ def get_zookeeper_address_agent():
 
 
 def get_zookeeper_address():
-    if os.path.exists('/etc/mesosphere/roles/master'):
+    roles = os.listdir('/opt/mesosphere/etc/roles')
+
+    # Masters use a special zk address since spartan and the like aren't up yet.
+    if 'master' in roles:
         return '127.0.0.1:2181'
-    else:
+
+    if 'slave' in roles or 'slave_public' in roles:
         return get_zookeeper_address_agent()
+
+    raise Exception("Can't get zookeeper address. Unknown role: {}".format(roles))
 
 
 def parse_args():

--- a/packages/boto/extra/cfn-signal
+++ b/packages/boto/extra/cfn-signal
@@ -25,7 +25,7 @@ whereas <role> is specified by either
     AWS_IAM_SLAVE_ROLE_NAME
 
 depending on whether this instance is a slave or master. It is considered
-master only if a file named 'master' is contained in /etc/mesosphere/roles.
+master only if a file named 'master' is contained in /opt/mesosphere/etc/roles.
 
 (Note: boto3 would query the security-credentials service automatically if
 it does not find credentials in the environment or in one of its config files.
@@ -69,8 +69,8 @@ instance_id = requests.get(instance_id_url).text
 print('cfn-signal: obtained instance ID: %s' % instance_id)
 
 assume_role_name = slave_role_name
-if 'master' in os.listdir('/etc/mesosphere/roles'):
-    print('cfn-signal: master entry found in /etc/mesosphere/roles.')
+if 'master' in os.listdir('/opt/mesosphere/etc/roles'):
+    print('cfn-signal: master entry found in /opt/mesosphere/etc/roles.')
     assume_role_name = master_role_name
 
 credential_url = '%s/iam/security-credentials/%s' % (

--- a/packages/pkgpanda-role/build
+++ b/packages/pkgpanda-role/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Same structure as `/etc/mesosphere/roles` for now.
+mkdir -p $PKG_PATH/etc_master/roles/master
+mkdir -p $PKG_PATH/etc_slave/roles/slave
+mkdir -p $PKG_PATH/etc_slave_public/roles/slave_public


### PR DESCRIPTION
This makes it so we have a state of what is currently running, instead of the state of what might be running.

cc: @alberts @orsenthil @lingmann @spahl 