### PR TITLE
Octarine: Golang 1.7, godep, and parsing changes

### DIFF
--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",
-    "ref": "426a6db3ec0ea4a86af05a6c7585722e4d636e3f",
+    "ref": "abd003681cf65e984f12168d6120cfd48c179fc6",
     "ref_origin": "master"
   }
 }

--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "docker": "golang:1.6",
+  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",


### PR DESCRIPTION
Update to golang 1.7 and move parsing from general HTTP handler to just SRV records. Also updated the project to use godep, a golang dependency tracking tool.