### PR TITLE
Replace isort with flake8-import-order

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,0 @@
-[settings]
-known_first_party=deploy,gen,pkgpanda,release,ssh,test_util
-known_third_party=bs4,dns,docopt,kazoo,requests,retrying,pytest,yaml
-not_skip=__init__.py

--- a/ext/dcos-installer/dcos_installer/action_lib.py
+++ b/ext/dcos-installer/dcos_installer/action_lib.py
@@ -4,8 +4,8 @@ import logging
 import os
 
 import pkgpanda
-from ssh.ssh_runner import Node
 import ssh.utils
+from ssh.ssh_runner import Node
 
 REMOTE_TEMP_DIR = '/opt/dcos_install_tmp'
 CLUSTER_PACKAGES_FILE = '/genconf/cluster_packages.json'

--- a/ext/dcos-installer/dcos_installer/async_server.py
+++ b/ext/dcos-installer/dcos_installer/async_server.py
@@ -13,7 +13,6 @@ import dcos_installer.action_lib
 import gen.calc
 from dcos_installer import backend
 from dcos_installer.constants import STATE_DIR
-
 from ssh.ssh_runner import Node
 
 

--- a/ext/dcos-installer/dcos_installer/backend.py
+++ b/ext/dcos-installer/dcos_installer/backend.py
@@ -5,12 +5,10 @@ libraries to support the dcos installer.
 import logging
 import os
 
-
+import ssh.validate as validate_ssh
 from dcos_installer import config_util
 from dcos_installer.config import DCOSConfig
-from dcos_installer.constants import CONFIG_PATH, SSH_KEY_PATH, IP_DETECT_PATH
-
-import ssh.validate as validate_ssh
+from dcos_installer.constants import CONFIG_PATH, IP_DETECT_PATH, SSH_KEY_PATH
 
 log = logging.getLogger()
 

--- a/ext/dcos-installer/dcos_installer/cli.py
+++ b/ext/dcos-installer/dcos_installer/cli.py
@@ -1,18 +1,18 @@
 import argparse
 import asyncio
-import coloredlogs
 import json
 import logging
 import os
 import sys
 
+import coloredlogs
 from passlib.hash import sha512_crypt
 
 import dcos_installer.async_server
 import gen.calc
 from dcos_installer import action_lib, backend
-from dcos_installer.prettyprint import print_header, PrettyPrint
 from dcos_installer.installer_analytics import InstallerAnalytics
+from dcos_installer.prettyprint import PrettyPrint, print_header
 
 from ssh.utils import AbstractSSHLibDelegate
 

--- a/ext/dcos-installer/dcos_installer/config.py
+++ b/ext/dcos-installer/dcos_installer/config.py
@@ -13,7 +13,7 @@ import logging
 import os
 import yaml
 
-from dcos_installer.constants import CONFIG_PATH, SSH_KEY_PATH, IP_DETECT_PATH
+from dcos_installer.constants import CONFIG_PATH, IP_DETECT_PATH, SSH_KEY_PATH
 log = logging.getLogger(__name__)
 
 

--- a/ext/dcos-installer/dcos_installer/config_util.py
+++ b/ext/dcos-installer/dcos_installer/config_util.py
@@ -4,8 +4,8 @@ import subprocess
 import sys
 
 import gen
-import pkgpanda
 import gen.installer.bash
+import pkgpanda
 from dcos_installer.constants import SERVE_DIR
 
 log = logging.getLogger(__name__)

--- a/ext/dcos-installer/dcos_installer/installer_analytics.py
+++ b/ext/dcos-installer/dcos_installer/installer_analytics.py
@@ -1,6 +1,7 @@
-import analytics
 import os
 import uuid
+
+import analytics
 
 from dcos_installer import backend
 

--- a/gen/test_template.py
+++ b/gen/test_template.py
@@ -1,8 +1,8 @@
 import pytest
 
 import gen.template
-from gen.template import (For, Replacement, Switch, Tokenizer, UnsetParameter,
-                          parse_str)
+from gen.template import For, parse_str, Replacement, Switch, Tokenizer, UnsetParameter
+
 
 just_text = "foo"
 more_complex_text = "foo {"

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -4,8 +4,8 @@ import sys
 
 import requests
 
