### PR TITLE
Misc. tox flags cleanup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ application-import-names=dcos_installer,dcos_internal_utils,gen,history,pkgpanda
 import-order-style=smarkets
 
 [pytest]
-addopts = -vv
+addopts = -rs -vv
 testpaths =
   gen
   packages/dcos-history/extra/
@@ -58,7 +58,7 @@ deps =
   webtest-aiohttp
 commands=
   ./prep_local
-  py.test -rs --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}
+  py.test --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}
 
 [testenv:py34-pkgpanda-build]
 whitelist_externals=bash
@@ -68,7 +68,7 @@ deps=
 changedir=pkgpanda/build/tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-unit-tests]
 whitelist_externals=bash
@@ -78,7 +78,7 @@ deps=
 changedir=pkgpanda/tests/unit_tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-integration]
 whitelist_externals=bash
@@ -88,7 +88,7 @@ deps=
 changedir=pkgpanda/tests/integration_tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-bootstrap]
 deps=
@@ -97,4 +97,4 @@ deps=
 changedir=packages/bootstrap/extra
 commands=
   pip install .
-  py.test -rs -vv {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
 
 [testenv:py34-unittests]
 passenv =
+  TEAMCITY_VERSION
   SSH_AUTH_SOCK
   AZURE_PROD_STORAGE_ACCOUNT
   AZURE_PROD_STORAGE_ACCESS_KEY
@@ -58,9 +59,11 @@ deps =
   webtest-aiohttp
 commands=
   ./prep_local
-  py.test --basetemp={envtmpdir} {env:CI_FLAGS:} {posargs}
+  py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-build]
+passenv =
+  TEAMCITY_VERSION
 whitelist_externals=bash
 deps=
   pytest
@@ -68,9 +71,11 @@ deps=
 changedir=pkgpanda/build/tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-unit-tests]
+passenv =
+  TEAMCITY_VERSION
 whitelist_externals=bash
 deps=
   pytest
@@ -78,9 +83,11 @@ deps=
 changedir=pkgpanda/tests/unit_tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-pkgpanda-integration]
+passenv =
+  TEAMCITY_VERSION
 whitelist_externals=bash
 deps=
   pytest
@@ -88,13 +95,15 @@ deps=
 changedir=pkgpanda/tests/integration_tests
 commands=
   bash -c "cd ../../../ && ./prep_local"
-  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test --basetemp={envtmpdir} {posargs}
 
 [testenv:py34-bootstrap]
+passenv =
+  TEAMCITY_VERSION
 deps=
   pytest
   teamcity-messages
 changedir=packages/bootstrap/extra
 commands=
   pip install .
-  py.test {env:CI_FLAGS:} --basetemp={envtmpdir} {posargs}
+  py.test --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
- Use TEAMCITY_VERSION to trigger teamcity messages rather than explicit flag
- move `-rs -vv` to `addopts` for py.test