### PR TITLE
Fix template links in azure.html

### DIFF
--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -12,6 +12,8 @@ import gen
 import gen.installer.util as util
 import gen.template
 import pkgpanda.build
+import release
+import release.storage
 
 # TODO(cmaloney): Make it so the template only completes when services are properly up.
 late_services = ""
@@ -20,7 +22,7 @@ ILLEGAL_ARM_CHARS_PATTERN = re.compile("[']")
 
 TEMPLATE_PATTERN = re.compile('(?P<pre>.*?)\[\[\[(?P<inject>.*?)\]\]\]')
 
-UPLOAD_URL = ("https://az837203.vo.msecnd.net/dcos/{channel_commit_path}/azure/{arm_template_name}")
+DOWNLOAD_URL_TEMPLATE = ("{download_url}{channel_commit_path}/azure/{arm_template_name}")
 
 INSTANCE_GROUPS = {
     'master': {
@@ -241,12 +243,14 @@ def gen_buttons(repo_channel_path, channel_commit_path, tag, commit):
     Generate the button page, that is, "Deploy a cluster to Azure" page
     '''
     dcos_urls = [
-        encode_url_as_param(UPLOAD_URL.format(
+        encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
+            download_url=get_download_url(),
             channel_commit_path=channel_commit_path,
             arm_template_name='dcos-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
     acs_urls = [
-        encode_url_as_param(UPLOAD_URL.format(
+        encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
+            download_url=get_download_url(),
             channel_commit_path=channel_commit_path,
             arm_template_name='acs-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
@@ -266,3 +270,26 @@ def encode_url_as_param(s):
     s = s.encode('utf8')
     s = urllib.parse.quote_plus(s)
     return s
+
+
+def get_download_url():
+    assert release._config is not None
+    # TODO: HACK. Stashing and pulling the config from release/__init__.py
+    # is definitely not the right way to do this.
+    # See also gen/installer/aws.py#get_cloudformation_s3_url
+
+    if 'storage' not in release._config:
+        raise RuntimeError("No storage section in configuration")
+
+    if 'azure' not in release._config['storage']:
+        raise RuntimeError("No azure section in storage configuration")
+
+    if 'download_url' not in release._config['storage']['azure']:
+        raise RuntimeError("No download_url section in azure configuration")
+
+    download_url = release._config['storage']['azure']['download_url']
+
+    if not download_url.endswith('/'):
+        raise RuntimeError("Azure download_url must end with a '/'")
+
+    return download_url

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -573,11 +573,16 @@ def mock_get_cf_s3_url():
     return "http://mock_cf_s3_url"
 
 
+def mock_get_azure_download_url():
+    return "http://mock_azure_download_url"
+
+
 # Test that the do_create functions for each provider output data in the right
 # shape.
 def test_make_channel_artifacts(monkeypatch):
     monkeypatch.setattr('gen.installer.bash.make_installer_docker', mock_make_installer_docker)
     monkeypatch.setattr('gen.installer.aws.get_cloudformation_s3_url', mock_get_cf_s3_url)
+    monkeypatch.setattr('gen.installer.azure.get_download_url', mock_get_azure_download_url)
 
     metadata = {
         'commit': 'sha-1',


### PR DESCRIPTION
Update the azure.html page to render links using the configured Azure
release location (dcosio.azureedge.net). FIXES: https://mesosphere.atlassian.net/browse/DCOS-9357