### PR TITLE
Octarine bugfix

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -68,7 +68,7 @@ def test_octarine_http(cluster, timeout=30):
     octarine_id = uuid.uuid4().hex
     proxy = ('"http://127.0.0.1:$(/opt/mesosphere/bin/octarine ' +
              '--client --port {})"'.format(octarine_id))
-    check_command = 'curl --fail --proxy {} marathon.mesos'.format(proxy)
+    check_command = 'curl --fail --proxy {} marathon.mesos.mydcos.directory'.format(proxy)
 
     app_definition = {
         'id': '/integration-test-app-octarine-http-{}'.format(test_uuid),
@@ -107,8 +107,10 @@ def test_octarine_srv(cluster, timeout=30):
     cmd = ('/opt/mesosphere/bin/octarine {} & '.format(octarine_id) +
            '/opt/mesosphere/bin/python -m http.server ${PORT0}')
     raw_app_id = 'integration-test-app-octarine-srv-{}'.format(test_uuid)
-    check_command = ('curl --fail --proxy {} _{}._{}._tcp.marathon.mesos')
-    check_command = check_command.format(proxy, port_name, raw_app_id)
+    check_command = 'curl --fail --proxy {} _{}._{}._tcp.marathon.mesos.mydcos.directory'.format(
+        proxy,
+        port_name,
+        raw_app_id)
 
     app_definition = {
         'id': '/{}'.format(raw_app_id),

--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",
-    "ref": "2fe29e69e636157b481a4c2cfb6b0a55920e7644",
+    "ref": "426a6db3ec0ea4a86af05a6c7585722e4d636e3f",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
Octarine tests were hitting the wrong url, this was causing tests to pass even though it was misbehaving. Also updated Octarine to fix this.