### PR TITLE
Use TCP for AWS CF LB Health Checks

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -314,7 +314,7 @@
             "InstanceProtocol" : "HTTP"
           }],
         "HealthCheck" : {
-          "Target" : "HTTP:5050/health",
+          "Target" : "TCP:5050",
           "HealthyThreshold" : "2",
           "UnhealthyThreshold" : "2",
           "Interval" : "30",
@@ -341,7 +341,7 @@
             "InstanceProtocol" : "TCP"
           }],
         "HealthCheck" : {
-          "Target" : "HTTP:5050/health",
+          "Target" : "TCP:5050",
           "HealthyThreshold" : "2",
           "UnhealthyThreshold" : "2",
           "Interval" : "30",

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -669,7 +669,7 @@
             "InstanceProtocol" : "HTTP"
           }],
         "HealthCheck" : {
-          "Target" : "HTTP:5050/health",
+          "Target" : "TCP:5050",
           "HealthyThreshold" : "2",
           "UnhealthyThreshold" : "2",
           "Interval" : "30",
@@ -697,7 +697,7 @@
             "InstanceProtocol" : "TCP"
           }],
         "HealthCheck" : {
-          "Target" : "HTTP:5050/health",
+          "Target" : "TCP:5050",
           "HealthyThreshold" : "2",
           "UnhealthyThreshold" : "2",
           "Interval" : "30",


### PR DESCRIPTION
If DC/OS is configured for HTTPS, these loadbalancers become useless

See: https://mesosphere.atlassian.net/browse/DCOS-10219