-from pkgpanda.util import load_string, write_string
 from dcos_internal_utils import utils
+from pkgpanda.util import load_string, write_string
 
 log = logging.getLogger(__name__)
 

--- a/packages/bootstrap/extra/tests/test_bootstrap.py
+++ b/packages/bootstrap/extra/tests/test_bootstrap.py
@@ -1,11 +1,11 @@
 import getpass
 import logging
 import pwd
-import pytest
 import random
 import string
 import subprocess
 
+import pytest
 from kazoo.client import KazooClient, KazooRetry
 
 from dcos_internal_utils import bootstrap

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -1,10 +1,10 @@
 import json
-import os
-import pytest
-import subprocess
 import logging
+import os
+import subprocess
 
 import kazoo.client
+import pytest
 import requests
 
 

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -1,8 +1,8 @@
 #!/opt/mesosphere/bin/python
 import os
+import socket
 import sys
-from socket import inet_aton, error as socket_error
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import CalledProcessError, check_call, check_output
 
 
 def get_var_assert_set(name):
@@ -28,9 +28,9 @@ def invoke_detect_ip():
         print("check_output exited with {}".format(e))
         sys.exit(1)
     try:
-        inet_aton(ip)
+        socket.inet_aton(ip)
         return ip
-    except socket_error as e:
+    except socket.error as e:
         print(
             "inet_aton exited with {}. {} is not a valid IPv4 address".format(e, ip))
         sys.exit(1)

--- a/packages/spartan/extra/gen_resolvconf.py
+++ b/packages/spartan/extra/gen_resolvconf.py
@@ -2,9 +2,9 @@
 
 import errno
 import os
+import random
 import socket
 import sys
-import random
 
 import dns.query
 

--- a/pkgpanda/build/cli.py
+++ b/pkgpanda/build/cli.py
@@ -15,8 +15,8 @@ from os.path import basename, normpath
 
 from docopt import docopt
 
+import pkgpanda.build
 import pkgpanda.build.constants
-from pkgpanda.build import (BuildError, PackageStore, build_package_variants, build_tree)
 
 
 def main():
@@ -26,15 +26,15 @@ def main():
 
         # Make a local repository for build dependencies
         if arguments['tree']:
-            package_store = PackageStore(getcwd(), arguments['--repository-url'])
-            build_tree(package_store, arguments['--mkbootstrap'], arguments['<variant>'])
+            package_store = pkgpanda.build.PackageStore(getcwd(), arguments['--repository-url'])
+            pkgpanda.build.build_tree(package_store, arguments['--mkbootstrap'], arguments['<variant>'])
             sys.exit(0)
 
         # Package name is the folder name.
         name = basename(getcwd())
 
         # Package store is always the parent directory
-        package_store = PackageStore(normpath(getcwd() + '/../'), arguments['--repository-url'])
+        package_store = pkgpanda.build.PackageStore(normpath(getcwd() + '/../'), arguments['--repository-url'])
 
         # Check that the folder is a package folder (the name was found by the package store as a
         # valid package with 1+ variants).
@@ -43,7 +43,7 @@ def main():
             sys.exit(1)
 
         # No command -> build package.
