### PR TITLE
Improvements to support AWS govcloud

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -56,7 +56,8 @@ region_to_endpoint = {
     'ap-northeast-1': 's3-ap-northeast-1.amazonaws.com',
     'eu-central-1': 's3.eu-central-1.amazonaws.com',
     'eu-west-1': 's3-eu-west-1.amazonaws.com',
-    'sa-east-1': 's3-sa-east-1.amazonaws.com'
+    'sa-east-1': 's3-sa-east-1.amazonaws.com',
+    'us-gov-west-1': 's3-us-gov-west-1.amazonaws.com'
 }
 
 

--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -77,6 +77,12 @@
           ]
         }
       ]
+    },
+    "RegionIsUsGovWest1" : {
+      "Fn::Equals" : [
+        { "Ref" : "AWS::Region" },
+        "us-gov-west-1"
+      ]
     }
   },
   "Mappings": {
@@ -172,8 +178,21 @@
                 "s3:PutObjectAcl"
               ],
               "Resource": [
-                { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ExhibitorS3Bucket" }, "/*"]]},
-                { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ExhibitorS3Bucket" }]]}
+                { "Fn::Join" : [
+                  "",
+                  [
+                    { "Fn::If" : [ "RegionIsUsGovWest1", "arn:aws-us-gov:s3:::", "arn:aws:s3:::" ] },
+                    { "Ref" : "ExhibitorS3Bucket" },
+                    "/*"
+                  ]
+                ] },
+                { "Fn::Join" : [
+                  "",
+                  [
+                    { "Fn::If" : [ "RegionIsUsGovWest1", "arn:aws-us-gov:s3:::", "arn:aws:s3:::" ] },
+                    { "Ref" : "ExhibitorS3Bucket" }
+                  ]
+                ] }
               ]
             },
             {

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -294,7 +294,7 @@
       },
       "us-gov-west-1": {
         "coreos": "ami-b712acd6",
-        "el7": ""
+        "el7": "ami-c4a41da5"
       },
       "us-west-1": {
         "coreos": "ami-ee57148e",

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -286,7 +286,7 @@
       },
       "us-gov-west-1": {
         "coreos": "ami-b712acd6",
-        "el7": ""
+        "el7": "ami-c4a41da5"
       },
       "us-west-1": {
         "coreos": "ami-ee57148e",

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -104,6 +104,9 @@
       },
       "us-west-2": {
           "default": "ami-bb69128b"
+      },
+      "us-gov-west-1": {
+        "default": "ami-e8ab1489"
       }
     },
     "Parameters": {
@@ -132,7 +135,13 @@
   },
 
   "Conditions" : {
-    "RegionIsUsEast1": { "Fn::Equals": [ { "Ref": "AWS::Region" }, "us-east-1" ] }
+    "RegionIsUsEast1": { "Fn::Equals": [ { "Ref": "AWS::Region" }, "us-east-1" ] },
+    "RegionIsUsGovWest1" : {
+      "Fn::Equals" : [
+        { "Ref" : "AWS::Region" },
+        "us-gov-west-1"
+      ]
+    }
   },
 
   "Resources" : {
@@ -444,8 +453,21 @@
                 "s3:PutObjectAcl"
               ],
               "Resource": [
-                { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ExhibitorS3Bucket" }, "/*"]]},
-                { "Fn::Join" : ["", ["arn:aws:s3:::", { "Ref" : "ExhibitorS3Bucket" }]]}
+                { "Fn::Join" : [
+                  "",
+                  [
+                    { "Fn::If" : [ "RegionIsUsGovWest1", "arn:aws-us-gov:s3:::", "arn:aws:s3:::" ] },
+                    { "Ref" : "ExhibitorS3Bucket" },
+                    "/*"
+                  ]
+                ] },
+                { "Fn::Join" : [
+                  "",
+                  [
+                    { "Fn::If" : [ "RegionIsUsGovWest1", "arn:aws-us-gov:s3:::", "arn:aws:s3:::" ] },
+                    { "Ref" : "ExhibitorS3Bucket" }
+                  ]
+                ] }
               ]
             },
             {


### PR DESCRIPTION
* Fix missing NATAmi mapping in the Simple Template for the govcloud region
* Set the S3 Exhibitor ARN to the correct values required for us-gov-west-1
* Add CentOS7 base AMI images in the govcloud region for Advanced Templates