### PR TITLE
openssl package: update to 1.0.2i

### DIFF
--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2h.tar.gz",
-    "sha1": "577585f5f5d299c44dd3c993d3c0ac7a219e4949"
+    "url": "https://openssl.org/source/openssl-1.0.2i.tar.gz",
+    "sha1": "25a92574ebad029dcf2fa26c02e10400a0882111"
   }
 }


### PR DESCRIPTION
OpenSSL 1.0.2i was released yesterday, 22 Sep 2016:
https://www.openssl.org/news/cl102.txt
https://www.openssl.org/news/secadv/20160922.txt