### PR TITLE
Run Marathon/Metronome tasks as 'root' by default.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -412,6 +412,7 @@ package:
       METRONOME_MESOS_LEADER_UI_URL=http://leader.mesos:5050
       METRONOME_MESOS_MASTER_URL=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       METRONOME_PLAY_SERVER_HTTP_PORT=9000
+      METRONOME_MESOS_USER=root
   - path: /etc/user.config.yaml
     content: |
 {{ config_yaml }}

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -42,5 +42,6 @@ ExecStart=/opt/mesosphere/bin/java \\
     --zk_compression \\
     --mesos_leader_ui_url "/mesos" \\
     --enable_features "vips,task_killing,external_volumes" \\
-    --mesos_authentication_principal "dcos_marathon"
+    --mesos_authentication_principal "dcos_marathon" \\
+    --mesos_user "root"
 EOF


### PR DESCRIPTION
Marathon/Metronome are now run by the dcos_marathon and dcos_metronome linux users. Their schedulers default to setting FrameworkInfo.user to the user that launched the scheduler process. Since this used to be 'root', many users may be accustomed to just having access to things. Let's set the default FrameworkInfo.user to 'root' for now, since that's more sane than 'dcos_marathon', which is supposed to be just for root Marathon itself. In the future, I'd recommend we default this to 'nobody' or a generic 'dcos' user.
Note that this user can always be overridden on a per-task basis.