### PR TITLE
Tweak flake8

### DIFF
--- a/gen/template.py
+++ b/gen/template.py
@@ -58,12 +58,12 @@ class Tokenizer():
             if kind == "eof":
                 break
 
-    def Peek(self):
+    def peek(self):
         if self.__token_pos == len(self.tokens):
             raise RuntimeError("Walked past end of token list")
         return self.tokens[self.__token_pos]
 
-    def Advance(self):
+    def advance(self):
         if self.__token_pos >= len(self.tokens):
             raise RuntimeError("Walked past end of token list")
         self.__token_pos += 1
@@ -438,48 +438,48 @@ class Template():
 
 
 def _parse_for(tokenizer):
-    token_type, value = tokenizer.Peek()
+    token_type, value = tokenizer.peek()
     assert token_type == 'for'
 
     new_var, iterable = value
 
-    tokenizer.Advance()
+    tokenizer.advance()
 
     # Read out the body
     body = _parse_chunks(tokenizer)
 
     # Should stop reading the body at the endfor
-    token_type, value = tokenizer.Peek()
+    token_type, value = tokenizer.peek()
     if token_type != 'endfor':
         raise ValueError("Expecting end of for, but found {}.".format(token_type))
 
-    tokenizer.Advance()
+    tokenizer.advance()
     return For(new_var, iterable, body)
 
 
 def _parse_switch(tokenizer):
-    token_type, identifier = tokenizer.Peek()
+    token_type, identifier = tokenizer.peek()
     assert(token_type == 'switch')
 
     cases = dict()
     is_first = True
 
     # Immediately inside should be a case, followed by lots more of those
-    tokenizer.Advance()
+    tokenizer.advance()
     while(True):
-        token_type, value = tokenizer.Peek()
+        token_type, value = tokenizer.peek()
         if token_type == 'case':
-            tokenizer.Advance()
+            tokenizer.advance()
             cases[value] = _parse_chunks(tokenizer)
         elif token_type == 'endswitch':
-            tokenizer.Advance()
+            tokenizer.advance()
             return Switch(identifier, cases)
         elif token_type == 'blob':
             # Should be unreachable if not before the first as it should be picked up inside a case.
             assert is_first
             if not value.isspace():
                 raise ValueError("Unexpected blob of text outside of switch case statements. Whitespace is all that is allowed.")  # noqa
-            tokenizer.Advance()
+            tokenizer.advance()
         else:
             raise ValueError(
                 "Unexpected token of type {} inside switch. Expected a case or endswitch.".format(token_type))
@@ -491,13 +491,13 @@ def _parse_chunks(tokenizer):
     # Read Chunks
     chunks = []
     while True:
-        token_type, value = tokenizer.Peek()
+        token_type, value = tokenizer.peek()
         if token_type == 'blob':
             chunks.append(value)
-            tokenizer.Advance()
+            tokenizer.advance()
         elif token_type == 'replacement':
             chunks.append(Replacement(value))
-            tokenizer.Advance()
+            tokenizer.advance()
         elif token_type == 'switch':
             chunks.append(_parse_switch(tokenizer))
         elif token_type == 'for':
@@ -509,7 +509,7 @@ def _parse_chunks(tokenizer):
 def parse_str(text):
     tokenizer = Tokenizer(text)
     ast = _parse_chunks(tokenizer)
-    token_type, _ = tokenizer.Peek()
+    token_type, _ = tokenizer.peek()
     if token_type != "eof":
         raise ValueError(
             "Unexpected token of type {} at end of text, expecting EOF".format(token_type))

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -66,7 +66,7 @@ class Cluster:
     @retrying.retry(wait_fixed=1000,
                     retry_on_result=lambda ret: ret is False,
                     retry_on_exception=lambda x: False)
-    def _wait_for_Marathon_up(self):
+    def _wait_for_marathon_up(self):
         r = self.get('/marathon/ui/')
         # resp_code >= 500 -> backend is still down probably
         if r.status_code < 500:
@@ -103,7 +103,7 @@ class Cluster:
     @retrying.retry(wait_fixed=1000,
                     retry_on_result=lambda ret: ret is False,
                     retry_on_exception=lambda x: False)
-    def _wait_for_DCOS_history_up(self):
+    def _wait_for_dcos_history_up(self):
         r = self.get('/dcos-history-service/ping')
         # resp_code >= 500 -> backend is still down probably
         if r.status_code <= 500:
