### PR TITLE
Enable the Marathon 'gpu_resources' feature by default.

### DIFF
--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -42,7 +42,7 @@ ExecStart=/opt/mesosphere/bin/java \\
     --revive_offers_for_new_apps \\
     --zk_compression \\
     --mesos_leader_ui_url "/mesos" \\
-    --enable_features "vips,task_killing,external_volumes" \\
+    --enable_features "vips,task_killing,external_volumes,gpu_resources" \\
     --mesos_authentication_principal "dcos_marathon" \\
     --mesos_user "root"
 EOF


### PR DESCRIPTION
By default, enabling this feature will have absolutely no affect on the
existing operation of marathon.

However, it makes it much easier for people to use GPUs in DC/OS if they
wish to go through the manual process of enabling the mesos GPU isolator
on a per-agent basis via /opt/mesosphere/etc/mesos-slave-common.

In future releases, we should come up with a way to make enabling this
isolator less manual, but for now enabling this marathon feature by
default should suffice for early users.