### PR TITLE
Add a dcos_add_user.py script to add oauth users from the command line while in a shell on the masters

### DIFF
--- a/packages/dcos-oauth/build
+++ b/packages/dcos-oauth/build
@@ -14,3 +14,5 @@ service="$PKG_PATH/dcos.target.wants_master/dcos-oauth.service"
 mkdir -p "$(dirname "$service")"
 
 cp /pkg/extra/dcos-oauth.service "$service"
+cp /pkg/extra/dcos_add_user.py "$PKG_PATH/bin/"
+chmod +x "$PKG_PATH/bin/dcos_add_user.py"

--- a/packages/dcos-oauth/extra/dcos_add_user.py
+++ b/packages/dcos-oauth/extra/dcos_add_user.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import argparse
+from kazoo.client import KazooClient
+from kazoo.handlers.threading import SequentialThreadingHandler
+from kazoo.retry import KazooRetry
+
+# Retry every .3 seconds for up to 1 second.
+retry_policy = KazooRetry(
+    max_tries=3,
+    delay=0.3,
+    backoff=1,
+    max_jitter=0.1,
+    max_delay=1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('email')
+parser.add_argument('--zk', default='127.0.0.1:2181')
+
+args = parser.parse_args()
+email = args.email
+
+zk = KazooClient(
+    hosts=args.zk,
+    timeout=1.0,
+    handler=SequentialThreadingHandler(),
+    connection_retry=retry_policy,
+    command_retry=retry_policy)
+zk.start()
+zk.ensure_path("/dcos/users/")
+zk.create("/dcos/users/{}".format(email), email.encode())

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} ./
-  isort --recursive --check-only --diff --verbose docker gen packages/dcos-history/extra pkgpanda tests release ssh test_util
+  isort --recursive --check-only --diff --verbose docker gen packages/dcos-history/extra packages/dcos-oauth/extra pkgpanda tests release ssh test_util
 
 [testenv:py34-unittests]
 passenv =


### PR DESCRIPTION
`sudo -i /opt/mesosphere/bin/dcos_add_user.py`

TODO:
 - [x] Manually test on a cluster to make sure it works in practice from masters and agents (agents require setting --zk)