### PR TITLE
Support getting the docker client version for older versions of docker

### DIFF
--- a/release/__init__.py
+++ b/release/__init__.py
@@ -450,7 +450,7 @@ def do_build_docker(name, path):
     # mark as latest so it will be used when building packages
     # extract the docker client version string
     try:
-        docker_version = subprocess.check_output(['docker', 'version', '-f', '"{{.Client.Version}}"']).decode()
+        docker_version = subprocess.check_output(['docker', 'version', '-f', '{{.Client.Version}}']).decode()
     except subprocess.CalledProcessError:
         # If the above command fails then we know we have an older version of docker
         # Older versions of docker spit out an entirely different format

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -449,7 +449,13 @@ def do_build_docker(name, path):
 
     # mark as latest so it will be used when building packages
     # extract the docker client version string
-    docker_version = subprocess.check_output(['docker', 'version']).decode().split("\n")[1].split()[1]
+    try:
+        docker_version = subprocess.check_output(['docker', 'version', '-f', '"{{.Client.Version}}"']).decode()
+    except subprocess.CalledProcessError:
+        # If the above command fails then we know we have an older version of docker
+        # Older versions of docker spit out an entirely different format
+        docker_version = subprocess.check_output(['docker', 'version']).decode().split("\n")[0].split()[2]
+
     # only use force tag if using docker version 1.9 or earlier
     container_name_t = 'dcos/dcos-builder:{}_dockerdir-latest'.format(name)
     if LooseVersion(docker_version) < LooseVersion('1.10'):


### PR DESCRIPTION
This fixes failures when older versions of Docker are used. The format is pretty different, here's an example of the output from older versions:
```
Client version: 1.6.2
Client API version: 1.18
Go version (client): go1.4.2
Git commit (client): 7c8fca2
OS/Arch (client): linux/amd64
Server version: 1.6.2
Server API version: 1.18
Go version (server): go1.4.2
Git commit (server): 7c8fca2
OS/Arch (server): linux/amd64
```

And here's what it looks like from newer versions:
```
Client:
 Version:      1.12.0
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   8eab29e
 Built:        Thu Jul 28 23:54:00 2016
 OS/Arch:      darwin/amd64

Server:
 Version:      1.12.1
 API version:  1.24
 Go version:   go1.6.3
 Git commit:   23cf638
 Built:        Thu Aug 18 17:52:38 2016
 OS/Arch:      linux/amd64
```

Without this change the build fails with:
```
Traceback (most recent call last):
File "/tmp/dcos_build_venv/bin/release", line 9, in <module>
  load_entry_point('dcos-image==0.1', 'console_scripts', 'release')()
File "/dcos/release/__init__.py", line 786, in main
  release_manager.create('testing', options.channel, options.tag)
File "/dcos/release/__init__.py", line 679, in create
  metadata = make_stable_artifacts(self.__config['options']['cloudformation_s3_url'] + '/' + repository_path)
File "/dcos/release/__init__.py", line 279, in make_stable_artifacts
  all_completes = do_build_packages(cache_repository_url)
File "/dcos/release/__init__.py", line 495, in do_build_packages
  _build_builders(package_store)
File "/dcos/release/__init__.py", line 488, in _build_builders
  do_build_docker(name, path)
File "/dcos/release/__init__.py", line 455, in do_build_docker
  if LooseVersion(docker_version) < LooseVersion('1.10'):
File "/usr/lib/python3.4/distutils/version.py", line 58, in __lt__
  c = self._cmp(other)
File "/usr/lib/python3.4/distutils/version.py", line 343, in _cmp
  if self.version < other.version:
TypeError: unorderable types: str() < int()
```