-        pkg_dict = build_package_variants(
+        pkg_dict = pkgpanda.build.build_package_variants(
             package_store,
             name,
             not arguments['--dont-clean-after-build'],
@@ -56,7 +56,7 @@ def main():
             print(k + ':' + v)
 
         sys.exit(0)
-    except BuildError as ex:
+    except pkgpanda.build.BuildError as ex:
         print("ERROR: {}".format(ex))
         sys.exit(1)
 

--- a/pkgpanda/cli.py
+++ b/pkgpanda/cli.py
@@ -32,7 +32,7 @@ from subprocess import CalledProcessError, check_call
 
 from docopt import docopt
 
-from pkgpanda import Install, PackageId, Repository, actions, constants
+from pkgpanda import actions, constants, Install, PackageId, Repository
 from pkgpanda.exceptions import PackageError, PackageNotFound, ValidationError
 
 

--- a/pkgpanda/http/__init__.py
+++ b/pkgpanda/http/__init__.py
@@ -5,9 +5,9 @@ import logging
 import os
 import sys
 
-from flask import Flask, current_app, jsonify, make_response, request
+from flask import current_app, Flask, jsonify, make_response, request
 
-from pkgpanda import Install, Repository, actions
+from pkgpanda import actions, Install, Repository
 from pkgpanda.exceptions import (PackageConflict, PackageError,
                                  PackageNotFound, ValidationError)
 

--- a/pkgpanda/tests/integration_tests/test_pkgpanga_check.py
+++ b/pkgpanda/tests/integration_tests/test_pkgpanga_check.py
@@ -1,4 +1,4 @@
-from subprocess import PIPE, STDOUT, Popen, check_output
+from subprocess import check_output, PIPE, Popen, STDOUT
 
 
 list_output = """WARNING: `not_executable.py` is not executable

--- a/ssh/ssh_tunnel.py
+++ b/ssh/ssh_tunnel.py
@@ -9,7 +9,7 @@ with contextlib.closing(SSHTunnel(*args, **kwargs)) as tunnel:
 import logging
 import tempfile
 from contextlib import closing
-from subprocess import TimeoutExpired, check_call, check_output
+from subprocess import check_call, check_output, TimeoutExpired
 
 logger = logging.getLogger(__name__)
 

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -9,7 +9,7 @@ import requests
 import yaml
 from retrying import retry
 
-from ssh.ssh_tunnel import SSHTunnel, run_scp_cmd, run_ssh_cmd
+from ssh.ssh_tunnel import run_scp_cmd, run_ssh_cmd, SSHTunnel
 
 MAX_STAGE_TIME = int(os.getenv('INSTALLER_API_MAX_STAGE_TIME', '900'))
 

--- a/tests/test_installer_async_api.py
+++ b/tests/test_installer_async_api.py
@@ -1,10 +1,10 @@
 import asyncio
 
-import pytest
-
 import aiohttp
-import gen.calc
+import pytest
 import webtest_aiohttp
+
+import gen.calc
 from dcos_installer.async_server import build_app
 
 version = 1

--- a/tests/test_ssh_integration.py
+++ b/tests/test_ssh_integration.py
@@ -16,8 +16,7 @@ from retrying import retry
 
 import pkgpanda.util
 from ssh.ssh_runner import MultiRunner, Node
-from ssh.ssh_tunnel import (SSHTunnel, TunnelCollection, run_scp_cmd,
-                            run_ssh_cmd)
+from ssh.ssh_tunnel import run_scp_cmd, run_ssh_cmd, SSHTunnel, TunnelCollection
 from ssh.utils import AbstractSSHLibDelegate, CommandChain
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ exclude=
     .git,.tox
 ignore=
 
+# TODO(cmaloney): Reduce the number of top level modules we have
+application-import-names=dcos_installer,dcos_internal_utils,gen,history,pkgpanda,release,ssh,test_util
+import-order-style=smarkets
+
 [pytest]
 addopts = -vv
 testpaths =
@@ -21,13 +25,12 @@ testpaths =
 [testenv:py34-syntax]
 deps =
   flake8
+  flake8-import-order
   pep8-naming
   teamcity-messages
-  isort
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} ./
-  isort --recursive --check-only --diff --verbose gen packages/dcos-history/extra packages/dcos-oauth/extra pkgpanda tests release ssh test_util
 
 [testenv:py34-unittests]
 passenv =


### PR DESCRIPTION
This replaces isort which is painful to use / maintain with the
flake8-import-order plugin which means we don't have do things like manually
maintain a whitelist for isort and a blacklist for flake8. Don't have to remember
to add things to isort. Don't have to manually set known_first_party and known_third_party

Style wise the biggest difference from current the "smarkets" style which is set
now is that from `x import a, B, c` cares about sorting alphabetically without
caring about case now

Based on the code changes, this catches a bunch of basic sorting was off which says the tool config
for isort was too complicated and the new plugin is a lot easier in that respect.

I think the improvement in CI usability (They show up on the teamcity base page) and catching
programmer mistakes / harder to forget to add things to be isorted, this is worth the slightly worse
diagnostics in telling people how to fix it (isort would print a diff and auto-fix, this just says "higher or lower")