### PR TITLE
3dt bug fixes

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -4,7 +4,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "2bed06726e0a2b6acce42f46e8ddf4e1ee6a40d0",
+    "ref": "ac15605f71487b16f5afadd0f1239cbc30db7dbf",
     "ref_origin": "master"
   },
   "username": "dcos_3dt",


### PR DESCRIPTION
- increase exhibitor response timeout to 11sec.
  If a master node goes down, a get request to exhibitor may take up to 10 sec.
  (http://127.0.0.1:8181/exhibitor/v1/cluster/status).
  https://github.com/dcos/3dt/pull/50

- fix typo
  https://github.com/dcos/3dt/pull/51