### PR TITLE
Split dcos-adminrouter-reload.service between masters and agents

### DIFF
--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -48,10 +48,26 @@ systemd_agent_public="$PKG_PATH"/dcos.target.wants_slave_public/dcos-adminrouter
 mkdir -p "$(dirname "$systemd_agent_public")"
 envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-agent.service > "$systemd_agent_public"
 
-systemd_reload="$PKG_PATH"/dcos.target.wants/dcos-adminrouter-reload.service
+systemd_reload="$PKG_PATH"/dcos.target.wants_master/dcos-adminrouter-reload.service
 mkdir -p "$(dirname "$systemd_reload")"
 envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-reload.service > "$systemd_reload"
 
-systemd_timer="$PKG_PATH"/dcos.target.wants/dcos-adminrouter-reload.timer
+systemd_timer="$PKG_PATH"/dcos.target.wants_master/dcos-adminrouter-reload.timer
+mkdir -p "$(dirname "$systemd_timer")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-reload.timer > "$systemd_timer"
+
+systemd_reload="$PKG_PATH"/dcos.target.wants_slave/dcos-adminrouter-agent-reload.service
+mkdir -p "$(dirname "$systemd_reload")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-agent-reload.service > "$systemd_reload"
+
+systemd_reload="$PKG_PATH"/dcos.target.wants_slave_public/dcos-adminrouter-agent-reload.service
+mkdir -p "$(dirname "$systemd_reload")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-agent-reload.service > "$systemd_reload"
+
+systemd_timer="$PKG_PATH"/dcos.target.wants_slave/dcos-adminrouter-agent-reload.timer
+mkdir -p "$(dirname "$systemd_timer")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-reload.timer > "$systemd_timer"
+
+systemd_timer="$PKG_PATH"/dcos.target.wants_slave_public/dcos-adminrouter-agent-reload.timer
 mkdir -p "$(dirname "$systemd_timer")"
 envsubst '$PKG_PATH' < /pkg/extra/dcos-adminrouter-reload.timer > "$systemd_timer"

--- a/packages/adminrouter/extra/dcos-adminrouter-agent-reload.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent-reload.service
@@ -4,4 +4,4 @@ Description=Admin Router Reloader: Reload admin router to get new DNS
 [Service]
 Type=oneshot
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=-$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf -s reload
+ExecStart=-$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.agent.conf -s reload

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -111,6 +111,8 @@ def test_signal_service(cluster):
     # Insert all the diagnostics data programmatically
     master_units = [
         'adminrouter-service',
+        'adminrouter-reload-service',
+        'adminrouter-reload-timer',
         'cosmos-service',
         'exhibitor-service',
         'history-service',
@@ -122,8 +124,6 @@ def test_signal_service(cluster):
         'metronome-service',
         'signal-service']
     all_node_units = [
-        'adminrouter-reload-service',
-        'adminrouter-reload-timer',
         '3dt-service',
         'epmd-service',
         'gen-resolvconf-service',
@@ -145,6 +145,8 @@ def test_signal_service(cluster):
     all_slave_units = [
         '3dt-socket',
         'adminrouter-agent-service',
+        'adminrouter-agent-reload-service',
+        'adminrouter-agent-reload-timer',
         'logrotate-agent-service',
         'logrotate-agent-timer',
         'rexray-service']


### PR DESCRIPTION
Previously it was failing every run because the `nginx reload` pointed to a
non-existent configuration file. This makes it point to the master configuration
on masters, and agent configuration on agents.

Should unblock #551

cc: @branden @jgehrcke @darkonie 