### PR TITLE
Replace simplejson exception

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -145,8 +145,8 @@ def validate_dcos_overlay_network(dcos_overlay_network):
     assert isinstance(dcos_overlay_network, str)
     try:
         overlay_network = json.loads(dcos_overlay_network)
-    except json.JSONDecodeError as ex:
-        assert False, "Must be a valid JSON . Errors while parsing at position {}: {}".format(ex.pos, ex.msg)
+    except ValueError:
+        assert False, "Provided input was not valid JSON: "+dcos_overlay_network
     # Check the VTEP IP, VTEP MAC keys are present in the overlay
     # configuration
     assert 'vtep_subnet' in overlay_network.keys(), (
@@ -217,8 +217,8 @@ def validate_json_list(json_list):
         list_data = json.loads(json_list)
 
         assert type(list_data) is list, "Must be a JSON list. Got a {}".format(type(list_data))
-    except json.JSONDecodeError as ex:
-        assert False, "Must be a valid JSON list. Errors while parsing at position {}: {}".format(ex.pos, ex.msg)
+    except ValueError:
+        assert False, "Provided input was not valid JSON: "+json_list
 
     return list_data
 


### PR DESCRIPTION
Currently, we raise the wrong error:
```
except json.JSONDecodeError:
    assert False, ...
AttributeError: 'module' object has no attribute 'JSONDecodeError'
```
This exception is from simplejson module. We use json