@@ -189,13 +189,13 @@ class Cluster:
             return False
         assert r.status_code == 200
 
-    def _wait_for_DCOS(self):
+    def _wait_for_dcos(self):
         self._wait_for_leader_election()
         self._wait_for_adminrouter_up()
         self._authenticate()
-        self._wait_for_Marathon_up()
+        self._wait_for_marathon_up()
         self._wait_for_slaves_to_join()
-        self._wait_for_DCOS_history_up()
+        self._wait_for_dcos_history_up()
         self._wait_for_srouter_slaves_endpoints()
         self._wait_for_metronome()
 
@@ -260,7 +260,7 @@ class Cluster:
         # Make URI never end with /
         self.dcos_uri = dcos_uri.rstrip('/')
 
-        self._wait_for_DCOS()
+        self._wait_for_dcos()
 
     @staticmethod
     def _marathon_req_headers():

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 
 
-def test_if_Marathon_app_can_be_deployed(cluster):
+def test_if_marathon_app_can_be_deployed(cluster):
     """Marathon app deployment integration test
 
     This test verifies that marathon app can be deployed, and that service points
@@ -35,7 +35,7 @@ def test_if_Marathon_app_can_be_deployed(cluster):
     cluster.destroy_marathon_app(app_definition['id'])
 
 
-def test_if_Marathon_app_can_be_deployed_with_Mesos_containerizer(cluster):
+def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
     """Marathon app deployment integration test using the Mesos Containerizer
 
     This test verifies that a Marathon app using the Mesos containerizer with

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -8,7 +8,7 @@ import kazoo.client
 import requests
 
 
-def test_if_all_Mesos_masters_have_registered(cluster):
+def test_if_all_mesos_masters_have_registered(cluster):
     # Currently it is not possible to extract this information through Mesos'es
     # API, let's query zookeeper directly.
     zk = kazoo.client.KazooClient(hosts=cluster.zk_hostports, read_only=True)

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -3,7 +3,7 @@ import urllib.parse
 import bs4
 
 
-def test_if_DCOS_UI_is_up(cluster):
+def test_if_dcos_ui_is_up(cluster):
     r = cluster.get('/')
 
     assert r.status_code == 200
@@ -22,7 +22,7 @@ def test_if_DCOS_UI_is_up(cluster):
         assert link_response.status_code == 200
 
 
-def test_if_Mesos_is_up(cluster):
+def test_if_mesos_is_up(cluster):
     r = cluster.get('/mesos')
 
     assert r.status_code == 200
@@ -30,7 +30,7 @@ def test_if_Mesos_is_up(cluster):
     assert '<title>Mesos</title>' in r.text
 
 
-def test_if_all_Mesos_slaves_have_registered(cluster):
+def test_if_all_mesos_slaves_have_registered(cluster):
     r = cluster.get('/mesos/master/slaves')
     assert r.status_code == 200
 
@@ -40,7 +40,7 @@ def test_if_all_Mesos_slaves_have_registered(cluster):
     assert slaves_ips == cluster.all_slaves
 
 
-def test_if_Exhibitor_API_is_up(cluster):
+def test_if_exhibitor_api_is_up(cluster):
     r = cluster.get('/exhibitor/exhibitor/v1/cluster/list')
     assert r.status_code == 200
 
@@ -48,13 +48,13 @@ def test_if_Exhibitor_API_is_up(cluster):
     assert data["port"] > 0
 
 
-def test_if_Exhibitor_UI_is_up(cluster):
+def test_if_exhibitor_ui_is_up(cluster):
     r = cluster.get('/exhibitor')
     assert r.status_code == 200
     assert 'Exhibitor for ZooKeeper' in r.text
 
 
-def test_if_ZooKeeper_cluster_is_up(cluster):
+def test_if_zookeeper_cluster_is_up(cluster):
     r = cluster.get('/exhibitor/exhibitor/v1/cluster/status')
     assert r.status_code == 200
 
@@ -75,14 +75,14 @@ def test_if_uiconfig_is_available(cluster):
     assert 'uiConfiguration' in r.json()
 
 
-def test_if_DCOSHistoryService_is_up(cluster):
+def test_if_dcos_history_service_is_up(cluster):
     r = cluster.get('/dcos-history-service/ping')
 
     assert r.status_code == 200
     assert 'pong' == r.text
 
 
