### PR TITLE
Fixed namespace check in CNI package.

### DIFF
--- a/packages/cni/buildinfo.json
+++ b/packages/cni/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/containernetworking/cni.git",
-      "ref" : "b8e92ed030588120f9fda47dd359e17a3234142d",
+      "ref" : "e0ea82b229f6517d033462c5cf57b698c6a89d1f",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
Fixed the namespace path check in `pkg/ns` package in the upstream `containernetworking/cni` repo:
https://github.com/containernetworking/cni/pull/290

Updating the CNI plugins package to reflect this PR.

Fixes https://dcosjira.atlassian.net/browse/DCOS-300