### PR TITLE
Pull out a "Config Target" from gen.calculate, use it for ssh configuration

### DIFF
--- a/ext/dcos-installer/dcos_installer/action_lib.py
+++ b/ext/dcos-installer/dcos_installer/action_lib.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def get_async_runner(config, hosts, async_delegate=None):
+    # TODO(cmaloney): Delete these repeats. Use gen / expanded configuration to get all the values.
     process_timeout = config.get('process_timeout', 120)
     extra_ssh_options = config.get('extra_ssh_options', '')
     ssh_key_path = config.get('ssh_key_path', 'genconf/ssh_key')

--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -120,13 +120,6 @@ def print_validation_errors(messages):
         log.error('{}: {}'.format(key, message))
 
 
-def validate_ssh_config_or_exit():
-    validation_errors = backend.do_validate_ssh_config()
-    if validation_errors:
-        print_validation_errors(validation_errors)
-        sys.exit(1)
-
-
 def do_version(args):
     print(json.dumps(
         {
@@ -138,7 +131,7 @@ def do_version(args):
 
 def do_validate_config(args):
     log_warn_only()
-    validation_errors = backend.do_validate_gen_config()
+    validation_errors = backend.do_validate_config()
     if validation_errors:
         print_validation_errors(validation_errors)
         return 1
@@ -234,7 +227,8 @@ def dispatch(args):
     # Dispatches CLI options which are installer actions ran through AIO event loop
     if args.action in dispatch_dict_aio:
         action = dispatch_dict_aio[args.action]
-        validate_ssh_config_or_exit()
+        if do_validate_config(args) != 0:
+            sys.exit(1)
         if action[1] is not None:
             print_header(action[1])
         errors = run_loop(action[0], args)

--- a/ext/dcos-installer/dcos_installer/config.py
+++ b/ext/dcos-installer/dcos_installer/config.py
@@ -78,11 +78,6 @@ bootstrap_url: file:///opt/dcos_install_tmp
         for k, v in self.items():
             log.debug("%s: %s", k, v)
 
-    def get_hidden_config(self):
-        self.hidden_config = {
-            'ssh_key_path': SSH_KEY_PATH,
-        }
-
     def get_external_config(self):
         self.external_config = {
             'ssh_key': self._try_loading_from_disk(SSH_KEY_PATH),

--- a/ext/dcos-installer/dcos_installer/config_util.py
+++ b/ext/dcos-installer/dcos_installer/config_util.py
@@ -14,11 +14,8 @@ log = logging.getLogger(__name__)
 def do_configure(gen_config):
     gen_config.update(get_gen_extra_args())
 
-    subprocess.check_output(['mkdir', '-p', SERVE_DIR])
-
-    do_validate_gen_config(gen_config)
-
     gen_out = gen.generate(arguments=gen_config)
+    subprocess.check_call(['mkdir', '-p', SERVE_DIR])
     gen.installer.bash.generate(gen_out, SERVE_DIR)
 
     # Get bootstrap from artifacts
@@ -29,12 +26,6 @@ def do_configure(gen_config):
 
 def get_gen_extra_args():
     return {'provider': 'onprem'}
-
-
-def do_validate_gen_config(gen_config):
-    # run validate first as this is the only way we have for now to remove "optional" keys
-    gen_config.update(get_gen_extra_args())
-    return gen.validate(arguments=gen_config)
 
 
 def do_move_atomic(src_dir, dest_dir, filenames):

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -1,16 +1,11 @@
 import os
-import socket
 import stat
 
-
-def validate_ssh_user(ssh_user):
-    assert ssh_user, 'ssh_user must be set'
-    assert isinstance(ssh_user, str), 'ssh_user must be a string'
+import gen
+from dcos_installer.config import stringify_configuration
 
 
 def validate_ssh_key_path(ssh_key_path):
-    assert isinstance(ssh_key_path, str), 'ssh_key_path must be a string'
-    assert ssh_key_path, 'ssh_key_path must be set'
     assert os.path.isfile(ssh_key_path), 'could not find ssh private key: {}'.format(ssh_key_path)
     assert stat.S_IMODE(
         os.stat(ssh_key_path).st_mode) & (stat.S_IRWXG + stat.S_IRWXO) == 0, (
@@ -21,105 +16,72 @@ def validate_ssh_key_path(ssh_key_path):
                                               'are not allowed. Use a key without a passphrase.')
 
 
-def validate_ssh_port(ssh_port):
-    # Validate ssh port between 1 - 32000
-    assert isinstance(ssh_port, int), 'ssh port should be integer'
-    assert 1 <= ssh_port <= 32000, 'ssh port should be int between 1 - 32000'
-
-
-def validate_hosts_list(nodes_list, name):
-    assert nodes_list, name + ' must be set'
-    assert isinstance(nodes_list, list), name + ' must be a list'
-    check_duplicates(nodes_list)
-    check_ipv4_addrs(nodes_list)
-
-
-def validate_master_agent_lists(master_list, agent_list, public_agent_list):
-    validate_hosts_list(master_list, 'master_list')
-
-    # Require only master_list
-    if agent_list:
-        compare_lists(master_list, agent_list)
-
-    if public_agent_list:
-        compare_lists(master_list, public_agent_list)
-
-
-def check_duplicates(arg_list):
-    assert isinstance(arg_list, list), 'only lists can be verified for duplicates'
-    dups = list(filter(lambda x: arg_list.count(x) > 1, arg_list))
-    assert not dups, 'List cannot contain duplicates: {}'.format(', '.join(set(dups)))
-
-
-def compare_lists(first_list, second_list):
-    assert isinstance(first_list, list), 'can compare only lists'
-    assert isinstance(second_list, list), 'can compare only lists'
+def compare_lists(first_json: str, second_json: str):
+    first_list = gen.calc.validate_json_list(first_json)
+    second_list = gen.calc.validate_json_list(second_json)
     dups = set(first_list) & set(second_list)
     assert not dups, 'master_list and agent_list cannot contain duplicates {}'.format(', '.join(dups))
 
 
-def check_ipv4_addrs(ips):
-    assert isinstance(ips, list)
-    invalid_ips = []
-    for ip in ips:
-        try:
-            socket.inet_pton(socket.AF_INET, str(ip))
-        except OSError:
-            invalid_ips.append(ip)
-    assert not invalid_ips, ('Only IPv4 values are allowed. The following are invalid IPv4 addresses: '
-                             '{}'.format(', '.join(invalid_ips)))
+def validate_agent_lists(agent_list, public_agent_list):
+    compare_lists(agent_list, public_agent_list)
 
 
-def validate_optional_agent(agent_list, public_agent_list):
-    if agent_list:
-        validate_hosts_list(agent_list, 'agent_list')
-
-    if public_agent_list:
-        validate_hosts_list(public_agent_list, 'public_agent_list')
-
-    if agent_list and public_agent_list:
-        compare_lists(agent_list, public_agent_list)
-
-
-def run_validate_config_chunk(key_validate_fn_map, config, keys_required):
-    assert isinstance(keys_required, bool)
-    errors = {}
-    for ssh_key, validate_func in key_validate_fn_map.items():
-        if ssh_key not in config:
-            if keys_required:
-                errors[ssh_key] = 'required parameter {} was not provided'.format(ssh_key)
-            continue
-        try:
-            validate_func(config[ssh_key])
-        except AssertionError as err:
-            errors[ssh_key] = str(err)
-    return errors
-
-
-def validate_ssh_parallelism(value):
-    assert isinstance(value, int), 'ssh_parallelism must be integer'
-    assert 0 < value <= 100, 'ssh_parallelism must be within the range 1..100'
-
-
-def validate_config(config):
-    assert isinstance(config, dict)
-    ssh_keys_checks_map_required = {
-        'ssh_user': validate_ssh_user,
-        'ssh_port': validate_ssh_port,
-        'ssh_key_path': validate_ssh_key_path,
-        'master_list': lambda master_list: validate_master_agent_lists(
-            master_list,
-            config.get('agent_list', []),
-            config.get('public_agent_list', []))
+entry = {
+    'validate': [
+        lambda agent_list: gen.calc.validate_ip_list(agent_list),
+        lambda public_agent_list: gen.calc.validate_ip_list(public_agent_list),
+        lambda master_list: gen.calc.validate_ip_list(master_list),
+        # master list shouldn't contain anything in either agent lists
+        lambda master_list, agent_list: compare_lists(master_list, agent_list),
+        lambda master_list, public_agent_list: compare_lists(master_list, public_agent_list),
+        # the agent lists shouldn't contain any common items
+        lambda agent_list, public_agent_list: compare_lists(agent_list, public_agent_list),
+        validate_ssh_key_path,
+        lambda ssh_port: gen.calc.validate_int_in_range(ssh_port, 1, 32000),
+        lambda ssh_parallelism: gen.calc.validate_int_in_range(ssh_parallelism, 1, 100)
+    ],
+    'default': {
+        'ssh_key_path': 'genconf/ssh_key',
+        'agent_list': '[]',
+        'agent_public_list': '[]',
+        'ssh_port': '22',
+        'process_timeout': '120',
+        'ssh_parallelism': '20'
     }
-    ssh_keys_checks_map_optional = {
-        'agent_list': lambda agent_list: validate_optional_agent(agent_list, config.get('public_agent_list')),
-        'public_agent_list': lambda public_agent_list: validate_optional_agent(
-            config.get('agent_list'),
-            public_agent_list),
-        'ssh_parallelism': validate_ssh_parallelism
-    }
+}
 
-    errors = run_validate_config_chunk(ssh_keys_checks_map_required, config, True)
-    errors.update(run_validate_config_chunk(ssh_keys_checks_map_optional, config, False))
-    return errors
+parameters = {
+    'variables': {
+        'ssh_user',
+        'ssh_port',
+        'ssh_key_path',
+        'master_list',
+        'agent_list',
+        'public_agent_list',
+        'ssh_parallelism',
+        'process_timeout'
+    }
+}
+
+
+def get_config_target():
+    config_target = gen.ConfigTarget(parameters)
+    config_target.add_entry(entry, False)
+    return config_target
+
+
+# TODO(cmaloney): Work this API, callers until this result remapping is unnecessary
+# and the couple places that need this can just make a trivial call directly.
+def validate_config(user_arguments):
+    user_arguments = stringify_configuration(user_arguments)
+    messages = gen.validate_config_for_targets([get_config_target()], user_arguments)
+    if messages['status'] == 'ok':
+        return {}
+
+    # Re-format to the expected format
+    # TODO(cmaloney): Make the unnecessary
+    final_errors = dict()
+    for name, message_blob in messages['errors'].items():
+        final_errors[name] = message_blob['message']
+    return final_errors

--- a/tests/test_gen_validation.py
+++ b/tests/test_gen_validation.py
@@ -13,7 +13,6 @@ def validate_helper(arguments):
 @pytest.fixture
 def default_arguments():
     return copy.deepcopy({
-        'cluster_id': 'TODO',
         'ip_detect_filename': pkg_resources.resource_filename('gen', 'ip-detect/aws.sh'),
         'bootstrap_id': '123',
         'exhibitor_zk_path': '/dcos',
@@ -57,7 +56,7 @@ def test_invalid_telemetry_enabled(default_arguments):
 
 def test_invalid_ipv4(default_arguments):
     test_ips = '["52.37.192.49", "52.37.181.230", "foo", "52.37.163.105", "bar"]'
-    err_msg = "Only IPv4 values are allowed. The following are invalid IPv4 addresses: foo, bar"
+    err_msg = "Invalid IPv4 addresses in list: foo, bar"
     validate_error(
         {'master_list': test_ips},
         'master_list',
@@ -94,7 +93,7 @@ def test_validate_duplicates(default_arguments):
     validate_error(
         {'master_list': '["10.0.0.1", "10.0.0.2", "10.0.0.1"]'},
         'master_list',
-        'List cannot contain duplicates: 10.0.0.1, 10.0.0.1')
+        'List cannot contain duplicates: 10.0.0.1 appears 2 times')
 
 
 def test_invalid_oauth_enabled(default_arguments):

--- a/tests/test_installer_async_api.py
+++ b/tests/test_installer_async_api.py
@@ -101,13 +101,10 @@ def test_configure_status(client, mocker):
         'CONNECT': [405, 'text/plain'],
     }
 
-    mocked_do_validate_ssh_config = mocker.patch('dcos_installer.backend.do_validate_ssh_config')
-    mocked_do_validate_ssh_config.return_value = {
+    mocked_do_validate_config = mocker.patch('dcos_installer.backend.do_validate_config')
+    mocked_do_validate_config.return_value = {
         'ssh_user': 'error'
     }
-
-    mocked_do_validate_gen_config = mocker.patch('dcos_installer.backend.do_validate_gen_config')
-    mocked_do_validate_gen_config.return_value = {}
 
     for method, expected in featured_methods.items():
         res = client.request(route, method=method, expect_errors=True)

--- a/tests/test_ssh_unittest.py
+++ b/tests/test_ssh_unittest.py
@@ -50,7 +50,7 @@ def test_agent_list_ipv4(default_config):
         default_config['ssh_key_path'] = tmp.name
         default_config['agent_list'] = ['127.0.0.1', '127.0.0.2', 'foo']
         assert ssh.validate.validate_config(default_config) == {
-            'agent_list': 'Only IPv4 values are allowed. The following are invalid IPv4 addresses: foo'
+            'agent_list': 'Invalid IPv4 addresses in list: foo'
         }
 
 
@@ -59,7 +59,7 @@ def test_agent_list_dups(default_config):
         default_config['ssh_key_path'] = tmp.name
         default_config['agent_list'] = ['127.0.0.1', '127.0.0.2', '127.0.0.1']
         assert ssh.validate.validate_config(default_config) == {
-            'agent_list': 'List cannot contain duplicates: 127.0.0.1'}
+            'agent_list': 'List cannot contain duplicates: 127.0.0.1 appears 2 times'}
 
 
 def test_master_agent_list_dups(default_config):
@@ -67,22 +67,17 @@ def test_master_agent_list_dups(default_config):
         default_config['ssh_key_path'] = tmp.name
         default_config['master_list'] = ['10.10.0.1', '10.10.0.2', '127.0.0.2']
         assert ssh.validate.validate_config(default_config) == {
-            'master_list': 'master_list and agent_list cannot contain duplicates 127.0.0.2'
+            'master_list': 'master_list and agent_list cannot contain duplicates 127.0.0.2',
+            'agent_list': 'master_list and agent_list cannot contain duplicates 127.0.0.2'
         }
-
-
-def test_ssh_user(default_config):
-    with tempfile.NamedTemporaryFile() as tmp:
-        default_config['ssh_key_path'] = tmp.name
-        default_config['ssh_user'] = 123
-        assert ssh.validate.validate_config(default_config) == {'ssh_user': 'ssh_user must be a string'}
 
 
 def test_ssh_port(default_config):
     with tempfile.NamedTemporaryFile() as tmp:
         default_config['ssh_key_path'] = tmp.name
         default_config['ssh_port'] = 100000
-        assert ssh.validate.validate_config(default_config) == {'ssh_port': 'ssh port should be int between 1 - 32000'}
+        assert ssh.validate.validate_config(default_config) == \
+            {'ssh_port': 'Must be between 1 and 32000 inclusive'}
 
 
 def test_public_agent_list(default_config):
@@ -103,15 +98,16 @@ def test_ssh_parallelism(default_config):
         # test ssh_parallelism range, should be ok within 1.100
         default_config['ssh_parallelism'] = 101
         assert ssh.validate.validate_config(default_config) == {
-            'ssh_parallelism': 'ssh_parallelism must be within the range 1..100'}
+            'ssh_parallelism': 'Must be between 1 and 100 inclusive'}
 
         default_config['ssh_parallelism'] = 0
         assert ssh.validate.validate_config(default_config) == {
-            'ssh_parallelism': 'ssh_parallelism must be within the range 1..100'}
+            'ssh_parallelism': 'Must be between 1 and 100 inclusive'}
 
         default_config['ssh_parallelism'] = 20
         assert ssh.validate.validate_config(default_config) == {}
 
         # ssh_parallelism must be integer
-        default_config['ssh_parallelism'] = '20'
-        assert ssh.validate.validate_config(default_config) == {'ssh_parallelism': 'ssh_parallelism must be integer'}
+        default_config['ssh_parallelism'] = 'foo'
+        assert ssh.validate.validate_config(default_config) == {
+            'ssh_parallelism': 'Must be an integer but got a str: foo'}


### PR DESCRIPTION
The ConfigTarget will also get used for AWS Key validation and allow using one config.yaml which doesn't have all of it's parameters go into the cluster: AWS keys, SSH keys, etc in config.yaml shouldn't end up on every host.

# TODO
 - [x] Make backend.do_validate_gen_config() work
 - [x] Make backend.do_validate_ssh_config() wok
 - [x] Make sure an [Azure PR Test](https://teamcity.mesosphere.io/viewType.html?buildTypeId=ClosedSource_Dcos_IntegrationTests_CloudIntegrationTests_DcosOssAzureIntegrati_2) passes

This includes:
#627 (although can land independently)
Replaces
#620 (Adds fixes, integration test by way of ssh validation test)

# Needed followup
 - Make it so gen knows all parameters that are ever available and makes sure the user doesn't have random unknown parameters
 - Make ConfigTarget get the full computed arguments for that one config target and stash them on the ConfigTarget. This is critical so that with the AWS Advanced templates from dcos_generate_config.sh the AWS keys for uploading templates don't end up on every host in the cluster / in the cluster at all