### PR TITLE
Rework gen/ to be made of three primitives: Source, Target, Scope and Resolver

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -99,12 +99,13 @@ class Config():
 
     def do_validate(self, include_ssh):
         user_arguments = self.as_gen_format()
-        config_targets = [gen.get_dcosconfig_target_and_templates(user_arguments, [])[0]]
+        sources, targets, _ = gen.get_dcosconfig_source_target_and_templates(user_arguments, [])
 
         if include_ssh:
-            config_targets.append(ssh.validate.get_config_target())
+            sources.append(ssh.validate.source)
+            targets.append(ssh.validate.target)
 
-        messages = gen.validate_config_for_targets(config_targets, user_arguments)
+        messages = gen.internals.validate_configuration(sources, targets, user_arguments)
         # TODO(cmaloney): kill this function and make the API return the structured
         # results api as was always intended rather than the flattened / lossy other
         # format. This will be an  API incompatible change. The messages format was

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -12,23 +12,23 @@ Operates strictly:
 """
 
 import importlib.machinery
-import inspect
 import json
 import logging as log
 import os
 import os.path
 import textwrap
 from copy import copy, deepcopy
-from functools import partialmethod
 from subprocess import check_call
 from tempfile import TemporaryDirectory
 
 import yaml
 
 import gen.calc
+import gen.internals
 import gen.template
+from gen.exceptions import ValidationError
 from pkgpanda import PackageId
-from pkgpanda.util import load_string, make_tar
+from pkgpanda.util import json_prettyprint, load_string, make_tar, write_json
 
 # List of all roles all templates should have.
 role_names = {"master", "slave", "slave_public"}
@@ -186,44 +186,6 @@ def merge_dictionaries(base, additions):
     return base_copy
 
 
-# Recursively merge to python dictionaries.
-# If both base and addition contain the same key, that key's value will be
-# merged if it is a dictionary.
-# This is unlike the python dict.update() method which just overwrites matching
-# keys.
-def merge_replace_append_dictionaries(base, additions):
-    base_copy = base.copy()
-    for k, v in additions.items():
-        try:
-            if k not in base:
-                base_copy[k] = v
-                continue
-            if isinstance(v, dict) and isinstance(base_copy[k], dict):
-                base_copy[k] = merge_replace_append_dictionaries(base_copy.get(k, dict()), v)
-                continue
-
-            # Append arrays
-            if isinstance(v, list) and isinstance(base_copy[k], list):
-                base_copy[k].extend(v)
-                continue
-
-            # Merge sets
-            if isinstance(v, set) and isinstance(base_copy[k], set):
-                base_copy[k] |= v
-                continue
-
-            # Overwrite if the new one is a string
-            if isinstance(v, str):
-                base_copy[k] = v
-                continue
-
-            # Unknown types
-            raise ValueError("Can't merge type {} into type {}".format(type(v), type(base_copy[k])))
-        except ValueError as ex:
-            raise ValueError("{} inside key {}".format(ex, k)) from ex
-    return base_copy
-
-
 def load_templates(template_dict):
     result = dict()
     for name, template_list in template_dict.items():
@@ -267,214 +229,20 @@ def render_templates(template_dict, arguments):
     return rendered_templates
 
 
-# Load all the un-bound variables in the templates which need to be given values
-# in order to convert the templates to go from jinja -> final template. These
-# are effectively the set of DC/OS parameters.
-def get_parameters(template_dict):
-    parameters = {'variables': set(), 'sub_scopes': dict()}
+# Collect the un-bound / un-set variables from all the given templates to build
+# the schema / configuration target. The templates and their structure serve
+# as the schema for what configuration a user must provide.
+def target_from_templates(template_dict):
+    # NOTE: the individual yaml template targets are merged into one target
+    # since we never want to target just one template at a time for now (they
+    # all merge into one config package).
+    target = gen.internals.Target()
     templates = load_templates(template_dict)
     for template_list in templates.values():
         for template in template_list:
-            parameters = merge_dictionaries(parameters, template.get_scoped_arguments())
+            target += template.target_from_ast()
 
-    return parameters
-
-
-def get_function_parameters(function):
-    return set(inspect.signature(function).parameters)
-
-
-class CalculatorError(Exception):
-    def __init__(self, message, chain=[]):
-        assert isinstance(message, str)
-        assert isinstance(chain, list)
-        self.message = message
-        self.chain = chain
-        super().__init__(message)
-
-
-# Depth first search argument calculator. Detects cycles, as well as unmet
-# dependencies.
-# TODO(cmaloney): Separate chain / path building when unwinding from the root
-#                 error messages.
-class DFSArgumentCalculator():
-    def __init__(self, setters, validate_fns):
-        self._setters = setters
-        self._arguments = dict()
-        self.__in_progress = set()
-        self._errors = dict()
-        self._unset = set()
-
-        # Re-arrange the validation functions so we can more easily access them by
-        # argument name.
-        self._validate_by_arg = dict()
-        self._multi_arg_validate = dict()
-
-        for fn in validate_fns:
-            parameters = get_function_parameters(fn)
-            # Could build up the single and multi parameter validation function maps in the same
-            # thing but the timing / handling of when and how we run single vs. multi-parameter
-            # validation functions is fairly different, the extra bit here simplifies the later code.
-            if len(parameters) == 1:
-                self._validate_by_arg[parameters.pop()] = fn
-                assert not parameters
-            else:
-                self._multi_arg_validate[frozenset(parameters)] = fn
-
-    def _calculate_argument(self, name):
-        # Filter out any setters which have predicates / conditions which are
-        # satisfiably false.
-        def all_conditions_met(setter):
-            for condition_name, condition_value in setter.conditions:
-                try:
-                    if self._get(condition_name) != condition_value:
-                        return False
-                except CalculatorError as ex:
-                    raise CalculatorError(
-                        ex.message,
-                        ex.chain + ['trying to test condition {}={}'.format(condition_name, condition_value)]) from ex
-            return True
-
-        # Find the right setter to calculate the argument.
-        feasible = list(filter(all_conditions_met, self._setters.get(name, list())))
-
-        if len(feasible) == 0:
-            self._unset.add(name)
-            raise CalculatorError("no way to set")
-
-        # Filtier out all optional setters if there is more than one way to set.
-        if len(feasible) > 1:
-            final_feasible = list(filter(lambda setter: not setter.is_optional, feasible))
-            assert final_feasible, "Had multiple optionals and no musts. Template internal error: {!r}".format(feasible)
-            feasible = final_feasible
-
-        # Must be calculated but user tried to provide.
-        if len(feasible) == 2 and (feasible[0].is_user or feasible[1].is_user):
-            self._errors[name] = ("{} must be calculated, but was explicitly set in the "
-                                  "configuration. Remove it from the configuration.").format(name)
-            raise CalculatorError("{} must be calculated but set twice".format(name))
-
-        if len(feasible) > 1:
-            self._errors[name] = "Internal error: Multiple ways to set {}.".format(name)
-            raise CalculatorError("multiple ways to set",
-                                  ["options: {}".format(feasible)])
-
-        setter = feasible[0]
-
-        # Get values for the parameters, then call. the setter function.
-        kwargs = {}
-        for parameter in setter.parameters:
-            kwargs[parameter] = self._get(parameter)
-
-        try:
-            value = setter.calc(**kwargs)
-        except AssertionError as ex:
-            self._errors[name] = ex.args[0]
-            raise CalculatorError("assertion while calc")
-
-        if name in self._validate_by_arg:
-            try:
-                self._validate_by_arg[name](value)
-            except AssertionError as ex:
-                self._errors[name] = ex.args[0]
-                raise CalculatorError("assertion while validate")
-
-        return value
-
-    def _get(self, name):
-        if name in self._arguments:
-            if self._arguments[name] is None:
-                raise CalculatorError("No way to set", [name])
-            return self._arguments[name]
-
-        # Detect cycles by checking if we're in the middle of calculating the
-        # argument being asked for
-        if name in self.__in_progress:
-            raise CalculatorError("Internal error. cycle detected. re-encountered {}".format(name))
-
-        self.__in_progress.add(name)
-        try:
-            self._arguments[name] = self._calculate_argument(name)
-            return self._arguments[name]
-        except CalculatorError as ex:
-            self._arguments[name] = None
-            raise CalculatorError(ex.message, ex.chain + ['while calculating {}'.format(name)]) from ex
-        except:
-            self._arguments[name] = None
-            raise
-        finally:
-            self.__in_progress.remove(name)
-
-    # Force calculation of all arguments by accessing the arguments in this
-    # scope and recursively all sub-scopes.
-    def calculate(self, scope, throw_on_error=True):
-        def evaluate_var(name):
-            try:
-                self._get(name)
-            except CalculatorError as ex:
-                log.debug("Error calculating %s: %s. Chain: %s", name, ex.message, ex.chain)
-
-        assert scope.keys() <= {'sub_scopes', 'variables'}, \
-            "scope should only have variables and sub_scopes. Found: {}".format(scope)
-
-        for name in scope.get('variables', set()):
-            evaluate_var(name)
-
-        for name, sub_scope in scope.get('sub_scopes', dict()).items():
-            if name not in self._arguments:
-                evaluate_var(name)
-
-            # If the internal arg is None, there was an error, don't check if it
-            # is a legal choice.
-            if self._arguments[name] is None:
-                continue
-
-            choice = self._get(name)
-
-            if choice not in sub_scope:
-                self._errors[name] = "Invalid choice {}. Must choose one of {}".format(
-                    choice, ", ".join(sorted(sub_scope.keys())))
-                continue
-
-            self.calculate(sub_scope[choice], throw_on_error=False)
-
-        # Perform all multi-argument validations
-        for parameter_set, validate_fn in self._multi_arg_validate.items():
-            # Build up argument map for validate function. If any arguments are
-            # unset then skip this validate function.
-            kwargs = dict()
-            skip = False
-            for parameter in parameter_set:
-                if parameter not in self._arguments or self._arguments[parameter] is None:
-                    skip = True
-                    break
-                kwargs[parameter] = self._arguments[parameter]
-            if skip:
-                continue
-
-            # Call the validation function, catching AssertionErrors and turning them into errors in
-            # the error dictionary.
-            try:
-                validate_fn(**kwargs)
-            except AssertionError as ex:
-                self._errors[parameter_set] = ex.args[0]
-
-        if throw_on_error and (len(self._errors) or len(self._unset)):
-            raise ValidationError(self._errors, self._unset)
-
-        return self._arguments
-
-
-json_prettyprint_args = {
-    "sort_keys": True,
-    "indent": 2,
-    "separators": (',', ':')
-}
-
-
-def write_json(filename, data):
-    with open(filename, "w+") as f:
-        return json.dump(data, f, **json_prettyprint_args)
+    return [target]
 
 
 def write_to_non_taken(base_filename, json):
@@ -537,19 +305,6 @@ def do_gen_package(config, package_filename):
     log.info("Package filename: %s", package_filename)
 
 
-def validate_arguments_strings(arguments: dict):
-    errors = dict()
-    # Validate that all keys and vlaues of arguments are strings
-    for k, v in arguments.items():
-        if not isinstance(k, str):
-            errors[''] = "All keys in arguments must be strings. '{}' isn't.".format(k)
-        if not isinstance(v, str):
-            errors[k] = ("All values in arguments must be strings. Value for argument {} isn't. " +
-                         "Given value: {}").format(k, v)
-    if len(errors):
-        raise ValidationError(errors, set())
-
-
 def extract_files_with_path(start_files, paths):
     found_files = []
     found_file_paths = []
@@ -570,35 +325,6 @@ def extract_files_with_path(start_files, paths):
     return found_files, left_files
 
 
-class Setter():
-    # NOTE: value may either be a function or a string.
-    def __init__(self, name, value, is_optional, conditions, is_user):
-        assert isinstance(conditions, list)
-        self.name = name
-        self.is_optional = is_optional
-        self.conditions = conditions
-        self.is_user = is_user
-
-        def get_value():
-            return value
-
-        if isinstance(value, str):
-            self.calc = get_value
-            self.parameters = set()
-        else:
-            assert callable(value), "{} should be a string or callable. Got: {}".format(name, value)
-            self.calc = value
-            self.parameters = get_function_parameters(value)
-
-    def __repr__(self):
-        return "<Setter {}{}{}, conditions: {}{}>".format(
-            self.name,
-            ", optional" if self.is_optional else "",
-            ", user" if self.is_user else "",
-            self.conditions,
-            ", parameters {}".format(self.parameters))
-
-
 # Validate all arguments passed in actually correspond to parameters to
 # prevent human typo errors.
 # This includes all possible sub scopes (Including config for things you don't use is fine).
@@ -610,19 +336,6 @@ def flatten_parameters(scoped_parameters):
             flat |= flatten_parameters(sub_scope)
 
     return flat
-
-
-class ValidationError(Exception):
-    def __init__(self, errors, unset):
-        self.errors = errors
-        self.unset = unset
-        super().__init__(str(errors), str(unset))
-
-    def __str__(self):
-        return "<ValidationError errors: {}; unset: {}".format(self.errors, self.unset)
-
-    def __repr__(self):
-        return "<ValidationError errors: {}; unset: {}".format(self.errors, self.unset)
 
 
 def validate_all_arguments_match_parameters(parameters, setters, arguments):
@@ -645,151 +358,17 @@ def validate_all_arguments_match_parameters(parameters, setters, arguments):
         raise ValidationError(errors, set())
 
 
-class ConfigTarget():
-    def __init__(self, mandatory_parameters):
-        self.validate = list()
-        self.setters = dict()
-        self.mandatory_parameters = mandatory_parameters
-
-    def add_setter(self, name, value, is_optional, conditions, is_user):
-        self.setters.setdefault(name, list()).append(Setter(name, value, is_optional, conditions, is_user))
-
-    add_must = partialmethod(add_setter, is_optional=False, conditions=[], is_user=False)
-
-    def add_conditional_scope(self, scope, conditions):
-        # TODO(cmaloney): 'defaults' are the same as 'can' and 'must' is identical to 'arguments' except
-        # that one takes functions and one takes strings. Simplify to just 'can', 'must'.
-        assert scope.keys() <= {'validate', 'default', 'must', 'conditional'}
-
-        self.validate += scope.get('validate', list())
-
-        for name, fn in scope.get('must', dict()).items():
-            self.add_setter(name, fn, False, conditions, False)
-
-        for name, fn in scope.get('default', dict()).items():
-            self.add_setter(name, fn, True, conditions, False)
-
-        for name, cond_options in scope.get('conditional', dict()).items():
-            for value, sub_scope in cond_options.items():
-                self.add_conditional_scope(sub_scope, conditions + [(name, value)])
-
-    def remove_setters(self, scope):
-        def del_setter(name):
-            if name in self.setters:
-                del self.setters[name]
-
-        for name in scope.get('must', dict()).keys():
-            del_setter(name)
-
-        for name in scope.get('default', dict()).keys():
-            del_setter(name)
-
-        for name, cond_options in scope.get('conditional', dict()).items():
-            if name in self.setters:
-                raise NotImplementedError("Should conditional setters overwrite all setters?")
-
-    def add_entry(self, entry, replace_existing):
-        if replace_existing:
-            self.remove_setters(entry)
-
-        self.add_conditional_scope(entry, [])
-
-
-def calculate_config_for_targets(config_targets, user_arguments):
-    assert isinstance(config_targets, list)
-
-    # Make sure all user provided arguments are strings.
-    validate_arguments_strings(user_arguments)
-
-    validate = list()
-    setters = dict()
-    mandatory_parameters = {'variables': set(), 'sub_scopes': dict()}
-
-    # Merge all the config targets into one big group of setters for providing
-    # to the calculator
-    # TODO(cmaloney): The setter management / set code is very similar to that in ConfigTarget, they
-    # could probably be joined.
-    for target in config_targets:
-        for name, setter_list in target.setters.items():
-            setters.setdefault(name, list())
-            setters[name] = setters[name] + setter_list
-        validate = validate + target.validate
-
-        # TODO(cmaloney): The building of mandatory_parameters is identical to how we build it up in
-        # get_parameters()
-        mandatory_parameters = merge_dictionaries(mandatory_parameters, target.mandatory_parameters)
-
-    # TODO(cmaloney): Validate recursively that mandatory_parameters has the right keys and only the
-    # right keys.
-    assert mandatory_parameters.keys() == {'variables', 'sub_scopes'}
-
-    # TODO(cmaloney): Re-enable this after sorting out how to have "optional" config targets which
-    # add in extra "acceptable" parameters (SSH Config, AWS Advanced Template config, etc)
-    # validate_all_arguments_match_parameters(mandatory_parameters, setters, user_arguments)
-
-    # Add in all user arguments as setters.
-    # Happens last so that they are never overwritten with replace_existing=True
-    for name, value in user_arguments.items():
-        setters.setdefault(name, list()).append(Setter(name, value, False, [], True))
-
-    # Use setters to caluclate every required parameter
-    arguments = DFSArgumentCalculator(setters, validate).calculate(mandatory_parameters)
-
-    # Validate all new / calculated arguments are strings.
-    validate_arguments_strings(arguments)
-
-    log.info("Final arguments:" + json.dumps(arguments, **json_prettyprint_args))
-
-    # TODO(cmaloney) Give each config target the values for all it's parameters that were hit as
-    # well as any parameters that led to those parameters.
-    return arguments
-
-
-def validate_config_for_targets(config_targets, user_arguments):
-    try:
-        calculate_config_for_targets(config_targets, user_arguments)
-        return {'status': 'ok'}
-    except ValidationError as ex:
-        messages = {}
-
-        # Defer multi-key validation errors and noramlize them to be single-key
-        # ones. The multi-key is always less important than the single-key
-        # messages which is why single-key messages we never overwrite.
-        # TODO(cmaloney): Teach the whole stack to be able to handle multi-key
-        # validation errors.
-        to_do = dict()
-        for key, msg in ex.errors.items():
-            if isinstance(key, frozenset):
-                to_do[key] = msg
-                continue
-
-            assert isinstance(key, str)
-            messages[key] = {'message': msg}
-
-        for keys, msg in to_do.items():
-            for name in keys:
-                # Skip ones we already have one message for.
-                if name in messages:
-                    continue
-
-                messages[name] = {'message': msg}
-
-        return {
-            'status': 'errors',
-            'errors': messages,
-            'unset': ex.unset
-        }
-
-
 def validate(
         arguments,
         extra_templates=list(),
         cc_package_files=list()):
-    config_target, _ = get_dcosconfig_target_and_templates(arguments, extra_templates)
-    return validate_config_for_targets([config_target], arguments)
+    sources, targets, _ = get_dcosconfig_source_target_and_templates(arguments, extra_templates)
+    return gen.internals.validate_configuration(sources, targets, arguments)
 
 
-def get_dcosconfig_target_and_templates(user_arguments, extra_templates: list):
+# TODO(cmaloney): This function should disolve away like the ssh one is and just become a big
+# static dictonary or pass in / construct on the fly at the various template callsites.
+def get_dcosconfig_source_target_and_templates(user_arguments, extra_templates: list):
     log.info("Generating configuration files...")
 
     # TODO(cmaloney): Make these all just defined by the base calc.py
@@ -812,23 +391,24 @@ def get_dcosconfig_target_and_templates(user_arguments, extra_templates: list):
                 "Internal Error: Only know how to merge YAML templates at this point in time. "
                 "Can't merge template {} in template_list {}".format(filename, templates[key]))
 
-    mandatory_parameters = get_parameters(templates)
-    config_target = ConfigTarget(mandatory_parameters)
-
-    config_target.add_entry(gen.calc.entry, replace_existing=False)
+    targets = target_from_templates(templates)
+    base_source = gen.internals.Source(is_user=False)
+    base_source.add_entry(gen.calc.entry, replace_existing=False)
 
     # Allow overriding calculators with a `gen_extra/calc.py` if it exists
     if os.path.exists('gen_extra/calc.py'):
         mod = importlib.machinery.SourceFileLoader('gen_extra.calc', 'gen_extra/calc.py').load_module()
-        config_target.add_entry(mod.entry, replace_existing=True)
+        base_source.add_entry(mod.entry, replace_existing=True)
 
     def add_builtin(name, value):
-        config_target.add_must(name, json.dumps(value, **json_prettyprint_args))
+        base_source.add_must(name, json_prettyprint(value))
 
     # TODO(cmaloney): Hash the contents of all the templates rather than using the list of filenames
     # since the filenames might not live in this git repo, or may be locally modified.
     add_builtin('template_filenames', template_filenames)
     add_builtin('package_names', list(package_names))
+    # TODO(cmaloney): user_arguments needs to be a temporary_str since we need to only include used
+    # arguments inside of it.
     add_builtin('user_arguments', user_arguments)
 
     # Add a builtin for expanded_config, so that we won't get unset argument errors. The temporary
@@ -836,7 +416,7 @@ def get_dcosconfig_target_and_templates(user_arguments, extra_templates: list):
     temporary_str = 'DO NOT USE THIS AS AN ARGUMENT TO OTHER ARGUMENTS. IT IS TEMPORARY'
     add_builtin('expanded_config', temporary_str)
 
-    return config_target, templates
+    return [base_source], targets, templates
 
 
 def generate(
@@ -847,19 +427,18 @@ def generate(
     user_arguments = arguments
     arguments = None
 
-    config_target, templates = get_dcosconfig_target_and_templates(user_arguments, extra_templates)
+    sources, targets, templates = get_dcosconfig_source_target_and_templates(user_arguments, extra_templates)
 
     # TODO(cmaloney): Make it so we only get out the dcosconfig target arguments not all the config target arguments.
-    arguments = calculate_config_for_targets([config_target], user_arguments)
-    log.debug("Final arguments:" + json.dumps(arguments, **json_prettyprint_args))
+    arguments = gen.internals.resolve_configuration(sources, targets, user_arguments)
+    log.debug("Final arguments:" + json_prettyprint(arguments))
 
     # expanded_config is a special result which contains all other arguments. It has to come after
     # the calculation of all the other arguments so it can be filled with everything which was
     # calculated. Can't be calculated because that would have an infinite recursion problem (the set
     # of all arguments would want to include itself).
     # Explicitly / manaully setup so that it'll fit where we want it.
-    arguments['expanded_config'] = textwrap.indent(json.dumps(arguments, **json_prettyprint_args),
-                                                   prefix='  ' * 3)
+    arguments['expanded_config'] = textwrap.indent(json_prettyprint(arguments), prefix='  ' * 3)
 
     # Fill in the template parameters
     rendered_templates = render_templates(templates, arguments)

--- a/gen/exceptions.py
+++ b/gen/exceptions.py
@@ -1,0 +1,13 @@
+
+
+class ValidationError(Exception):
+    def __init__(self, errors, unset):
+        self.errors = errors
+        self.unset = unset
+        super().__init__(str(errors), str(unset))
+
+    def __str__(self):
+        return "<ValidationError errors: {}; unset: {}".format(self.errors, self.unset)
+
+    def __repr__(self):
+        return self.__str__()

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -1,0 +1,457 @@
+import copy
+import inspect
+import logging
+from functools import partialmethod
+
+from gen.exceptions import ValidationError
+from pkgpanda.util import json_prettyprint
+
+log = logging.getLogger(__name__)
+
+
+def get_function_parameters(function):
+    return set(inspect.signature(function).parameters)
+
+
+def validate_arguments_strings(arguments: dict):
+    errors = dict()
+    # Validate that all keys and vlaues of arguments are strings
+    for k, v in arguments.items():
+        if not isinstance(k, str):
+            errors[''] = "All keys in arguments must be strings. '{}' isn't.".format(k)
+        if not isinstance(v, str):
+            errors[k] = ("All values in arguments must be strings. Value for argument {} isn't. " +
+                         "Given value: {}").format(k, v)
+    if len(errors):
+        raise ValidationError(errors, set())
+
+
+class Setter:
+
+    # NOTE: value may either be a function or a string.
+    def __init__(self, name, value, is_optional, conditions, is_user):
+        assert isinstance(conditions, list)
+        self.name = name
+        self.is_optional = is_optional
+        self.conditions = conditions
+        self.is_user = is_user
+
+        def get_value():
+            return value
+
+        if isinstance(value, str):
+            self.calc = get_value
+            self.parameters = set()
+        else:
+            assert callable(value), "{} should be a string or callable. Got: {}".format(name, value)
+            self.calc = value
+            self.parameters = get_function_parameters(value)
+
+    def __repr__(self):
+        return "<Setter {}{}{}, conditions: {}{}>".format(
+            self.name,
+            ", optional" if self.is_optional else "",
+            ", user" if self.is_user else "",
+            self.conditions,
+            ", parameters {}".format(self.parameters))
+
+
+class Scope:
+    def __init__(self, name: str, cases=None):
+        self.name = name
+        self.cases = cases if cases else dict()
+
+    def add_case(self, value: str, target):
+        assert isinstance(target, Target)
+        self.cases[value] = target
+
+    def __iadd__(self, other):
+        assert isinstance(other, Scope), "Internal consistency error, expected Scope but got {}".format(type(other))
+
+        # Must have the same name and same options in order to be merged (can't have a new
+        # switch add new, unhandled cases to a switch already included / represented by this scope).
+        assert self.name == other.name, "Internal consistency error: Trying to merge scopes with " \
+            "different names: {} and {}".format(self.name, other.name)
+        assert self.cases.keys() == other.cases.keys(), "Same name / switch variable introduced " \
+            "with a different set of possible cases. name: {}. First options: {}, Second " \
+            "options: {}".format(self.name, self.cases.keys(), other.cases.keys())
+
+        # Merge the targets for the cases
+        for name in self.cases:
+            self.cases[name] += other.cases[name]
+
+        return self
+
+    def __eq__(self, other):
+        assert isinstance(other, Scope)
+        return self.name == other.name and self.cases == other.cases
+
+
+class Target:
+
+    # TODO(cmaloney): Make a better API for working with and managing sub scopes. The current
+    # dictionary of dictionaries is really hard to use right.
+    def __init__(self, variables=None, sub_scopes=None):
+        self.variables = variables if variables else set()
+        self.sub_scopes = sub_scopes if sub_scopes else dict()
+
+    def add_variable(self, variable: str):
+        self.variables.add(variable)
+
+    def add_scope(self, scope: Scope):
+        self.sub_scopes[scope.name] = scope
+
+    def __iadd__(self, other):
+        assert isinstance(other, Target), "Internal consistency error, expected Target but got {}".format(type(other))
+        self.variables |= other.variables
+
+        # Add all scopes from the other to this, merging all common sub scopes.
+        for name, scope in other.sub_scopes.items():
+            if name in self.sub_scopes:
+                self.sub_scopes[name] += scope
+            else:
+                self.sub_scopes[name] = scope
+
+        return self
+
+    def __eq__(self, other):
+        assert isinstance(other, Target)
+        return self.variables == other.variables and self.sub_scopes == other.sub_scopes
+
+
+class Source:
+    def __init__(self, entry=None, is_user=False,):
+        self.setters = dict()
+        self.validate = list()
+        self.is_user = is_user
+        if entry:
+            self.add_entry(entry, False)
+
+    def add_setter(self, name, value, is_optional, conditions):
+        self.setters.setdefault(name, list()).append(Setter(name, value, is_optional, conditions, self.is_user))
+
+    def add_conditional_scope(self, scope, conditions):
+        # TODO(cmaloney): 'defaults' are the same as 'can' and 'must' is identical to 'arguments' except
+        # that one takes functions and one takes strings. Simplify to just 'can', 'must'.
+        assert scope.keys() <= {'validate', 'default', 'must', 'conditional'}
+
+        self.validate += scope.get('validate', list())
+
+        for name, fn in scope.get('must', dict()).items():
+            self.add_setter(name, fn, False, conditions)
+
+        for name, fn in scope.get('default', dict()).items():
+            self.add_setter(name, fn, True, conditions)
+
+        for name, cond_options in scope.get('conditional', dict()).items():
+            for value, sub_scope in cond_options.items():
+                self.add_conditional_scope(sub_scope, conditions + [(name, value)])
+
+    add_must = partialmethod(add_setter, is_optional=False, conditions=[])
+
+    def add_value_dict(self, value_dict):
+        for name, value in value_dict.items():
+            self.add_must(name, value)
+
+    def remove_setters(self, scope):
+        def del_setter(name):
+            if name in self.setters:
+                del self.setters[name]
+
+        for name in scope.get('must', dict()).keys():
+            del_setter(name)
+
+        for name in scope.get('default', dict()).keys():
+            del_setter(name)
+
+        for name, cond_options in scope.get('conditional', dict()).items():
+            if name in self.setters:
+                raise NotImplementedError("Should conditional setters overwrite all setters?")
+
+    def add_entry(self, entry, replace_existing):
+        if replace_existing:
+            self.remove_setters(entry)
+
+        self.add_conditional_scope(entry, [])
+
+
+# NOTE: This exception should never escape the DFSArgumentCalculator
+class CalculatorError(Exception):
+    def __init__(self, message, chain=[]):
+        assert isinstance(message, str)
+        assert isinstance(chain, list)
+        self.message = message
+        self.chain = chain
+        super().__init__(message)
+
+
+# Depth first search argument calculator. Detects cycles, as well as unmet
+# dependencies.
+# TODO(cmaloney): Separate chain / path building when unwinding from the root
+#                 error messages.
+class DFSArgumentCalculator():
+    def __init__(self, setters, validate_fns):
+        self._setters = setters
+        self._arguments = dict()
+        self.__in_progress = set()
+        self._errors = dict()
+        self._unset = set()
+
+        # Re-arrange the validation functions so we can more easily access them by
+        # argument name.
+        self._validate_by_arg = dict()
+        self._multi_arg_validate = dict()
+
+        for fn in validate_fns:
+            parameters = get_function_parameters(fn)
+            # Could build up the single and multi parameter validation function maps in the same
+            # thing but the timing / handling of when and how we run single vs. multi-parameter
+            # validation functions is fairly different, the extra bit here simplifies the later code.
+            if len(parameters) == 1:
+                self._validate_by_arg[parameters.pop()] = fn
+                assert not parameters
+            else:
+                self._multi_arg_validate[frozenset(parameters)] = fn
+
+    def _calculate_argument(self, name):
+        # Filter out any setters which have predicates / conditions which are
+        # satisfiably false.
+        def all_conditions_met(setter):
+            for condition_name, condition_value in setter.conditions:
+                try:
+                    if self._get(condition_name) != condition_value:
+                        return False
+                except CalculatorError as ex:
+                    raise CalculatorError(
+                        ex.message,
+                        ex.chain + ['trying to test condition {}={}'.format(condition_name, condition_value)]) from ex
+            return True
+
+        # Find the right setter to calculate the argument.
+        feasible = list(filter(all_conditions_met, self._setters.get(name, list())))
+
+        if len(feasible) == 0:
+            self._unset.add(name)
+            raise CalculatorError("no way to set")
+
+        # Filtier out all optional setters if there is more than one way to set.
+        if len(feasible) > 1:
+            final_feasible = list(filter(lambda setter: not setter.is_optional, feasible))
+            assert final_feasible, "Had multiple optionals and no musts. Template internal error: {!r}".format(feasible)
+            feasible = final_feasible
+
+        # Must be calculated but user tried to provide.
+        if len(feasible) == 2 and (feasible[0].is_user or feasible[1].is_user):
+            self._errors[name] = ("{} must be calculated, but was explicitly set in the "
+                                  "configuration. Remove it from the configuration.").format(name)
+            raise CalculatorError("{} must be calculated but set twice".format(name))
+
+        if len(feasible) > 1:
+            self._errors[name] = "Internal error: Multiple ways to set {}.".format(name)
+            raise CalculatorError("multiple ways to set",
+                                  ["options: {}".format(feasible)])
+
+        setter = feasible[0]
+
+        # Get values for the parameters, then call. the setter function.
+        kwargs = {}
+        for parameter in setter.parameters:
+            kwargs[parameter] = self._get(parameter)
+
+        try:
+            value = setter.calc(**kwargs)
+        except AssertionError as ex:
+            self._errors[name] = ex.args[0]
+            raise CalculatorError("assertion while calc")
+
+        if name in self._validate_by_arg:
+            try:
+                self._validate_by_arg[name](value)
+            except AssertionError as ex:
+                self._errors[name] = ex.args[0]
+                raise CalculatorError("assertion while validate")
+
+        return value
+
+    def _get(self, name):
+        if name in self._arguments:
+            if self._arguments[name] is None:
+                raise CalculatorError("No way to set", [name])
+            return self._arguments[name]
+
+        # Detect cycles by checking if we're in the middle of calculating the
+        # argument being asked for
+        if name in self.__in_progress:
+            raise CalculatorError("Internal error. cycle detected. re-encountered {}".format(name))
+
+        self.__in_progress.add(name)
+        try:
+            self._arguments[name] = self._calculate_argument(name)
+            return self._arguments[name]
+        except CalculatorError as ex:
+            self._arguments[name] = None
+            raise CalculatorError(ex.message, ex.chain + ['while calculating {}'.format(name)]) from ex
+        except:
+            self._arguments[name] = None
+            raise
+        finally:
+            self.__in_progress.remove(name)
+
+    def _calculate_target(self, target):
+        def evaluate_var(name):
+            try:
+                self._get(name)
+            except CalculatorError as ex:
+                log.debug("Error calculating %s: %s. Chain: %s", name, ex.message, ex.chain)
+
+        for name in target.variables:
+            evaluate_var(name)
+
+        for name, sub_scope in target.sub_scopes.items():
+            if name not in self._arguments:
+                evaluate_var(name)
+
+            # If the internal arg is None, there was an error, don't check if it
+            # is a legal choice.
+            if self._arguments[name] is None:
+                continue
+
+            choice = self._get(name)
+
+            if choice not in sub_scope.cases:
+                self._errors[name] = "Invalid choice {}. Must choose one of {}".format(
+                    choice, ", ".join(sorted(sub_scope.keys())))
+                continue
+
+            self._calculate_target(sub_scope.cases[choice])
+
+        # Perform all multi-argument validations
+        for parameter_set, validate_fn in self._multi_arg_validate.items():
+            # Build up argument map for validate function. If any arguments are
+            # unset then skip this validate function.
+            kwargs = dict()
+            skip = False
+            for parameter in parameter_set:
+                if (parameter not in self._arguments) or (self._arguments[parameter] is None):
+                    skip = True
+                    break
+                kwargs[parameter] = self._arguments[parameter]
+            if skip:
+                continue
+
+            # Call the validation function, catching AssertionErrors and turning them into errors in
+            # the error dictionary.
+            try:
+                validate_fn(**kwargs)
+            except AssertionError as ex:
+                self._errors[parameter_set] = ex.args[0]
+
+        # TODO(cmaloney): Return per-target results with the path to calculate each argument and the
+        # full set of arguments touched included.
+        return self._arguments
+
+    # Force calculation of all arguments by accessing the arguments in this
+    # scope and recursively all sub-scopes.
+    def calculate(self, targets):
+        for target in targets:
+            self._calculate_target(target)
+
+        if len(self._errors) or len(self._unset):
+            raise ValidationError(self._errors, self._unset)
+
+        return self._arguments
+
+
+def resolve_configuration(sources: list, targets: list, user_arguments: dict):
+
+    # Make sure all user provided arguments are strings.
+    # TODO(cmaloney): Loosen this restriction  / allow arbitrary types as long
+    # as they all have a gen specific string form.
+    validate_arguments_strings(user_arguments)
+
+    # Merge the sources into a big dictionary of setters + validators, ensuring
+    # that all setters are either strings or functions.
+    validate = list()
+    setters = dict()
+
+    # Merge all the config targets into one big group of setters for providing
+    # to the calculator
+    # TODO(cmaloney): The setter management / set code is very similar to that in ConfigTarget, they
+    # could probably be joined.
+    for source in sources:
+        for name, setter_list in source.setters.items():
+            setters.setdefault(name, list())
+            setters[name] += setter_list
+        validate += source.validate
+
+    # Validate that targets is a list of Targets
+    for target in targets:
+        assert isinstance(target, Target), \
+            "target should be a Target found a {} with value: {}".format(type(target), target)
+
+    # TODO(cmaloney): Re-enable this after sorting out how to have "optional" config targets which
+    # add in extra "acceptable" parameters (SSH Config, AWS Advanced Template config, etc)
+    # validate_all_arguments_match_parameters(mandatory_parameters, setters, user_arguments)
+
+    # Add in all user arguments as setters.
+    # Happens last so that they are never overwritten with replace_existing=True
+    user_config = Source(is_user=True)
+    user_config.add_value_dict(user_arguments)
+
+    # Merge all the seters and validate function into one uber list
+    setters = copy.deepcopy(user_config.setters)
+    validate = copy.deepcopy(user_config.validate)
+    for source in sources:
+        for name, setter_list in source.setters.items():
+            # TODO(cmaloney): Make a setter manager already...
+            setters.setdefault(name, list())
+            setters[name] += setter_list
+        validate += source.validate
+
+    # Use setters to caluclate every required parameter
+    arguments = DFSArgumentCalculator(setters, validate).calculate(targets)
+
+    # Validate all new / calculated arguments are strings.
+    validate_arguments_strings(arguments)
+
+    log.info("Final arguments:" + json_prettyprint(arguments))
+
+    # TODO(cmaloney) Give each config target the values for all it's parameters that were hit as
+    # well as any parameters that led to those parameters.
+    return arguments
+
+
+def validate_configuration(sources: list, targets: list, user_arguments: dict):
+    try:
+        resolve_configuration(sources, targets, user_arguments)
+        return {'status': 'ok'}
+    except ValidationError as ex:
+        messages = {}
+
+        # Defer multi-key validation errors and noramlize them to be single-key
+        # ones. The multi-key is always less important than the single-key
+        # messages which is why single-key messages we never overwrite.
+        # TODO(cmaloney): Teach the whole stack to be able to handle multi-key
+        # validation errors.
+        to_do = dict()
+        for key, msg in ex.errors.items():
+            if isinstance(key, frozenset):
+                to_do[key] = msg
+                continue
+
+            assert isinstance(key, str)
+            messages[key] = {'message': msg}
+
+        for keys, msg in to_do.items():
+            for name in keys:
+                # Skip ones we already have one message for.
+                if name in messages:
+                    continue
+
+                messages[name] = {'message': msg}
+
+        return {
+            'status': 'errors',
+            'errors': messages,
+            'unset': ex.unset
+        }

--- a/gen/test_template.py
+++ b/gen/test_template.py
@@ -1,6 +1,7 @@
 import pytest
 
 import gen.template
+from gen.internals import Scope, Target
 from gen.template import For, parse_str, Replacement, Switch, Tokenizer, UnsetParameter
 
 
@@ -102,38 +103,23 @@ def test_parse():
     assert parse_str("{% for foo in bar %}{{ foo }}{% endfor %}").ast == [For("foo", "bar", [Replacement('foo')])]
 
 
-def test_get_variables():
-    assert(parse_str("a").get_scoped_arguments() ==
-           {'variables': set(), 'sub_scopes': dict()})
-    assert(parse_str("{{ a }}").get_scoped_arguments() ==
-           {'variables': {"a"}, 'sub_scopes': dict()})
-    assert(parse_str("{{ a | foo }}").get_scoped_arguments() ==
-           {'variables': {"a"}, 'sub_scopes': dict()})
-    assert(parse_str("a{{ a }}b{{ c }}").get_scoped_arguments() ==
-           {'variables': {"a", "c"}, 'sub_scopes': dict()})
-    assert(parse_str("a{{ a }}b{{ a }}c{{ c | baz }}").get_scoped_arguments() ==
-           {'variables': {"a", "c"}, 'sub_scopes': dict()})
-    assert(parse_str("a{{ a }}b{{ a | bar }}c{{ c }}").get_scoped_arguments() ==
-           {'variables': {"a", "c"}, 'sub_scopes': dict()})
-    assert(parse_str("{{ a }}{% switch b %}{% case \"c\" %}{{ d }}{% endswitch %}{{ e }}").get_scoped_arguments() == {
-        'variables': {'a', 'e'},
-        'sub_scopes': {
-            'b': {
-                'c': {
-                    'variables': {'d'},
-                    'sub_scopes': {}
-                }
+def test_target_from_ast():
+    assert parse_str("a").target_from_ast() == Target()
 
-            }
-        }
-    })
+    assert parse_str("{{ a }}").target_from_ast() == Target({'a'})
+    assert parse_str("{{ a | foo }}").target_from_ast() == Target({'a'})
+    assert parse_str("a{{ a }}b{{ c }}").target_from_ast() == Target({'a', 'c'})
+    assert parse_str("a{{ a }}b{{ a }}c{{ c | baz }}").target_from_ast() == Target({'a', 'c'})
+    assert parse_str("a{{ a }}b{{ a | bar }}c{{ c }}").target_from_ast() == Target({'a', 'c'})
+    assert(parse_str("{{ a }}{% switch b %}{% case \"c\" %}{{ d }}{% endswitch %}{{ e }}").target_from_ast() ==
+           Target({'a', 'e'}, {'b': Scope('b', {'c': Target({'d'})})}))
 
-    assert (parse_str("{% for foo in bar %}{{ foo }}{{ bar }}{{ baz }}{% endfor %}").get_scoped_arguments() ==
-            {'variables': {'bar', 'baz'}, 'sub_scopes': dict()})
+    assert (parse_str("{% for foo in bar %}{{ foo }}{{ bar }}{{ baz }}{% endfor %}").target_from_ast() ==
+            Target({'bar', 'baz'}))
 
     # TODO(cmaloney): Disallow reusing a for new variable as a general variable.
-    assert (parse_str("{% for foo in bar %}{{ foo }}{{ bar }}{{ baz }}{% endfor %}{{ foo }}").get_scoped_arguments() ==
-            {'variables': {'foo', 'bar', 'baz'}, 'sub_scopes': dict()})
+    assert (parse_str("{% for foo in bar %}{{ foo }}{{ bar }}{{ baz }}{% endfor %}{{ foo }}").target_from_ast() ==
+            Target({'foo', 'bar', 'baz'}))
 
 
 def test_get_filters():

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -13,6 +13,13 @@ import requests
 from pkgpanda.exceptions import FetchError, ValidationError
 
 
+json_prettyprint_args = {
+    "sort_keys": True,
+    "indent": 2,
+    "separators": (',', ':')
+}
+
+
 def variant_str(variant):
     """Return a string representation of variant."""
     if variant is None:
@@ -121,7 +128,7 @@ def make_file(name):
 
 def write_json(filename, data):
     with open(filename, "w+") as f:
-        return json.dump(data, f, indent=2, sort_keys=True)
+        return json.dump(data, f, **json_prettyprint_args)
 
 
 def write_string(filename, data):
@@ -132,6 +139,10 @@ def write_string(filename, data):
 def load_string(filename):
     with open(filename) as f:
         return f.read().strip()
+
+
+def json_prettyprint(data):
+    return json.dumps(data, **json_prettyprint_args)
 
 
 def if_exists(fn, *args, **kwargs):

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -2,6 +2,7 @@ import os
 import stat
 
 import gen
+from gen.internals import Source, Target
 
 
 def validate_ssh_key_path(ssh_key_path):
@@ -26,7 +27,7 @@ def validate_agent_lists(agent_list, public_agent_list):
     compare_lists(agent_list, public_agent_list)
 
 
-entry = {
+source = Source({
     'validate': [
         lambda agent_list: gen.calc.validate_ip_list(agent_list),
         lambda public_agent_list: gen.calc.validate_ip_list(public_agent_list),
@@ -48,33 +49,24 @@ entry = {
         'process_timeout': '120',
         'ssh_parallelism': '20'
     }
-}
+})
 
-parameters = {
-    'variables': {
-        'ssh_user',
-        'ssh_port',
-        'ssh_key_path',
-        'master_list',
-        'agent_list',
-        'public_agent_list',
-        'ssh_parallelism',
-        'process_timeout'
-    }
-}
-
-
-def get_config_target():
-    config_target = gen.ConfigTarget(parameters)
-    config_target.add_entry(entry, False)
-    return config_target
+target = Target({
+    'ssh_user',
+    'ssh_port',
+    'ssh_key_path',
+    'master_list',
+    'agent_list',
+    'public_agent_list',
+    'ssh_parallelism',
+    'process_timeout'})
 
 
 # TODO(cmaloney): Work this API, callers until this result remapping is unnecessary
 # and the couple places that need this can just make a trivial call directly.
 def validate_config(user_arguments):
     user_arguments = gen.stringify_configuration(user_arguments)
-    messages = gen.validate_config_for_targets([get_config_target()], user_arguments)
+    messages = gen.internals.validate_configuration([source], [target], user_arguments)
     if messages['status'] == 'ok':
         return {}
 


### PR DESCRIPTION
This reworks the gen a bit to make the library more understandable in terms of what it is doing. It introduces four main primitives:

`Source` is a source of configuration variables. A `Target` is a set of configuration variables which
need to be set to have a complete configuration. The `Resolver` figures out how to use a collection of
sources to fill in a collection of targets and check for conflicts.

`Source`s can be user-provided (a dictionary loaded out of a config file). They can also be provided
by different contexts (AWS templates have a source of AWS which implies things likes resolvers). A
third common provider is deriving from other already given values (master count is derived from a
master list if a master list is given).

`Target`s are a set of variables which need to be set, as well as a set of variables which need to be
set under certain conditions. The "conditional" variables you can think of as a "Switch". Based on
the value of the argument to the switch, one of multiple paths are going to be taken, and all
configuration variables in that particular path are expected to be taken.

The `Resolver` takes a collection of sources and targets, then tries to calculate (and validate) all
the values needed to satisfy the targets. It keeps track of the path to get to a specific value, if
there are any conflicts between different sources (master_count is set to a conflicting / different
value than the length of master_list).