### PR TITLE
Introduce Legacy Resources Mode, allowing for more ports when disabled

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -34,6 +34,19 @@ rexray:
 """
 
 
+def enum_validator(enums):
+
+    def validator(enum):
+        assert enum in enums, 'Must be one of {}. Got {}.'.format(enums, enum)
+    return validator
+
+true_false_enum_validator = enum_validator(['true', 'false'])
+
+
+def validate_legacy_agent_resources_mode(legacy_agent_resources_mode):
+    true_false_enum_validator(legacy_agent_resources_mode)
+
+
 def calculate_bootstrap_variant():
     variant = os.getenv('BOOTSTRAP_VARIANT')
     assert variant is not None, "BOOTSTRAP_VARIANT must be set"
@@ -120,21 +133,18 @@ def calculate_use_mesos_hooks(mesos_hooks):
 
 
 def validate_telemetry_enabled(telemetry_enabled):
-    can_be = ['true', 'false']
-    assert telemetry_enabled in can_be, 'Must be one of {}. Got {}.'.format(can_be, telemetry_enabled)
+    true_false_enum_validator(telemetry_enabled)
 
 
 def validate_oauth_enabled(oauth_enabled):
     # Should correspond with oauth_enabled in gen/azure/calc.py
     if oauth_enabled in ["[[[variables('oauthEnabled')]]]", '{ "Ref" : "OAuthEnabled" }']:
         return
-    can_be = ['true', 'false']
-    assert oauth_enabled in can_be, 'Must be one of {}. Got {}'.format(can_be, oauth_enabled)
+    true_false_enum_validator(oauth_enabled)
 
 
 def validate_dcos_overlay_enable(dcos_overlay_enable):
-    can_be = ['true', 'false']
-    assert dcos_overlay_enable in can_be, 'Must be one of {}. Got {}.'.format(can_be, dcos_overlay_enable)
+    true_false_enum_validator(dcos_overlay_enable)
 
 
 def validate_dcos_overlay_mtu(dcos_overlay_mtu):
@@ -179,9 +189,7 @@ def validate_dcos_overlay_network(dcos_overlay_network):
 
 
 def validate_dcos_remove_dockercfg_enable(dcos_remove_dockercfg_enable):
-    can_be = ['true', 'false']
-    assert dcos_remove_dockercfg_enable in can_be, (
-       'Must be one of {}. Got {}.'.format(can_be, dcos_remove_dockercfg_enable))
+    true_false_enum_validator(dcos_remove_dockercfg_enable)
 
 
 def calculate_oauth_available(oauth_enabled):
@@ -189,7 +197,7 @@ def calculate_oauth_available(oauth_enabled):
 
 
 def validate_num_masters(num_masters):
-    assert int(num_masters) in [1, 3, 5, 7, 9], "Must have 1, 3, 5, 7, or 9 masters. Found {}".format(num_masters)
+    enum_validator([1, 3, 5, 7, 9])
 
 
 def validate_bootstrap_url(bootstrap_url):
@@ -260,20 +268,19 @@ def validate_duplicates(input_list):
 
 
 def validate_master_list(master_list):
-    return validate_host_list(master_list)
+    validate_host_list(master_list)
 
 
 def validate_resolvers(resolvers):
-    return validate_host_list(resolvers)
+    validate_host_list(resolvers)
 
 
 def validate_mesos_dns_ip_sources(mesos_dns_ip_sources):
-    return validate_json_list(mesos_dns_ip_sources)
+    validate_json_list(mesos_dns_ip_sources)
 
 
 def validate_master_dns_bindall(master_dns_bindall):
-    can_be = ['true', 'false']
-    assert master_dns_bindall in can_be, 'Must be one of {}. Got {}.'.format(can_be, master_dns_bindall)
+    true_false_enum_validator(master_dns_bindall)
 
 
 def calc_num_masters(master_list):
@@ -332,8 +339,7 @@ def calculate_config_yaml(user_arguments):
 
 
 def validate_os_type(os_type):
-    can_be = ['coreos', 'el7']
-    assert os_type in can_be, 'Must be one of {}. Got {}'.format(can_be, os_type)
+    enum_validator(['coreos', 'el7'])(os_type)
 
 
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
@@ -358,7 +364,8 @@ entry = {
         validate_dcos_overlay_network,
         validate_dcos_overlay_enable,
         validate_dcos_overlay_mtu,
-        validate_dcos_remove_dockercfg_enable],
+        validate_dcos_remove_dockercfg_enable,
+        validate_legacy_agent_resources_mode],
     'default': {
         'bootstrap_variant': calculate_bootstrap_variant,
         'weights': '',
@@ -391,6 +398,7 @@ entry = {
         'ui_banner_dismissible': 'null',
         'dcos_overlay_mtu': '1420',
         'dcos_overlay_enable': "true",
+        'legacy_agent_resources_mode': 'false',
         'dcos_overlay_network': '{                      \
             "vtep_subnet": "44.128.0.0/20",             \
             "vtep_mac_oui": "70:B3:D5:00:00:00",        \

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -262,12 +262,20 @@ package:
       GLOG_drop_log_memory=false
 {% switch use_mesos_hooks %}
 {% case "true" %}
-      MESOS_HOOKS={{ mesos_hooks }} 
+      MESOS_HOOKS={{ mesos_hooks }}
 {% case "false" %}
 {% endswitch %}
+
+{% switch legacy_agent_resources_mode %}
+{% case "true" %}
   - path: /etc/mesos-slave
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]
+{% case "false" %}
+  - path: /etc/mesos-slave
+    content: |
+      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]
+{% endswitch %}
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]

--- a/pytest/test_gen_validation.py
+++ b/pytest/test_gen_validation.py
@@ -5,6 +5,8 @@ import pytest
 
 import gen
 
+GOT_FOO = "Must be one of ['true', 'false']. Got foo."
+
 
 def validate_helper(arguments):
     return gen.validate(arguments=arguments)
@@ -48,11 +50,10 @@ def validate_error(new_arguments, key, message):
 
 
 def test_invalid_telemetry_enabled(default_arguments):
-    err_msg = "Must be one of ['true', 'false']. Got foo."
     validate_error(
         {'telemetry_enabled': 'foo'},
         'telemetry_enabled',
-        err_msg)
+        GOT_FOO)
 
 
 def test_invalid_ipv4(default_arguments):
@@ -101,4 +102,11 @@ def test_invalid_oauth_enabled(default_arguments):
     validate_error(
         {'oauth_enabled': 'foo'},
         'oauth_enabled',
-        "Must be one of ['true', 'false']. Got foo")
+        GOT_FOO)
+
+
+def test_legacy_agent_resources_mode(default_arguments):
+    validate_error(
+        {'legacy_agent_resources_mode': 'foo'},
+        'legacy_agent_resources_mode',
+        GOT_FOO)


### PR DESCRIPTION
```
commit 496ce70b4be91fcfd1074d34be288af7ab29365b
Author: Sargun Dhillon <sargun@sargun.me>
Date:   Sat Aug 6 15:26:20 2016 -0700

    gen: Add true_false_enum_validator helper for config validation, Introduce legacy_agent_resources_mode

    This commit adds a true_false_enum_validator to replace a pattern
    that was being repeated throughout gen/calc.py.

    legacy_agent_resources_mode makes it so that by default (if set to
    false), it will make nearly all ports 1-32000 available in offers,
    versus traditional mode, which restricts access to ports 1-1024.
```
