### PR TITLE
Remove `After=` lines that don't do what people want / expect.

### DIFF
--- a/packages/adminrouter/extra/dcos-adminrouter-agent.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Admin Router Agent: A high performance web server and a reverse proxy server
-After=dcos-gen-resolvconf.service
 
 [Service]
 Restart=always

--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Admin Router Master: A high performance web server and a reverse proxy server
-After=dcos-gen-resolvconf.service
 
 [Service]
 Restart=always

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -12,8 +12,6 @@ mkdir -p $(dirname "$cosmos_service")
 cat <<EOF > "$cosmos_service"
 [Unit]
 Description=Package Service: DC/OS Packaging API
-After=dcos-mesos-master.service
-After=dcos-gen-resolvconf.service
 
 [Service]
 Restart=always

--- a/packages/dcos-history/extra/dcos-history.service
+++ b/packages/dcos-history/extra/dcos-history.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Mesos History: DC/OS Resource Metrics History Service/API
-After=dcos-mesos-master.service
 [Service]
 User=dcos_history
 PermissionsStartOnly=True
@@ -10,5 +9,6 @@ RestartSec=5
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/run/dcos/etc/history-service/history-service.env
 Environment=HISTORY_BUFFER_DIR=/var/lib/dcos/dcos-history
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-history
 ExecStart=/opt/mesosphere/bin/dcos-history

--- a/packages/dcos-signal/extra/dcos-signal.service
+++ b/packages/dcos-signal/extra/dcos-signal.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Signal: DC/OS Telemetry and Tracking Service
-After=dcos-mesos-master.service
 [Service]
 Type=simple
 Restart=on-failure
@@ -9,5 +8,6 @@ PermissionsStartOnly=True
 User=dcos_signal
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/opt/mesosphere/etc/cfn_signal_metadata
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-signal
 ExecStart=/opt/mesosphere/bin/dcos-signal -segment-key 51ybGTeFEFU1xo6u10XMDrr6kATFyRyh

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Exhibitor: Zookeeper Supervisor Service
-After=network-online.target
 [Service]
 User=dcos_exhibitor
 StandardOutput=journal

--- a/packages/mesos-dns/extra/dcos-mesos-dns.service
+++ b/packages/mesos-dns/extra/dcos-mesos-dns.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Mesos DNS: DNS based Service Discovery
-After=dcos-mesos-master.service
 [Service]
 User=dcos_mesos_dns
 PermissionsStartOnly=true

--- a/packages/minuteman/build
+++ b/packages/minuteman/build
@@ -14,8 +14,6 @@ mkdir -p $(dirname $service)
 cat <<EOF > $service
 [Unit]
 Description=Layer 4 Load Balancer: DC/OS Layer 4 Load Balancing Service
-After=dcos-gen-resolvconf.service
-After=dcos-epmd.service
 
 [Service]
 Restart=always

--- a/packages/navstar/build
+++ b/packages/navstar/build
@@ -21,8 +21,6 @@ mkdir -p $(dirname $service)
 cat <<EOF > $service
 [Unit]
 Description=Navstar: A distributed systems & network overlay orchestration engine
-After=dcos-gen-resolvconf.service
-After=dcos-epmd.service
 
 [Service]
 Restart=always

--- a/packages/spartan/extra/dcos-gen-resolvconf.service
+++ b/packages/spartan/extra/dcos-gen-resolvconf.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Generate resolv.conf: Update systemd-resolved for MesosDNS
-After=dcos-spartan.service
 
 [Service]
 Type=oneshot

--- a/packages/spartan/extra/dcos-spartan-watchdog.service
+++ b/packages/spartan/extra/dcos-spartan-watchdog.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=DNS Dispatcher Watchdog: Make sure spartan is running
-After=dcos-spartan.service
 
 [Service]
 Type=oneshot

--- a/packages/spartan/extra/dcos-spartan.service
+++ b/packages/spartan/extra/dcos-spartan.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=DNS Dispatcher: An RFC5625 Compliant DNS Forwarder
-After=dcos-epmd.service
 
 [Service]
 Restart=always


### PR DESCRIPTION
see [Systemd Rules](https://github.com/dcos/dcos/blob/master/docs/systemd-rules.md)

When we have restarting services, Before= and After= don't really mean anything.

That these don't match expectations can be seen by the needing to add `ping` checks for the various services / DNS resolutions because the services came up before what they were `After`