### PR TITLE
Move app building into a function, upgrade to aiohttp 0.22.5

### DIFF
--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 
+import dcos_installer.async_server
 import gen.calc
 from dcos_installer import action_lib, backend
 from dcos_installer.action_lib.prettyprint import print_header, PrettyPrint
@@ -53,8 +54,7 @@ class CliDelegate(AbstractSSHLibDelegate):
 
 def run_loop(action, options):
     assert callable(action)
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+    loop = asyncio.get_event_loop()
 
     print_header('START {}'.format(action.__name__))
     try:
@@ -136,7 +136,6 @@ def do_version(args):
 
 def do_web(args):
     print_header("Starting DC/OS installer in web mode")
-    import dcos_installer.async_server
     dcos_installer.async_server.start(args)
     return 0
 

--- a/ext/dcos-installer/setup.py
+++ b/ext/dcos-installer/setup.py
@@ -12,18 +12,12 @@ setup(
         'License :: OSI Approved :: Apache Software License',
     ],
     install_requires=[
-        'aiohttp==0.20.0',
+        'aiohttp==0.22.5',
         'aiohttp_jinja2',
         'coloredlogs',
         'passlib',
         'analytics-python',
         'pyyaml'],
-    tests_require=[
-        'pytest==2.9.0',
-        'pytest-mock==0.11.0',
-        'webtest==2.0.20',
-        'webtest-aiohttp==1.0.0'],
-    test_suite='pytest',
     entry_points={
         'console_scripts': [
             'dcos_installer = dcos_installer.cli:main']

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -10,6 +10,7 @@ for package in aiohttp_jinja2 analytics-python azure-nspkg azure-common azure-mg
   pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$package/*.whl
 done
 
-for package in aiohttp chardet coloredlogs docker-py humanfriendly oauthlib waitress websocket-client; do
+for package in aiohttp chardet coloredlogs docker-py humanfriendly multidict oauthlib waitress \
+    websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -16,8 +16,8 @@
   "sources": {
     "aiohttp": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/a/aiohttp/aiohttp-0.20.0.tar.gz",
-      "sha1": "4ab710f2e03a2d8414382d98b9832a6f0022a780"
+      "url": "https://pypi.python.org/packages/55/9d/38fb3cb174f4723b50a3f0593e18a51418c9a73a7857fdcaee46b83ff1c4/aiohttp-0.22.5.tar.gz",
+      "sha1": "d391ae04d2aa97be14ef7de13e7ee2b9939ce8b4"
     },
     "aiohttp_jinja2": {
       "kind": "url",
@@ -108,6 +108,11 @@
       "kind": "url",
       "url": "https://pypi.python.org/packages/9a/1e/8b0290dc98de928b04c6fc73c301faebf52b9479a3c772edc77b92b4d6f6/keyring-9.1-py2.py3-none-any.whl",
       "sha1": "9c1d41e9e9e30c02cb49f4d6c7f377311c0f347d"
+    },
+    "multidict": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/fd/5b/3dd32b8e53703ff7a27a72e9a118e7f78c14a171554ec8c99dd4759c4018/multidict-1.2.2.tar.gz",
+      "sha1": "cf2a93c62b2813a07d113d9bfef057a06feedf27"
     },
     "oauthlib": {
       "kind": "url_extract",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -110,7 +110,7 @@
       "sha1": "9c1d41e9e9e30c02cb49f4d6c7f377311c0f347d"
     },
     "multidict": {
-      "kind": "url",
+      "kind": "url_extract",
       "url": "https://pypi.python.org/packages/fd/5b/3dd32b8e53703ff7a27a72e9a118e7f78c14a171554ec8c99dd4759c4018/multidict-1.2.2.tar.gz",
       "sha1": "cf2a93c62b2813a07d113d9bfef057a06feedf27"
     },

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'test_util'],
     install_requires=[
         'Flask',
+        'flask-compress',
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.0',
         'msrestazure==0.4.1',

--- a/tox.ini
+++ b/tox.ini
@@ -38,14 +38,12 @@ passenv =
 setenv =
   PYTHONPATH={toxinidir}
 deps =
-  flask>=0.10.1
-  flask-compress
   pytest
-  pytest-mock==0.11.0
+  pytest-mock
   requests
   teamcity-messages
-  webtest==2.0.20
-  webtest-aiohttp==1.0.0
+  webtest
+  webtest-aiohttp
 commands=
   ./prep_local
   py.test -rs --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}


### PR DESCRIPTION
This makes it so importing async_server doesn't cause a bunch of code to run, which helps separate concerns.

The aiohttp updates fix some issues that certain version mixes had with the tests resulting in a "has no method is_closing" error.