### PR TITLE
Make it so build_teamcity is stuck to python 3.4 while hosts get python 3.5

### DIFF
--- a/build_teamcity
+++ b/build_teamcity
@@ -25,7 +25,7 @@ rm -rf wheelhouse/
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-virtualenv --always-copy build/env
+python3.4 -m venv --always-copy build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}


### PR DESCRIPTION
Helps switching to ubuntu 16.04 which always has python 3.5 by default.