### PR TITLE
WIP: Enabling docker 1.12

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 Documentation of changes which may break some install environments
 
+1.9-dev
+ - Docker 1.12 for azure, --install-prerequisites
 
 1.8-dev
  - Marathon will refuse to accept new apps, and will refuse changes to existing

--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -384,10 +384,15 @@ StartLimitInterval=0
 RestartSec=15
 ExecStartPre=-/sbin/ip link del docker0
 ExecStart=
-ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://
+ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H unix:///var/run/docker.sock
 EOF
 
-sudo yum install -y docker-engine-1.11.2
+sudo systemctl daemon-reload
+# try to stop the older docker version, but do not hard fail if it does not
+# exist.
+sudo systemctl stop docker || true
+
+sudo yum install -y docker-engine
 sudo systemctl start docker
 sudo systemctl enable docker
 


### PR DESCRIPTION
Newer non-broken CentOS packages have been pushed which makes this a bit happer

TODO
 - [ ] Update azure to 1.12
 - [ ] Update CentOS 7 AMI building to use docker 1.12
 - [ ] Verify mesos and docker 1.12 work reasonably together.

Replaces #462 