### PR TITLE
Proper way to upgrade pip.

### DIFF
--- a/prep_local
+++ b/prep_local
@@ -10,7 +10,7 @@ set -o errexit -o nounset -o pipefail
 : ${VIRTUAL_ENV?"Must be run in a python virtual environment"}
 
 # Install the latest version of pip
-pip install pip==8.1.2
+pip install -U pip
 
 # Install the packages in editable mode to the virtual environment.
 pip install -e $PWD

--- a/prep_teamcity
+++ b/prep_teamcity
@@ -27,7 +27,7 @@ git -C ext/dcos-image checkout -qf `git rev-parse --verify HEAD^{commit}`
 popd
 
 # Install the latest version of pip
-pip install pip==8.1.2
+pip install -U pip
 
 # We have wheel as a dependency since we use it to build the wheels
 pip install wheel


### PR DESCRIPTION
This seems to be recommended way to upgrade pip. (https://pip.pypa.io/en/stable/installing/) 

The reason being, pip we use is being shipped with python 3.4 and we have to upgrade pip as soon as we encounter it first time.

The two ways to upgrade are 

1. Download and install
```
curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
```

2. Or the current way.

Since this 2. way delegates the download to pip itself, this is better than explicit download and run.

--- 

**Testing**

Upgrade happens like this:


```
+ ./prep_local
Collecting pip
  Using cached pip-8.1.2-py2.py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 8.1.1
    Uninstalling pip-8.1.1:
      Successfully uninstalled pip-8.1.1
Successfully installed pip-8.1.2
```