### PR TITLE
Fix Erlang ENV Problems

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -37,6 +37,9 @@ package:
   - path: /etc_master/master_count
     content: |
       {{ num_masters }}
+  - path: /etc/spartan.env
+    content: |
+      ERL_FLAGS=" -kernel inet_dist_listen_min 62501 -kernel inet_dist_listen_max 62501"
   - path: /etc_slave/spartan.json
     content: |
       {
@@ -91,6 +94,9 @@ package:
           ]
         }
       ].
+  - path: /etc/navstar.env
+    content: |
+      ERL_FLAGS=" -kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502"
   - path: /etc_master/navstar.app.config
     content: |
       [
@@ -287,6 +293,9 @@ package:
   - path: /etc/dns_search_config
     content: |
       {{ dcos_gen_resolvconf_search_str }}
+  - path: /etc/minuteman.env
+    content: |
+      ERL_FLAGS=" -kernel inet_dist_listen_min 62503 -kernel inet_dist_listen_max 62503"
   - path: /etc/minuteman/overrides.json
     content: |
       {

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -396,7 +396,7 @@ class Cluster:
         return app, test_uuid
 
     def deploy_test_app_and_check(self, app, test_uuid):
-        with self.marathon_deploy_and_cleanup(app) as service_points:
+        with self.marathon_deploy_and_cleanup(app, timeout=240) as service_points:
             r = requests.get('http://{}:{}/test_uuid'.format(service_points[0].host,
                                                              service_points[0].port))
             if r.status_code != 200:

--- a/packages/minuteman/build
+++ b/packages/minuteman/build
@@ -20,10 +20,9 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=${PKG_PATH}/minuteman
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62503 -kernel inet_dist_listen_max 62503
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=-/opt/mesosphere/etc/minuteman.env
+EnvironmentFile=/opt/mesosphere/etc/minuteman.env
 EnvironmentFile=-/run/dcos/etc/minuteman_auth.env
 ExecStartPre=/opt/mesosphere/bin/check-time
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-minuteman

--- a/packages/navstar/build
+++ b/packages/navstar/build
@@ -27,10 +27,9 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=${PKG_PATH}/navstar
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=-/opt/mesosphere/etc/navstar.env
+EnvironmentFile=/opt/mesosphere/etc/navstar.env
 EnvironmentFile=-/run/dcos/etc/navstar_auth.env
 ExecStartPre=/opt/mesosphere/bin/check-time
 ExecStartPre=/bin/ping -c1 ready.spartan

--- a/packages/spartan/extra/dcos-spartan.service
+++ b/packages/spartan/extra/dcos-spartan.service
@@ -6,12 +6,11 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=/opt/mesosphere/active/spartan/spartan
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62501 -kernel inet_dist_listen_max 62501
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config
 EnvironmentFile=-/opt/mesosphere/etc/dns_config_master
-EnvironmentFile=-/opt/mesosphere/etc/spartan.env
+EnvironmentFile=/opt/mesosphere/etc/spartan.env
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-spartan
 ExecStartPre=/usr/bin/env modprobe dummy
 ExecStartPre=-/usr/bin/env ip link add spartan type dummy


### PR DESCRIPTION
The current build of DCOS warns about certain Erlang apps like navstar, minuteman, and spartan on certain operating systems due to a systemd Enviroment config problem that results in log line like this:

```
Sep 16 10:12:12 p1.dcos systemd[1]: [/opt/mesosphere/packages/navstar--525060447dd2b1b09088865e6d0ebb0d209558c0/dcos.target.wants/dcos-navstar.service:9] Invalid environment assignment, ignoring: ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502
```

As a result, those services never get the correct `ERL_FLAGS` env var.

This PR fixes the problem by putting those env vars in service-specific `*.env` files on all hosts.