### PR TITLE
Change do_create interface to make more sense when reused from other places

### DIFF
--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -81,7 +81,7 @@
        "Infrastructure": {
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/infra.json",
+               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/infra.json",
                "TimeoutInMinutes": "60",
                "Parameters": {
                     "KeyName": {
@@ -109,7 +109,7 @@
            "DependsOn": ["Infrastructure"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
+               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -160,7 +160,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
+               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -199,7 +199,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_s3_url }}/{{ channel_commit_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
+               "TemplateURL": "{{ cloudformation_s3_url }}/{{ reproducible_artifact_path }}/cloudformation/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"

--- a/gen/aws/templates/aws.html
+++ b/gen/aws/templates/aws.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
 <head>
-  <title>DC/OS {{ repo_channel_path }} AWS CloudFormation</title>
+  <title>DC/OS {{ build_name }} AWS CloudFormation</title>
 </head>
 <body>
-<h1>DC/OS {{ repo_channel_path }} AWS CloudFormation</h1>
+<h1>DC/OS {{ build_name }} AWS CloudFormation</h1>
 <ul>
   <li>For more information on creating a DC/OS cluster, see the <a href='https://dcos.io/docs/latest/administration/installing/cloud/aws/'>DC/OS AWS documentation</a>.</li>
 </ul>

--- a/gen/azure/templates/azure.html
+++ b/gen/azure/templates/azure.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html>
   <head>
-    <title>DC/OS {{ repo_channel_path }} ARM Template</title>
+    <title>DC/OS {{ build_name }} ARM Template</title>
   </head>
 <body>
 
-  <h1>DC/OS {{ repo_channel_path }} ARM Templates</h1>
+  <h1>DC/OS {{ build_name }} ARM Templates</h1>
 <ul>
   <li>For more information on creating a DC/OS cluster, see the <a href='https://dcos.io/docs/latest/administration/installing/cloud/azure/'>DC/OS Azure documentation</a>.</li>
 </ul>

--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -22,7 +22,7 @@ ILLEGAL_ARM_CHARS_PATTERN = re.compile("[']")
 
 TEMPLATE_PATTERN = re.compile('(?P<pre>.*?)\[\[\[(?P<inject>.*?)\]\]\]')
 
-DOWNLOAD_URL_TEMPLATE = ("{download_url}{channel_commit_path}/azure/{arm_template_name}")
+DOWNLOAD_URL_TEMPLATE = ("{download_url}{reproducible_artifact_path}/azure/{arm_template_name}")
 
 INSTANCE_GROUPS = {
     'master': {
@@ -215,7 +215,7 @@ def make_template(num_masters, gen_arguments, varietal, bootstrap_variant_prefix
     }
 
 
-def do_create(tag, repo_channel_path, channel_commit_path, commit, variant_arguments, all_bootstraps):
+def do_create(tag, build_name, reproducible_artifact_path, commit, variant_arguments, all_bootstraps):
     for arm_t in ['dcos', 'acs']:
         for num_masters in [1, 3, 5]:
             for bootstrap_name, gen_arguments in variant_arguments.items():
@@ -231,30 +231,30 @@ def do_create(tag, repo_channel_path, channel_commit_path, commit, variant_argum
 
     yield {
         'channel_path': 'azure.html',
-        'local_content': gen_buttons(repo_channel_path, channel_commit_path, tag, commit),
+        'local_content': gen_buttons(build_name, reproducible_artifact_path, tag, commit),
         'content_type': 'text/html; charset=utf-8'
     }
 
 
-def gen_buttons(repo_channel_path, channel_commit_path, tag, commit):
+def gen_buttons(build_name, reproducible_artifact_path, tag, commit):
     '''
     Generate the button page, that is, "Deploy a cluster to Azure" page
     '''
     dcos_urls = [
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
             download_url=get_download_url(),
-            channel_commit_path=channel_commit_path,
+            reproducible_artifact_path=reproducible_artifact_path,
             arm_template_name='dcos-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
     acs_urls = [
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
             download_url=get_download_url(),
-            channel_commit_path=channel_commit_path,
+            reproducible_artifact_path=reproducible_artifact_path,
             arm_template_name='acs-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
 
     return gen.template.parse_resources('azure/templates/azure.html').render({
-        'repo_channel_path': repo_channel_path,
+        'build_name': build_name,
         'tag': tag,
         'commit': commit,
         'dcos_urls': dcos_urls,

--- a/gen/installer/bash.py
+++ b/gen/installer/bash.py
@@ -626,7 +626,7 @@ def make_installer_docker(variant, bootstrap_id, installer_bootstrap_id):
     return installer_filename
 
 
-def do_create(tag, repo_channel_path, channel_commit_path, commit, variant_arguments, all_bootstraps):
+def do_create(tag, build_name, reproducible_artifact_path, commit, variant_arguments, all_bootstraps):
     """Create a installer script for each variant in bootstrap_dict.
 
     Writes a dcos_generate_config.<variant>.sh for each variant in

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -435,7 +435,7 @@ def test_repository():
         release.Repository("foo", "", "testing_commit")
 
     # Repository path with no channel (Like we'd do for a stable or EA release).
-    no_channel = release.Repository("stable", None, "testing_commit_2")
+    no_channel = release.Repository("stable", None, "commit/testing_commit_2")
     assert no_channel.channel_prefix == ''
     assert no_channel.path_channel_commit_prefix + 'foo' == 'stable/commit/testing_commit_2/foo'
     assert no_channel.path_channel_prefix + 'bar' == 'stable/bar'
@@ -443,7 +443,7 @@ def test_repository():
     exercise_make_commands(no_channel)
 
     # Repository path with a channel (Like we do for PRs)
-    with_channel = release.Repository("testing", "pull/283", "testing_commit_3")
+    with_channel = release.Repository("testing", "pull/283", "commit/testing_commit_3")
     assert with_channel.channel_prefix == 'pull/283/'
     assert with_channel.path_channel_commit_prefix + "foo" == 'testing/pull/283/commit/testing_commit_3/foo'
     assert with_channel.path_channel_prefix + "bar" == 'testing/pull/283/bar'
@@ -597,8 +597,8 @@ def test_make_channel_artifacts(monkeypatch):
             'installer': 'installer_bootstrap_id',
             'ee.installer': 'ee_installer_bootstrap_id'
         },
-        'repo_channel_path': 'r_path/channel',
-        'channel_commit_path': 'r_path/channel/commit/sha-1',
+        'build_name': 'r_path/channel',
+        'reproducible_artifact_path': 'r_path/channel/commit/sha-1',
         'repository_path': 'r_path',
         'storage_urls': {
             'aws': 'https://aws.example.com/',


### PR DESCRIPTION
This makes some code when we try making dcos_generate_config.sh call aws
do_create make a lot more sense to write. In that context the release tooling
internal channel_commit_path and friends don't make a lot of sense.

cc: @lingmann: This should help make the calling do_create from the AWS advanced templates much cleaner looking.