### PR TITLE
Fix Pkgpanda API JSON response serialization

### DIFF
--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -1,6 +1,7 @@
 {
   "requires": [
     "boto",
+    "flask",
     "python",
     "python-docopt",
     "python-isodate",

--- a/packages/flask/build
+++ b/packages/flask/build
@@ -4,6 +4,6 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Build all the packages. We'd use pip to install them but that fails badly.
-for package in Flask flask-compress itsdangerous Werkzeug; do
+for package in Flask click flask-compress itsdangerous Werkzeug; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ "/pkg/src/$package"
 done

--- a/packages/flask/buildinfo.json
+++ b/packages/flask/buildinfo.json
@@ -3,8 +3,13 @@
   "sources": {
     "Flask": {
       "kind": "url_extract",
-      "url": "https://github.com/mitsuhiko/flask/archive/0.10.1.tar.gz",
-      "sha1": "232f15e4f95f299e79b1e7f44304527f60234b2a"
+      "url": "https://github.com/pallets/flask/archive/0.11.1.tar.gz",
+      "sha1": "6350522686e0463e01e453d2a7c0d04203083d0f"
+    },
+    "click": {
+      "kind": "url_extract",
+      "url": "https://github.com/pallets/click/archive/6.6.tar.gz",
+      "sha1": "766c6595cc7a1ed12051306094d010e7d85c027f"
     },
     "flask-compress": {
       "kind": "url_extract",


### PR DESCRIPTION
This adds `flask` as a dependency of `dcos-image-deps` and updates it to [version 0.11.1](http://flask.pocoo.org/docs/0.11/changelog/) to include this fix:

> Added support to serializing top-level arrays to flask.jsonify(). This introduces a security risk in ancient browsers. See [JSON Security](http://flask.pocoo.org/docs/0.11/security/#json-security) for details.