### PR TITLE
De-duplicate test logging

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -50,13 +50,7 @@ def cluster():
 
 def _setup_logging():
     """Setup logging for the script"""
-    logger = logging.getLogger()
-    logger.setLevel(LOG_LEVEL)
-    fmt = logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s')
-    handler = logging.StreamHandler()
-    handler.setFormatter(fmt)
-    logger.addHandler(handler)
-
+    logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=LOG_LEVEL)
     logging.getLogger("requests").setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
Right now we get double the messages:
[2016-09-09 23:56:24,681|root|INFO]: Response from marathon: {'portDefinitions': [{'port': 0, 'protocol
[2016-09-09 23:56:24,681] INFO: Response from marathon: {'portDefinitions': [{'port': 0, 'protocol': 'tcp',
