### PR TITLE
Bump to Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ All code in this repository is Python 3
   1. git 1.8.5+
   1. Docker
     - [Install Instructions for various distributions](https://docs.docker.com/engine/installation/). Docker needs to be configured so your user can run docker containers. The command `docker run alpine  /bin/echo 'Hello, World!'` when run at a new terminal as your user should just print `"Hello, World!"`. If it says something like "Unable to find image 'alpine:latest' locally" then re-run and the message should go away.
-  1. Python 3.4
+  1. Python 3.5
     - Arch Linux: `sudo pacman -S python`
     - Fedora 23 Workstation: Already installed by default / no steps
     - Ubuntu 16.04 LTS:
       - [pyenv-installer](https://github.com/yyuu/pyenv-installer)
       - Python dependencies: `sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils liblzma-dev`
-      - Install Python 3.4.5: `pyenv install 3.4.5`
-      - Create DC/OS virtualenv: `pyenv virtualenv 3.4.5 dcos`
+      - Install Python 3.5.2: `pyenv install 3.5.2`
+      - Create DC/OS virtualenv: `pyenv virtualenv 3.5.2 dcos`
       - Activate environment: `pyenv activate dcos`
   1. Over 10GB of free disk space
   1. _Optional_ pxz (speeds up package and bootstrap compression)

--- a/packages/bootstrap/build
+++ b/packages/bootstrap/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/extra

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='support@mesosphere.io',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4'],
+        'Programming Language :: Python :: 3.5'],
     entry_points={
         'console_scripts': [
             'bootstrap=dcos_internal_utils.cli:main'

--- a/packages/boto/build
+++ b/packages/boto/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 for package in futures jmespath botocore boto3; do

--- a/packages/curl/build
+++ b/packages/curl/build
@@ -40,7 +40,7 @@ pushd /pkg/src/curl
             --without-spnego \
             --without-winidn \
             --without-winssl \
-            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.4/site-packages/requests/cacert.pem
+            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.5/site-packages/requests/cacert.pem
 make -j8
 make install
 popd

--- a/packages/dcos-history/build
+++ b/packages/dcos-history/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Copy from the ro /pkg/extra to a rw folder.

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.

--- a/packages/dcos-image/build
+++ b/packages/dcos-image/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/dnspython/build
+++ b/packages/dnspython/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/flask/build
+++ b/packages/flask/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Build all the packages. We'd use pip to install them but that fails badly.

--- a/packages/pytest/build
+++ b/packages/pytest/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 for package in pytest teamcity-messages; do

--- a/packages/python-azure-mgmt-resource/build
+++ b/packages/python-azure-mgmt-resource/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-dateutil/build
+++ b/packages/python-dateutil/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-docopt/build
+++ b/packages/python-docopt/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-gunicorn/build
+++ b/packages/python-gunicorn/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-isodate/build
+++ b/packages/python-isodate/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-jinja2/build
+++ b/packages/python-jinja2/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-kazoo/build
+++ b/packages/python-kazoo/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-markupsafe/build
+++ b/packages/python-markupsafe/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-passlib/build
+++ b/packages/python-passlib/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-pyyaml/build
+++ b/packages/python-pyyaml/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-requests/build
+++ b/packages/python-requests/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-retrying/build
+++ b/packages/python-retrying/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-tox/build
+++ b/packages/python-tox/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python/build
+++ b/packages/python/build
@@ -12,7 +12,7 @@ make -j8
 make install
 
 # Remove some big things we don't use at all
-rm -rf "$PKG_PATH/lib/python3.4/test"
+rm -rf "$PKG_PATH/lib/python3.5/test"
 
 # TODO(cmaloney): This sort of stripping static libraries should be a generic
 # mkpanda option to apply to any package.
@@ -23,7 +23,7 @@ find "$PKG_PATH/lib/" ! -type d -name "*.a" -exec rm -f -- '{}' +
 # Note(JP): For making pip upgrade itself reliably, it's best
 # to run pip as a module (python -m pip).
 export LD_LIBRARY_PATH=$PKG_PATH/lib
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/setuptools/*.whl
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip/*.whl
 echo "pip version: $($PKG_PATH/bin/pip3 --version)"
@@ -31,7 +31,7 @@ echo "pip version: $($PKG_PATH/bin/pip3 --version)"
 
 # Setup helper symlinks, force overwrite if link name exists.
 ln -fs "$PKG_PATH/bin/python3" "$PKG_PATH/bin/python"
-ln -fs "$PKG_PATH/bin/easy_install-3.4" "$PKG_PATH/bin/easy_install-3"
+ln -fs "$PKG_PATH/bin/easy_install-3.5" "$PKG_PATH/bin/easy_install-3"
 ln -fs "$PKG_PATH/bin/easy_install-3" "$PKG_PATH/bin/easy_install"
 ln -fs "$PKG_PATH/bin/pip3" "$PKG_PATH/bin/pip"
 ln -fs "$PKG_PATH/bin/python3-config" "$PKG_PATH/bin/python-config"

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -1,19 +1,19 @@
 {
   "requires": ["openssl"],
   "environment": {
-    "PYTHONPATH": "/opt/mesosphere/lib/python3.4/site-packages",
+    "PYTHONPATH": "/opt/mesosphere/lib/python3.5/site-packages",
     "PYTHONUNBUFFERED": "true"
   },
   "sources": {
     "python": {
       "kind": "url_extract",
-      "url": "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tgz",
-      "sha1": "7d192dec3dfc45a2d4a05b8d3512fa6fa2f64a72"
+      "url": "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz",
+      "sha1": "4843aabacec5bc0cdd3e1f778faa926e532794d2"
     },
     "setuptools": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/15/b7/a76624e5a3b18c8c1c8d33a5240b34cdabb08aef2da44b536a8b53ba1a45/setuptools-21.0.0-py2.py3-none-any.whl",
-      "sha1": "0f1ac25c51d66e269d1449ad8650624fca8e3f03"
+      "url": "https://pypi.python.org/packages/0c/5d/309113d5359654094f7423ad9c32ac55255b83304f36d0fa96129f28db83/setuptools-27.2.0-py2.py3-none-any.whl",
+      "sha1": "e3e473b1a56dce0bb1892a004153cbaad6ddca8c"
     },
     "pip": {
       "kind": "url",

--- a/packages/six/build
+++ b/packages/six/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     packages=[
         'dcos_installer',


### PR DESCRIPTION
Things noticed so far:
 - [x] Need code quality hosts to have Python 3.5 available for running bumped integration tests (might compromise and make the req `py3` to land then bump to 3.5 once we switch to ubuntu 16.04 for build hosts. Local tests show all tests passing with python 3.5