### PR TITLE
WIP: Complexity Checking

### DIFF
--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -777,7 +777,10 @@ class IdBuilder():
         return self._buildinfo
 
 
-def build(package_store, name, variant, clean_after_build, recursive=False):
+def build(package_store, name, variant, clean_after_build, recursive=False):  # noqa: C901
+    # C901: Ignoring because is is a very long very linear thing. Should definitely work on
+    # factoring into more testable chunks over time but it's to big a job for blocking keeping out
+    # new overly complex stuff.
     assert isinstance(package_store, PackageStore)
     print("Building package {} variant {}".format(name, pkgpanda.util.variant_str(variant)))
     tmpdir = tempfile.TemporaryDirectory(prefix="pkgpanda_repo")

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ ignore=
 # TODO(cmaloney): Reduce the number of top level modules we have
 application-import-names=dcos_installer,dcos_internal_utils,gen,history,pkgpanda,release,ssh,test_util
 import-order-style=smarkets
+max_complexity=10
 
 [pytest]
 addopts = -rs -vv


### PR DESCRIPTION
This sets a McCabe complexity limit for the codebase of 15.

The goal would be to reduce the complexity of functions generally and make them more testable.

Things which are long, largely linear runs for now get exclusions. Ideally we work on refactoring them long term.

Things which started with a lower score are being reworked / refactored to reduce their complexity.

See: https://en.wikipedia.org/wiki/Cyclomatic_complexity for some backround on McCabe complexity
