### PR TITLE
Add cluster_docker_credentials configuration

### DIFF
--- a/gen/cloud-config.yaml
+++ b/gen/cloud-config.yaml
@@ -25,3 +25,14 @@ root:
   - path: /etc/rexray/config.yml
     permissions: "0644"
     content: {{ rexray_config_contents }}
+{% switch cluster_docker_credentials_dcos_owned %}
+{% case "true" %}
+{% case "false" %}
+{% switch cluster_docker_credentials_write_to_etc %}
+{% case "true" %}
+  - path: /etc/mesosphere/docker_credentials
+    permissions: "0600"
+    content: {{ cluster_docker_credentials }}
+{% case "false" %}
+{% endswitch %}
+{% endswitch %}

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -318,6 +318,23 @@ package:
       MESOS_HOOKS={{ mesos_hooks }}
 {% case "false" %}
 {% endswitch %}
+{% switch cluster_docker_registry_enabled %}
+{% case "true" %}
+      MESOS_DOCKER_REGISTRY={{ cluster_docker_registry_url }}
+{% case "false" %}
+{% endswitch %}
+{% switch cluster_docker_credentials_enabled %}
+{% case "true" %}
+      MESOS_DOCKER_CONFIG=file://{{ cluster_docker_credentials_path }}
+{% case "false" %}
+{% endswitch %}
+{% switch cluster_docker_credentials_dcos_owned %}
+{% case "true" %}
+  - path: /etc/docker_credentials
+    permissions: "0600"
+    content: {{ cluster_docker_credentials }}
+{% case "false" %}
+{% endswitch %}
   - path: /etc/mesos-slave
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]

--- a/tests/test_gen_validation.py
+++ b/tests/test_gen_validation.py
@@ -6,6 +6,9 @@ import pytest
 import gen
 
 
+true_false_msg = "Must be one of 'true', 'false'. Got 'foo'."
+
+
 def validate_helper(arguments):
     return gen.validate(arguments=arguments)
 
@@ -46,7 +49,7 @@ def validate_error(new_arguments, key, message):
     assert validated == expected
 
 
-def test_invalid_telemetry_enabled(default_arguments):
+def test_invalid_telemetry_enabled():
     err_msg = "Must be one of 'true', 'false'. Got 'foo'."
     validate_error(
         {'telemetry_enabled': 'foo'},
@@ -54,7 +57,7 @@ def test_invalid_telemetry_enabled(default_arguments):
         err_msg)
 
 
-def test_invalid_ports(default_arguments):
+def test_invalid_ports():
     test_bad_range = '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:65536"]'
     range_err_msg = "Must be between 1 and 65535 inclusive"
     test_bad_value = '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:abc"]'
@@ -71,7 +74,7 @@ def test_invalid_ports(default_arguments):
         value_err_msg)
 
 
-def test_invalid_ipv4(default_arguments):
+def test_invalid_ipv4():
     test_ips = '["52.37.192.49", "52.37.181.230", "foo", "52.37.163.105", "bar"]'
     err_msg = "Invalid IPv4 addresses in list: foo, bar"
     validate_error(
@@ -85,36 +88,50 @@ def test_invalid_ipv4(default_arguments):
         err_msg)
 
 
-def test_invalid_zk_path(default_arguments):
+def test_invalid_zk_path():
     validate_error(
         {'exhibitor_zk_path': 'bad/path'},
         'exhibitor_zk_path',
         "Must be of the form /path/to/znode")
 
 
-def test_invalid_zk_hosts(default_arguments):
+def test_invalid_zk_hosts():
     validate_error(
         {'exhibitor_zk_hosts': 'zk://10.10.10.10:8181'},
         'exhibitor_zk_hosts',
         "Must be of the form `host:port,host:port', not start with zk://")
 
 
-def test_invalid_bootstrap_url(default_arguments):
+def test_invalid_bootstrap_url():
     validate_error(
         {'bootstrap_url': '123abc/'},
         'bootstrap_url',
         "Must not end in a '/'")
 
 
-def test_validate_duplicates(default_arguments):
+def test_validate_duplicates():
     validate_error(
         {'master_list': '["10.0.0.1", "10.0.0.2", "10.0.0.1"]'},
         'master_list',
         'List cannot contain duplicates: 10.0.0.1 appears 2 times')
 
 
-def test_invalid_oauth_enabled(default_arguments):
+def test_invalid_oauth_enabled():
     validate_error(
         {'oauth_enabled': 'foo'},
         'oauth_enabled',
-        "Must be one of 'true', 'false'. Got 'foo'.")
+        true_false_msg)
+
+
+def test_cluster_docker_credentials():
+    validate_error(
+        {'cluster_docker_credentials': 'foo'},
+        'cluster_docker_credentials',
+        "Must be valid JSON. Got: foo")
+
+    validate_error(
+        {'cluster_docker_credentials_dcos_owned': 'foo'},
+        'cluster_docker_credentials_dcos_owned',
+        true_false_msg)
+
+# TODO(cmaloney): Add tests that specific config leads to specific files in specific places at install time.


### PR DESCRIPTION
The cluster_docker_credentials can either be owned by DC/OS or a sysadmin's
configuration management system (ansible, chef, puppet, salt, etc.).

Core config options:
```
cluster_docker_credentials:
    Dictionary of credentials to pass.

    If unset / left the default, this will cause an empty credentials file to be placed in
    /etc/mesosphere/docker_credentials on DC/OS install. Sysadmin scripts can then edit that file
    and do a `systemctl restart dcos-mesos-slave` / `systemctl restart dcos-mesos-slave-public`.

    It can also be set as: http://mesos.apache.org/documentation/latest/configuration/
    '--docker_config' json format. Note that in config.yaml just write yaml and it will be mapped to
    the JSON format for you. This will cause the docker credentials configuration to be part of the
    DC/OS internal configuration (live in /opt/mesosphere) and the only way to update / change it is
    to roll out a new DC/OS internal configuration.

    More precise behavior can be controlled with the following options:

    cluster_docker_credentials_dcos_owned: <true|false>
        If true, then credentials file will always be in /opt/mesosphere. If false, it will always
        be in /etc/mesosphere/docker_credentials. Defaults to false if and only if the credentials are default / unset.

    cluster_docker_credentials_write_to_etc: <true|false>
        Only used if cluster_docker_credentials_dcos_owned is true. If set to true, then rather than
        writing a docker credentials file to /etc/mesosphere/docker_credentials on DC/OS install, no
        file is written. This is useful if the file is baked into an machine image / AMI and
        installing DC/OS overwriting it will cause problems.

    cluster_docker_credentials_enabled: <true|false>
        Defaults to true. If true, then the mesos --docker_config option will be passed to Mesos. If
        false, it will not.

cluster_docker_registry_url: <url>
    Optional. If set, will configure Mesos' `--docker_registry` flag to the given url. This changes the default URL Mesos uses for pulling docker images. By default https://registry-1.docker.io is used.
```