### PR TITLE
exhibitor: check existance of realm file in /opt instead of in /run

### DIFF
--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -7,11 +7,11 @@ StandardError=journal
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+# Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
 RuntimeDirectory=dcos_exhibitor
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor
 EnvironmentFile=-/opt/mesosphere/etc/exhibitor-extras
-# run in new mount namespace to create custom resolv.conf
 ExecStart=$PKG_PATH/usr/exhibitor/start_exhibitor.py

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -56,7 +56,7 @@ exhibitor_cmdline = [
 
 # Optionally pick up web server security configuration.
 if os.path.exists('/opt/mesosphere/etc/exhibitor_web.xml') and \
-        os.path.exists('/run/dcos_exhibitor/exhibitor_realm'):
+        os.path.exists('/opt/mesosphere/etc/exhibitor_realm'):
     exhibitor_cmdline.extend([
         '--security', '/opt/mesosphere/etc/exhibitor_web.xml',
         '--realm', 'DCOS:/opt/mesosphere/etc/exhibitor_realm',


### PR DESCRIPTION
- start_exhibitor.py: check existance of realm file in /opt instead of in /run
- run ExecStartPre as root and chown realm file to user dcos_exhibitor

Note that /usr/bin/chown is a standardized location that should exist on all target platforms, and that it dereferences symlinks by default.