### PR TITLE
Change adminrouter ExecReload to work

### DIFF
--- a/packages/adminrouter/extra/dcos-adminrouter-agent.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent.service
@@ -16,6 +16,6 @@ EnvironmentFile=/opt/mesosphere/etc/adminrouter.env
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.agent.conf
-ExecReload=/usr/bin/kill -HUP \$MAINPID
+ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT
 KillMode=mixed

--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -23,6 +23,6 @@ ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 # Wait for auth backend to seed the secret key
 ExecStartPre=/usr/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
 ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf
-ExecReload=/usr/bin/kill -HUP \$MAINPID
+ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT
 KillMode=mixed


### PR DESCRIPTION
Cuttent one doesn't work when a `systemctl reload dcos-adminrouter` is run (same fix applies to dcos-adminrouter-agent)


Internal JIRA: https://mesosphere.atlassian.net/browse/DCOS-10580