### PR TITLE
Remove dcos-installer package

### DIFF
--- a/packages/dcos-image/build
+++ b/packages/dcos-image/build
@@ -4,3 +4,8 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME
+
+pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME/ext/dcos-installer
+
+mkdir -p "$LIB_INSTALL_DIR/dcos_installer/"
+ln -s /opt/mesosphere/active/dcos-installer-ui/usr/ "$LIB_INSTALL_DIR/dcos_installer/templates"

--- a/packages/dcos-installer/build
+++ b/packages/dcos-installer/build
@@ -1,9 +1,0 @@
-#!/bin/bash
-source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
-mkdir -p "$LIB_INSTALL_DIR"
-
-pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME/ext/dcos-installer
-
-mkdir -p "$LIB_INSTALL_DIR/dcos_installer/"
-ln -s /opt/mesosphere/active/dcos-installer-ui/usr/ "$LIB_INSTALL_DIR/dcos_installer/templates"

--- a/packages/dcos-installer/buildinfo.json
+++ b/packages/dcos-installer/buildinfo.json
@@ -1,7 +1,0 @@
-{
-  "requires": ["python", "dcos-image-deps"],
-  "single_source": {
-    "kind": "git_local",
-    "rel_path": "../../"
-  }
-}

--- a/packages/installer.treeinfo.json
+++ b/packages/installer.treeinfo.json
@@ -1,7 +1,6 @@
 {
   "core_package_list": [
     "dcos-image",
-    "dcos-installer",
     "dcos-installer-ui"
   ]
 }

--- a/packages/treeinfo.json
+++ b/packages/treeinfo.json
@@ -1,6 +1,5 @@
 {
   "exclude": [
-    "dcos-installer",
     "dcos-installer-ui"
   ]
 }


### PR DESCRIPTION
No point in having it separate from dcos-image, both always get rebuilt in the same circumstances