### PR TITLE
Add tooling to make `dcos-launch` binary

### DIFF
--- a/build_dcos_launch.sh
+++ b/build_dcos_launch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Simple helper script to build dcos-launch binary
+# NOTE: this needs to be kept in sync with gen.installer.bash::make_dcos_launch()
+
+set -x
+set -o errexit -o pipefail
+
+# Cleanup from previous build
+rm -rf /tmp/dcos_build_venv
+
+# Force Python stdout/err to be unbuffered.
+export PYTHONUNBUFFERED="notemtpy"
+
+# Create a python virtual environment to install the DC/OS tools to
+python3 -m venv /tmp/dcos_launch_venv
+. /tmp/dcos_launch_venv/bin/activate
+
+# Make a clean as possible clone
+rm -rf /tmp/dcos-installer-build
+git clone "file://$PWD" /tmp/dcos-installer-build
+pushd /tmp/dcos-installer-build
+# Install the DC/OS tools
+pip install -e /tmp/dcos-installer-build
+cp gen/installer/bash/dcos-launch.spec ./
+pyinstaller dcos-launch.spec
+popd
+cp /tmp/dcos-installer-build/dist/dcos-launch ./

--- a/gen/installer/bash/dcos-launch.spec
+++ b/gen/installer/bash/dcos-launch.spec
@@ -1,0 +1,13 @@
+a = Analysis(['test_util/launch.py'])
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name='dcos-launch',
+    debug=False,
+    strip=False,
+    upx=True,
+    console=True)

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -10,7 +10,7 @@ for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
   pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$package/*.whl
 done
 
-for package in aiohttp chardet coloredlogs docker-py humanfriendly multidict oauthlib waitress \
-    websocket-client; do
+for package in aiohttp chardet coloredlogs docker-py humanfriendly multidict oauthlib pyinstaller \
+    waitress websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -120,6 +120,11 @@
       "url": "https://pypi.python.org/packages/2.7/p/py/py-1.4.31-py2.py3-none-any.whl",
       "sha1": "ffcba27ff8391f46904c2762135a383d29a4bf1b"
     },
+    "pyinstaller": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/33/f9/034a89276301ef5e88efd11e5ea592e3d3b2324706e65bdff7445d271077/PyInstaller-3.2.tar.gz",
+      "sha1": "a53b882adbd3f9f4fd14b482ad9467f90ad5154e"
+    },
     "requests-oauthlib": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/3d/b9/895abf47ce871c80460727ba385d10d246a2d9ded1bc82ba3748d02e5196/requests_oauthlib-0.6.1-py2.py3-none-any.whl",

--- a/release/storage/http.py
+++ b/release/storage/http.py
@@ -44,7 +44,7 @@ class HttpStorageProvider(AbstractStorageProvider):
                 os.remove(local_path_tmp)
             except Exception:
                 pass
-        self.get_object(path).download_file(local_path)
+            raise
 
     def exists(self, path):
         url = self._get_absolute(path)
@@ -57,7 +57,7 @@ class HttpStorageProvider(AbstractStorageProvider):
     def fetch(self, path):
         r = requests.get(url=self._get_absolute(path))
         r.raise_for_status()
-        return r.body
+        return r.content
 
     def remove_recursive(self, path):
         raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_advanced_templates():
 setup(
     name='dcos_image',
     version='0.1',
-    description='DC/OS packaging, management, install utilities',
+    description='DC/OS cluster configuration, assembly, and launch, and maintenance code',
     url='https://dcos.io',
     author='Mesosphere, Inc.',
     author_email='help@dcos.io',
@@ -52,6 +52,8 @@ setup(
         'coloredlogs',
         'docopt',
         'passlib',
+        'py',
+        'pyinstaller==3.2',
         'pyyaml',
         'requests==2.10.0',
         'retrying',
@@ -66,7 +68,8 @@ setup(
             'test-azure-rm-deploy=test_util.azure_test_driver:main',
             'pkgpanda=pkgpanda.cli:main',
             'mkpanda=pkgpanda.build.cli:main',
-            'dcos_installer=dcos_installer.cli:main'
+            'dcos_installer=dcos_installer.cli:main',
+            'dcos-launch=test_util.launch:main',
         ],
     },
     package_data={
@@ -90,12 +93,16 @@ setup(
             'installer/bash/dcos_generate_config.sh.in',
             'installer/bash/Dockerfile.in',
             'installer/bash/installer_internal_wrapper.in',
+            'installer/bash/dcos-launch.spec',
             'coreos-aws/cloud-config.yaml',
             'coreos/cloud-config.yaml'
         ] + get_advanced_templates(),
         'pkgpanda': [
             'docker/dcos-builder/Dockerfile'
         ],
+        'test_util': [
+            'launch.py'
+        ]
     },
     zip_safe=False
 )

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -1,0 +1,20 @@
+"""
+
+Usage:
+dcos-launch create [--wait] [--dump-info=cluster_info.json] <config=config.yaml>
+dcos-launch wait <path=cluster_info.json>
+dcos-launch describe <path=cluster_info.json>
+dcos-launch delete <path=cluster_info.json>
+"""
+
+from docopt import docopt
+
+
+def main():
+    docopt(__doc__)
+
+    raise NotImplementedError()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
First steps towards making the "launch cluster" stuff in test_util be usable via a simple / sane API via a binary (dcos-launch).

Fixes: https://mesosphere.atlassian.net/browse/DCOS-10196

TODO:
 - [x] have `release create` build dcos-launch and upload it (keeps us from having to build more CI)

cc: @mellenburg 