### PR TITLE
Add Cluster Marathon Client

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -1,5 +1,7 @@
 import uuid
 
+from test_util.marathon import get_test_app, get_test_app_in_docker
+
 
 def test_if_marathon_app_can_be_deployed(cluster):
     """Marathon app deployment integration test
@@ -15,8 +17,7 @@ def test_if_marathon_app_can_be_deployed(cluster):
     "GET /test_uuid" request is issued to the app. If the returned UUID matches
     the one assigned to test - test succeds.
     """
-    app, test_uuid = cluster.get_test_app()
-    cluster.deploy_test_app_and_check(app, test_uuid)
+    cluster.marathon.deploy_test_app_and_check(*get_test_app())
 
 
 def test_if_docker_app_can_be_deployed(cluster):
@@ -25,8 +26,7 @@ def test_if_docker_app_can_be_deployed(cluster):
     Verifies that a marathon app inside of a docker daemon container can be
     deployed and accessed as expected.
     """
-    app, test_uuid = cluster.get_test_app_in_docker(ip_per_container=False)
-    cluster.deploy_test_app_and_check(app, test_uuid)
+    cluster.marathon.deploy_test_app_and_check(*get_test_app_in_docker(ip_per_container=False))
 
 
 def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
@@ -43,7 +43,7 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
     When port mapping is available (MESOS-4777), this test should be updated to
     reflect that.
     """
-    app, test_uuid = cluster.get_test_app()
+    app, test_uuid = get_test_app()
     app['container'] = {
         'type': 'MESOS',
         'docker': {
@@ -56,7 +56,7 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
             'mode': 'RO'
         }]
     }
-    cluster.deploy_test_app_and_check(app, test_uuid)
+    cluster.marathon.deploy_test_app_and_check(app, test_uuid)
 
 
 def test_octarine_http(cluster, timeout=30):
@@ -90,7 +90,7 @@ def test_octarine_http(cluster, timeout=30):
         }]
     }
 
-    cluster.marathon_deploy_and_cleanup(app_definition)
+    cluster.marathon.deploy_and_cleanup(app_definition)
 
 
 def test_octarine_srv(cluster, timeout=30):
@@ -137,7 +137,7 @@ def test_octarine_srv(cluster, timeout=30):
         }]
     }
 
-    cluster.marathon_deploy_and_cleanup(app_definition)
+    cluster.marathon.deploy_and_cleanup(app_definition)
 
 
 def test_pkgpanda_api(cluster):

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -8,8 +8,13 @@ def auth_cluster(cluster):
     return cluster
 
 
-def test_adminrouter_access_control_enforcement(auth_cluster):
-    r = auth_cluster.get('/acs/api/v1', user=None)
+@pytest.fixture(scope='module')
+def noauth_cluster(auth_cluster):
+    return auth_cluster.get_user_session(None)
+
+
+def test_adminrouter_access_control_enforcement(auth_cluster, noauth_cluster):
+    r = noauth_cluster.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')
     # Make sure that this is UI's error page body,
@@ -20,7 +25,7 @@ def test_adminrouter_access_control_enforcement(auth_cluster):
     # Verify that certain locations are forbidden to access
     # when not authed, but are reachable as superuser.
     for path in ('/mesos_dns/v1/config', '/service/marathon/', '/mesos/'):
-        r = auth_cluster.get(path, user=None)
+        r = noauth_cluster.get(path)
         assert r.status_code == 401
         r = auth_cluster.get(path)
         assert r.status_code == 200
@@ -28,9 +33,8 @@ def test_adminrouter_access_control_enforcement(auth_cluster):
     # Test authentication with auth cookie instead of Authorization header.
     authcookie = {
         'dcos-acs-auth-cookie': auth_cluster.web_auth_default_user.auth_cookie}
