### PR TITLE
Make config.yaml settings for VPC tests can be set using env vars

### DIFF
--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -288,6 +288,7 @@ def install_dcos(
     api=False,
     setup=True,
     add_config_path=None,
+    add_config_keys=None,
     installer_api_offline_mode=True,
     install_prereqs=True,
     install_prereqs_only=False,
@@ -350,6 +351,7 @@ def install_dcos(
             ssh_user=cluster.ssher.user,
             ssh_key=ssh_key,
             add_config_path=add_config_path,
+            add_config_keys=add_config_keys,
             rexray_config_preset='aws')
 
         logging.info("Running Preflight...")
@@ -370,7 +372,7 @@ def install_dcos(
         installer.postflight()
 
 
-def upgrade_dcos(cluster, installer_url, add_config_path=None):
+def upgrade_dcos(cluster, installer_url, add_config_path=None, add_config_keys=None):
 
     def master_upgrade_order(cluster):
         """Return a list of masters with the ZooKeeper leader last."""
@@ -429,6 +431,7 @@ def upgrade_dcos(cluster, installer_url, add_config_path=None):
             ssh_user=cluster.ssher.user,
             ssh_key=ssh_key,
             add_config_path=add_config_path,
+            add_config_keys=add_config_keys,
             rexray_config_preset='aws',
         )
         # Remove docker (and associated journald) restart from the install

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections import namedtuple
 
 import requests
@@ -59,3 +60,11 @@ def wait_for_len(fetch_fn, target_count, timeout):
         if count != target_count:
             return False
     check_for_match()
+
+
+def gather_prefix_env(prefix):
+    gathered = dict()
+    for k, v in os.environ.items():
+        if k.startswith(prefix):
+            gathered[k.replace(prefix, '')] = v
+    return gathered

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -126,7 +126,7 @@ class DcosApiInstaller(AbstractDcosInstaller):
     def genconf(
             self, master_list, agent_list, public_agent_list, ssh_user, ssh_key,
             ip_detect, rexray_config=None, rexray_config_preset=None,
-            zk_host=None, expect_errors=False, add_config_path=None):
+            zk_host=None, expect_errors=False, add_config_path=None, add_config_keys=None):
         """Runs configuration generation.
 
         Args:
@@ -167,6 +167,8 @@ class DcosApiInstaller(AbstractDcosInstaller):
             with open(add_config_path, 'r') as fh:
                 add_config = yaml.load(fh)
             payload.update(add_config)
+        if add_config_keys:
+            payload.upldate(add_config_keys)
         response = requests.post(self.url + '/api/v1/configure', headers=headers, data=json.dumps(payload))
         assert response.status_code == 200, "{} {}".format(response.status_code, response.content)
         response_json_keys = list(response.json().keys())
@@ -279,7 +281,7 @@ class DcosCliInstaller(AbstractDcosInstaller):
             self, master_list, agent_list, public_agent_list, ssh_user, ssh_key,
             ip_detect, rexray_config=None, rexray_config_preset=None,
             zk_host=None, expect_errors=False, add_config_path=None,
-            bootstrap_url='file:///opt/dcos_install_tmp'):
+            add_config_keys=None, bootstrap_url='file:///opt/dcos_install_tmp'):
         """Runs configuration generation.
 
         Args:
@@ -326,6 +328,8 @@ class DcosCliInstaller(AbstractDcosInstaller):
             with open(add_config_path, 'r') as fh:
                 add_config = yaml.load(fh)
             test_config.update(add_config)
+        if add_config_keys:
+            test_config.update(add_config_keys)
         with open('config.yaml', 'w') as config_fh:
             config_fh.write(yaml.dump(test_config))
         with open('ip-detect', 'w') as ip_detect_fh:

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -48,6 +48,7 @@ import sys
 import test_util.aws
 import test_util.cluster
 from gen.calc import calculate_environment_variable
+from test_util.helpers import gather_prefix_env
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
@@ -97,12 +98,7 @@ def check_environment():
     options.aws_access_key_id = calculate_environment_variable('AWS_ACCESS_KEY_ID')
     options.aws_secret_access_key = calculate_environment_variable('AWS_SECRET_ACCESS_KEY')
 
-    add_env = {}
-    prefix = 'TEST_ADD_ENV_'
-    for k, v in os.environ.items():
-        if k.startswith(prefix):
-            add_env[k.replace(prefix, '')] = v
-    options.add_env = add_env
+    options.add_env = gather_prefix_env('TEST_ADD_ENV_')
     options.pytest_dir = os.getenv('DCOS_PYTEST_DIR', '/opt/mesosphere/active/dcos-integration-test')
     options.pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -rs ' + options.ci_flags)
     if options.test_resiliency:

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -64,6 +64,8 @@ import sys
 
 import test_util.aws
 import test_util.cluster
+from test_util.helpers import gather_prefix_env
+
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
@@ -132,12 +134,9 @@ def check_environment():
     if options.add_config_path:
         assert os.path.isfile(options.add_config_path)
 
-    add_env = {}
-    prefix = 'TEST_ADD_ENV_'
-    for k, v in os.environ.items():
-        if k.startswith(prefix):
-            add_env[k.replace(prefix, '')] = v
-    options.add_env = add_env
+    options.add_config_keys = gather_prefix_env('TEST_CONFIG_KEY_')
+
+    options.add_env = gather_prefix_env('TEST_ADD_ENV_')
 
     options.pytest_dir = os.getenv('DCOS_PYTEST_DIR', '/opt/mesosphere/active/dcos-integration-test')
     options.pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -rs -vv ' + options.ci_flags)


### PR DESCRIPTION
Also unify transforming env vars with prefix -> dictionary code

Should make testing things like https://github.com/dcos/dcos/pull/849 easier.

This could also be useful to replace the `test_add_config` file stuff.

Note: This needs to either land before https://github.com/dcos/dcos/pull/846 and have that updated, or if it lands updated to update the new `TEST_ADD_ENV_` in it.
