### PR TITLE
Allow changing the bootstrap download folder from `/tmp`

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -325,6 +325,15 @@ def validate_os_type(os_type):
     validate_one_of(os_type, ['coreos', 'el7'])
 
 
+def validate_bootstrap_tmp_dir(bootstrap_tmp_dir):
+    # Must be non_empty
+    assert bootstrap_tmp_dir, "Must not be empty"
+
+    # Should not start or end with `/`
+    assert bootstrap_tmp_dir[0] != '/' and bootstrap_tmp_dir[-1] != 0, \
+        "Must be an absolute path to a directory, although leave off the `/` at the beginning and end."
+
+
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
 
 
@@ -351,6 +360,7 @@ entry = {
         lambda dcos_remove_dockercfg_enable: validate_true_false(dcos_remove_dockercfg_enable),
         validate_rexray_config],
     'default': {
+        'bootstrap_tmp_dir': 'tmp',
         'bootstrap_variant': lambda: calculate_environment_variable('BOOTSTRAP_VARIANT'),
         'weights': '',
         'adminrouter_auth_enabled': calculate_adminrouter_auth_enabled,

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -26,10 +26,10 @@
     Type=oneshot
     StandardOutput=journal+console
     StandardError=journal+console
-    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
+    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
     ExecStartPre=/usr/bin/mkdir -p /opt/mesosphere
-    ExecStart=/usr/bin/tar -axf /tmp/bootstrap.tar.xz -C /opt/mesosphere
-    ExecStartPost=-/usr/bin/rm -f /tmp/bootstrap.tar.xz
+    ExecStart=/usr/bin/tar -axf /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz -C /opt/mesosphere
+    ExecStartPost=-/usr/bin/rm -f /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz
 - name: dcos-setup.service
   command: start
   no_block: true


### PR DESCRIPTION
Fixes: https://mesosphere.atlassian.net/browse/DCOS-6484 ('/tmp' is sometimes too small to contain the bootstrap tarball by allowing people to use a custom folder.