### PR TITLE
Handle connection error on dcos-history

### DIFF
--- a/packages/dcos-history/build
+++ b/packages/dcos-history/build
@@ -3,12 +3,18 @@ source /opt/mesosphere/environment.export
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.4/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
+
 # Copy from the ro /pkg/extra to a rw folder.
 cp -r /pkg/extra /build
+
+
+# Copy the gunicorn conf file to $PKG_PATH
+cp /pkg/extra/history/dcos_history_conf.py "$PKG_PATH/dcos_history_conf.py"
+
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /build
 
 # Create the service file
 service="$PKG_PATH/dcos.target.wants_master/dcos-history.service"
 mkdir -p "$(dirname "$service")"
-cp /pkg/extra/dcos-history.service  "$service"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-history.service > "$service"

--- a/packages/dcos-history/buildinfo.json
+++ b/packages/dcos-history/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["flask", "python", "python-requests"],
+  "requires": ["flask", "python", "python-gunicorn", "python-requests"],
   "state_directory": true,
   "username": "dcos_history"
 }

--- a/packages/dcos-history/extra/dcos-history.service
+++ b/packages/dcos-history/extra/dcos-history.service
@@ -12,4 +12,5 @@ EnvironmentFile=-/opt/mesosphere/etc/dcos-history-extras.env
 Environment=HISTORY_BUFFER_DIR=/var/lib/dcos/dcos-history
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-history
-ExecStart=/opt/mesosphere/bin/dcos-history
+ExecStart=/opt/mesosphere/bin/gunicorn -c $PKG_PATH/dcos_history_conf.py \
+                history.server:app

--- a/packages/dcos-history/extra/history/dcos_history_conf.py
+++ b/packages/dcos-history/extra/history/dcos_history_conf.py
@@ -1,0 +1,9 @@
+from history.server import on_starting_server
+
+
+bind = '0.0.0.0:15055'
+workers = 1
+
+
+def on_starting(server):
+    on_starting_server(server)

--- a/packages/dcos-history/extra/history/server.py
+++ b/packages/dcos-history/extra/history/server.py
@@ -2,9 +2,11 @@ import logging
 import os
 import sys
 
+
 from flask import Flask, Response
 from flask.ext.compress import Compress
 from history.statebuffer import BufferCollection, BufferUpdater
+
 
 app = Flask(__name__)
 compress = Compress()
@@ -79,7 +81,7 @@ def _response_(content):
     return Response(response=content, content_type="application/json", headers=headers_cb())
 
 
-def start():
+def on_starting_server(server):
     global state_buffer
     logging.basicConfig(format='[%(levelname)s:%(asctime)s] %(message)s', level='INFO')
 
@@ -90,4 +92,10 @@ def start():
 
     state_buffer = BufferCollection(os.environ['HISTORY_BUFFER_DIR'])
     BufferUpdater(state_buffer, headers_cb).run()
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', '15055')))
+
+
+def start():
+    # Used for testing only; on dc/os $PATH should have gunicorn
+    # Have to be in the same folder to run this
+    # In case of failure it will not sys.exit
+    os.system("gunicorn -c dcos_history_conf.py server:app")

--- a/packages/dcos-history/extra/setup.py
+++ b/packages/dcos-history/extra/setup.py
@@ -20,6 +20,7 @@ config = {
     'install_requires': [
         'Flask>=0.10.1',
         'flask-compress',
+        'gunicorn',
         'requests']
 }
 

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import bs4
+from retrying import retry
 
 
 def test_if_dcos_ui_is_up(cluster):
@@ -116,15 +117,20 @@ def test_if_pkgpanda_metadata_is_available(cluster):
 
 
 def test_if_dcos_history_service_is_getting_data(cluster):
-    r = cluster.get('/dcos-history-service/history/last')
-    assert r.status_code == 200
-    # Make sure some basic fields are present from state-summary which the DC/OS
-    # UI relies upon. Their exact content could vary so don't test the value.
-    json = r.json()
-    assert 'cluster' in json
-    assert 'frameworks' in json
-    assert 'slaves' in json
-    assert 'hostname' in json
+
+    @retry(stop_max_delay=20000, wait_fixed=500)
+    def check_up():
+        r = cluster.get('/dcos-history-service/history/last')
+        assert r.status_code == 200
+        # Make sure some basic fields are present from state-summary which the DC/OS
+        # UI relies upon. Their exact content could vary so don't test the value.
+        json = r.json()
+        assert 'cluster' in json
+        assert 'frameworks' in json
+        assert 'slaves' in json
+        assert 'hostname' in json
+
+    check_up()
 
 
 def test_if_we_have_capabilities(cluster):


### PR DESCRIPTION
When running dcos-history, if the flask app cannot bind to the port assigned it does not fail and keeps retrying. Using gunicorn ensures that the app fails and master is marked unhealthy.

https://mesosphere.atlassian.net/browse/DCOS-5334 

Unit tests passed
Syntax test passed