### PR TITLE
Fix some things I noticed in a cluster startup

### DIFF
--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -23,7 +23,7 @@ PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/var/lib/dcos/environment.proxy
-ExecStartPre=/bin/ping -c1 ready.spartan
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
 ExecStart=/opt/mesosphere/bin/java -Xmx2G -classpath ${PKG_PATH}/usr/cosmos.jar com.simontuffs.onejar.Boot -com.mesosphere.cosmos.dataDir=/var/lib/dcos/cosmos
 EOF

--- a/packages/mesos-dns/extra/dcos-mesos-dns.service
+++ b/packages/mesos-dns/extra/dcos-mesos-dns.service
@@ -10,5 +10,6 @@ RestartSec=5
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-dns.env
 EnvironmentFile=-/opt/mesosphere/etc/mesos-dns-extras.env
+ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-dns
 ExecStart=/opt/mesosphere/bin/mesos-dns --config=${MESOS_DNS_CONFIG} -logtostderr=true

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -20,6 +20,7 @@ PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/metronome
 EnvironmentFile=-/run/dcos/etc/metronome/service.env
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metronome
 ExecStartPre=/bin/bash -c 'mkdir -p /run/dcos/etc/metronome'
 ExecStartPre=/bin/bash -c 'echo "METRONOME_LEADER_ELECTION_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /run/dcos/etc/metronome/service.env'


### PR DESCRIPTION
 - Make Mesos-DNS wait for spartan
 - Teach metronome to wait for leader.mesos (marathon does already)
 - Teach cosmos to wait for leader.mesos

cc: @sargun @aquamatthias @BenWhitehead 