### PR TITLE
Install script: use non-gnu specific sed range to extract tar contents

### DIFF
--- a/gen/installer/bash/dcos_generate_config.sh.in
+++ b/gen/installer/bash/dcos_generate_config.sh.in
@@ -16,7 +16,7 @@ trap 'backout' INT
 if [ ! -f "{genconf_tar}" ]
 then
     echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
-    sed '0,/^#EOF#$/d' $0 | tar xv
+    sed '1,/^#EOF#$/d' $0 | tar xv
     docker load -i {genconf_tar}
 fi
 trap - INT


### PR DESCRIPTION
The install script doesn't pass the correct file contents to `tar` on OSX, since it uses a GNU specific form that is not supported, which results in a `tar: Unrecognized archive format` error.

From the GNU sed man page:
```
GNU `sed' also supports some special two-address forms; all these
are GNU extensions:
`0,/REGEXP/'
     A line number of `0' can be used in an address specification like
     `0,/REGEXP/' so that `sed' will try to match REGEXP in the first
     input line too.  In other words, `0,/REGEXP/' is similar to
     `1,/REGEXP/', except that if ADDR2 matches the very first line of
     input the `0,/REGEXP/' form will consider it to end the range,
     whereas the `1,/REGEXP/' form will match the beginning of its
     range and hence make the range span up to the _second_ occurrence
     of the regular expression.

     Note that this is the only place where the `0' address makes
     sense; there is no 0-th line and commands which are given the `0'
     address in any other way will give an error.
```

Therefore, for this install script, `1,/REGEXP/` will exhibit the same behavior on linux hosts using GNU sed and the sed on OSX, since the `#EOF#` marker will never be on the first line.