### PR TITLE
bump dcos-ui. Fixes styles being pasted into textareas.

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "5cb2fa12d3b5264fe59cc240043cebb5bd07746a",
+    "ref": "0e50b029e84877203cd5f3f2f49946e15b4129ca",
     "ref_origin": "release/1.8"
   }
 }


### PR DESCRIPTION
Fixes styles from being pasted into textareas.
![img](https://cl.ly/2v32351a3y31/Screen%20Recording%202016-09-15%20at%2012.08%20PM.gif)