### PR TITLE
Details skip test

### DIFF
--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -165,7 +165,7 @@ def run():
                     provider='azure',
                     test_dns_search=False,
                     pytest_dir=os.getenv('DCOS_PYTEST_DIR', '/opt/mesosphere/active/dcos-integration-test'),
-                    pytest_cmd=os.getenv('DCOS_PYTEST_CMD', "py.test -vv -m 'not ccm' ")+os.getenv('CI_FLAGS', ''))
+                    pytest_cmd=os.getenv('DCOS_PYTEST_CMD', "py.test -rs -vv -m 'not ccm' ")+os.getenv('CI_FLAGS', ''))
         test_successful = True
     except Exception as ex:
         print("ERROR: exception {}".format(ex))

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -94,7 +94,7 @@ export DNS_SEARCH=true
 export DCOS_AUTH_ENABLED=false
 export DCOS_PROVIDER=onprem
 cd /opt/mesosphere/active/dcos-integration-test
-py.test -vv -s -m "not ccm" ${CI_FLAGS:-}
+py.test -rs -vv -m "not ccm" ${CI_FLAGS:-}
 EOF
 chmod +x test_wrapper.sh
 echo "Running integration test"

--- a/test_util/test_installer_ccm.py
+++ b/test_util/test_installer_ccm.py
@@ -180,7 +180,7 @@ def check_environment():
     options.add_env = add_env
 
     options.pytest_dir = os.getenv('DCOS_PYTEST_DIR', '/opt/mesosphere/active/dcos-integration-test')
-    options.pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv '+options.ci_flags)
+    options.pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -rs -vv ' + options.ci_flags)
     return options
 
 

--- a/test_util/test_runner.py
+++ b/test_util/test_runner.py
@@ -19,7 +19,7 @@ def integration_test(
         dcos_dns, master_list, agent_list, public_agent_list,
         test_dns_search, provider,
         aws_access_key_id='', aws_secret_access_key='', region='', add_env=None,
-        pytest_cmd='py.test -vv',
+        pytest_cmd='py.test -rs -vv',
         pytest_dir='/opt/mesosphere/active/dcos-integration-test'):
     """Runs integration test on host
 
@@ -71,7 +71,7 @@ cd {pytest_dir}
 
     write_string('test_preflight.sh', test_boilerplate.format(
         env=test_env_str, pytest_dir=pytest_dir,
-        cmd='py.test -vv --collect-only'))
+        cmd='py.test -rs -vv --collect-only'))
     write_string('test_wrapper.sh', test_boilerplate.format(
         env=test_env_str, pytest_dir=pytest_dir,
         cmd=pytest_cmd))


### PR DESCRIPTION
Now that some tests may be skipped when testing ACS deployments,
explicitly print out details on skipped tests just like we do with our
tox configuration for py.test.

Update every single invocation of py.test in the project to do `-rs -vv`

Pulled out of #591, with some missing cases fixed