### PR TITLE
Add platform field to config.yaml

### DIFF
--- a/dcos_installer/installer_analytics.py
+++ b/dcos_installer/installer_analytics.py
@@ -21,10 +21,17 @@ class InstallerAnalytics():
 
         # Set customer key here rather than __init__ since we want the most up to date config
         # and config may change between __init__ and here.
-        customer_key = Config(CONFIG_PATH).hacky_default_get('customer_key', None)
+        config = Config(CONFIG_PATH)
+        customer_key = config.hacky_default_get('customer_key', None)
+
+        # provider is always onprem when the cli installer is used
+        provider = "onprem"
+        # platform defaults to provider value, if not specified
+        platform = config.hacky_default_get('platform', provider)
 
         analytics.track(user_id=customer_key, anonymous_id=self.uuid, event="installer", properties={
-            "provider": "onprem",
+            "platform": platform,
+            "provider": provider,
             "source": "installer",
             "variant": os.environ["BOOTSTRAP_VARIANT"],
             "install_id": self.uuid,

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -30,6 +30,7 @@ def calculate_ip_detect_public_contents(aws_masters_have_public_ip):
 
 aws_base_source = Source(entry={
     'default': {
+        'platform': 'aws',
         'resolvers': '["169.254.169.253"]',
         'num_private_slaves': '5',
         'num_public_slaves': '1',
@@ -38,6 +39,7 @@ aws_base_source = Source(entry={
         'enable_docker_gc': 'true'
     },
     'must': {
+        'provider': 'aws',
         'aws_region': '{ "Ref" : "AWS::Region" }',
         'ip_detect_contents': get_ip_detect('aws'),
         'ip_detect_public_contents': calculate_ip_detect_public_contents,

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -27,8 +27,13 @@ def get_ip_detect(name):
 def calculate_ip_detect_public_contents(aws_masters_have_public_ip):
     return get_ip_detect({'true': 'aws_public', 'false': 'aws'}[aws_masters_have_public_ip])
 
+def validate_provider(provider):
+    assert provider == 'aws'
 
 aws_base_source = Source(entry={
+    'validate': [
+        validate_provider
+    ],
     'default': {
         'platform': 'aws',
         'resolvers': '["169.254.169.253"]',
@@ -39,7 +44,6 @@ aws_base_source = Source(entry={
         'enable_docker_gc': 'true'
     },
     'must': {
-        'provider': 'aws',
         'aws_region': '{ "Ref" : "AWS::Region" }',
         'ip_detect_contents': get_ip_detect('aws'),
         'ip_detect_public_contents': calculate_ip_detect_public_contents,

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -27,8 +27,10 @@ def get_ip_detect(name):
 def calculate_ip_detect_public_contents(aws_masters_have_public_ip):
     return get_ip_detect({'true': 'aws_public', 'false': 'aws'}[aws_masters_have_public_ip])
 
+
 def validate_provider(provider):
     assert provider == 'aws'
+
 
 aws_base_source = Source(entry={
     'validate': [
@@ -61,6 +63,7 @@ aws_base_source = Source(entry={
         'rexray_config_preset': 'aws'
     }
 })
+
 
 aws_region_names = [
     {

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -42,9 +42,11 @@ INSTANCE_GROUPS = {
 
 azure_base_source = Source(entry={
     'default': {
+        'platform': 'azure',
         'enable_docker_gc': 'true'
     },
     'must': {
+        'provider': 'azure',
         'resolvers': '["168.63.129.16"]',
         'ip_detect_contents': yaml.dump(pkg_resources.resource_string('gen', 'ip-detect/azure.sh').decode()),
         'master_discovery': 'static',

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -39,8 +39,10 @@ INSTANCE_GROUPS = {
     }
 }
 
+
 def validate_provider(provider):
     assert provider == 'azure'
+
 
 azure_base_source = Source(entry={
     'validate': [

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -39,14 +39,18 @@ INSTANCE_GROUPS = {
     }
 }
 
+def validate_provider(provider):
+    assert provider == 'azure'
 
 azure_base_source = Source(entry={
+    'validate': [
+        validate_provider
+    ],
     'default': {
         'platform': 'azure',
         'enable_docker_gc': 'true'
     },
     'must': {
-        'provider': 'azure',
         'resolvers': '["168.63.129.16"]',
         'ip_detect_contents': yaml.dump(pkg_resources.resource_string('gen', 'ip-detect/azure.sh').decode()),
         'master_discovery': 'static',

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -18,6 +18,7 @@ from pkgpanda.util import logger
 
 onprem_source = Source(entry={
     'default': {
+        'platform': 'onprem',
         'resolvers': '["8.8.8.8", "8.8.4.4"]',
         'ip_detect_filename': 'genconf/ip-detect',
         'bootstrap_id': lambda: calculate_environment_variable('BOOTSTRAP_ID'),

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -462,6 +462,7 @@ package:
   - path: /etc/dcos-signal-config.json
     content: |
       {
+        "gen_platform": "{{ platform }}",
         "gen_provider": "{{ provider }}",
         "diagnostics_urls": [
           "http://leader.mesos:1050/system/health/v1/report?cache=0"

--- a/gen/test_validation.py
+++ b/gen/test_validation.py
@@ -17,6 +17,7 @@ def make_arguments(new_arguments):
         'bootstrap_id': '123',
         'exhibitor_zk_path': '/dcos',
         'master_discovery': 'static',
+        'platform': 'aws',
         'provider': 'onprem',
         'exhibitor_zk_hosts': '52.37.205.237:2181',
         'resolvers': '["8.8.8.8", "8.8.4.4"]',

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -114,6 +114,7 @@ def test_signal_service(dcos_api_session):
 
     # Generic properties which are the same between all tracks
     generic_properties = {
+        'platform': dcos_config['platform'],
         'provider': dcos_config['provider'],
         'source': 'cluster',
         'clusterId': cluster_id,

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -2,8 +2,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "375a6a7d6b6eedd5668e122888f735007c782430",
-    "ref_origin": "1.2.1"
+    "ref": "40a23b4dcba6b3053379235a96bc3ac53996e146",
+    "ref_origin": "1.3.0"
   },
   "username": "dcos_signal"
 }

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -73,6 +73,11 @@ class Cluster:
         self.public_agents = public_agents
         self.bootstrap_host = bootstrap_host
 
+        # Cluster object is currently aws-specific. These default values are passed to genconf.
+        self.ip_detect = 'aws'
+        self.platform = 'aws'
+        self.rexray_config_preset = 'aws'
+
         assert all(h.private_ip for h in self.hosts), (
             'All cluster hosts require a private IP. hosts: {}'.format(repr(self.hosts))
         )
@@ -289,11 +294,13 @@ def install_dcos(
             master_list=[h.private_ip for h in cluster.masters],
             agent_list=[h.private_ip for h in cluster.agents],
             public_agent_list=[h.private_ip for h in cluster.public_agents],
-            ip_detect='aws',
+            ip_detect=cluster.ip_detect,
+            platform=cluster.platform,
             ssh_user=cluster.ssher.user,
             ssh_key=cluster.ssher.key,
             add_config_path=add_config_path,
-            rexray_config_preset='aws')
+            rexray_config_preset=cluster.rexray_config_preset,
+        )
 
         logging.info("Running Preflight...")
         if install_prereqs:
@@ -358,11 +365,12 @@ def upgrade_dcos(cluster, installer_url, add_config_path=None):
             master_list=[h.private_ip for h in cluster.masters],
             agent_list=[h.private_ip for h in cluster.agents],
             public_agent_list=[h.private_ip for h in cluster.public_agents],
-            ip_detect='aws',
+            ip_detect=cluster.ip_detect,
+            platform=cluster.platform,
             ssh_user=cluster.ssher.user,
             ssh_key=cluster.ssher.key,
             add_config_path=add_config_path,
-            rexray_config_preset='aws',
+            rexray_config_preset=cluster.rexray_config_preset,
         )
         # Remove docker (and associated journald) restart from the install
         # script. This prevents Docker-containerized tasks from being killed

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -100,7 +100,7 @@ class DcosApiInstaller(AbstractDcosInstaller):
 
     def genconf(
             self, master_list, agent_list, public_agent_list, ssh_user, ssh_key,
-            ip_detect, rexray_config=None, rexray_config_preset=None,
+            ip_detect, platform=None, rexray_config=None, rexray_config_preset=None,
             zk_host=None, expect_errors=False, add_config_path=None):
         """Runs configuration generation.
 
@@ -108,10 +108,11 @@ class DcosApiInstaller(AbstractDcosInstaller):
             master_list: list of IPv4 addresses to be used as masters
             agent_list: list of IPv4 addresses to be used as agents
             public_agent_list: list of IPv4 addresses to be used as public agents
-            ip_detect (str):  name of preset IP-detect script
             ssh_user (str): name of SSH user that has access to targets
             ssh_key (str): complete public SSH key for ssh_user. Must already
                 be installed on tagets as authorized_key
+            ip_detect (str):  name of preset IP-detect script
+            platform (str): name of the infrastructure platform
             rexray_config: complete contents of REX-Ray config file. Must be a
                 JSON-serializable object.
             rexray_config_preset (str): name of preset REX-Ray config
@@ -132,6 +133,8 @@ class DcosApiInstaller(AbstractDcosInstaller):
             'ssh_user': ssh_user,
             'ssh_key': ssh_key,
             'ip_detect_script': self.ip_detect_script(ip_detect)}
+        if platform:
+            payload['platform'] = platform
         if rexray_config:
             payload['rexray_config'] = rexray_config
         if rexray_config_preset:
@@ -251,7 +254,7 @@ class DcosCliInstaller(AbstractDcosInstaller):
 
     def genconf(
             self, master_list, agent_list, public_agent_list, ssh_user, ssh_key,
-            ip_detect, rexray_config=None, rexray_config_preset=None,
+            ip_detect, platform=None, rexray_config=None, rexray_config_preset=None,
             zk_host=None, expect_errors=False, add_config_path=None,
             bootstrap_url='file:///opt/dcos_install_tmp'):
         """Runs configuration generation.
@@ -260,10 +263,11 @@ class DcosCliInstaller(AbstractDcosInstaller):
             master_list: list of IPv4 addresses to be used as masters
             agent_list: list of IPv4 addresses to be used as agents
             public_agent_list: list of IPv$ addresses to be used as public agents
-            ip_detect (str):  name of preset IP-detect script
             ssh_user (str): name of SSH user that has access to targets
             ssh_key (str): complete public SSH key for ssh_user. Must already
                 be installed on tagets as authorized_key
+            ip_detect (str):  name of preset IP-detect script
+            platform (str): name of the infrastructure platform
             rexray_config: complete contents of REX-Ray config file. Must be a
                 JSON-serializable object.
             rexray_config_preset (str): name of preset REX-Ray config
@@ -286,6 +290,8 @@ class DcosCliInstaller(AbstractDcosInstaller):
             'agent_list': agent_list,
             'public_agent_list': public_agent_list,
             'process_timeout': MAX_STAGE_TIME}
+        if platform:
+            test_config['platform'] = platform
         if rexray_config:
             test_config['rexray_config'] = rexray_config
         if rexray_config_preset:

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -75,6 +75,7 @@ master_list:
   - 192.168.65.95
   - 192.168.65.101
 oauth_enabled: 'false'
+platform: vagrant-virtualbox
 EOF
 
 cleanup_vagrant_leftovers


### PR DESCRIPTION
Feed `platform` gen config to dcos-signal as `gen_platform`.

`platform` is the WHAT, while `provider` is the HOW. For example, `onprem` (provider) is used by "advanced install" onto `aws` (platform) using VPC rather than cloud formation templates.

Depends on https://github.com/dcos/dcos-signal/pull/31
