### PR TITLE
Misc cleanup and speedup fixes extracted from #854

### DIFF
--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -20,7 +20,6 @@ import os.path
 import textwrap
 from copy import copy, deepcopy
 from functools import partialmethod
-from subprocess import check_call
 from tempfile import TemporaryDirectory
 
 import yaml
@@ -530,7 +529,7 @@ def do_gen_package(config, package_filename):
             os.makedirs(os.path.dirname(package_filename), exist_ok=True)
 
         # Make the package top level directory readable by users other than the owner (root).
-        check_call(['chmod', 'go+rx', tmpdir])
+        os.chmod(tmpdir, 0o755)
 
         make_tar(package_filename, tmpdir)
 

--- a/gen/installer/azure.py
+++ b/gen/installer/azure.py
@@ -48,11 +48,9 @@ def validate_cloud_config(cc_string):
 
     @param cc_string: str, Cloud Configuration
     '''
-    illegal_match = ILLEGAL_ARM_CHARS_PATTERN.search(cc_string)
-    if illegal_match:
+    if "'" in cc_string:
         print("ERROR: Illegal cloud config string detected.", file=sys.stderr)
-        print("ERROR: {} matches pattern {}".format(
-            illegal_match.string, illegal_match.re), file=sys.stderr)
+        print("ERROR: {} contains a `'`".format(cc_string), file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -577,12 +577,19 @@ def mock_get_azure_download_url():
     return "http://mock_azure_download_url"
 
 
+def mock_make_tar(result_filename, folder):
+    # Ensure the file exists.
+    with open(result_filename, 'a'):
+        pass
+
+
 # Test that the do_create functions for each provider output data in the right
 # shape.
 def test_make_channel_artifacts(monkeypatch):
     monkeypatch.setattr('gen.installer.bash.make_installer_docker', mock_make_installer_docker)
     monkeypatch.setattr('gen.installer.aws.get_cloudformation_s3_url', mock_get_cf_s3_url)
     monkeypatch.setattr('gen.installer.azure.get_download_url', mock_get_azure_download_url)
+    monkeypatch.setattr('pkgpanda.util.make_tar.__code__', mock_make_tar.__code__)
 
     metadata = {
         'commit': 'sha-1',

--- a/tests/test_ssh_integration.py
+++ b/tests/test_ssh_integration.py
@@ -248,7 +248,7 @@ def test_ssh_command_terminate_async(sshd_manager, loop):
         workspace = str(sshd_manager.tmpdir)
 
         runner = MultiRunner(['127.0.0.1:{}'.format(port) for port in sshd_ports], ssh_user=getpass.getuser(),
-                             ssh_key_path=sshd_manager.key_path, process_timeout=2)
+                             ssh_key_path=sshd_manager.key_path, process_timeout=0.05)
 
         chain = CommandChain('test')
         chain.add_execute(['sleep', '20'])


### PR DESCRIPTION
 - Lower ssh process timeout in test so we don't spend 2 seconds waiting
 - Use builtin system call rather than a subprocess
 - Remove unnecessary regex
 - Mock pkgpanda.util.make_tar in test_make_channel_artifacts (We didn't do anything with the produced tar).

cc: @darkonie @lingmann 