### PR TITLE
Add a `dcos-shell` program so dcos doesn't have to be added to the default `$PATH`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,9 @@
 Documentation of changes which may break some install environments
 
+1.9-dev
+ - DC/OS binaries / config is no longer injected to user environment via /etc/profile.d/dcos.sh. New installs have just a single binary, `dcos-shell` added to $PATH. Can be used as `dcos-shell <cmd>` to run a single command or `dcos-shell` to start a new shell which has the environment variables sourced in which arbitrary commands can be run.
 
-1.8-dev
+1.8
  - Marathon will refuse to accept new apps, and will refuse changes to existing
    apps which have the same servicePort as another app. servicePorts should be
    unique per app, but previously this wasn't enforced.

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -13,7 +13,7 @@
     StandardOutput=journal+console
     StandardError=journal+console
     ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
-    ExecStart=/usr/bin/ln -sf /opt/mesosphere/environment.export /etc/profile.d/dcos.sh
+    ExecStart=/usr/bin/ln -sf /opt/mesosphere/bin/add_dcos_path.sh /etc/profile.d/dcos.sh
 - name: dcos-download.service
   content: |
     [Unit]

--- a/packages/dcos-image/build
+++ b/packages/dcos-image/build
@@ -7,3 +7,11 @@ pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$
 
 mkdir -p "$LIB_INSTALL_DIR/dcos_installer/"
 ln -s /opt/mesosphere/active/dcos-installer-ui/usr/ "$LIB_INSTALL_DIR/dcos_installer/templates"
+
+mkdir -p "$PKG_PATH/bin/dcos-path"
+cp /pkg/extra/dcos-shell "$PKG_PATH/bin/dcos-path/dcos-shell"
+ln -s "$PKG_PATH/bin/dcos-path/dcos-shell" "$PKG_PATH/bin/dcos-shell"
+
+cat <<'EOF' > "$PKG_PATH/bin/add_dcos_path.sh"
+export PATH="$PATH:/opt/mesosphere/bin/dcos-path"
+EOF

--- a/packages/dcos-image/extra/dcos-shell
+++ b/packages/dcos-image/extra/dcos-shell
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+source /opt/mesosphere/environment.export
+
+if [ $# -eq 1 ]; then
+  exec "$SHELL"
+fi
+
+exec "$@"

--- a/packages/dcos-integration-test/extra/test_ec2.py
+++ b/packages/dcos-integration-test/extra/test_ec2.py
@@ -83,10 +83,9 @@ def test_move_external_volume_to_new_agent(cluster):
         cluster.destroy_marathon_app(read_app['id'])
     finally:
         logging.info('Deleting volume: ' + test_label)
-        delete_cmd = """#!/bin/bash
-source /opt/mesosphere/environment.export
-python /opt/mesosphere/active/dcos-integration-test/delete_ec2_volume.py {}
-""".format(test_label)
+        delete_cmd = \
+            "/opt/mesosphere/bin/dcos-shell python " \
+            "/opt/mesosphere/active/dcos-integration-test/delete_ec2_volume.py {}".format(test_label)
         delete_job = {
             'id': 'delete-volume-' + test_uuid,
             'run': {

--- a/test_util/cluster_api.py
+++ b/test_util/cluster_api.py
@@ -284,7 +284,7 @@ class ClusterApi:
             'instances': 1,
             # NOTE: uses '.' rather than `source`, since `source` only exists in bash and this is
             # run by sh
-            'cmd': '. /opt/mesosphere/environment.export && /opt/mesosphere/bin/python '
+            'cmd': '/opt/mesosphere/bin/dcos-shell python '
                    '/opt/mesosphere/active/dcos-integration-test/python_test_server.py ',
             'env': {
                 'DCOS_TEST_UUID': test_uuid,


### PR DESCRIPTION
The goal is this is the only thing that gets added to $PATH (Rather than the
python environment and everything else)

People can then use:
`dcos-shell` -- get a shell with all DC/OS bits in your environment
`dcos-shell pkgpanda --uninstall` -- run a pkgpanda command with all the right environment variables.