### PR TITLE
Make metronome, marathon run as non-root

### DIFF
--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -12,8 +12,9 @@ mkdir -p $(dirname "$marathon_service")
 cat <<EOF > "$marathon_service"
 [Unit]
 Description=Marathon: DC/OS Init System
-After=dcos-mesos-master.service
+
 [Service]
+User=dcos_marathon
 Restart=always
 StartLimitInterval=0
 RestartSec=15

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -10,12 +10,13 @@ mkdir -p $(dirname "$metronome_service")
 cat <<EOF > "$metronome_service"
 [Unit]
 Description=Jobs Service: DC/OS Metronome
-After=dcos-mesos-master.service
 
 [Service]
+User=dcos_metronome
 Restart=always
 StartLimitInterval=0
 RestartSec=15
+PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/metronome
 EnvironmentFile=-/run/dcos/etc/metronome/service.env

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -4,5 +4,7 @@
     "kind": "url_extract",
     "url": "https://downloads.mesosphere.com/maven/dcos/metronome/0.1.8/metronome-0.1.8.tgz",
     "sha1": "fd54079a94add7bcfbf2624799208ab3b055a8e7"
-  }
+  },
+  "username": "dcos_metronome",
+  "state_directory": true
 }


### PR DESCRIPTION
Fixes DCOS-317

TODO
 - [ ] Manually verify on a cluster metronome and marathon are indeed non-root.