### PR TITLE
Lock down distributed Erlang port usage

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -12,6 +12,9 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 61421: dcos-minuteman
  - 62053: dcos-spartan
  - 62080: dcos-navstar
+ - 62501 - Spartan
+ - 62502 - Navstar
+ - 62503 - Minuteman
 
 ### UDP
 
@@ -34,6 +37,7 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 8181: dcos-exhibitor
  - 9990: dcos-cosmos
  - 15055: dcos-history-service
+ - 62500: Networking API
 
 ### UDP
 

--- a/packages/minuteman/buildinfo.json
+++ b/packages/minuteman/buildinfo.json
@@ -4,7 +4,7 @@
     "minuteman": {
       "kind": "git",
       "git": "https://github.com/dcos/minuteman.git",
-      "ref": "7e3239d596579d5b947ce20a4389f19778a3f411",
+      "ref": "eddc5f66a0d775d695d3fac4870b418e759f696f",
       "ref_origin": "master"
     }
   },

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "2bc3a6ff71d461743dbc30a79521104262e9a986",
+      "ref": "be61432c24817319c676c3e5db4a7c84d96221bf",
       "ref_origin": "master"
     }
   }

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "eb5efddbaad190580e1f2c68b9d1774ef54025b7",
+      "ref": "d4933eed68d9900558d08702b32ebe818487d555",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
This PR limits disterl to using the ports that are mentioned in the PR doc.