### PR TITLE
Bump dcos-ui for 1.8.5

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "e2b540901418665287bbdf98e915e3da3e5966b0",
+    "ref": "80d938b3e3cd747ccce2ec394a4e89b0c7e40124",
     "ref_origin": "release/1.8"
   }
 }


### PR DESCRIPTION
Fixes launching apps with networking options and disables killing tasks that can't be deleted.