-    r = auth_cluster.get(
+    r = noauth_cluster.get(
         '/service/marathon/',
-        user=None,
         cookies=authcookie)
     assert r.status_code == 200
 

--- a/packages/dcos-integration-test/extra/test_ec2.py
+++ b/packages/dcos-integration-test/extra/test_ec2.py
@@ -76,11 +76,10 @@ def test_move_external_volume_to_new_agent(cluster):
     }
 
     try:
-        cluster.deploy_marathon_app(write_app, **deploy_kwargs)
-        cluster.destroy_marathon_app(write_app['id'])
-
-        cluster.deploy_marathon_app(read_app, **deploy_kwargs)
-        cluster.destroy_marathon_app(read_app['id'])
+        with cluster.marathon.deploy_and_cleanup(write_app, **deploy_kwargs):
+            logging.info('Successfully wrote to volume')
+        with cluster.marathon.deploy_and_cleanup(read_app, **deploy_kwargs):
+            logging.info('Successfully read from volume')
     finally:
         logging.info('Deleting volume: ' + test_label)
         delete_cmd = \

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -3,6 +3,8 @@ import logging
 import requests
 import retrying
 
+from test_util.marathon import get_test_app, get_test_app_in_docker
+
 
 def ensure_routable(cmd, service_points, timeout=120):
     @retrying.retry(wait_fixed=2000,
@@ -21,11 +23,11 @@ def ensure_routable(cmd, service_points, timeout=120):
 def test_if_minuteman_routes_to_vip(cluster):
     """Test if we are able to connect to a task with a vip using minuteman.
     """
-    origin_app, origin_uuid = cluster.get_test_app()
+    origin_app, origin_uuid = get_test_app()
     origin_app['portDefinitions'][0]['labels'] = {'VIP_0': '1.2.3.4:5000'}
-    with cluster.marathon_deploy_and_cleanup(origin_app):
-        proxy_app, proxy_uuid = cluster.get_test_app()
-        with cluster.marathon_deploy_and_cleanup(proxy_app) as service_points:
+    with cluster.marathon.deploy_and_cleanup(origin_app):
+        proxy_app, proxy_uuid = get_test_app()
+        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://1.2.3.4:5000/ping'
             ensure_routable(cmd, service_points)()
 
@@ -34,11 +36,11 @@ def test_if_minuteman_routes_to_named_vip(cluster):
     """Test if we are able to connect to a task with a named vip using minuteman.
     """
 
-    origin_app, origin_uuid = cluster.get_test_app()
+    origin_app, origin_uuid = get_test_app()
     origin_app['portDefinitions'][0]['labels'] = {'VIP_0': 'foo:5000'}
-    with cluster.marathon_deploy_and_cleanup(origin_app):
-        proxy_app, proxy_uuid = cluster.get_test_app()
-        with cluster.marathon_deploy_and_cleanup(proxy_app) as service_points:
+    with cluster.marathon.deploy_and_cleanup(origin_app):
+        proxy_app, proxy_uuid = get_test_app()
+        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://foo.marathon.l4lb.thisdcos.directory:5000/ping'
             ensure_routable(cmd, service_points)()
 
@@ -48,14 +50,14 @@ def test_ip_per_container(cluster):
     """
     # Launch the test_server in ip-per-container mode
 
-    app_definition, test_uuid = cluster.get_test_app_in_docker(ip_per_container=True)
+    app_definition, test_uuid = get_test_app_in_docker(ip_per_container=True)
 
     assert len(cluster.slaves) >= 2, "IP Per Container tests require 2 private agents to work"
 
     app_definition['instances'] = 2
     app_definition['constraints'] = [['hostname', 'UNIQUE']]
 
-    with cluster.marathon_deploy_and_cleanup(app_definition, check_health=True) as service_points:
+    with cluster.marathon.deploy_and_cleanup(app_definition, check_health=True) as service_points:
         app_port = app_definition['container']['docker']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points)()
@@ -64,14 +66,14 @@ def test_ip_per_container(cluster):
 def test_ip_per_container_with_named_vip(cluster):
     """Test if we are able to connect to a task with ip-per-container mode using named vip
     """
-    origin_app, test_uuid = cluster.get_test_app_in_docker(ip_per_container=True)
+    origin_app, test_uuid = get_test_app_in_docker(ip_per_container=True)
     origin_app['container']['docker']['portMappings'][0]['labels'] = {'VIP_0': 'foo:6000'}
     origin_app['healthChecks'][0]['port'] = origin_app['container']['docker']['portMappings'][0]['containerPort']
     del origin_app['container']['docker']['portMappings'][0]['hostPort']
     del origin_app['healthChecks'][0]['portIndex']
 
-    with cluster.marathon_deploy_and_cleanup(origin_app):
-        proxy_app, proxy_uuid = cluster.get_test_app()
-        with cluster.marathon_deploy_and_cleanup(proxy_app) as service_points:
+    with cluster.marathon.deploy_and_cleanup(origin_app):
+        proxy_app, proxy_uuid = get_test_app()
+        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f http://foo.marathon.l4lb.thisdcos.directory:6000/ping'
             ensure_routable(cmd, service_points)()

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -1,6 +1,7 @@
 """Various helpers for test runners and integration testing directly
 """
 import copy
+import functools
 import logging
 import time
 from collections import namedtuple
@@ -10,10 +11,13 @@ import requests
 import retrying
 from botocore.exceptions import ClientError, WaiterError
 
-import test_util
 
 Host = namedtuple('Host', ['private_ip', 'public_ip'])
 SshInfo = namedtuple('SshInfo', ['user', 'home_dir'])
+
+ADMINROUTER_PORT_MAPPING = {
+    'master': {'http': 80, 'https': 443},
+    'agent': {'http': 61001, 'https': 61002}}
 
 
 class DcosUser:
@@ -25,9 +29,13 @@ class DcosUser:
         self.auth_cookie = None
 
     def authenticate(self, cluster):
-        assert isinstance(cluster, test_util.cluster_api.ClusterApi), 'Unrecognized cluster object!'
         logging.info('Attempting authentication')
-        r = cluster.post(path='/acs/api/v1/auth/login', user=None, json=self.auth_json)
+        # explicitly use a session with no user authentication for requesting auth headers
+        if cluster.web_auth_default_user:
+            post = cluster.get_user_session(None).post
+        else:
+            post = cluster.post
+        r = post('/acs/api/v1/auth/login', json=self.auth_json)
         r.raise_for_status()
         logging.info('Received authorization blob: {}'.format(r.json()))
         assert r.ok, 'Authentication failed with status_code: {}'.format(r.status_code)
@@ -35,6 +43,87 @@ class DcosUser:
         self.auth_header = {'Authorization': 'token={}'.format(self.auth_token)}
         self.auth_cookie = r.cookies['dcos-acs-auth-cookie']
         logging.info('Authentication successful')
+
+
+class ApiClient:
+
+    def __init__(self, cluster, user, api_base, default_headers=None, ca_cert_path=None):
+        self.cluster = cluster
+        self.user = user
+        self.api_base = api_base
+        if default_headers is None:
+            default_headers = dict()
+        self.default_headers = default_headers
+        self.ca_cert_path = ca_cert_path
+
+    def api_request(self, method, path, node=None, port=None, **kwargs):
+        """
+        Makes a request with default headers + user auth headers if necessary
+        If DCOS_CA_CERT_PATH is set in environment, this method will pass it to requests
+        Args:
+            method: (str) name of method for requests.request
+            node: see get_url()
+            path: see get_url()
+            port: see get_url()
+            **kwargs: any optional arguments to be passed to requests.request
+        """
+        headers = copy.copy(self.default_headers)
+        if self.cluster.auth_enabled and self.cluster.web_auth_default_user:
+            headers.update(self.cluster.web_auth_default_user.auth_header)
+
+        if self.ca_cert_path:
+            kwargs['verify'] = self.ca_cert_path
+
+        headers.update(kwargs.pop('headers', {}))
+        url = self.get_url(node=node, path=path, port=port)
+        logging.info('Request method {}: {}'.format(method, url))
+        logging.debug('Reqeust kwargs: {}'.format(kwargs))
+        logging.debug('Request headers: {}'.format(headers))
+        return requests.request(method, url, headers=headers, **kwargs)
+
+    def get_url(self, node, path, port=None):
+        """
+        Args:
+            path: (str) URL path to request if self.api_base is set it will be prepended
+            node: (str) the hostname of the node to be requested from, if node=None,
+                then public cluster address (see environment DCOS_DNS_ADDRESS)
+            port: (int) port to be requested at. If port=None, the default port
+                for that given node type will be used
+        Returns:
+            fully-qualified URL string for this API
+        """
+        if node is None:
+            node = self.cluster.dns_host
+            role = 'master'
+        else:
+            if node in self.cluster.masters:
+                role = 'master'
+            elif node in self.cluster.all_slaves:
+                role = 'agent'
+            else:
+                raise Exception('Node {} is not recognized within the DC/OS cluster'.format(node))
+
+        if self.api_base:
+            path = '{}/{}'.format(self.api_base.rstrip('/'), path.lstrip('/'))
+
+        if port is None:
+            port = ADMINROUTER_PORT_MAPPING[role][self.cluster.scheme]
+
+        if (port == 80 and self.cluster.scheme == 'http') or (port == 443 and self.cluster.scheme == 'https'):
+            netloc = node
+        else:
+            netloc = '{}:{}'.format(node, port)
+
+        return '{}://{}/{}'.format(self.cluster.scheme, netloc, path.lstrip('/'))
+
+    get = functools.partialmethod(api_request, 'get')
+    post = functools.partialmethod(api_request, 'post')
+    put = functools.partialmethod(api_request, 'put')
+    delete = functools.partialmethod(api_request, 'delete')
+    options = functools.partialmethod(api_request, 'options')
+    head = functools.partialmethod(api_request, 'head')
+    patch = functools.partialmethod(api_request, 'patch')
+    delete = functools.partialmethod(api_request, 'delete')
 
 
 def retry_boto_rate_limits(boto_fn, wait=2, timeout=60 * 60):

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -1,0 +1,241 @@
+import collections
+import copy
+import logging
+import uuid
+from contextlib import contextmanager
+
+import requests
+import retrying
+
+import test_util.helpers
+
+TEST_APP_NAME_FMT = '/integration-test-{}'
+
+
+def get_test_app(custom_port=False):
+    test_uuid = uuid.uuid4().hex
+    app = copy.deepcopy({
+        'id': TEST_APP_NAME_FMT.format(test_uuid),
+        'cpus': 0.1,
+        'mem': 32,
+        'instances': 1,
+        'cmd': '/opt/mesosphere/bin/dcos-shell python '
+               '/opt/mesosphere/active/dcos-integration-test/python_test_server.py ',
+        'env': {
+            'DCOS_TEST_UUID': test_uuid,
+            # required for python_test_server.py to run as nobody
+            'HOME': '/'
+        },
+        'healthChecks': [
+            {
+                'protocol': 'HTTP',
+                'path': '/ping',
+                'portIndex': 0,
+                'gracePeriodSeconds': 5,
+                'intervalSeconds': 10,
+                'timeoutSeconds': 10,
+                'maxConsecutiveFailures': 3
+            }
+        ],
+    })
+    if not custom_port:
+        app['cmd'] += '$PORT0'
+        app['portDefinitions'] = [{
+            "protocol": "tcp",
+            "port": 0,
+            "name": "test"
+        }]
+    return app, test_uuid
+
+
+def get_test_app_in_docker(ip_per_container):
+    app, test_uuid = get_test_app(custom_port=True)
+    assert 'portDefinitions' not in app
+    app['cmd'] += '9080'  # Fixed port for inside bridge networking or IP per container
+    app['container'] = {
+        'type': 'DOCKER',
+        'docker': {
+            # TODO(cmaloney): Switch to alpine with glibc
+            'image': 'debian:jessie',
+            'portMappings': [{
+                'hostPort': 0,
+                'containerPort': 9080,
+                'protocol': 'tcp',
+                'name': 'test',
+                'labels': {}
+            }]},
+        'volumes': [{
+            'containerPath': '/opt/mesosphere',
+            'hostPath': '/opt/mesosphere',
+            'mode': 'RO'
+        }]
+    }
+    if ip_per_container:
+        app['container']['docker']['network'] = 'USER'
+        app['ipAddress'] = {'networkName': 'dcos'}
+    else:
+        app['container']['docker']['network'] = 'BRIDGE'
+    return app, test_uuid
+
+
+class Marathon(test_util.helpers.ApiClient):
+    def __init__(self, cluster, user, api_base='/marathon/v2', default_headers=None, ca_cert_path=None):
+        required_headers = {'Accept': 'application/json, text/plain, */*'}
+        if default_headers:
+            required_headers.update(default_headers)
+        super().__init__(
+            cluster=cluster,
+            user=user,
+            api_base=api_base,
+            default_headers=required_headers,
+            ca_cert_path=ca_cert_path)
+
+    def deploy_test_app_and_check(self, app, test_uuid):
+        """This method deploys the test server app and then
+        pings its /operating_environment endpoint to retrieve the container
+        user running the task.
+
+        In a mesos container, this will be the marathon user
+        In a docker container this user comes from the USER setting
+            from the app's Dockerfile, which, for the test application
+            is the default, root
+        """
+        if 'container' in app and app['container']['type'] == 'DOCKER':
+            marathon_user = 'root'
+        else:
+            marathon_user = app.get('user', self.cluster.default_os_user)
+        with self.deploy_and_cleanup(app) as service_points:
+            r = requests.get('http://{}:{}/test_uuid'.format(service_points[0].host,
+                                                             service_points[0].port))
+            if r.status_code != 200:
+                msg = "Test server replied with non-200 reply: '{0} {1}. "
+                msg += "Detailed explanation of the problem: {2}"
+                raise Exception(msg.format(r.status_code, r.reason, r.text))
+
+            r_data = r.json()
+
+            assert r_data['test_uuid'] == test_uuid
+
+            r = requests.get('http://{}:{}/operating_environment'.format(
+                service_points[0].host,
+                service_points[0].port))
+
+            if r.status_code != 200:
+                msg = "Test server replied with non-200 reply: '{0} {1}. "
+                msg += "Detailed explanation of the problem: {2}"
+                raise Exception(msg.format(r.status_code, r.reason, r.text))
+
+            assert r.json() == {'username': marathon_user}
+
+    def deploy_app(self, app_definition, timeout=120, check_health=True, ignore_failed_tasks=False):
+        """Deploy an app to marathon
+
+        This function deploys an an application and then waits for marathon to
+        aknowledge it's successfull creation or fails the test.
+
+        The wait for application is immediatelly aborted if Marathon returns
+        nonempty 'lastTaskFailure' field. Otherwise it waits until all the
+        instances reach tasksRunning and then tasksHealthy state.
+
+        Args:
+            app_definition: a dict with application definition as specified in
+                            Marathon API (https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps)
+            timeout: a time to wait for the application to reach 'Healthy' status
+                     after which the test should be failed.
+            check_health: wait until Marathon reports tasks as healthy before
+                          returning
+
+        Returns:
+            A list of named tuples which represent service points of deployed
+            applications. I.E:
+                [Endpoint(host='172.17.10.202', port=10464), Endpoint(host='172.17.10.201', port=1630)]
+        """
+        r = self.post('/apps', json=app_definition)
+        logging.info('Response from marathon: {}'.format(repr(r.json())))
+        assert r.ok
+
+        @retrying.retry(wait_fixed=1000, stop_max_delay=timeout * 1000,
+                        retry_on_result=lambda ret: ret is None,
+                        retry_on_exception=lambda x: False)
+        def _pool_for_marathon_app(app_id):
+            Endpoint = collections.namedtuple("Endpoint", ["host", "port", "ip"])
+            # Some of the counters need to be explicitly enabled now and/or in
+            # future versions of Marathon:
+            req_params = (('embed', 'apps.lastTaskFailure'),
+                          ('embed', 'apps.counts'))
+
+            r = self.get('/apps' + app_id, params=req_params)
+            assert r.ok
+
+            data = r.json()
+
+            if not ignore_failed_tasks:
+                assert 'lastTaskFailure' not in data['app'], (
+                    'Application deployment failed, reason: {}'.format(data['app']['lastTaskFailure']['message'])
+                )
+
+            check_tasks_running = (data['app']['tasksRunning'] == app_definition['instances'])
+            check_tasks_healthy = (not check_health or data['app']['tasksHealthy'] == app_definition['instances'])
+
+            if (check_tasks_running and check_tasks_healthy):
+                res = [Endpoint(t['host'], t['ports'][0], t['ipAddresses'][0]['ipAddress'])
+                       if len(t['ports']) is not 0
+                       else Endpoint(t['host'], 0, t['ipAddresses'][0]['ipAddress'])
+                       for t in data['app']['tasks']]
+                logging.info('Application deployed, running on {}'.format(res))
+                return res
+            elif (not check_tasks_running):
+                logging.info('Waiting for application to be deployed: '
+                             'Not all instances are running: {}'.format(repr(data)))
+                return None
+            elif (not check_tasks_healthy):
+                logging.info('Waiting for application to be deployed: '
+                             'Not all instances are healthy: {}'.format(repr(data)))
+                return None
+            else:
+                logging.info('Waiting for application to be deployed: {}'.format(repr(data)))
+                return None
+
+        try:
+            return _pool_for_marathon_app(app_definition['id'])
+        except retrying.RetryError:
+            raise Exception("Application deployment failed - operation was not "
+                            "completed in {} seconds.".format(timeout))
+
+    def destroy_app(self, app_name, timeout=120):
+        """Remove a marathon app
+
+        Abort the test if the removal was unsuccesful.
+
+        Args:
+            app_name: name of the applicatoin to remove
+            timeout: seconds to wait for destruction before failing test
+        """
+        @retrying.retry(wait_fixed=1000, stop_max_delay=timeout * 1000,
+                        retry_on_result=lambda ret: not ret,
+                        retry_on_exception=lambda x: False)
+        def _destroy_complete(deployment_id):
+            r = self.get('/deployments')
+            assert r.ok
+
+            for deployment in r.json():
+                if deployment_id == deployment.get('id'):
+                    logging.info('Waiting for application to be destroyed')
+                    return False
+            logging.info('Application destroyed')
+            return True
+
+        r = self.delete('/apps' + app_name)
+        assert r.ok
+
+        try:
+            _destroy_complete(r.json()['deploymentId'])
+        except retrying.RetryError:
+            raise Exception("Application destroy failed - operation was not "
+                            "completed in {} seconds.".format(timeout))
+
+    @contextmanager
+    def deploy_and_cleanup(self, app_definition, timeout=120, check_health=True, ignore_failed_tasks=False):
+        yield self.deploy_app(
+            app_definition, timeout, check_health, ignore_failed_tasks)
+        self.destroy_app(app_definition['id'], timeout)


### PR DESCRIPTION
-Adds generic get_client to cluster_api by which one may set an API base, user auth,  and default headers to make requests
-Adds marathon api client with marathon helpers for extended functionality 