### PR TITLE
Modified overlay modules to learn ZK URL from environment variables.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -96,11 +96,6 @@ package:
   - path: /etc/overlay/config/master.json
     content: |
       {
-        "zk":
-        {
-          "url": "zk://127.0.0.1:2181/mesos",
-          "quorum": {{ master_quorum }}
-        },
         "replicated_log_dir":"/var/lib/dcos/mesos/master/",
         "network": {{ dcos_overlay_network }}
        }
@@ -113,7 +108,6 @@ package:
   - path: /etc/overlay/config/agent.json
     content: |
       {
-        "master": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
         "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
         "network_config":
         {
@@ -126,7 +120,6 @@ package:
   - path: /etc/overlay/config/agent-master.json
     content: |
       {
-        "master": "zk://127.0.0.1:2181/mesos",
         "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
         "network_config" :
         {

--- a/packages/mesos-overlay-modules/buildinfo.json
+++ b/packages/mesos-overlay-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/mesos-overlay-modules.git",
-      "ref": "80cdf2544961e130b875c32138791017041103e2",
+      "ref": "7b93d68c7066a00c176d7d886cdad74096be8d90",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
Removed any references to ZK URL from overlay module JSON config. 
The ZK URL for master and agent overlay module can now be learned from
'MESOS_ZK' on the master and 'MESOS_MASTER' on the agent. So
specifying these URLs in the JSON should not be necessary.