### PR TITLE
Up the systemd-journald burst rate

### DIFF
--- a/gen/cloud-config.yaml
+++ b/gen/cloud-config.yaml
@@ -20,6 +20,8 @@ root:
     content: |
       [Journal]
       MaxLevelConsole=warning
+      RateLimitInterval=1s
+      RateLimitBurst=20000
   - path: /etc/rexray/config.yml
     permissions: "0644"
     content: {{ rexray_config_contents }}


### PR DESCRIPTION
Changing this setting globally, since most customers don't seem to touch it, and we have some issues currently in customer logs with things getting dropped fairly frequently.

cc: @bernadinm 