-def test_if_Marathon_UI_is_up(cluster):
+def test_if_marathon_ui_is_up(cluster):
     r = cluster.get('/marathon/ui/')
 
     assert r.status_code == 200
@@ -98,7 +98,7 @@ def test_if_srouter_service_endpoint_works(cluster):
     assert '<title>Marathon</title>' in r.text
 
 
-def test_if_Mesos_API_is_up(cluster):
+def test_if_mesos_api_is_up(cluster):
     r = cluster.get('/mesos_dns/v1/version')
     assert r.status_code == 200
 
@@ -106,7 +106,7 @@ def test_if_Mesos_API_is_up(cluster):
     assert data["Service"] == 'Mesos-DNS'
 
 
-def test_if_PkgPanda_metadata_is_available(cluster):
+def test_if_pkgpanda_metadata_is_available(cluster):
     r = cluster.get('/pkgpanda/active.buildinfo.full.json')
     assert r.status_code == 200
 
@@ -115,7 +115,7 @@ def test_if_PkgPanda_metadata_is_available(cluster):
     assert len(data) > 5  # (prozlach) We can try to put minimal number of pacakages required
 
 
-def test_if_DCOSHistoryService_is_getting_data(cluster):
+def test_if_dcos_history_service_is_getting_data(cluster):
     r = cluster.get('/dcos-history-service/history/last')
     assert r.status_code == 200
     # Make sure some basic fields are present from state-summary which the DC/OS

--- a/packages/dcos-integration-test/extra/test_server.py
+++ b/packages/dcos-integration-test/extra/test_server.py
@@ -117,7 +117,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
             TEST_DATA_CACHE = self.rfile.read(int(self.headers['Content-Length'])).decode()
         self._send_reply(TEST_DATA_CACHE)
 
-    def parse_POST_headers(self):
+    def parse_POST_headers(self):  # noqa: ignore=N802
         """Parse request's POST headers in utf8 aware way
 
         Returns:
@@ -240,7 +240,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         data = {"status": status, "output": output}
         self._send_reply(data)
 
-    def do_GET(self):
+    def do_GET(self):  # noqa: ignore=N802
         """Mini service router handling GET requests"""
         # TODO(cmaloney): Alphabetize these.
         if self.path == '/ping':
@@ -256,7 +256,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         else:
             self.send_error(404, 'Not found', 'Endpoint is not supported')
 
-    def do_POST(self):
+    def do_POST(self):  # noqa: ignore=N802
         """Mini service router handling POST requests"""
         if self.path == '/your_ip':
             try:

--- a/test_util/ccm.py
+++ b/test_util/ccm.py
@@ -104,7 +104,7 @@ class Ccm():
             print("Error: Could not extract ID; VPC creation failed!")
             print("Response data: {}".format(response))
             sys.exit(1)
-        return self.VpcCluster(cluster_id, instance_count)
+        return self.vpc_cluster(cluster_id, instance_count)
 
     def get_cluster_info(self, pk):
         response = self.get("/api/cluster/{}/".format(pk))
@@ -133,7 +133,7 @@ class Ccm():
     def delete_cluster(self, pk):
         return self.delete("/api/cluster/{}/".format(pk)).text
 
-    def VpcCluster(self, pk, instance_count):
+    def vpc_cluster(self, pk, instance_count):
         return VpcCluster(self, pk, node_count=instance_count)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length=120
+exclude=packages/*/src,packages/*/result,packages/cache,.git,.tox
 
 [pytest]
 addopts = -vv
@@ -15,7 +16,7 @@ deps =
   isort
 
 commands =
-  flake8 --verbose {env:CI_FLAGS:} --exclude="packages/*/src,packages/*/result,packages/cache,.git,.tox" ./
+  flake8 --verbose {env:CI_FLAGS:} ./
   isort --recursive --check-only --diff --verbose docker gen packages/dcos-history/extra pkgpanda tests release ssh test_util
 
 [testenv:py34-unittests]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ testpaths =
 [testenv:py34-syntax]
 deps =
   flake8
+  pep8-naming
   teamcity-messages
   isort
 


### PR DESCRIPTION
 - Move flake8 excludes to the config line rather than command line arg (Easier to read / deal with)
 - Add pep8-naming check


On my roadmap is enabling McCabe complexity checking, but that is more involved.

cc: @orsenthil @mellenburg 

The biggest thing this changes is a bunch of names in tests.