### PR TITLE
Add aiohttp_debugtoolbar to make debugging the web installer easier

### DIFF
--- a/dcos_installer/async_server.py
+++ b/dcos_installer/async_server.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 
+import aiohttp_debugtoolbar
 import pkg_resources
 from aiohttp import web
 
@@ -360,6 +361,10 @@ def start(cli_options):
     make_default_config_if_needed('genconf/config.yaml')
     loop = asyncio.get_event_loop()
     app = build_app(loop)
+
+    if options.verbose:
+        aiohttp_debugtoolbar.setup(app)
+
     handler = app.make_handler()
     f = loop.create_server(
         handler,

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -4,9 +4,9 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
-for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
-    azure-mgmt-network azure-storage beautifulsoup4 certifi docutils enum34 keyring msrest \
-    msrestazure py requests-oauthlib webob; do
+for package in aiohttp_debugtoolbar aiohttp_jinja2 analytics-python azure-nspkg azure-common \
+    azure-mgmt-nspkg azure-mgmt-network azure-storage beautifulsoup4 certifi docutils enum34 \
+    keyring msrest msrestazure py requests-oauthlib webob; do
   pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$package/*.whl
 done
 

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -20,6 +20,16 @@
       "url": "https://pypi.python.org/packages/55/9d/38fb3cb174f4723b50a3f0593e18a51418c9a73a7857fdcaee46b83ff1c4/aiohttp-0.22.5.tar.gz",
       "sha1": "d391ae04d2aa97be14ef7de13e7ee2b9939ce8b4"
     },
+    "aiohttp_debugtoolbar": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/dc/ab/295a2b71ba2bae78ae3b24c5aff8dace979def7fb192fafdbc1fc7ffe688/aiohttp_debugtoolbar-0.1.2-py3-none-any.whl",
+      "sha1": "630ece58391ce1f0d6ebeb2be8cc46bd29670c8c"
+    },
+    "aiohttp_jinja2": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/72/9c/7c3c91b0134b188eba9093e340777764133b0425ddf7d4979948b01ab06d/aiohttp_jinja2-0.8.0-py3-none-any.whl",
+      "sha1": "1da4edce12a8f0dfffd4216be2410cb2ed6fa51b"
+    },
     "analytics-python": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/39/db/ba6ce2c3f13dd046eec3a7767a7d10607c15dc8b23d68bc125ad577f924f/analytics_python-1.2.3-py2.py3-none-any.whl",

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'test_util'],
     install_requires=[
         'aiohttp==0.22.5',
+        'aiohttp_debugtoolbar',
         'analytics-python',
         'coloredlogs',
         'Flask',


### PR DESCRIPTION
Enabled whenever `--web --verbose` is run.
