### PR TITLE
Revert "Pin flake8==2.6.2 in tox"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ testpaths =
 
 [testenv:py34-syntax]
 deps =
-  flake8==2.6.2
+  flake8
   teamcity-messages
   isort
 


### PR DESCRIPTION
Reverts #411 

Flake8 3.0 and teamcity-messages are now compatible. See: https://github.com/JetBrains/teamcity-messages/releases/tag/v1.20

This reverts commit 0a39e4b4098ebf4928ee200388243277ce21c78d.

