### PR TITLE
Do a rename to move our resolv.conf into place to wipe out symlinks

### DIFF
--- a/packages/spartan/extra/gen_resolvconf.py
+++ b/packages/spartan/extra/gen_resolvconf.py
@@ -76,8 +76,17 @@ else:
 
 # Generate the resolv.conf config
 print('Updating {}'.format(resolvconf_path))
-with open(resolvconf_path, 'w') as f:
+with open(resolvconf_path + ".tmp", 'w') as f:
     print(contents, file=sys.stderr)
     f.write(contents)
+
+# Move the temp file into place. This also takes care of
+# making the file at resolvconf_path not a symlink if it
+# was one (writing directly we would just update the
+# target of the symlink). systemd-resolved updates the
+# target of the symlink itself though, which results in fun
+# conflicting things like https://dcosjira.atlassian.net/browse/DCOS-305
+
+os.rename(resolvconf_path + ".tmp", resolvconf_path)
 
 sys.exit(0)


### PR DESCRIPTION
Should resolve https://dcosjira.atlassian.net/browse/DCOS-305

Basically: Systemd by default makes `/etc/resolv.conf` a symlink to `/run/systemd/resolve/resolv.conf` which is owned by systemd-resolved / systemd-networkd. Just writing directly to that file, there ends up being some "contested" / racy ownership.

By writing to a temp file next to that, and moving into place we do two things
1. The symlink gets replaced by a file so there isn't a race anymore
2. Changing resolv.conf is "atomic" / can't have partial writes and the like show up in the file things use.