### PR TITLE
dcos-spaceport: cluster configuration, assembly, and launch, and maintenance code

### DIFF
--- a/build_dcos_spaceport.sh
+++ b/build_dcos_spaceport.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Simple helper script to build dcos-spaceport binary for Linux
+# NOTE: this needs to be kept in sync with gen.installer.bash::make_dcos_spaceport()
+
+set -x
+set -o errexit -o pipefail
+
+# Cleanup from previous build
+rm -rf /tmp/dcos_build_venv
+
+# Force Python stdout/err to be unbuffered.
+export PYTHONUNBUFFERED="notemtpy"
+
+# Create a python virtual environment to install the DC/OS tools to
+python3 -m venv /tmp/dcos_spaceport_venv
+. /tmp/dcos_spaceport_venv/bin/activate
+
+# Make a clean as possible clone
+rm -rf /tmp/dcos-spaceport-build
+git clone "file://$PWD" /tmp/dcos-spaceport-build
+pushd /tmp/dcos-spaceport-build
+# Install the DC/OS tools
+pip install -e /tmp/dcos-spaceport-build
+pyinstaller dcos-spaceport.spec
+popd
+cp /tmp/dcos-spaceport-build/dist/dcos-spaceport ./

--- a/dcos-spaceport.spec
+++ b/dcos-spaceport.spec
@@ -1,0 +1,13 @@
+a = Analysis(['spaceport/cli.py'])
+pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name='dcos-spaceport',
+    debug=False,
+    strip=False,
+    upx=True,
+    console=True)

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
             'mkpanda=pkgpanda.build.cli:main',
             'dcos_installer=dcos_installer.cli:main',
             'dcos-launch=test_util.launch:main',
+            'dcos-spaceport=spaceport.cli:main'
         ],
     },
     package_data={

--- a/spaceport/cli.py
+++ b/spaceport/cli.py
@@ -1,0 +1,20 @@
+"""DC/OS Spaceport: Configuration, Assemble, Launch, and Update DC/OS
+
+Usage:
+  dcos-spaceport launch
+  dcos-spaceport configure
+  dcos-spaceport configure aws-advanced
+  dcos-spaceport configure azure-advanced
+  dcos-spaceport configure ssh
+  dcos-spaceport web
+"""
+
+from docopt import docopt
+
+
+def main():
+    docopt(__doc__)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This replaces `dcos_generate_config.sh` with a PyInstaller binary (linux-only for now) which is called `dcos-spaceport`. The `dcos-spaceport` should have the functionality of dcos_generate_config.sh (although restructuring the command line a bit to cleanup some old tech debt), while also bring in a few more members of the family
1. `dcos-spaceport launch`: What was being worked on as dcos-launch, as a subcommand.
2. `dcos-spaceport upgrade node`: Upgrade or create a script to upgrade an individual node in a DC/OS cluster
3. `dcos-spaceport config-update`: Guidance around migrating from current config.yaml to the new / next config.yaml.

The goal would be to cleanup some old installer tech debt, as well as "unify" the code into a single cohesive goal, re-arranging it a bit to make more sense. The code structure I have been thinking of as a goal to ehad towards:

```
spaceport
  internals/
    history/  # (dcos-history-service)
    bootstrap/  # (Common code from the bootstrap package to share with downstreams)
    pkgpanda/  # (pkgpanda/)
  config/  # (what was gen + dcos_installer/config.py)
  launch/  # (what was test_util/launch, as well as possibly the ssh and web installers)
    ssh/     # (the ssh library, might just go in internals)
  release/  # The release/ tools
packages/  # Just what it is today
```
