### PR TITLE
[minor] Use tempfile.tempdir in http.config instead of hardcoding to /tmp.

### DIFF
--- a/pkgpanda/http/config.py
+++ b/pkgpanda/http/config.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 from pkgpanda import constants
 
 
@@ -6,4 +9,4 @@ DCOS_CONFIG_DIR = constants.config_dir
 DCOS_REPO_DIR = constants.repository_base
 DCOS_ROOTED_SYSTEMD = False
 
-WORK_DIR = '/tmp/pkgpanda_api'
+WORK_DIR = os.path.join(tempfile.gettempdir(), 'pkgpanda_api')


### PR DESCRIPTION
Review Request: @branden  

I noticed this while merging to master today. This change provides a reliable way point to the tempdir.

Linux
```
>>> WORK_DIR = os.path.join(tempfile.gettempdir(), 'pkgpanda_api')
>>> WORK_DIR
'/tmp/pkgpanda_api
```

Mac

```
>>> WORK_DIR = os.path.join(tempfile.gettempdir(), 'pkgpanda_api')
>>> WORK_DIR
'/var/folders/yx/tn9fxy1s4qz1vf2cbb5fwlw00000gn/T/pkgpanda_api'
```