### PR TITLE
[Mesos] Limit logrotate module libprocess worker threads to 2.

### DIFF
--- a/packages/mesos/extra/slave_logrotate_module.json
+++ b/packages/mesos/extra/slave_logrotate_module.json
@@ -25,6 +25,10 @@
             {
               "key": "logrotate_stderr_options",
               "value": "rotate 9"
+            },
+            {
+              "key": "libprocess_num_worker_threads",
+              "value": "2"
             }
           ]
         }


### PR DESCRIPTION
This change depends on https://reviews.apache.org/r/50766/