### PR TITLE
Make it so if no azure storage backend is provided we use a fake / borked url to the azure templates

### DIFF
--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -280,7 +280,10 @@ def get_download_url():
         raise RuntimeError("No storage section in configuration")
 
     if 'azure' not in release._config['storage']:
-        raise RuntimeError("No azure section in storage configuration")
+        # No azure storage, inject a fake url for now so if people want to use
+        # the azure templates they know to come look here.
+        return "https://AZURE NOT CONFIGURED, ADD A storage.azure section to " \
+            "dcos-release.config.yaml to use the Azure templates"
 
     if 'download_url' not in release._config['storage']['azure']:
         raise RuntimeError("No download_url section in azure configuration")


### PR DESCRIPTION
The fake url explains how to put in a legitimate url by configuring some azure storage.

Reported by a community member, should resolve:
```
WARNING:root:Skipping  AWS CloudFormation validation because couldn't get a test session: No testing section in configuration
Validating CloudFormation: advanced-priv-agent.json
WARNING:root:Skipping  AWS CloudFormation validation because couldn't get a test session: No testing section in configuration
Validating CloudFormation: advanced-pub-agent.json
WARNING:root:Skipping  AWS CloudFormation validation because couldn't get a test session: No testing section in configuration
Validating CloudFormation: aws/templates/advanced/infra.json
WARNING:root:Skipping  AWS CloudFormation validation because couldn't get a test session: No testing section in configuration
Traceback (most recent call last):
  File "/tmp/dcos_build_venv/bin/release", line 9, in <module>
    load_entry_point('dcos-image==0.1', 'console_scripts', 'release')()
  File "/jenkins/release/__init__.py", line 822, in main
    release_manager.create('testing', options.channel, options.tag)
  File "/jenkins/release/__init__.py", line 738, in create
    metadata['channel_artifacts'] = make_channel_artifacts(metadata)
  File "/jenkins/release/__init__.py", line 407, in make_channel_artifacts
    all_bootstraps=metadata["all_bootstraps"]):
  File "/jenkins/gen/installer/azure.py", line 234, in do_create
    'local_content': gen_buttons(build_name, reproducible_artifact_path, tag, commit),
  File "/jenkins/gen/installer/azure.py", line 248, in gen_buttons
    for x in [1, 3, 5]]
  File "/jenkins/gen/installer/azure.py", line 248, in <listcomp>
    for x in [1, 3, 5]]
  File "/jenkins/gen/installer/azure.py", line 283, in get_download_url
    raise RuntimeError("No azure section in storage configuration")
RuntimeError: No azure section in storage configuration
```

cc: @aaronjwood 