### PR TITLE
Fixed compilation error of mesos-overlay-module.

### DIFF
--- a/packages/mesos-overlay-modules/buildinfo.json
+++ b/packages/mesos-overlay-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/mesos-overlay-modules.git",
-      "ref": "931e174fe3d104bb70bbcbcf701577db92048693",
+      "ref": "0cff3a004729a8f220d6347ad453a390d3dc74c7",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
Removing an unused namespace from the overlay-module, that was causing compilation failure with Mesos HEAD (since that namespace has been removed in the newer version of the API).