### PR TITLE
Move all of the ERL_FLAGS statements to EnvironmentFiles

### DIFF
--- a/docs/systemd-rules.md
+++ b/docs/systemd-rules.md
@@ -10,5 +10,6 @@ These are coding style guidelines for our systemd units, based on bugs we've run
  - All Exec and ExecStart lines must be trivial. If you're starting bash to do some computation, or a python interpreter with an embedded script which is doing something it will be rejected. Make a simple helper script. One-liners aren't cool to maintain.
  - `Description=` is used by the diagnostics service.  Should be of the form `$SERVICE_NAME: $DESCRIPTION`
  - All new services must run as non-root `User=` must be set in their service files.
+ - Do not add `Environment=` directly to systemd units. Use EnvironmentFile, and create the EnvironmentFile in dcos-config.yaml
 
 Note some of the units do not follow these guidelines. They're being updated.

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -37,6 +37,15 @@ package:
   - path: /etc_master/master_count
     content: |
       {{ num_masters }}
+  - path: /etc/spartan-erl.env
+    content: |
+      ERL_FLAGS=-kernel inet_dist_listen_min 62501 -kernel inet_dist_listen_max 62501
+  - path: /etc/navstar-erl.env
+    content: |
+      ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502
+  - path: /etc/minuteman-erl.env
+    content: |
+      ERL_FLAGS=-kernel inet_dist_listen_min 62503 -kernel inet_dist_listen_max 62503
   - path: /etc_slave/spartan.json
     content: |
       {

--- a/packages/minuteman/build
+++ b/packages/minuteman/build
@@ -20,7 +20,7 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=${PKG_PATH}/minuteman
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62503 -kernel inet_dist_listen_max 62503
+EnvironmentFile=/opt/mesosphere/etc/minuteman-erl.env
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/opt/mesosphere/etc/minuteman.env

--- a/packages/navstar/build
+++ b/packages/navstar/build
@@ -27,7 +27,7 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=${PKG_PATH}/navstar
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502
+EnvironmentFile=/opt/mesosphere/etc/navstar-erl.env
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/opt/mesosphere/etc/navstar.env

--- a/packages/spartan/extra/dcos-spartan.service
+++ b/packages/spartan/extra/dcos-spartan.service
@@ -6,7 +6,7 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 WorkingDirectory=/opt/mesosphere/active/spartan/spartan
-Environment=ERL_FLAGS=-kernel inet_dist_listen_min 62501 -kernel inet_dist_listen_max 62501
+EnvironmentFile=/opt/mesosphere/etc/spartan-erl.env
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config


### PR DESCRIPTION
This seems to be the only thing that works reliably across CoreOS / Ubuntu / CentOS