### PR TITLE
Change AWS Simple template AMI back to CoreOS

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-264f8747"
+        "stable": "ami-965899f7"
       },
       "ap-southeast-1": {
-        "stable": "ami-0765bd64"
+        "stable": "ami-3120fe52"
       },
       "ap-southeast-2": {
-        "stable": "ami-3f1a2c5c"
+        "stable": "ami-b1291dd2"
       },
       "eu-central-1": {
-        "stable": "ami-846e9eeb"
+        "stable": "ami-3ae31555"
       },
       "eu-west-1": {
-        "stable": "ami-250c7f56"
+        "stable": "ami-b7cba3c4"
       },
       "sa-east-1": {
-        "stable": "ami-0e019062"
+        "stable": "ami-61e3750d"
       },
       "us-east-1": {
-        "stable": "ami-47096750"
+        "stable": "ami-6d138f7a"
       },
       "us-gov-west-1": {
-        "stable": ""
+        "stable": "ami-b712acd6"
       },
       "us-west-1": {
-        "stable": "ami-e4afe284"
+        "stable": "ami-ee57148e"
       },
       "us-west-2": {
-        "stable": "ami-ab07d1cb"
+        "stable": "ami-dc6ba3bc"
       }
     },
     "NATAmi" : {


### PR DESCRIPTION
This was inadvertently changed in 28e52bd6ffe8af5e49fcd2d12499ccc92476f2f9

That was supposed to just update the custom CentOS AMI, but caught the CoreOS
AMI as well

cc: @lingmann 