### PR TITLE
Add pytest ordering plugin

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -21,6 +21,26 @@ LOGIN_UNAME = os.getenv('DCOS_LOGIN_UNAME')
 LOGIN_PW = os.getenv('DCOS_LOGIN_PW')
 
 
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'first: run test before all not marked first')
+    config.addinivalue_line('markers', 'last: run test after all not marked last')
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """Reorders test using order mark
+    """
+    new_items = []
+    last_items = []
+    for item in items:
+        if hasattr(item.obj, 'first'):
+            new_items.insert(0, item)
+        elif hasattr(item.obj, 'last'):
+            last_items.append(item)
+        else:
+            new_items.append(item)
+    items[:] = new_items + last_items
+
+
 @pytest.fixture(scope='session')
 def cluster():
     assert 'DCOS_DNS_ADDRESS' in os.environ

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -8,6 +8,11 @@ import pytest
 import requests
 
 
+@pytest.mark.first
+def test_cluster_is_up(cluster):
+    pass
+
+
 def test_if_all_mesos_masters_have_registered(cluster):
     # Currently it is not possible to extract this information through Mesos'es
     # API, let's query zookeeper directly.


### PR DESCRIPTION
Allows having a test that just establishes a cluster
is up. So, if the cluster fails to come up, the user
will see waiting for the test_cluster_is_up and not
some arbitrarily chosen test