### PR TITLE
[Testing] Experimental GPU Support

### DIFF
--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -11,6 +11,10 @@ export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
 # Comma separated string of AWS regions to copy the resulting DC/OS AMI to
 export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
 
+# The version component of the dcos-nvidia-drivers/ bucket to use
+# for fetching the nVidia drivers
+export NVIDIA_VERSION=${NVIDIA_VERSION:-"367.35"}
+
 # Useful options include -debug and -machine-readable
 PACKER_BUILD_OPTIONS=${PACKER_BUILD_OPTIONS:-""}
 

--- a/cloud_images/centos7/install_nvidia.sh
+++ b/cloud_images/centos7/install_nvidia.sh
@@ -1,0 +1,198 @@
+set -o errexit -o nounset -o pipefail
+unset HISTFILE
+
+# Root directories for source and target (Default to same machine)
+TARGETROOT=""
+SRCROOT=""
+
+# Prepare target directory configuration
+DST_USERSPACE_DIR="${TARGETROOT}/usr"
+DST_USERSPACE_LOCAL_DIR="${TARGETROOT}/usr/local"
+DST_BOOT_DIR="${TARGETROOT}/boot"
+DST_ETC_DIR="${TARGETROOT}/etc"
+TEMP_DIR="/tmp"
+
+# If we only need to prepare, do clean-ups and reboot
+if [ "$1" == "prepare" ]; then
+
+  # Disable nouveau from kernel cmdline
+  echo ">>> Blacklisting nouveau driver through GRUB"
+  sed -r -i 's/^(GRUB_CMDLINE_LINUX=.*)"$/\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' \
+    /etc/default/grub
+
+  # Update GRUB
+  grub2-mkconfig -o /boot/grub2/grub.cfg
+
+  # Shutdown
+  echo ">>> Rebooting instance"
+  sync
+  nohup sh -c 'kill $(pidof sshd); reboot' </dev/null >/dev/null 2>&1 &
+  sleep 60
+  exit 0
+fi
+
+# Get cuda bucket to use from command-line
+NVIDIA_VERSION=$1
+
+# The nVidia driver files to download and install
+NVIDIA_KERNEL_DRIVER_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/${NVIDIA_VERSION}-Linux-x86_64/nvidia.run"
+NVIDIA_GPU_GDK_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/${NVIDIA_VERSION}-Linux-x86_64/gdk.run"
+NVIDIA_CUDA_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/${NVIDIA_VERSION}-Linux-x86_64/cuda.run"
+NVIDIA_CUDNN_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/${NVIDIA_VERSION}-Linux-x86_64/cudnn.tgz"
+#
+# WARNING: Some nVidia's hard-links will require authorization, making
+#          the link impossible to use. On production, please downoad all
+#          these files to a separate directory first.
+
+echo ">>> Removing nouveau module from kernel..."
+rmmod nouveau
+
+# Get the kernel to install packages for
+KERNEL=$(uname -r)
+
+# Install missing dependencies
+echo ">>> Installing required packages to build for kernel ${KERNEL}..."
+yum install -y kernel-devel-${KERNEL} kernel-headers-${KERNEL} gcc make pciutils
+
+# Prepare kernel-specific directories
+DST_KERNEL_DIR="${TARGETROOT}/lib/modules/${KERNEL}/kernel/drivers/video"
+SRC_KERNEL_DIR="${SRCROOT}/lib/modules/${KERNEL}/build"
+
+# Crawl latest URL from here: http://www.nvidia.com/Download/index.aspx?lang=en-us
+echo ""
+echo ">>> Downloading nvidia kernel modules..."
+curl -s ${NVIDIA_KERNEL_DRIVER_URL} > ${TEMP_DIR}/NVIDIA-kernel.run
+chmod +x ${TEMP_DIR}/NVIDIA-kernel.run
+
+echo ">>> Installing nvidia kernel modules..."
+${TEMP_DIR}/NVIDIA-kernel.run \
+  --accept-license \
+  --no-questions \
+  --ui=none \
+  --disable-nouveau \
+  --utility-prefix=${DST_USERSPACE_DIR} \
+  --documentation-prefix=${DST_USERSPACE_DIR} \
+  --application-profile-path=${DST_USERSPACE_DIR}/share/nvidia \
+  --kernel-source-path=${SRC_KERNEL_DIR} \
+  --kernel-install-path=${DST_KERNEL_DIR} \
+  --kernel-name=${KERNEL}
+
+# Crawl latest URL from here: https://developer.nvidia.com/gpu-deployment-kit
+echo ""
+echo ">>> Downloading nvidia GPU GDK..."
+curl -s ${NVIDIA_GPU_GDK_URL} > ${TEMP_DIR}/NVIDIA-gdk.run
+chmod +x ${TEMP_DIR}/NVIDIA-gdk.run
+
+echo ">>> Installing nvidia GPU GDK..."
+${TEMP_DIR}/NVIDIA-gdk.run \
+  --silent \
+  --installdir=${TARGETROOT}/
+
+# Crawl latest URL from here: https://developer.nvidia.com/cuda-downloads
+echo ""
+echo ">>> Downloading CUDA..."
+curl -s ${NVIDIA_CUDA_URL} > ${TEMP_DIR}/NVIDIA-cuda.run
+chmod +x ${TEMP_DIR}/NVIDIA-cuda.run
+
+echo ">>> Installing CUDA..."
+${TEMP_DIR}/NVIDIA-cuda.run \
+  --silent \
+  --kernel-source-path=${SRC_KERNEL_DIR} \
+  --toolkit \
+  --toolkitpath=${DST_USERSPACE_LOCAL_DIR}
+
+
+# Crawl latest URL from here:
+echo ""
+echo ">>> Downloading cuDNN..."
+curl -s ${NVIDIA_CUDNN_URL} > ${TEMP_DIR}/NVIDIA-cudnn.tgz
+
+echo ">>> Installing cuDNN..."
+tar -C ${DST_USERSPACE_DIR} --strip-components=1 -zxf ${TEMP_DIR}/NVIDIA-cudnn.tgz
+
+echo ">>> Installing nVidia boot scripts..."
+cat <<"EOF" > /usr/local/sbin/start-nvidia-drivers.sh
+#!/bin/bash
+
+start() {
+  /sbin/modprobe nvidia
+  if [ "$?" -eq 0 ]; then
+    # Count the number of NVIDIA controllers found.
+    NVDEVS=`lspci | grep -i NVIDIA`
+    N3D=`echo "$NVDEVS" | grep "3D controller" | wc -l`
+    NVGA=`echo "$NVDEVS" | grep "VGA compatible controller" | wc -l`
+    N=`expr $N3D + $NVGA - 1`
+    for i in `seq 0 $N`; do
+      mknod -m 666 /dev/nvidia$i c 195 $i
+    done
+    mknod -m 666 /dev/nvidiactl c 195 255
+  else
+    exit 1
+  fi
+  /sbin/modprobe nvidia-uvm
+  if [ "$?" -eq 0 ]; then
+    # Find out the major device number used by the nvidia-uvm driver
+    D=`grep nvidia-uvm /proc/devices | awk '{print $1}'`
+    mknod -m 666 /dev/nvidia-uvm c $D 0
+  else
+    exit 1
+  fi
+}
+
+stop() {
+  /sbin/rmmod nvidia
+  /sbin/rmmod nvidia-uvm
+  rm -f /dev/nvidia*
+}
+
+case $1 in
+  start|stop) "$1" ;;
+esac
+EOF
+chmod 0755 /usr/local/sbin/start-nvidia-drivers.sh
+
+# Create service
+cat <<"EOF" > /etc/systemd/system/nvidia.service
+[Unit]
+Description=Load nVidia kernel drivers and populate devices
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/start-nvidia-drivers.sh start
+ExecStop=/usr/local/sbin/start-nvidia-drivers.sh stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Register service
+echo ">>> Enabling nVidia service"
+systemctl enable nvidia.service
+
+# Clean-up
+echo ">>> Remove temporary files"
+rm ${TEMP_DIR}/NVIDIA-kernel.run
+rm ${TEMP_DIR}/NVIDIA-gdk.run
+rm ${TEMP_DIR}/NVIDIA-cuda.run
+rm ${TEMP_DIR}/NVIDIA-cudnn.tgz
+rm -rf /tmp/* /var/tmp/*
+rm /usr/local/sbin/install_nvidia.sh
+
+echo ">>> Cleaning up SSH host keys"
+shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+
+echo ">>> Cleaning up accounting files"
+rm -f rm -f /var/run/utmp
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+echo ">>> Remove temporary files"
+rm -rf /tmp/* /var/tmp/*
+
+echo ">>> Remove ssh client directories"
+rm -rf /home/*/.ssh /root/.ssh
+
+echo ">>> Remove history"
+rm -rf /home/*/.*history /root/.*history

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
+MODE=${1:-}
 
 echo ">>> Kernel: $(uname -r)"
 echo ">>> Updating system"
@@ -61,6 +62,9 @@ EOF
 
 echo ">>> Adding group [nogroup]"
 /usr/sbin/groupadd -f nogroup
+
+# Skip cleanup if requested
+[ "$MODE" == "no-cleanup" ] && exit 0
 
 echo ">>> Cleaning up SSH host keys"
 shred -u /etc/ssh/*_key /etc/ssh/*_key.pub

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -2,11 +2,13 @@
   "min_packer_version": "0.10.1",
   "variables": {
     "cloud_builder_version": "0.1",
+    "nvidia_version": "{{env `NVIDIA_VERSION`}}",
     "deploy_regions": "{{env `DEPLOY_REGIONS`}}",
     "source_ami": "{{env `SOURCE_AMI`}}",
     "source_ami_region": "{{env `SOURCE_AMI_REGION`}}"
   },
   "builders": [{
+    "name": "builder-generic",
     "type": "amazon-ebs",
     "communicator": "ssh",
     "ssh_pty": true,
@@ -44,6 +46,46 @@
     "ami_groups": [
       "all"
     ]
+  }, {
+    "name": "builder-gpu",
+    "type": "amazon-ebs",
+    "communicator": "ssh",
+    "ssh_pty": true,
+    "region": "{{user `source_ami_region`}}",
+    "source_ami": "{{user `source_ami`}}",
+    "instance_type": "g2.2xlarge",
+    "ssh_username": "centos",
+    "ami_name": "dcos-centos7-gpu-nvidia-{{user `nvidia_version`}}-{{isotime \"200601021504\"}}",
+    "ami_description": "DC/OS Cloud Image for CentOS 7, with nVidia {{user `nvidia_version`}} GPU Drivers",
+    "ami_regions": "{{user `deploy_regions`}}",
+    "ebs_optimized": true,
+    "ami_block_device_mappings": [
+      {
+        "device_name": "/dev/sde",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdf",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      }
+    ],
+    "tags": {
+      "cloud_builder_version": "{{user `cloud_builder_version`}}",
+      "nvidia_version": "{{user `nvidia_version`}}"
+    },
+    "ami_groups": [
+      "all"
+    ]
   }],
   "provisioners": [
     {
@@ -57,12 +99,39 @@
       "destination": "/tmp/install_prereqs.sh"
     },
     {
+      "type": "file",
+      "source": "install_nvidia.sh",
+      "destination": "/tmp/install_nvidia.sh",
+      "only": [ "builder-gpu" ]
+    },
+    {
       "type": "shell",
       "inline_shebang": "/bin/bash -e",
+      "override": {
+        "builder-generic": {
+          "inline": [
+            "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+            "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_prereqs.sh",
+            "sudo /tmp/install_prereqs.sh"
+          ]
+        },
+        "builder-gpu": {
+          "inline": [
+            "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+            "sudo mv /tmp/install_nvidia.sh /usr/local/sbin/",
+            "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /usr/local/sbin/install_nvidia.sh /tmp/install_prereqs.sh",
+            "sudo /tmp/install_prereqs.sh no-cleanup",
+            "sudo /usr/local/sbin/install_nvidia.sh prepare"
+          ]
+        }
+      }
+    },
+    {
+      "type": "shell",
+      "inline_shebang": "/bin/bash -e",
+      "only": [ "builder-gpu" ],
       "inline": [
-        "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
-        "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_prereqs.sh",
-        "sudo /tmp/install_prereqs.sh"
+        "sudo /usr/local/sbin/install_nvidia.sh '{{user `nvidia_version`}}'"
       ]
     }
   ]

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -64,6 +64,22 @@ disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
 
+# setup additional isolator detection service that is responsible for identifying additional isolators,
+# (such as GPU) and creates an EnvironmentFile that contains a MESOS_ISOLATION env variable, with
+# additional isolators APPENDED to the current environment.
+
+public_isolators_service="$PKG_PATH"/dcos.target.wants_slave_public/dcos-isolators-discovery-pub-agent.service
+mkdir -p "$(dirname ${public_isolators_service})"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-isolators-discovery-pub-agent.service > "$public_isolators_service"
+
+private_isolators_service="$PKG_PATH"/dcos.target.wants_slave/dcos-isolators-discovery-priv-agent.service
+mkdir -p "$(dirname ${private_isolators_service})"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-isolators-discovery-priv-agent.service > "$private_isolators_service"
+
+isolators_script="$PKG_PATH/bin/make_isolators.py"
+cp /pkg/extra/make_isolators.py "$isolators_script"
+chmod +x "$isolators_script"
+
 # Install slave modules.
 mkdir -p "$PKG_PATH/etc/mesos-slave-modules"
 cp /pkg/extra/slave_logrotate_module.json "$PKG_PATH/etc/mesos-slave-modules/"

--- a/packages/mesos/extra/dcos-isolators-discovery-priv-agent.service
+++ b/packages/mesos/extra/dcos-isolators-discovery-priv-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mesos Isolator Discovery: Discovers isolators and generate mesos-isolators
+ConditionPathExists=!/var/lib/dcos/mesos-isolators
+
+[Service]
+Type=simple
+StandardOutput=journal+console
+StandardError=journal+console
+Restart=always
+StartLimitInterval=0
+RestartSec=60
+EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
+EnvironmentFile=/opt/mesosphere/etc/mesos-slave
+EnvironmentFile=-/var/lib/dcos/mesos-slave-common
+ExecStartPre=/usr/bin/env mkdir -p /var/lib/dcos
+ExecStart=/opt/mesosphere/bin/make_isolators.py /var/lib/dcos/mesos-isolators

--- a/packages/mesos/extra/dcos-isolators-discovery-pub-agent.service
+++ b/packages/mesos/extra/dcos-isolators-discovery-pub-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Mesos Isolator Discovery: Discovers isolators and generate mesos-isolators
+ConditionPathExists=!/var/lib/dcos/mesos-isolators
+
+[Service]
+Type=simple
+StandardOutput=journal+console
+StandardError=journal+console
+Restart=always
+StartLimitInterval=0
+RestartSec=60
+EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
+EnvironmentFile=/opt/mesosphere/etc/mesos-slave-public
+EnvironmentFile=-/var/lib/dcos/mesos-slave-common
+ExecStartPre=/usr/bin/env mkdir -p /var/lib/dcos
+ExecStart=/opt/mesosphere/bin/make_isolators.py /var/lib/dcos/mesos-isolators

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -16,6 +16,7 @@ EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave-public
+EnvironmentFile=/var/lib/dcos/mesos-isolators
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -16,6 +16,7 @@ EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
+EnvironmentFile=/var/lib/dcos/mesos-isolators
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave

--- a/packages/mesos/extra/make_isolators.py
+++ b/packages/mesos/extra/make_isolators.py
@@ -1,0 +1,67 @@
+#!/opt/mesosphere/bin/python3
+
+import os
+import subprocess
+import sys
+
+class IsolatorDiscoveryException(Exception):
+    pass
+
+def has_nvidia():
+  """
+  Test if we have nvidia available
+  """
+  nvidia_smi_binary = '/bin/nvidia-smi'
+
+  # Make sure file is there and with correct permissions
+  if not os.path.isfile(nvidia_smi_binary):
+    return False
+  if not os.access(nvidia_smi_binary, os.X_OK):
+    return False
+
+  # Try to run it
+  proc = subprocess.Popen([ nvidia_smi_binary, '-L' ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+  # Wait for stdout/err
+  (stdout, stderr) = proc.communicate()
+  proc.wait()
+
+  # Test for lack of errors
+  if proc.returncode != 0:
+    return False
+
+  # Everything looks good
+  return True
+
+def main(output_env_file):
+  """
+  This script detects if nVidia driver is available
+  and if yes, it appends the gpu/nvidia isolator
+  """
+
+  # Get current environment variable value
+  isolators = os.environ.get('MESOS_ISOLATION', '')
+
+  # Append isolators
+  if has_nvidia():
+
+    # Add ',' if we have other isolators
+    if isolators:
+      isolators += ','
+
+    # Append gpu/nvidia
+    isolators += 'gpu/nvidia'
+
+  # Create environment script
+  with open(output_env_file, 'w') as f:
+    f.write('MESOS_ISOLATION=%s\n' % isolators)
+
+if __name__ == '__main__':
+    try:
+        main(sys.argv[1])
+    except KeyError as e:
+        print('ERROR: Missing key {}'.format(e), file=sys.stderr)
+        sys.exit(1)
+    except IsolatorDiscoveryException as e:
+        print('ERROR: {}'.format(e), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
- Adding additional rules to the `cloud_images/centos7` for creating `centos7` images with nvidia drivers
- Adding general purpose isolator detection to private/public slaves in mesos package (currently only detecting GPUs and adding `gpu/nvidia` isolator)