### PR TITLE
Add support for configuring a proxy via config.yaml

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -296,6 +296,11 @@ def validate_cluster_packages(cluster_packages):
             raise AssertionError(str(ex)) from ex
 
 
+def calculate_no_proxy(no_proxy):
+    user_proxy_config = validate_json_list(no_proxy)
+    return ",".join(['*.mesos,127.0.0.1,localhost'] + user_proxy_config)
+
+
 def validate_zk_hosts(exhibitor_zk_hosts):
     # TODO(malnick) Add validation of IPv4 address and port to this
     assert not exhibitor_zk_hosts.startswith('zk://'), "Must be of the form `host:port,host:port', not start with zk://"
@@ -352,6 +357,7 @@ entry = {
         validate_rexray_config],
     'default': {
         'bootstrap_variant': lambda: calculate_environment_variable('BOOTSTRAP_VARIANT'),
+        'use_proxy': 'false',
         'weights': '',
         'adminrouter_auth_enabled': calculate_adminrouter_auth_enabled,
         'oauth_enabled': 'true',
@@ -394,6 +400,7 @@ entry = {
               }                                         \
             ]}',
         'dcos_remove_dockercfg_enable': "false",
+        'no_proxy': '',
         'rexray_config_preset': '',
         'rexray_config': json.dumps({
             # Disabled. REX-Ray will start but not register as a volume driver.
@@ -431,7 +438,8 @@ entry = {
         'config_yaml': calculate_config_yaml,
         'mesos_hooks': calculate_mesos_hooks,
         'use_mesos_hooks': calculate_use_mesos_hooks,
-        'rexray_config_contents': calculate_rexray_config_contents
+        'rexray_config_contents': calculate_rexray_config_contents,
+        'no_proxy_final': calculate_no_proxy
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -403,6 +403,15 @@ package:
   - path: /etc_master/marathon
     content: |
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
+  - path: /etc/proxy.env
+    content: ""
+{% switch use_proxy %}
+{% case "true" %}
+        http_proxy={{ http_proxy }}
+        https_proxy={{ https_proxy }}
+        no_proxy="{{ no_proxy_final }}"
+{% case "false" %}
+{% endswitch %}
   - path: /etc_master/metronome
     content: |
       METRONOME_MESOS_LEADER_UI_URL=http://leader.mesos:5050

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -22,7 +22,7 @@ RestartSec=15
 PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=-/var/lib/dcos/environment.proxy
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
 ExecStart=/opt/mesosphere/bin/java -Xmx2G -classpath ${PKG_PATH}/usr/cosmos.jar com.simontuffs.onejar.Boot -com.mesosphere.cosmos.dataDir=/var/lib/dcos/cosmos

--- a/packages/dcos-oauth/extra/dcos-oauth.service
+++ b/packages/dcos-oauth/extra/dcos-oauth.service
@@ -8,7 +8,7 @@ StartLimitInterval=0
 RestartSec=5
 PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=-/var/lib/dcos/environment.proxy
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 EnvironmentFile=/opt/mesosphere/etc/dcos-oauth.env
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-oauth
 ExecStart=/opt/mesosphere/bin/dcos-oauth serve --addr=127.0.0.1:8101 --zk-addr=127.0.0.1:2181 --secret-key-path=/var/lib/dcos/dcos-oauth/auth-token-secret --segment-key=51ybGTeFEFU1xo6u10XMDrr6kATFyRyh

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -9,6 +9,7 @@ TasksMax=infinity
 PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-master
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 EnvironmentFile=-/opt/mesosphere/etc/mesos-master-provider
 EnvironmentFile=-/opt/mesosphere/etc/mesos-master-extras
 EnvironmentFile=-/run/dcos/etc/mesos-master

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -12,6 +12,7 @@ TasksMax=infinity
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-public
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -12,6 +12,7 @@ TasksMax=infinity
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave-common
 EnvironmentFile=/opt/mesosphere/etc/mesos-slave
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 EnvironmentFile=-/opt/mesosphere/etc/mesos-slave-common-extras
 EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources


### PR DESCRIPTION
Sample config.yaml snippet:
```
use_proxy: true
http_proxy: <your_http_proxy>
https_proxy: <your_https_proxy>
```

All but .mesos domains will be proxied

Users can add more domains to the `no_proxy` list by setting `no_proxy` to a list of things to exclude in their config.yaml

TODO:
 - [x] Allow adding more to no_proxy
 - [ ] Integration test?
 - [ ] Allow arbitrary extension of the config / setting extra proxy variables?

Fixes: https://mesosphere.atlassian.net/browse/DCOS-6619
Makes progress towards: https://dcosjira.atlassian.net/browse/DCOS-34