### PR TITLE
Fix conftest bugs

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -13,7 +13,6 @@ LOG_LEVEL = logging.INFO
 def pytest_configure(config):
     config.addinivalue_line('markers', 'first: run test before all not marked first')
     config.addinivalue_line('markers', 'last: run test after all not marked last')
-    config.addinivalue_line('markers', 'resiliency: Run tests that cause critical failures')
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -29,16 +28,6 @@ def pytest_collection_modifyitems(session, config, items):
         else:
             new_items.append(item)
     items[:] = new_items + last_items
-
-
-def pytest_addoption(parser):
-    parser.addoption('--resiliency', action='store_true')
-
-
-def pytest_runtest_setup(item):
-    if item.get_marker('resiliency'):
-        if not item.config.getoption('--resiliency'):
-            pytest.skip('Test requires --resiliency option')
 
 
 @pytest.yield_fixture

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -7,7 +7,9 @@ import pytest
 from test_util.cluster_api import ClusterApi
 from test_util.helpers import DcosUser
 
-LOG_LEVEL = logging.INFO
+logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=logging.INFO)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("botocore").setLevel(logging.WARNING)
 
 
 def pytest_configure(config):
@@ -78,10 +80,6 @@ def cluster(user):
     assert os.environ['DNS_SEARCH'] in ['true', 'false']
 
     assert os.environ['DCOS_PROVIDER'] in ['onprem', 'aws', 'azure']
-
-    logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=LOG_LEVEL)
-    logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.getLogger("botocore").setLevel(logging.WARNING)
 
     cluster_api = ClusterApi(
         dcos_uri=os.environ['DCOS_DNS_ADDRESS'],

--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -5,6 +5,12 @@ import pytest
 import test_util.aws
 import test_util.helpers
 
+ENV_FLAG = 'ENABLE_RESILIENCY_TESTING'
+
+pytestmark = pytest.mark.skipif(
+    ENV_FLAG not in os.environ or os.environ[ENV_FLAG] != 'true',
+    reason='Must explicitly enable resiliency testing with {}'.format(ENV_FLAG))
+
 
 @pytest.fixture(scope='session')
 def dcos_launchpad(cluster):
@@ -23,7 +29,6 @@ def dcos_launchpad(cluster):
 
 
 @pytest.mark.last
-@pytest.mark.resiliency
 def test_agent_failure(dcos_launchpad, cluster, vip_apps):
     # make sure the app works before starting
     test_util.helpers.wait_for_pong(vip_apps[0][1], 120)

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -27,10 +27,6 @@ DCOS_HOST_OS: 'coreos' or 'centos'
     This must be set only if you are attaching to an already provisioned
     DC/OS Advanced template cluster
 
-TEST_DCOS_RESILIENCY: true/false (default: false)
-    Will setup a cluster for resiliency testing and then run the resiliency tests
-    after the standard integration tests
-
 CI_FLAGS: string (default=None)
     If provided, this string will be passed directly to py.test as in:
     py.test -vv CI_FLAGS integration_test.py
@@ -78,7 +74,6 @@ def check_environment():
     options.agents = int(os.environ.get('AGENTS', '2'))
     options.public_agents = int(os.environ.get('PUBLIC_AGENTS', '1'))
     options.ssh_key_path = os.getenv('DCOS_SSH_KEY_PATH', 'default_ssh_key')
-    options.test_resiliency = os.getenv('TEST_DCOS_RESILIENCY', 'false') == 'true'
 
     # Mandatory
     options.stack_name = os.getenv('DCOS_STACK_NAME', None)
@@ -105,8 +100,6 @@ def check_environment():
     options.add_env = add_env
     options.pytest_dir = os.getenv('DCOS_PYTEST_DIR', '/opt/mesosphere/active/dcos-integration-test')
     options.pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -rs ' + options.ci_flags)
-    if options.test_resiliency:
-        options.pytest_cmd += ' --resiliency '
     return options
 
 
@@ -177,8 +170,8 @@ def provide_cluster(options):
             cf = test_util.aws.DcosCfSimple(options.stack_name, bw)
         ssh_info = test_util.aws.SSH_INFO[options.host_os]
         stack_name = options.stack_name
-    if options.test_resiliency:
-        options.add_env['AWS_STACK_NAME'] = stack_name
+    # Resiliency testing requires knowing the stack name
+    options.add_env['AWS_STACK_NAME'] = stack_name
     return cf, ssh_info
 
 if __name__ == '__main__':


### PR DESCRIPTION
-resiliency mark makes it impossible to run just open_source_tests in downstream; simple env is better
-if logging is declared in cluster fixutre, -s option will not work when selecting specific tests