### PR TITLE
Improve the runtime of make_channel_artifacts and it's unit test

### DIFF
--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -150,7 +150,7 @@ utils = Bunch({
 
 
 def render_yaml(data):
-    return yaml.dump(data, default_style='|', default_flow_style=False, Dumper=yaml.CDumper)
+    return yaml.dump(data, default_style='|', default_flow_style=False)
 
 
 # Recursively merge to python dictionaries.
@@ -255,7 +255,7 @@ def render_templates(template_dict, arguments):
                 assert len(templates) == 1
                 full_template = rendered_template
                 continue
-            template_data = yaml.load(rendered_template, Loader=yaml.CLoader)
+            template_data = yaml.load(rendered_template)
 
             if full_template:
                 full_template = merge_dictionaries(full_template, template_data)

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -150,7 +150,7 @@ utils = Bunch({
 
 
 def render_yaml(data):
-    return yaml.dump(data, default_style='|', default_flow_style=False)
+    return yaml.dump(data, default_style='|', default_flow_style=False, Dumper=yaml.CDumper)
 
 
 # Recursively merge to python dictionaries.
@@ -255,7 +255,7 @@ def render_templates(template_dict, arguments):
                 assert len(templates) == 1
                 full_template = rendered_template
                 continue
-            template_data = yaml.load(rendered_template)
+            template_data = yaml.load(rendered_template, Loader=yaml.CLoader)
 
             if full_template:
                 full_template = merge_dictionaries(full_template, template_data)

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -20,7 +20,6 @@ import os.path
 import textwrap
 from copy import copy, deepcopy
 from functools import partialmethod
-from subprocess import check_call
 from tempfile import TemporaryDirectory
 
 import yaml

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -530,7 +530,7 @@ def do_gen_package(config, package_filename):
             os.makedirs(os.path.dirname(package_filename), exist_ok=True)
 
         # Make the package top level directory readable by users other than the owner (root).
-        check_call(['chmod', 'go+rx', tmpdir])
+        os.chmod(tmpdir, 0o755)
 
         make_tar(package_filename, tmpdir)
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -184,7 +184,7 @@ def calculate_mesos_log_directory_max_files(mesos_log_retention_mb):
 
 def calculate_ip_detect_contents(ip_detect_filename):
     assert os.path.exists(ip_detect_filename), "ip-detect script `{}` must exist".format(ip_detect_filename)
-    return yaml.dump(open(ip_detect_filename, encoding='utf-8').read())
+    return yaml.dump(open(ip_detect_filename, encoding='utf-8').read(), Dumper=yaml.CDumper)
 
 
 def calculate_ip_detect_public_contents(ip_detect_contents):
@@ -194,7 +194,8 @@ def calculate_ip_detect_public_contents(ip_detect_contents):
 def calculate_rexray_config_contents(rexray_config):
     return yaml.dump(
         # Assume block style YAML (not flow) for REX-Ray config.
-        yaml.dump(json.loads(rexray_config), default_flow_style=False)
+        yaml.dump(json.loads(rexray_config), default_flow_style=False, Dumper=yaml.Dumper),
+        Dumper=yaml.Dumper
     )
 
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -184,7 +184,7 @@ def calculate_mesos_log_directory_max_files(mesos_log_retention_mb):
 
 def calculate_ip_detect_contents(ip_detect_filename):
     assert os.path.exists(ip_detect_filename), "ip-detect script `{}` must exist".format(ip_detect_filename)
-    return yaml.dump(open(ip_detect_filename, encoding='utf-8').read(), Dumper=yaml.CDumper)
+    return yaml.dump(open(ip_detect_filename, encoding='utf-8').read())
 
 
 def calculate_ip_detect_public_contents(ip_detect_contents):

--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -46,11 +46,9 @@ def validate_cloud_config(cc_string):
 
     @param cc_string: str, Cloud Configuration
     '''
-    illegal_match = ILLEGAL_ARM_CHARS_PATTERN.search(cc_string)
-    if illegal_match:
+    if "'" in cc_string:
         print("ERROR: Illegal cloud config string detected.", file=sys.stderr)
-        print("ERROR: {} matches pattern {}".format(
-            illegal_match.string, illegal_match.re), file=sys.stderr)
+        print("ERROR: {} contains a `'`".format(cc_string), file=sys.stderr)
         sys.exit(1)
 
 

--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -6,8 +6,6 @@ import sys
 import urllib
 from copy import deepcopy
 
-import yaml
-
 import gen
 import gen.installer.util as util
 import gen.template
@@ -56,14 +54,14 @@ def validate_cloud_config(cc_string):
         sys.exit(1)
 
 
-def transform(cloud_config_yaml_str):
+def transform(cloud_config):
     '''
     Transforms the given yaml into a list of strings which are concatenated
     together by the ARM template system. We must make it a list of strings so
     that ARM template parameters appear at the top level of the template and get
     substituted.
     '''
-    cc_json = json.dumps(yaml.load(cloud_config_yaml_str), sort_keys=True)
+    cc_json = json.dumps(cloud_config, sort_keys=True)
     arm_list = ["[base64(concat('#cloud-config\n\n', "]
     # Find template parameters and seperate them out as seperate elements in a
     # json list.
@@ -86,14 +84,14 @@ def transform(cloud_config_yaml_str):
 
 def render_arm(
         arm_template,
-        master_cloudconfig_yaml_str,
-        slave_cloudconfig_yaml_str,
-        slave_public_cloudconfig_yaml_str):
+        master_cloudconfig,
+        slave_cloudconfig,
+        slave_public_cloudconfig):
 
     template_str = gen.template.parse_str(arm_template).render({
-        'master_cloud_config': transform(master_cloudconfig_yaml_str),
-        'slave_cloud_config': transform(slave_cloudconfig_yaml_str),
-        'slave_public_cloud_config': transform(slave_public_cloudconfig_yaml_str)
+        'master_cloud_config': transform(master_cloudconfig),
+        'slave_cloud_config': transform(slave_cloudconfig),
+        'slave_public_cloud_config': transform(slave_public_cloudconfig)
     })
 
     # Add in some metadata to help support engineers
@@ -144,7 +142,7 @@ def gen_templates(user_args, arm_template):
         # NOTE: If this gets printed in string stylerather than '|' the Azure
         # parameters which need to be split out for the arm to
         # interpret end up all escaped and undoing it would be hard.
-        variant_cloudconfig[variant] = results.utils.render_cloudconfig(cc_variant)
+        variant_cloudconfig[variant] = cc_variant
 
     # Render the arm
     arm = render_arm(

--- a/gen/template.py
+++ b/gen/template.py
@@ -514,9 +514,18 @@ def parse_str(text):
     return Template(ast)
 
 
+parse_cache = dict()
+
+
 def parse_resources(filename):
+    global parse_cache
+
     try:
-        return parse_str(resource_string(__name__, filename).decode())
+        if filename in parse_cache:
+            return parse_cache[filename]
+        value = parse_str(resource_string(__name__, filename).decode())
+        parse_cache[filename] = value
+        return value
     except SyntaxError as ex:
         # Don't accidentally overwrite a previously set filename. Shouldn't
         # happen since no code this calls sets ex.filename.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -577,12 +577,19 @@ def mock_get_azure_download_url():
     return "http://mock_azure_download_url"
 
 
+def mock_make_tar(result_filename, folder):
+    # Ensure the file exists.
+    with open(result_filename, 'a'):
+        pass
+
+
 # Test that the do_create functions for each provider output data in the right
 # shape.
 def test_make_channel_artifacts(monkeypatch):
     monkeypatch.setattr('gen.installer.bash.make_installer_docker', mock_make_installer_docker)
     monkeypatch.setattr('gen.installer.aws.get_cloudformation_s3_url', mock_get_cf_s3_url)
     monkeypatch.setattr('gen.installer.azure.get_download_url', mock_get_azure_download_url)
+    monkeypatch.setattr('pkgpanda.util.make_tar.__code__', mock_make_tar.__code__)
 
     metadata = {
         'commit': 'sha-1',

--- a/tests/test_ssh_integration.py
+++ b/tests/test_ssh_integration.py
@@ -248,7 +248,7 @@ def test_ssh_command_terminate_async(sshd_manager, loop):
         workspace = str(sshd_manager.tmpdir)
 
         runner = MultiRunner(['127.0.0.1:{}'.format(port) for port in sshd_ports], ssh_user=getpass.getuser(),
-                             ssh_key_path=sshd_manager.key_path, process_timeout=2)
+                             ssh_key_path=sshd_manager.key_path, process_timeout=0.05)
 
         chain = CommandChain('test')
         chain.add_execute(['sleep', '20'])

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
   AWS_DEFAULT_REGION
 deps =
   pytest
+  pytest-profiling
   teamcity-messages
   webtest
   webtest-aiohttp


### PR DESCRIPTION
On my machine the patches reduce the time make_channel artifacts run (`tox -e py34-unittests -- --durations=3 tests/test_release.py::test_make_channel_artifacts` and look at the "call" time) from ~8.01seconds duration for the test call from ~7.1 seconds to 1.00 seconds. Individual commits say the time improvement. Found where most time was spent calls using profiling.

Most of the commits are reasonable to land (mock make_tar, azure extra copy, global parse cache, regex, chmod, scanning). The yaml CLoader stuff I'd rather stay away from (right now dcos/dcos is all pure python).