### PR TITLE
[Ignore]Pull the tagged version of dcos-builder.

### DIFF
--- a/packages/python-gunicorn/buildinfo.json
+++ b/packages/python-gunicorn/buildinfo.json
@@ -1,6 +1,6 @@
 {
   "requires": ["python"],
-  "docker": "dcos-builder",
+  "docker": "dcos-builder:dcos-builder_dockerdir-0dd9fc80447b2db87b807f6c66261287a0abfd8b",
   "single_source": {
     "kind": "url_extract",
     "url": "https://pypi.python.org/packages/84/ce/7ea5396efad1cef682bbc4068e72a0276341d9d9d0f501da609fab9fcb80/gunicorn-19.6.0.tar.gz",

--- a/packages/python-gunicorn/buildinfo.json
+++ b/packages/python-gunicorn/buildinfo.json
@@ -1,6 +1,6 @@
 {
   "requires": ["python"],
-  "docker": "dcos-builder:dcos-builder_dockerdir-0dd9fc80447b2db87b807f6c66261287a0abfd8b",
+  "docker": "dcos/dcos-builder:dcos-builder_dockerdir-0dd9fc80447b2db87b807f6c66261287a0abfd8b",
   "single_source": {
     "kind": "url_extract",
     "url": "https://pypi.python.org/packages/84/ce/7ea5396efad1cef682bbc4068e72a0276341d9d9d0f501da609fab9fcb80/gunicorn-19.6.0.tar.gz",


### PR DESCRIPTION
Trying to fix this issue.
```
[20:01:44][Step 1/1] Building package python-gunicorn variant 
[20:01:44][Step 1/1] Error: No such image or container: dcos-builder
[20:01:44][Step 1/1] Using default tag: latest
[20:01:45][Step 1/1] Pulling repository docker.io/library/dcos-builder
[20:01:45][Step 1/1] Error: image library/dcos-builder:latest not found
[20:01:45][Step 1/1] Traceback (most recent call last):
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/pkgpanda/build/__init__.py", line 850, in build
[20:01:45][Step 1/1]     docker_id = get_docker_id(docker_name)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/pkgpanda/build/__init__.py", line 395, in get_docker_id
[20:01:45][Step 1/1]     return check_output(["docker", "inspect", "-f", "{{ .Id }}", docker_name]).decode('utf-8').strip()
[20:01:45][Step 1/1]   File "/usr/lib/python3.4/subprocess.py", line 620, in check_output
[20:01:45][Step 1/1]     raise CalledProcessError(retcode, process.args, output=output)
[20:01:45][Step 1/1] subprocess.CalledProcessError: Command '['docker', 'inspect', '-f', '{{ .Id }}', 'dcos-builder']' returned non-zero exit status 1
[20:01:45][Step 1/1] 
[20:01:45][Step 1/1] During handling of the above exception, another exception occurred:
[20:01:45][Step 1/1] 
[20:01:45][Step 1/1] Traceback (most recent call last):
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/bin/release", line 11, in <module>
[20:01:45][Step 1/1]     sys.exit(main())
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/release/__init__.py", line 783, in main
[20:01:45][Step 1/1]     release_manager.create('testing', options.channel, options.tag)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/release/__init__.py", line 676, in create
[20:01:45][Step 1/1]     metadata = make_stable_artifacts(self.__config['options']['cloudformation_s3_url'] + '/' + repository_path)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/release/__init__.py", line 280, in make_stable_artifacts
[20:01:45][Step 1/1]     all_completes = do_build_packages(cache_repository_url)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/release/__init__.py", line 494, in do_build_packages
[20:01:45][Step 1/1]     result = pkgpanda.build.build_tree(package_store, True, None)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/pkgpanda/build/__init__.py", line 665, in build_tree
[20:01:45][Step 1/1]     True)
[20:01:45][Step 1/1]   File "/teamcity/work/19ad0dff41587ee6/build/env/lib/python3.4/site-packages/pkgpanda/build/__init__.py", line 853, in build
[20:01:45][Step 1/1]     check_call(['docker', 'pull', docker_name])
[20:01:45][Step 1/1]   File "/usr/lib/python3.4/subprocess.py", line 561, in check_call
[20:01:45][Step 1/1]     raise CalledProcessError(retcode, cmd)
[20:01:45][Step 1/1] subprocess.CalledProcessError: Command '['docker', 'pull', 'dcos-builder']' returned non-zero exit status 1
[20:01:45][Step 1/1] Process exited with code 1
[20:01:46][Step 1/1] Step Command Line failed
```