### PR TITLE
Excluding docker-engine from yum update in preflight

### DIFF
--- a/ext/dcos-installer/dcos_installer/action_lib/__init__.py
+++ b/ext/dcos-installer/dcos_installer/action_lib/__init__.py
@@ -334,7 +334,7 @@ gpgcheck=1
 gpgkey=https://yum.dockerproject.org/gpg
 EOF
 
-sudo yum -y update
+sudo yum -y update --exclude=docker-engine
 
 sudo mkdir -p /etc/systemd/system/docker.service.d
 sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF


### PR DESCRIPTION
We have faced a problem when retrying the preflight phase. The problem was that if during the first attempt docker has been installed (or it already installed in the machines), the command `sudo yum -y update` will update docker to the lastest version (currently 1.12). The PR excludes package docker-engine in the `sudo yum -y update` command, but it could be resolved by other ways (for example blacklisting the update of docker-engine package)