### PR TITLE
Teach tests to get a new auth token when the current one expires

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -289,11 +289,23 @@ class Cluster:
             return self.superuser_auth_header
         return {}
 
+
+    def _try_authenticate(result):
+        """If the value of the get request is 401, we should authenticate
+        in the case that we have an expired auth token."""
+        if result.status_code == 401:
+            self._authenticate()
+            return true
+        return false
+
+
+    @retry(retry_on_result=_try_authenticate, stop_max_attempt_number=1)
     def get(self, path="", params=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)
         hdrs.update(kwargs.pop('headers', {}))
         return requests.get(
             self.dcos_uri + path, params=params, headers=hdrs, **kwargs)
+
 
     def post(self, path="", payload=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -289,20 +289,21 @@ class Cluster:
             return self.superuser_auth_header
         return {}
 
-    def _try_authenticate(self, result):
-        """If the value of the get request is 401, we should authenticate
-        in the case that we have an expired auth token."""
-        if result.status_code == 401:
-            self._authenticate()
-            return True
-        return False
-
-    @retrying.retry(retry_on_result=_try_authenticate, stop_max_attempt_number=1)
     def get(self, path="", params=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)
         hdrs.update(kwargs.pop('headers', {}))
-        return requests.get(
-            self.dcos_uri + path, params=params, headers=hdrs, **kwargs)
+
+        def _get():
+            return requests.get(
+                self.dcos_uri + path, params=params, headers=hdrs, **kwargs)
+
+        resp = _get()
+        """If the status code is 401, try authenticating once more in the case
+        that the token has expired."""
+        if resp.status_code == 401:
+            self._authenticate()
+            return _get()
+        return resp
 
     def post(self, path="", payload=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -298,9 +298,9 @@ class Cluster:
                 self.dcos_uri + path, params=params, headers=hdrs, **kwargs)
 
         resp = _get()
-        """If the status code is 401, try authenticating once more in the case
-        that the token has expired."""
-        if resp.status_code == 401:
+        """If the status code is 401 and the authorization header is set,
+        try authenticating once more in the case that the token has expired."""
+        if resp.status_code == 401 and not disable_suauth:
             self._authenticate()
             return _get()
         return resp

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -289,23 +289,20 @@ class Cluster:
             return self.superuser_auth_header
         return {}
 
-
-    def _try_authenticate(result):
+    def _try_authenticate(self, result):
         """If the value of the get request is 401, we should authenticate
         in the case that we have an expired auth token."""
         if result.status_code == 401:
             self._authenticate()
-            return true
-        return false
+            return True
+        return False
 
-
-    @retry(retry_on_result=_try_authenticate, stop_max_attempt_number=1)
+    @retrying.retry(retry_on_result=_try_authenticate, stop_max_attempt_number=1)
     def get(self, path="", params=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)
         hdrs.update(kwargs.pop('headers', {}))
         return requests.get(
             self.dcos_uri + path, params=params, headers=hdrs, **kwargs)
-
 
     def post(self, path="", payload=None, disable_suauth=False, **kwargs):
         hdrs = self._suheader(disable_suauth)

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -31,9 +31,6 @@ def test_if_mesos_is_up(cluster):
 
 
 def test_if_all_mesos_slaves_have_registered(cluster):
-    # If we set the token TTL to a very short time, we need to log
-    # back into the cluster before running this test.
-    cluster._login()
     r = cluster.get('/mesos/master/slaves')
     assert r.status_code == 200
 

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -31,6 +31,9 @@ def test_if_mesos_is_up(cluster):
 
 
 def test_if_all_mesos_slaves_have_registered(cluster):
+    # If we set the token TTL to a very short time, we need to log
+    # back into the cluster before running this test.
+    cluster._login()
     r = cluster.get('/mesos/master/slaves')
     assert r.status_code == 200
 


### PR DESCRIPTION
This PR invokes the `_login()` function before running the test on registered slaves to ensure we have a fresh token in the case that we use a short lived token TTL. 
