### PR TITLE
Updated mesos-overlay-modules with fix for configuration failure.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -123,6 +123,13 @@ def validate_dcos_overlay_mtu(dcos_overlay_mtu):
     assert int(dcos_overlay_mtu) >= 552, 'Linux allows a minimum MTU of 552 bytes'
 
 
+def validate_dcos_overlay_config_attempts(dcos_overlay_config_attempts):
+    assert dcos_overlay_config_attempts.isdigit(), (
+        'dcos_overlay_config_attempts needs to be a positive integer between 0 and 10')
+    assert int(dcos_overlay_config_attempts) >= 0 and int(dcos_overlay_config_attempts) < 10, (
+        'The acceptable range of values for dcos_overlay_config_attempts is between 0 and 10')
+
+
 def validate_dcos_overlay_network(dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
@@ -339,6 +346,7 @@ entry = {
         validate_dcos_overlay_network,
         validate_dcos_overlay_enable,
         validate_dcos_overlay_mtu,
+        validate_dcos_overlay_config_attempts,
         validate_dcos_remove_dockercfg_enable,
         validate_rexray_config],
     'default': {
@@ -371,6 +379,7 @@ entry = {
         'ui_banner_footer_content': 'null',
         'ui_banner_image_path': 'null',
         'ui_banner_dismissible': 'null',
+        'dcos_overlay_config_attempts': '4',
         'dcos_overlay_mtu': '1420',
         'dcos_overlay_enable': "true",
         'dcos_overlay_network': '{                      \

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -115,7 +115,8 @@ package:
           "mesos_bridge": true,
           "docker_bridge": true,
           "overlay_mtu": {{ dcos_overlay_mtu }}
-        }
+        },
+        "max_configuration_attempts": {{ dcos_overlay_config_attempts }}
        }
   - path: /etc/overlay/config/agent-master.json
     content: |
@@ -127,7 +128,8 @@ package:
           "mesos_bridge": false,
           "docker_bridge": true,
           "overlay_mtu": {{ dcos_overlay_mtu }}
-        }
+        },
+        "max_configuration_attempts": {{ dcos_overlay_config_attempts }}
       }
 {% switch dcos_overlay_enable %}
 {% case "true" %}

--- a/packages/mesos-overlay-modules/buildinfo.json
+++ b/packages/mesos-overlay-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/mesos-overlay-modules.git",
-      "ref": "7b93d68c7066a00c176d7d886cdad74096be8d90",
+      "ref": "931e174fe3d104bb70bbcbcf701577db92048693",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
* The mesos-overlay-module on the agent will try to re-register with the master in case of a configuration failure, forcing it to reattempt the configuration of the overlay network. On failing more than four times (default value) it will bail.