### PR TITLE
Handle version number with decimals

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -351,7 +351,7 @@ if ([ x$dist != 'xrhel' ] && [ x$dist != 'xcentos' ]); then
   exit 0
 fi
 
-version=$(cat /etc/*-release | sed -n 's@^VERSION_ID="\(.*\)"$@\\1@p')
+version=$(cat /etc/*-release | sed -n 's@^VERSION_ID="\([0-9]*\)\([0-9\.]*\)"$@\1@p')
 if [ $version -lt 7 ]; then
   echo "$version is not supported. Only >= 7 version is supported" >&2
   exit 0


### PR DESCRIPTION
Our prereq installation was failing because we were on RHEL 7.2

It would be nice if instead of a 700MB shell script you created a compressed file containing scripts separated from binaries, so that people can fix errors on the fly.