### PR TITLE
ssh_tunnel: Fix byte / str type mismatch in logging

### DIFF
--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -73,7 +73,7 @@ class SSHTunnel():
                 return check_output(run_cmd, timeout=timeout)
         except TimeoutExpired as e:
             logging.exception('{} timed out after {} seconds'.format(cmd, timeout))
-            logging.debug('Timed out process output:\n' + e.output)
+            logging.debug('Timed out process output:\n' + e.output.decode())
             raise
 
     def write_to_remote(self, src, dst):


### PR DESCRIPTION
[11:44:28]Traceback (most recent call last):
[11:44:28]  File "/teamcity/work/4b75044667254774/env/bin/ccm-deploy-test", line 11, in <module>
[11:44:28]    sys.exit(main())
[11:44:28]  File "/teamcity/work/4b75044667254774/env/lib/python3.4/site-packages/test_util/test_installer_ccm.py", line 318, in main
[11:44:28]    installer.postflight()
[11:44:28]  File "/teamcity/work/4b75044667254774/env/lib/python3.4/site-packages/test_util/installer_api_test.py", line 330, in postflight
[11:44:28]    self.run_cli_cmd('--postflight', expect_errors=expect_errors)
[11:44:28]  File "/teamcity/work/4b75044667254774/env/lib/python3.4/site-packages/test_util/installer_api_test.py", line 254, in run_cli_cmd
[11:44:28]    print(self.ssh(cmd))
[11:44:28]  File "/teamcity/work/4b75044667254774/env/lib/python3.4/site-packages/test_util/installer_api_test.py", line 43, in ssh
[11:44:28]    return tunnel.remote_cmd(cmd, timeout=MAX_STAGE_TIME)
[11:44:28]  File "/teamcity/work/4b75044667254774/env/lib/python3.4/site-packages/ssh/ssh_tunnel.py", line 76, in remote_cmd
[11:44:28]    logging.debug('Timed out process output:\n' + e.output)

cc: @mellenburg 