### PR TITLE
Remove BUILD_DIR printing, doesn't particularly add a lot of value

### DIFF
--- a/gen/installer/bash/dcos_generate_config.sh.in
+++ b/gen/installer/bash/dcos_generate_config.sh.in
@@ -21,7 +21,6 @@ then
 fi
 trap - INT
 
-echo "Running mesosphere/dcos-genconf docker with BUILD_DIR set to $PWD/genconf"
 if [ ! -d genconf/state ]; then
     mkdir -p genconf/state
 fi


### PR DESCRIPTION
There are no other uses of BUILD_DIR in the entire codebase