### PR TITLE
Report on py.test skip reasons

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
   webtest-aiohttp==1.0.0
 commands=
   ./prep_local
-  py.test --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}
+  py.test -rs --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}
 
 [testenv:py34-pkgpanda]
 whitelist_externals=bash
@@ -54,7 +54,7 @@ deps=
 changedir=pkgpanda/tests
 commands=
   bash -c "cd ../../ && ./prep_local"
-  py.test -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-build]
 whitelist_externals=bash
@@ -64,7 +64,7 @@ deps=
 changedir=pkgpanda/build/tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-integration]
 whitelist_externals=bash
@@ -74,7 +74,7 @@ deps=
 changedir=pkgpanda/integration-tests
 commands=
   bash -c "cd ../../ && ./prep_local"
-  py.test -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-bootstrap]
 deps=
@@ -83,4 +83,4 @@ deps=
 changedir=packages/bootstrap/extra
 commands=
   pip install .
-  py.test -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
Show in test summary reasons for any tests which were 'skipped'. For
example:

```
============================================================================= short test summary info =============================================================================
SKIP [2] /dcos/pytest/test_release.py:17: Skipping because there is no configuration in dcos-release.config.yaml

============================================================ 75 passed, 2 skipped, 1 pytest-warnings in 20.41 seconds =============================================================
_____________________________________________________________________________________ summary _____________________________________________________________________________________
```