### PR TITLE
Stabilize dcos-setup.service

### DIFF
--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -26,7 +26,7 @@
     Type=oneshot
     StandardOutput=journal+console
     StandardError=journal+console
-    ExecStartPre=/usr/bin/curl -fLsSv --retry 20 -Y 100000 -y 60 -o /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
+    ExecStartPre=/usr/bin/curl --keepalive-time 2 -fLsSv --retry 20 -Y 100000 -y 60 -o /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz {{ bootstrap_url }}/bootstrap/${BOOTSTRAP_ID}.bootstrap.tar.xz
     ExecStartPre=/usr/bin/mkdir -p /opt/mesosphere
     ExecStart=/usr/bin/tar -axf /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz -C /opt/mesosphere
     ExecStartPost=-/usr/bin/rm -f /{{ bootstrap_tmp_dir }}/bootstrap.tar.xz


### PR DESCRIPTION
Many stacks fail to create in AWS because of
curl: (18) transfer closed with ___ bytes remaining to read
curl's default keepalive interval is 60s

From what I can tell, this error is generated when the server side cuts off the transfer so it would make sense to bump up keepalive-time. And it helped at least one person http://stackoverflow.com/questions/33522615/curl-transfer-closed-with-outstanding-read-data-remaining