### PR TITLE
Scripts to create DC/OS compatible cloud images

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -1,0 +1,31 @@
+## Changelog
+
+### 2016-08-09
+
+Move AMI builds to dcos.io CI: https://teamcity.mesosphere.io/project.html?projectId=DcosIo_Dcos_BuildCloudBaseImages&tab=projectOverview
+
+### 2016-06-07
+
+#### centos7-201606080106
+
+Base (source) AMI:
+* ami-c5af54a5
+
+DC/OS AMI's:
+* ap-northeast-1: ami-b8d831d9
+* ap-southeast-1: ami-133eee70
+* ap-southeast-2: ami-f57d5496
+* eu-central-1: ami-2e6f8141
+* eu-west-1: ami-20af3253
+* sa-east-1: ami-89179ce5
+* us-east-1: ami-7848b115
+* us-west-1: ami-a891ebc8
+* us-west-2: ami-1e22d97e
+
+#### centos7-201606081536
+
+Base (source) AMI:
+* ami-7dff411c
+
+DC/OS AMI's:
+* us-gov-west-1: ami-4e02bd2f

--- a/cloud_images/README.md
+++ b/cloud_images/README.md
@@ -1,0 +1,29 @@
+# CentOS 7
+
+## Create CentOS 7 base AMI
+
+Steps to create a base CentOS 7 AMI which does not have any marketplace codes attached. This is necessary because any images derived from a Marketplace image cannot be shared publicly.
+
+1. In the dcos.io AWS account, launch latest [CentOS 7 Marketplace AMI](https://wiki.centos.org/Cloud/AWS) with secondary 8GB EBS volume attached
+2. Copy `centos7/create_base_ami.sh` to the launched instance and run the script with DEVICE set to secondary EBS volume (e.g. /dev/xvdf)
+3. Detach secondary EBS volume
+4. Create snapshot of EBS volume with name: centos7-YYYYMMDDhhmm
+5. Create AMI from snapshot
+   Name: centos7-YYYYMMDDhhmm (use same value as snapshot)
+   Virtualization type: Hardware-assisted virtualization
+   Volume Type: GP2
+   Everything else: defaults
+6. Update AMI Permissions to 'Public'
+6. Record in CHANGELOG new AMI details
+
+## Create DC/OS ready CentOS 7 AMI
+
+Steps to create a new AMI with the DC/OS pre-requisites installed using a base CentOS 7 AMI (Marketplace or otherwise) and [Packer](https://www.packer.io/).
+
+1. Change the working directory to the `centos7` subdirectory
+2. Run the helper script `create_dcos_ami.sh` to build and deploy new DC/OS AMI's. Default values can be overridden by setting the appropriate environment variables.
+
+# Reference Material
+
+[Guidelines for Shared Linux AMIs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/building-shared-amis.html)
+

--- a/cloud_images/centos7/create_base_ami.sh
+++ b/cloud_images/centos7/create_base_ami.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# Run from a CentOS or RHEL instance on AWS with a secondary 8GB EBS volume
+# ($DEVICE) attached to create a fresh installation of CentOS7 on $DEVICE.
+
+# When complete, convert the $DEVICE into an AMI by creating a snapshot of the
+# EBS volume and converting the snapshot into an AMI.  These steps can be done
+# with the AWS web console or using the CLI tools.
+
+: ${DEVICE:?"ERROR: DEVICE must be set"}
+
+ROOTFS=/rootfs
+PARTITION=${DEVICE}1
+
+parted -s "$DEVICE" -- \
+  mklabel msdos \
+  mkpart primary xfs 1 -1 \
+  set 1 boot on
+
+# Wait for device partition creation which happens asynchronously
+while [ ! -e "$PARTITION" ]; do sleep 1; done
+
+mkfs.xfs -f -L root "$PARTITION"
+mkdir -p "$ROOTFS"
+mount "$PARTITION" "$ROOTFS"
+
+rpm --root="$ROOTFS" --initdb
+rpm --root="$ROOTFS" -ivh \
+  http://mirrors.kernel.org/centos/7.2.1511/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm
+yum --installroot="$ROOTFS" --nogpgcheck -y groupinstall core
+yum --installroot="$ROOTFS" --nogpgcheck -y install openssh-server grub2 tuned kernel chrony
+yum --installroot="$ROOTFS" -C -y remove NetworkManager firewalld --setopt="clean_requirements_on_remove=1"
+
+cp -a /etc/skel/.bash* "${ROOTFS}/root"
+
+cat > "${ROOTFS}/etc/hosts" << END
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+END
+
+touch "${ROOTFS}/etc/resolv.conf"
+
+cat > "${ROOTFS}/etc/sysconfig/network" << END
+NETWORKING=yes
+NOZEROCONF=yes
+END
+
+cat > "${ROOTFS}/etc/sysconfig/network-scripts/ifcfg-eth0" << END
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+USERCTL="yes"
+PEERDNS="yes"
+IPV6INIT="no"
+PERSISTENT_DHCLIENT="1"
+END
+
+cp /usr/share/zoneinfo/UTC "${ROOTFS}/etc/localtime"
+
+echo 'ZONE="UTC"' > "${ROOTFS}/etc/sysconfig/clock"
+
+cat > "${ROOTFS}/etc/fstab" << END
+LABEL=root / xfs defaults 0 0
+END
+
+echo 'RUN_FIRSTBOOT=NO' > "${ROOTFS}/etc/sysconfig/firstboot"
+
+BINDMNTS="dev sys etc/hosts etc/resolv.conf"
+
+for d in $BINDMNTS ; do
+  mount --bind "/${d}" "${ROOTFS}/${d}"
+done
+mount -t proc none "${ROOTFS}/proc"
+
+cat > "${ROOTFS}/etc/default/grub" << END
+GRUB_TIMEOUT=1
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL="serial console"
+GRUB_SERIAL_COMMAND="serial --speed=115200"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200"
+GRUB_DISABLE_RECOVERY="true"
+END
+
+chroot "$ROOTFS" grub2-mkconfig -o /boot/grub2/grub.cfg
+chroot "$ROOTFS" grub2-install "$DEVICE"
+chroot "$ROOTFS" yum --nogpgcheck -y install cloud-init cloud-utils-growpart
+chroot "$ROOTFS" systemctl enable sshd.service
+chroot "$ROOTFS" systemctl enable cloud-init.service
+chroot "$ROOTFS" systemctl enable chronyd.service
+chroot "$ROOTFS" systemctl mask tmp.mount
+chroot "$ROOTFS" systemctl set-default multi-user.target
+
+cat > "${ROOTFS}/etc/cloud/cloud.cfg" << END
+users:
+ - default
+
+disable_root: 1
+ssh_pwauth:   0
+
+locale_configfile: /etc/sysconfig/i18n
+mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
+resize_rootfs_tmp: /dev
+ssh_deletekeys:   0
+ssh_genkeytypes:  ~
+syslog_fix_perms: ~
+
+cloud_init_modules:
+ - migrator
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - rsyslog
+ - users-groups
+ - ssh
+
+cloud_config_modules:
+ - mounts
+ - locale
+ - set-passwords
+ - yum-add-repo
+ - package-update-upgrade-install
+ - timezone
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - disable-ec2-metadata
+ - runcmd
+
+cloud_final_modules:
+ - rightscale_userdata
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+
+system_info:
+  default_user:
+    name: centos
+    lock_passwd: true
+    gecos: Cloud User
+    groups: [wheel, adm, systemd-journal]
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+  distro: rhel
+  paths:
+    cloud_dir: /var/lib/cloud
+    templates_dir: /etc/cloud/templates
+  ssh_svcname: sshd
+
+# vim:syntax=yaml
+END
+
+umount -AR "$ROOTFS"

--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# AWS profile with appropriate credentials for Packer to create the AMI
+export AWS_PROFILE=${AWS_PROFILE:-"development"}
+
+# Base CentOS 7 AMI and region
+export SOURCE_AMI=${SOURCE_AMI:-"ami-c5af54a5"}
+export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
+
+# Comma separated string of AWS regions to copy the resulting DC/OS AMI to
+export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
+
+# Useful options include -debug and -machine-readable
+PACKER_BUILD_OPTIONS=${PACKER_BUILD_OPTIONS:-""}
+
+packer build $PACKER_BUILD_OPTIONS packer.json

--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+export device=${1:-}
+export mount_location=${2:-}
+
+function usage {
+cat <<USAGE
+ USAGE: $(basename "$0") <device> <mount_location>
+
+  This script will partition, format, and persistently mount the device to the specified location.
+  It is intended to run as an early systemd unit (local-fs-pre.target) on AWS to set up EBS volumes.
+  It will only execute if <device> is not yet partitioned.
+
+ EXAMPLES:
+
+  $(basename "$0") /dev/xvde /dcos/volume1
+
+USAGE
+}
+
+for i in "$@"
+do
+  case "$i" in                                      # Munging globals, beware
+    -h|--help)                usage                 ;;
+    --)                       break                 ;;
+    *)                        # unknown option      ;;
+  esac
+done
+
+function main {
+  if [[ -z "$mount_location" || -z "$device" ]]
+  then
+    usage
+    exit 1
+  fi
+
+  partition=${device}1
+  if [[ ! -b "$partition" ]]
+  then
+    echo "Partition $partition not detected: creating partitions"
+    parted -s -a optimal "$device" -- \
+      mklabel gpt \
+      mkpart primary xfs 1 -1
+    partprobe "$device"
+    echo "Formatting: $partition"
+    mkfs.xfs "$partition" >/dev/null
+    echo "Setting up partition mount"
+    mkdir -p "$mount_location"
+    fstab="$partition $mount_location xfs defaults,nofail 0 2"
+    echo "Adding entry to fstab: $fstab"
+    echo "$fstab" >> /etc/fstab
+    echo "Mounting: $partition to $mount_location"
+    mount -a
+  else
+    echo "Partition $partition detected: no action taken"
+    exit
+  fi
+}
+
+if [[ ${1:-} ]] && declare -F | cut -d' ' -f3 | fgrep -qx -- "${1:-}"
+then "$@"
+else main "$@"
+fi

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+echo ">>> Kernel: $(uname -r)"
+echo ">>> Updating system"
+yum update --assumeyes
+
+echo ">>> Disabling SELinux"
+sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
+
+echo ">>> Adjusting SSH Daemon Configuration"
+
+sed -i '/^\s*PermitRootLogin /d' /etc/ssh/sshd_config
+echo -e "\nPermitRootLogin without-password" >> /etc/ssh/sshd_config
+
+sed -i '/^\s*UseDNS /d' /etc/ssh/sshd_config
+echo -e "\nUseDNS no" >> /etc/ssh/sshd_config
+
+echo ">>> Disabling IPV6"
+sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+echo ">>> Installing DC/OS dependencies and essential packages"
+yum install --assumeyes --tolerant perl tar xz unzip curl bind-utils net-tools ipset libtool-ltdl rsync
+
+echo ">>> Set up filesystem mounts"
+cat << 'EOF' > /etc/systemd/system/dcos_vol_setup.service
+[Unit]
+Description=Initial setup of volume mounts
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/dcos_vol_setup.sh /dev/xvde /var/lib/mesos
+ExecStart=/usr/local/sbin/dcos_vol_setup.sh /dev/xvdf /var/lib/docker
+ExecStart=/usr/local/sbin/dcos_vol_setup.sh /dev/xvdg /dcos/volume0
+
+[Install]
+WantedBy=local-fs.target
+EOF
+systemctl enable dcos_vol_setup
+
+echo ">>> Install Docker"
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-1.11.2-1.el7.centos.x86_64.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.11.2-1.el7.centos.x86_64.rpm
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-selinux-1.11.2-1.el7.centos.noarch.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-1.11.2-1.el7.centos.noarch.rpm
+rpm -i /tmp/docker*.rpm || true
+systemctl enable docker
+
+echo ">>> Creating docker group"
+/usr/sbin/groupadd -f docker
+
+echo ">>> Customizing Docker storage driver to use Overlay"
+docker_service_d=/etc/systemd/system/docker.service.d
+mkdir -p "$docker_service_d"
+cat << 'EOF' > "${docker_service_d}/execstart.conf"
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// --graph=/var/lib/docker --storage-driver=overlay
+EOF
+
+echo ">>> Adding group [nogroup]"
+/usr/sbin/groupadd -f nogroup
+
+echo ">>> Cleaning up SSH host keys"
+shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+
+echo ">>> Cleaning up accounting files"
+rm -f rm -f /var/run/utmp
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+echo ">>> Remove temporary files"
+rm -rf /tmp/* /var/tmp/*
+
+echo ">>> Remove ssh client directories"
+rm -rf /home/*/.ssh /root/.ssh
+
+echo ">>> Remove history"
+unset HISTFILE
+rm -rf /home/*/.*history /root/.*history
+
+# Make sure we wait until all the data is written to disk, otherwise
+# Packer might quite too early before the large files are deleted
+sync

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -1,0 +1,69 @@
+{
+  "min_packer_version": "0.10.1",
+  "variables": {
+    "cloud_builder_version": "0.1",
+    "deploy_regions": "{{env `DEPLOY_REGIONS`}}",
+    "source_ami": "{{env `SOURCE_AMI`}}",
+    "source_ami_region": "{{env `SOURCE_AMI_REGION`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "communicator": "ssh",
+    "ssh_pty": true,
+    "region": "{{user `source_ami_region`}}",
+    "source_ami": "{{user `source_ami`}}",
+    "instance_type": "m3.xlarge",
+    "ssh_username": "centos",
+    "ami_name": "dcos-centos7-{{isotime \"200601021504\"}}",
+    "ami_description": "DC/OS Cloud Image for CentOS 7",
+    "ami_regions": "{{user `deploy_regions`}}",
+    "ebs_optimized": true,
+    "ami_block_device_mappings": [
+      {
+        "device_name": "/dev/sde",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdf",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      }
+    ],
+    "tags": {
+      "cloud_builder_version": "{{user `cloud_builder_version`}}"
+    },
+    "ami_groups": [
+      "all"
+    ]
+  }],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "dcos_vol_setup.sh",
+      "destination": "/tmp/dcos_vol_setup.sh"
+    },
+    {
+      "type": "file",
+      "source": "install_prereqs.sh",
+      "destination": "/tmp/install_prereqs.sh"
+    },
+    {
+      "type": "shell",
+      "inline_shebang": "/bin/bash -e",
+      "inline": [
+        "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+        "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_prereqs.sh",
+        "sudo /tmp/install_prereqs.sh"
+      ]
+    }
+  ]
+}

--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -72,31 +72,31 @@
     "RegionToAmi": {
       "ap-northeast-1": {
         "coreos": "ami-bebc4ddf",
-        "el7": "ami-b8d831d9"
+        "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
         "coreos": "ami-3602d055",
-        "el7": "ami-133eee70"
+        "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
         "coreos": "ami-07be9664",
-        "el7": "ami-f57d5496"
+        "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
         "coreos": "ami-8d8d66e2",
-        "el7": "ami-2e6f8141"
+        "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
         "coreos": "ami-0d68f37e",
-        "el7": "ami-20af3253"
+        "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
         "coreos": "ami-18a23774",
-        "el7": "ami-89179ce5"
+        "el7": "ami-ac980ec0"
       },
       "us-east-1": {
         "coreos": "ami-153af578",
-        "el7": "ami-7848b115"
+        "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
         "coreos": "ami-96b50bf7",
@@ -104,11 +104,11 @@
       },
       "us-west-1": {
         "coreos": "ami-8befabeb",
-        "el7": "ami-a891ebc8"
+        "el7": "ami-a883c0c8"
       },
       "us-west-2": {
         "coreos": "ami-02bf7962",
-        "el7": "ami-1e22d97e"
+        "el7": "ami-a4dd16c4"
       }
     },
     "Parameters": {

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -255,31 +255,31 @@
     "RegionToAmi": {
       "ap-northeast-1": {
         "coreos": "ami-bebc4ddf",
-        "el7": "ami-b8d831d9"
+        "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
         "coreos": "ami-3602d055",
-        "el7": "ami-133eee70"
+        "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
         "coreos": "ami-07be9664",
-        "el7": "ami-f57d5496"
+        "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
         "coreos": "ami-8d8d66e2",
-        "el7": "ami-2e6f8141"
+        "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
         "coreos": "ami-0d68f37e",
-        "el7": "ami-20af3253"
+        "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
         "coreos": "ami-18a23774",
-        "el7": "ami-89179ce5"
+        "el7": "ami-ac980ec0"
       },
       "us-east-1": {
         "coreos": "ami-153af578",
-        "el7": "ami-7848b115"
+        "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
         "coreos": "ami-96b50bf7",
@@ -287,11 +287,11 @@
       },
       "us-west-1": {
         "coreos": "ami-8befabeb",
-        "el7": "ami-a891ebc8"
+        "el7": "ami-a883c0c8"
       },
       "us-west-2": {
         "coreos": "ami-02bf7962",
-        "el7": "ami-1e22d97e"
+        "el7": "ami-a4dd16c4"
       }
     }
   },

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -247,31 +247,31 @@
     "RegionToAmi": {
       "ap-northeast-1": {
         "coreos": "ami-bebc4ddf",
-        "el7": "ami-b8d831d9"
+        "el7": "ami-abf535ca"
       },
       "ap-southeast-1": {
         "coreos": "ami-3602d055",
-        "el7": "ami-133eee70"
+        "el7": "ami-c47ba5a7"
       },
       "ap-southeast-2": {
         "coreos": "ami-07be9664",
-        "el7": "ami-f57d5496"
+        "el7": "ami-bc2f1bdf"
       },
       "eu-central-1": {
         "coreos": "ami-8d8d66e2",
-        "el7": "ami-2e6f8141"
+        "el7": "ami-d934c2b6"
       },
       "eu-west-1": {
         "coreos": "ami-0d68f37e",
-        "el7": "ami-20af3253"
+        "el7": "ami-dabdd6a9"
       },
       "sa-east-1": {
         "coreos": "ami-18a23774",
-        "el7": "ami-89179ce5"
+        "el7": "ami-ac980ec0"
       },
       "us-east-1": {
         "coreos": "ami-153af578",
-        "el7": "ami-7848b115"
+        "el7": "ami-44f66853"
       },
       "us-gov-west-1": {
         "coreos": "ami-96b50bf7",
@@ -279,11 +279,11 @@
       },
       "us-west-1": {
         "coreos": "ami-8befabeb",
-        "el7": "ami-a891ebc8"
+        "el7": "ami-a883c0c8"
       },
       "us-west-2": {
         "coreos": "ami-02bf7962",
-        "el7": "ami-1e22d97e"
+        "el7": "ami-a4dd16c4"
       }
     }
   },


### PR DESCRIPTION
* Original work and reviews in #205 and #311.
* Now uses Overlay + XFS with the EL7 base image for Docker storage, so that problematic containers like `rastasheep/ubuntu-sshd` work properly.
* Updates AWS Advanced Templates default EL7 base image to use new AMI's.
* Automated builds are now available at https://teamcity.mesosphere.io/project.html?projectId=DcosIo_Dcos_BuildCloudBaseImages&tab=projectOverview