### PR TITLE
Revert "test: Updated Marathon app definition for Mesos containerizer"

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -46,14 +46,9 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
     app, test_uuid = cluster.get_test_app()
     app['container'] = {
         'type': 'MESOS',
-        'mesos': {
+        'docker': {
             # TODO(cmaloney): Switch to an alpine image with glibc inside.
-            'image': {
-                'type': 'DOCKER',
-                'docker': {
-                    'name': 'debian:jessie'
-                }
-            }
+            'image': 'debian:jessie'
         },
         'volumes': [{
             'containerPath': '/opt/mesosphere',


### PR DESCRIPTION
This reverts commit de9842a766582355079ba4dab1032f832ff76485.

See comments on #717 

cc: @rukletsov 