### PR TITLE
Remove LD_LIBRARY_PATH from executor environment variables, set RPATH for mesos

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -447,8 +447,6 @@ package:
       {
         "PATH": "/usr/bin:/bin",
         "SHELL": "/usr/bin/bash",
-        "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
-        "SASL_PATH": "/opt/mesosphere/lib/sasl2",
         "LIBPROCESS_NUM_WORKER_THREADS": "8"
       }
   - path: /etc/dns_search_config

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -9,7 +9,9 @@ mkdir -p build
 pushd build
 # TODO(cmaloney): --with-glog=/usr --with-protobuf=/usr --with-boost=/usr
 # TODO(cmaloney): DESTDIR builds so we don't have to build as root?
-LIBS="-lssl -lcrypto" LDFLAGS="-L/opt/mesosphere/active/openssl/lib" "/pkg/src/mesos/configure" \
+LIBS="-lssl -lcrypto" \
+  LDFLAGS="-L/opt/mesosphere/active/openssl/lib -Wl,-rpath=/opt/mesosphere/lib"  \
+  "/pkg/src/mesos/configure" \
   --prefix="$PKG_PATH" --enable-optimize --disable-python \
   --enable-libevent --enable-ssl \
   --enable-install-module-dependencies \


### PR DESCRIPTION
This was supposed to happen in DC/OS 1.3 but it didn't because frameworks broke (https://github.com/mesosphere/dcos-image/commit/17aa4adf79f7946f9a536c0b78b8bd11f7e325de).

Frameworks should now be bundling their own libmesos or using the HTTP API. Same
goes for all software on top of DC/OS. This enforces the separation of the
"system" internals from stuff on top of the cluster.

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)