### PR TITLE
use latest 3dt; update test

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -4,7 +4,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "ac15605f71487b16f5afadd0f1239cbc30db7dbf",
+    "ref": "1081f24cc1774405c09693b1e9b79b0c580afcca",
     "ref_origin": "master"
   },
   "username": "dcos_3dt",


### PR DESCRIPTION
- add timeout to `detect_ip` script execution
  https://github.com/dcos/3dt/pull/53

- add no cache functionality. This feature allows to get most recent health
  status by getting endpoint with ?cache=0 parameter.
  https://github.com/dcos/3dt/pull/52

- add `-pull-timeout` flag. Allows user to specify the get health status
  timeout.
  https://github.com/dcos/3dt/pull/54

- add a new 3dt test to make sure all units are healthy.