### PR TITLE
Add spotify/docker-gc to help cleanup left around dockers on agents

### DIFF
--- a/gen/aws/calc.py
+++ b/gen/aws/calc.py
@@ -17,7 +17,8 @@ entry = {
         'num_private_slaves': '5',
         'num_public_slaves': '1',
         'os_type': '',
-        'aws_masters_have_public_ip': 'true'
+        'aws_masters_have_public_ip': 'true',
+        'enable_docker_gc': 'true'
     },
     'must': {
         'aws_region': '{ "Ref" : "AWS::Region" }',

--- a/gen/azure/calc.py
+++ b/gen/azure/calc.py
@@ -3,6 +3,9 @@ import pkg_resources
 import yaml
 
 entry = {
+    'default': {
+        'enable_docker_gc': 'true'
+    },
     'must': {
         'resolvers': '["168.63.129.16"]',
         'ip_detect_contents': yaml.dump(pkg_resources.resource_string('gen', 'ip-detect/azure.sh').decode()),

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -582,7 +582,8 @@ entry = {
                 'default': {
                     'resolvers': '["8.8.8.8", "8.8.4.4"]',
                     'ip_detect_filename': 'genconf/ip-detect',
-                    'bootstrap_id': lambda: calculate_environment_variable('BOOTSTRAP_ID')
+                    'bootstrap_id': lambda: calculate_environment_variable('BOOTSTRAP_ID'),
+                    'enable_docker_gc': 'false',
                 },
             },
             'azure': gen.azure.calc.entry,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -461,6 +461,12 @@ package:
       com.netflix.exhibitor.azure.account-name={{ exhibitor_azure_account_name }}
       com.netflix.exhibitor.azure.account-key={{ exhibitor_azure_account_key }}
 {% endswitch %}
+{% switch enable_docker_gc %}
+{% case "true" %}
+  - path: /etc/docker_gc_enabled
+    content: ""
+{% case "false" %}
+{% endswitch %}
 # /etc/ui-config.json is minified due to late-binding and to preserve available cloud-config space
   - path: /etc/ui-config.json
     content: |

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -146,6 +146,8 @@ def test_signal_service(cluster):
     public_slave_units = [
         'mesos-slave-public-service']
     all_slave_units = [
+        'docker-gc-service',
+        'docker-gc-timer',
         '3dt-socket',
         'adminrouter-agent-service',
         'adminrouter-agent-reload-service',

--- a/packages/docker-gc/build
+++ b/packages/docker-gc/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+cp /pkg/src/docker-gc/docker-gc "$PKG_PATH/docker-gc"
+cp /pkg/src/docker-gc/LICENSE "$PKG_PATH/LICENSE"
+
+service="$PKG_PATH/dcos.target.wants_slave/dcos-docker-gc.service"
+mkdir -p $(dirname "$service")
+envsubst '$PKG_PATH' < /pkg/extra/dcos-docker-gc.service > "$service"
+
+service="$PKG_PATH/dcos.target.wants_slave_public/dcos-docker-gc.service"
+mkdir -p $(dirname "$service")
+envsubst '$PKG_PATH' < /pkg/extra/dcos-docker-gc.service > "$service"
+
+timer="$PKG_PATH/dcos.target.wants_slave/dcos-docker-gc.timer"
+mkdir -p $(dirname "$timer")
+envsubst '$PKG_PATH' < /pkg/extra/dcos-docker-gc.timer > "$timer"
+
+timer="$PKG_PATH/dcos.target.wants_slave_public/dcos-docker-gc.timer"
+mkdir -p $(dirname "$timer")
+envsubst '$PKG_PATH' < /pkg/extra/dcos-docker-gc.timer > "$timer"
+
+

--- a/packages/docker-gc/buildinfo.json
+++ b/packages/docker-gc/buildinfo.json
@@ -1,0 +1,11 @@
+{
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/spotify/docker-gc.git",
+    "ref": "4ee60137cfc76cf568b47f9b459b851d59325311",
+    "ref_origin": "master"
+  },
+  "username": "dcos_docker_gc",
+  "group": "docker",
+  "state_directory": true
+}

--- a/packages/docker-gc/extra/dcos-docker-gc.service
+++ b/packages/docker-gc/extra/dcos-docker-gc.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Docker GC: Periodically Garbate Collect Docker Containers using spotify/docker-gc
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=20
+User=dcos_docker_gc
+ConditionPathExists=/opt/mesosphere/etc/docker_gc_enabled
+EnvironmentFile=/opt/mesosphere/environment
+Environment=STATE_DIR=/var/lib/dcos/docker-gc
+Environment=PID_DIR=/var/lib/dcos/docker-gc
+Environment=LOG_TO_SYSLOG=1
+ExecStart=$PKG_PATH/docker-gc

--- a/packages/docker-gc/extra/dcos-docker-gc.timer
+++ b/packages/docker-gc/extra/dcos-docker-gc.timer
@@ -1,0 +1,5 @@
+[Unit]
+Description=Docker GC Timer: Timer to trigger periodic `docker-gc`
+[Timer]
+OnBootSec=45sec
+OnCalendar=hourly


### PR DESCRIPTION
To Enable/Disable in config.yaml:
```
enable_docker_gc: true
```

Disabled by default (landing late, no integration test). See https://github.com/spotify/docker-gc for documentation on configuration, the `/etc/` configuration folders mentioned should work. It is
run hourly in DC/OS.

Fixes internal bug: https://mesosphere.atlassian.net/browse/DCOS-7618

# TODO
 - [ ] Integration test triggering dcos-docker-gc.service and making sure some docker containers are cleaned up.