### PR TITLE
Cleanup env vars a bit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,8 @@ testpaths =
   tests
 
 [testenv:py34-syntax]
+passenv =
+    TEAMCITY_VERSION
 deps =
   flake8
   flake8-import-order
@@ -39,7 +41,6 @@ passenv =
   AZURE_PROD_STORAGE_ACCESS_KEY
   AZURE_DEV_STORAGE_ACCOUNT
   AZURE_DEV_STORAGE_ACCESS_KEY
-  ENV_AWS_CONFIG
   AWS_TESTING_ACCESS_KEY_ID
   AWS_TESTING_SECRET_ACCESS_KEY
   AWS_PROD_ACCESS_KEY_ID


### PR DESCRIPTION
 - The teamcity messages weren't showing up because TEAMCITY_VERSION wasn't getting through
 - The AWS var we moved off of a while ago

Noticed the first one in #623 where they weren't showing as nice structured errors