### PR TITLE
Ensure Spartan running when running watchdog

### DIFF
--- a/packages/spartan/build
+++ b/packages/spartan/build
@@ -29,6 +29,10 @@ gen_resolvconf="$PKG_PATH/bin/gen_resolvconf.py"
 cp /pkg/extra/gen_resolvconf.py "$gen_resolvconf"
 chmod +x "$gen_resolvconf"
 
+watchdog_sh="$PKG_PATH/bin/dcos-spartan-watchdog.sh"
+cp /pkg/extra/dcos-spartan-watchdog.sh "$watchdog_sh"
+chmod +x "$watchdog_sh"
+
 ### Spartan watchdog
 watchdog_service="$PKG_PATH/dcos.target.wants/dcos-spartan-watchdog.service"
 mkdir -p "$(dirname "$watchdog_service")"

--- a/packages/spartan/extra/dcos-spartan-watchdog.service
+++ b/packages/spartan/extra/dcos-spartan-watchdog.service
@@ -11,4 +11,4 @@ EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config
 EnvironmentFile=-/opt/mesosphere/etc/dns_config_master
 ExecStartPre=/bin/sleep 60
-ExecStart=/opt/mesosphere/active/toybox/bin/toybox timeout -k 1m 1m /bin/bash -c "/opt/mesosphere/active/toybox/bin/toybox host ready.spartan 198.51.100.1 || /opt/mesosphere/active/toybox/bin/toybox pkill -l 9 -f spartan"
+ExecStart=/opt/mesosphere/bin/dcos-spartan-watchdog.sh

--- a/packages/spartan/extra/dcos-spartan-watchdog.sh
+++ b/packages/spartan/extra/dcos-spartan-watchdog.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+LOCKFILE=/opt/mesosphere/active/spartan/spartan/bin/spartan-env
+# If the file is not locked
+if ! flock -n $LOCKFILE true; then
+  if ! /opt/mesosphere/active/toybox/bin/toybox timeout -k 1m 1m /opt/mesosphere/active/toybox/bin/toybox host ready.spartan 198.51.100.1; then
+    /opt/mesosphere/active/toybox/bin/toybox pkill -l 9 -f spartan
+  fi
+else
+  echo "Not running watchdog, Spartan not running"
+fi

--- a/packages/spartan/extra/dcos-spartan.service
+++ b/packages/spartan/extra/dcos-spartan.service
@@ -19,6 +19,6 @@ ExecStartPre=/usr/bin/env ip link set spartan up
 ExecStartPre=-/usr/bin/env ip addr add 198.51.100.1/32 dev spartan
 ExecStartPre=-/usr/bin/env ip addr add 198.51.100.2/32 dev spartan
 ExecStartPre=-/usr/bin/env ip addr add 198.51.100.3/32 dev spartan
-ExecStart=/opt/mesosphere/active/spartan/spartan/bin/spartan-env foreground
+ExecStart=/usr/bin/env flock -x /opt/mesosphere/active/spartan/spartan/bin/spartan-env /opt/mesosphere/active/spartan/spartan/bin/spartan-env foreground
 Environment=HOME=/opt/mesosphere
 


### PR DESCRIPTION
This change ensures that Spartan itself is actually running before trying the watchdog.
