### PR TITLE
test: Updated Marathon app definition for Mesos containerizer

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -46,9 +46,14 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
     app, test_uuid = cluster.get_test_app()
     app['container'] = {
         'type': 'MESOS',
-        'docker': {
+        'mesos': {
             # TODO(cmaloney): Switch to an alpine image with glibc inside.
-            'image': 'debian:jessie'
+            'image': {
+                'type': 'DOCKER',
+                'docker': {
+                    'name': 'debian:jessie'
+                }
+            }
         },
         'volumes': [{
             'containerPath': '/opt/mesosphere',


### PR DESCRIPTION
If Mesos containerizer shall be used, 'ContainerInfo.mesos' field should be set instead of 'ContainerInfo.docker'.