### PR TITLE
Add dcos-launch

### DIFF
--- a/build_dcos_launch.sh
+++ b/build_dcos_launch.sh
@@ -17,12 +17,16 @@ python3 -m venv /tmp/dcos_launch_venv
 . /tmp/dcos_launch_venv/bin/activate
 
 # Make a clean as possible clone
+if [[ -n $(git -C $PWD status --porcelain -uno -z) ]]; then
+  echo "Commit all changes before attempting to build!";
+  exit 1;
+fi
 rm -rf /tmp/dcos-installer-build
-git clone "file://$PWD" /tmp/dcos-installer-build
+git clone -q "file://$PWD" /tmp/dcos-installer-build/
 pushd /tmp/dcos-installer-build
 # Install the DC/OS tools
 pip install -e /tmp/dcos-installer-build
 cp gen/build_deploy/bash/dcos-launch.spec ./
-pyinstaller dcos-launch.spec
+pyinstaller --log-level=DEBUG dcos-launch.spec
 popd
 cp /tmp/dcos-installer-build/dist/dcos-launch ./

--- a/gen/build_deploy/bash/dcos-launch.spec
+++ b/gen/build_deploy/bash/dcos-launch.spec
@@ -1,4 +1,12 @@
-a = Analysis(['test_util/launch.py'])
+# Warning:
+#   - hidden import must be used as there is a bug in pyinstaller
+#     https://github.com/pyinstaller/pyinstaller/issues/2185
+#   - data must be decalared explicitly if not a .py file
+#   - Building will suck up the local SSL .so and package it
+#     with the final exe. Ensure build system has OpenSSL 1.0.2g or greater
+a = Analysis(['test_util/launch.py'],
+             hiddenimports=['html.parser'],
+             datas=[('gen/ip-detect/*.sh', 'gen/ip-detect/')])
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 exe = EXE(
     pyz,

--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -48,8 +48,8 @@ class BotoWrapper():
     def create_key_pair(self, key_name):
         """Returns private key of newly generated pair
         """
-        key = self.resource('ec2').KeyPair(key_name)
-        return key.key_material
+        key = self.client('ec2').create_key_pair(KeyName=key_name)
+        return key['KeyMaterial']
 
     def delete_key_pair(self, key_name):
         self.resource('ec2').KeyPair(key_name).delete()

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -1,20 +1,292 @@
-"""
+"""DC/OS Launch
 
 Usage:
-dcos-launch create [--wait] [--dump-info=cluster_info.json] <config=config.yaml>
-dcos-launch wait <path=cluster_info.json>
-dcos-launch describe <path=cluster_info.json>
-dcos-launch delete <path=cluster_info.json>
+  dcos-launch create [--config-path=<path> --info-path=<path>]
+  dcos-launch wait [--info-path=<path>]
+  dcos-launch describe [--info-path=<path>]
+  dcos-launch pytest [--info-path=<path> --env=<envlist>] [--] [<pytest_extras>]...
+  dcos-launch delete [--info-path=<path>]
+
+Commands:
+  create    Reads the file given by --config-path, creates the cluster described therein
+            and finally dumps a JSON file to the path given in --info-path which can then
+            be used with the wait, describe, and delete calls.
+  wait      Block until the cluster is up and running.
+  describe  Return additional information about the composition of the cluster.
+  pytest    Runs integration test suite on cluster. Can optionally supply options and arguments to pytest
+  delete    Destroying the provided cluster deployment.
+
+Options:
+  --config-path=<path>  Path for config to create cluster from [default: config.yaml].
+  --info-path=<path>    JSON file output by create and consumed by wait, describe,
+                        and delete [default: cluster_info.json].
+  --env=<envlist>       Specifies a comma-delimited list of environment variables to be
+                        passed from the local environment into the test environment.
 """
+import abc
+import copy
+import os
+import sys
 
 from docopt import docopt
 
+import ssh.tunnel
+import test_util.runner
+from pkgpanda.util import json_prettyprint, load_json, load_string, load_yaml, write_json, YamlParseError
+from test_util.aws import BotoWrapper, DcosCfSimple
 
-def main():
-    docopt(__doc__)
 
-    raise NotImplementedError()
+class LauncherError(Exception):
+    def __init__(self, error, msg):
+        self.error = error
+        self.msg = msg
+
+    def __repr__(self):
+        return '{}: {}'.format(self.error, self.msg)
+
+
+class AbstractLauncher(metaclass=abc.ABCMeta):
+    def create(self, config):
+        raise NotImplementedError()
+
+    def wait(self, info):
+        raise NotImplementedError()
+
+    def describe(self, info):
+        raise NotImplementedError()
+
+    def delete(self, info):
+        raise NotImplementedError()
+
+    def ssh_from_config(self, info):
+        raise NotImplementedError()
+
+    def test(self, info):
+        raise NotImplementedError()
+
+
+class AwsCloudformationLauncher(AbstractLauncher):
+    def __init__(self, boto_wrapper):
+        self.boto_wrapper = boto_wrapper
+
+    def create(self, config):
+        check_keys(config, ['stack_name', 'template_url'])
+        ssh_info = self.ssh_from_config(config)
+        # NOTE: even if parameters not given, ssh_from_config will add KeyName
+        # parameter to config['parameters']
+        self.boto_wrapper.create_stack(
+            config['stack_name'], config['template_url'], config['parameters'])
+        return {
+            'type': 'cloudformation',
+            'stack_name': config['stack_name'],
+            'provider': {
+                'region': config['provider_info']['region'],
+                'access_key_id': config['provider_info']['access_key_id'],
+                'secret_access_key': config['provider_info']['secret_access_key']},
+            'ssh': ssh_info}
+
+    def wait(self, info):
+        # TODO: should this support the case where the cluster is being updated?
+        cf = self.get_stack(info)
+        status = cf.get_stack_details()['StackStatus']
+        if status == 'CREATE_IN_PROGRESS':
+            cf.wait_for_stack_creation(wait_before_poll_min=0)
+        elif status == 'CREATE_COMPLETE':
+            return
+        else:
+            raise LauncherError('WaitError', 'AWS Stack has entered unexpected state: {}'.format(status))
+
+    def describe(self, info):
+        desc = copy.copy(info)
+        cf = self.get_stack(info)
+        desc.update({
+            'masters': convert_host_list(cf.get_master_ips()),
+            'private_agents': convert_host_list(cf.get_private_agent_ips()),
+            'public_agents': convert_host_list(cf.get_public_agent_ips())})
+        return desc
+
+    def delete(self, info):
+        if info['ssh']['delete_with_stack']:
+            self.boto_wrapper.delete_key_pair(info['ssh']['key_name'])
+        self.get_stack(info).delete()
+
+    def ssh_from_config(self, config):
+        """
+        In AWS simple deploys, SSH is only used for running the integration test suite.
+        In order to use SSH with AWS, one must use an SSH key pair that was previously created
+        in and downloaded from AWS. The private key cannot be obtained after its creation, so there
+        are three supported possibilities:
+        1. User has no preset key pair and would like one to be created for just this instance.
+            The keypair will be generated and the private key and key name will be added to the
+            ssh_info of the cluster info JSON. This key will be marked in the ssh_info for deletion
+            by dcos-launch when the entire cluster is deleted. SSH user name cannot be inferred so
+            it must still be provided in the ssh_info of the config
+        2. User has a preset AWS KeyPair and no corresponding private key. Testing will not be possible
+            without the private key, so ssh_info can be completely omitted with no loss.
+        3. User has a preset AWS KeyPair and has the corresponding private key. The private key must be
+            pointed to with private_key_path in the config ssh_info along with user.
+
+        Case 2 and 3 require specifying key name. The key name can be provided to dcos-launch in two ways:
+        1. Passed directly to the template like other template parameters.
+        ---
+        parameters:
+          - ParameterKey: KeyName
+            ParameterValue: my_key_name
+        ssh_info:
+          user: foo
+          private_key_path: path_to_my_key
+        2. Provided with the other SSH paramters:
+        ---
+        ssh_info:
+          user: foo
+          key_name: my_key_name
+          private_key_path: path_to_my_key
+
+        This method will take the config dict, determine if a key name is provided, if necessary, generate
+        the key and amend the config, and return the ssh_info for the cluster info JSON
+        """
+        generate_key = False
+        key_name = None
+        private_key = None
+        # Native AWS parameters take precedence
+        if 'parameters' in config:
+            for p in config['parameters']:
+                if p['ParameterKey'] == 'KeyName':
+                    key_name = p['ParameterValue']
+        # check ssh_info data
+        if 'ssh_info' in config:
+            if key_name is None:
+                key_name = config['ssh_info'].get('key_name', None)
+            elif 'key_name' in config['ssh_info']:
+                raise LauncherError('ValidationError',
+                                    'Provide key name as either a parameter or in ssh_info; not both')
+            if 'private_key_path' in config['ssh_info']:
+                if key_name is None:
+                    raise LauncherError('ValidationError', 'If a private_key_path is provided, '
+                                        'then the KeyName template parameter must be set')
+                private_key = load_string(config['ssh_info']['private_key_path'])
+        if not key_name:
+            key_name = config['stack_name']
+            generate_key = True
+            private_key = self.boto_wrapper.create_key_pair(key_name)
+            cf_params = config.get('parameters', list())
+            cf_params.append({'ParameterKey': 'KeyName', 'ParameterValue': key_name})
+            config['parameters'] = cf_params
+        return {
+            'delete_with_stack': generate_key,
+            'private_key': private_key,
+            'key_name': key_name,
+            'user': config.get('ssh_info', dict()).get('user', None)}
+
+    def test(self, info, test_cmd):
+        ssh_info = info['ssh']
+        for param in ['user', 'private_key']:
+            if param not in ssh_info:
+                raise LauncherError('MissingInfo', 'Cluster was created without providing ssh_info: {}'.format(param))
+        details = self.describe(info)
+        test_host = details['masters'][0]['public_ip']
+        # TODO: section should be generalized for use by other pr
+        with ssh.tunnel.tunnel(ssh_info['user'], ssh_info['private_key'], test_host) as test_tunnel:
+            return test_util.runner.integration_test(
+                tunnel=test_tunnel,
+                dcos_dns=test_host,
+                master_list=[m['private_ip'] for m in details['masters']],
+                agent_list=[a['private_ip'] for a in details['private_agents']],
+                public_agent_list=[a['private_ip'] for a in details['public_agents']],
+                aws_access_key_id=info['provider']['access_key_id'],
+                aws_secret_access_key=info['provider']['secret_access_key'],
+                region=info['provider']['region'],
+                test_cmd=test_cmd)
+
+    def get_stack(self, info):
+        """Returns the correct class interface depending how the AWS CF is configured
+        NOTE: only supports Simple Cloudformation currently
+        """
+        try:
+            return DcosCfSimple(info['stack_name'], self.boto_wrapper)
+        except Exception as ex:
+            raise LauncherError('StackNotFound', '{} is not accessible'.format(info['stack_name'])) from ex
+
+
+def get_launcher(launcher_type, provider_info):
+    """Returns a launcher given a launcher type (string) and a dictionary of
+    appropriate provier_info
+    """
+    if launcher_type == 'cloudformation':
+        check_keys(provider_info, ['region', 'access_key_id', 'secret_access_key'])
+        boto_wrapper = BotoWrapper(
+            provider_info['region'], provider_info['access_key_id'], provider_info['secret_access_key'])
+        return AwsCloudformationLauncher(boto_wrapper)
+    else:
+        raise LauncherError('UnsupportedAction', 'Launcher type not supported: {}'.format(launcher_type))
+
+
+def convert_host_list(host_list):
+    """ Makes Host tuples more readable when using describe
+    """
+    return [{'private_ip': h.private_ip, 'public_ip': h.public_ip} for h in host_list]
+
+
+def check_keys(user_dict, key_list):
+    missing = [k for k in key_list if k not in user_dict]
+    if len(missing) > 0:
+        raise LauncherError('MissingInput', 'The following keys were required but '
+                            'not provided: {}'.format(repr(missing)))
+
+
+def do_main(args):
+    if args['create']:
+        info_path = args['--info-path']
+        if os.path.exists(info_path):
+            raise LauncherError('InputConflict', 'Target info path already exists!')
+        config = load_yaml(args['--config-path'])
+        check_keys(config, ['type', 'provider_info', 'this_is_a_temporary_config_format_do_not_put_in_production'])
+        write_json(info_path, get_launcher(config['type'], config['provider_info']).create(config))
+        return 0
+
+    info = load_json(args['--info-path'])
+    check_keys(info, ['type', 'provider'])
+    launcher = get_launcher(info['type'], info['provider'])
+
+    if args['wait']:
+        launcher.wait(info)
+        print('Cluster is ready!')
+        return 0
+
+    if args['describe']:
+        print(json_prettyprint(launcher.describe(info)))
+        return 0
+
+    if args['pytest']:
+        test_cmd = 'py.test'
+        if args['--env'] is not None:
+            if '=' in args['--env']:
+                # User is attempting to do an assigment with the option
+                raise LauncherError('OptionError', "The '--env' option can only pass through environment variables "
+                                    "from the current environment. Set variables according to the shell being used.")
+            var_list = args['--env'].split(',')
+            check_keys(os.environ, var_list)
+            test_cmd = ' '.join(['{}={}'.format(e, os.environ[e]) for e in var_list]) + ' ' + test_cmd
+        if len(args['<pytest_extras>']) > 0:
+            test_cmd += ' ' + ' '.join(args['<pytest_extras>'])
+        launcher.test(info, test_cmd)
+        return 0
+
+    if args['delete']:
+        launcher.delete(info)
+        return 0
+
+
+def main(argv=None):
+    args = docopt(__doc__, argv=argv, version='DC/OS Launch v.0.1')
+
+    try:
+        return do_main(args)
+    except (LauncherError, YamlParseError) as ex:
+        print('DC/OS Launch encountered an error!')
+        print(repr(ex))
+        return 1
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/test_util/test_launch.py
+++ b/test_util/test_launch.py
@@ -1,0 +1,316 @@
+import json
+from contextlib import contextmanager
+
+import pytest
+import yaml
+from docopt import DocoptExit
+
+import ssh.tunnel
+import test_util
+from pkgpanda.util import load_json
+from test_util.helpers import Host
+from test_util.launch import get_launcher, LauncherError, main
+
+MOCK_SSH_KEY_DATA = 'ssh_key_data'
+MOCK_KEY_NAME = 'my_key_name'
+
+
+def check_cli(cmd):
+    assert main(cmd) == 0, 'Command failed! {}'.format(' '.join(cmd))
+
+
+def check_success(capsys, tmpdir, config_str):
+    """
+    Runs through the required functions of a launcher and then
+    runs through the default usage of the script for a
+    given config path and info path, ensuring each step passes
+    if all steps finished successfully, this parses and returns the generated
+    info JSON and stdout description JSON for more specific checks
+    """
+    # Test launcher directly first
+    config = yaml.safe_load(config_str)
+    launcher = get_launcher(config['type'], config['provider_info'])
+    info = launcher.create(config)
+    launcher.wait(info)
+    launcher.describe(info)
+    launcher.test(info, 'py.test')
+    launcher.delete(info)
+
+    # add config to disk and make info path for CLI testing
+    config_path = tmpdir.join('my_specific_config.yaml')  # test non-default name
+    config_path.write(config_str)
+    config_path = str(config_path)
+    info_path = str(tmpdir.join('my_specific_info.json'))  # test non-default name
+
+    # Now check launcher via CLI
+    check_cli(['create', '--config-path={}'.format(config_path), '--info-path={}'.format(info_path)])
+    # use the info written to disk to ensure JSON parsable
+    info = load_json(info_path)
+    # General assertions about info
+    assert 'type' in info
+    assert 'provider' in info
+    assert 'ssh' in info
+    assert 'user' in info['ssh']
+    assert 'private_key' in info['ssh']
+
+    check_cli(['wait', '--info-path={}'.format(info_path)])
+
+    # clear stdout capture
+    capsys.readouterr()
+    check_cli(['describe', '--info-path={}'.format(info_path)])
+    # capture stdout from describe and ensure JSON parse-able
+    description = json.loads(capsys.readouterr()[0])
+
+    # general assertions about description
+    assert 'masters' in description
+    assert 'private_agents' in description
+    assert 'public_agents' in description
+
+    check_cli(['pytest', '--info-path={}'.format(info_path)])
+
+    check_cli(['delete', '--info-path={}'.format(info_path)])
+
+    return info, description
+
+
+@contextmanager
+def mocked_context(*args, **kwargs):
+    """ To be directly patched into an ssh.tunnel invocation to prevent
+    any real SSH attempt
+    """
+    yield type('Tunnelled', (object,), {})
+
+
+@pytest.fixture
+def mocked_test_runner(monkeypatch):
+    monkeypatch.setattr(ssh.tunnel, 'tunnel', mocked_context)
+    monkeypatch.setattr(test_util.runner, 'integration_test', lambda *args, **kwargs: 0)
+
+
+@pytest.fixture
+def mocked_ssh_key_path(tmpdir):
+    ssh_key_path = tmpdir.join('ssh_key')
+    ssh_key_path.write(MOCK_SSH_KEY_DATA)
+    return str(ssh_key_path)
+
+
+@pytest.fixture
+def mocked_aws_cf_simple_backend(monkeypatch, mocked_test_runner):
+    """Does not include SSH key mocking
+    """
+    # mock create
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_stack', lambda *args: None)
+    # mock wait
+    monkeypatch.setattr(test_util.aws.CfStack, 'get_stack_details', lambda _: {'StackStatus': 'CREATE_COMPLETE'})
+    # mock describe
+    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_master_ips',
+                        lambda _: [Host('127.0.0.1', '12.34.56')])
+    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_private_agent_ips',
+                        lambda _: [Host('127.0.0.1', None)])
+    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_public_agent_ips',
+                        lambda _: [Host('127.0.0.1', '12.34.56')])
+    # mock delete
+    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'delete', lambda _: None)
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_key_pair', lambda *args: None)
+    # mock config
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_key_pair', lambda *args: MOCK_SSH_KEY_DATA)
+
+
+@pytest.fixture
+def mocked_aws_cf_simple(mocked_ssh_key_path, mocked_aws_cf_simple_backend):
+    return """
+---
+this_is_a_temporary_config_format_do_not_put_in_production: yes_i_agree
+type: cloudformation
+template_url: http://us-west-2.amazonaws.com/downloads
+stack_name: foobar
+provider_info:
+  region: us-west-2
+  access_key_id: asdf09iasdf3m19238jowsfn
+  secret_access_key: asdf0asafawwa3j8ajn
+ssh_info:
+  user: core
+  private_key_path: {}
+parameters:
+  - ParameterKey: KeyName
+    ParameterValue: default
+  - ParameterKey: AdminLocation
+    ParameterValue: 0.0.0.0/0
+  - ParameterKey: PublicSlaveInstanceCount
+    ParameterValue: 1
+  - ParameterKey: SlaveInstanceCount
+    ParameterValue: 5
+""".format(mocked_ssh_key_path)
+
+
+def test_aws_cf_simple(capsys, tmpdir, mocked_aws_cf_simple):
+    """Test that required parameters are consumed and appropriate output is generated
+    """
+    info, desc = check_success(capsys, tmpdir, mocked_aws_cf_simple)
+    # check AWS specific info
+    assert info['type'] == 'cloudformation'
+    assert 'stack_name' in info
+    assert 'region' in info['provider']
+    assert 'access_key_id' in info['provider']
+    assert 'secret_access_key' in info['provider']
+    assert info['ssh']['key_name'] == 'default'
+    assert info['ssh']['delete_with_stack'] is False
+    assert info['ssh']['private_key'] == MOCK_SSH_KEY_DATA
+    assert info['ssh']['user'] == 'core'
+    # check that description is updated with info
+    assert 'stack_name' in desc
+
+
+@pytest.mark.usefixtures('mocked_aws_cf_simple')
+def test_aws_cf_simple_make_key(capsys, tmpdir):
+    """ Same mocked backend as other aws_cf_simple tests, but marginally different config
+    Test that required parameters are consumed and appropriate output is generated
+    """
+    config = """
+---
+this_is_a_temporary_config_format_do_not_put_in_production: yes_i_agree
+type: cloudformation
+template_url: http://us-west-2.amazonaws.com/downloads
+stack_name: foobar
+provider_info:
+  region: us-west-2
+  access_key_id: asdf09iasdf3m19238jowsfn
+  secret_access_key: asdf0asafawwa3j8ajn
+ssh_info:
+  user: core
+parameters:
+  - ParameterKey: AdminLocation
+    ParameterValue: 0.0.0.0/0
+  - ParameterKey: PublicSlaveInstanceCount
+    ParameterValue: 1
+  - ParameterKey: SlaveInstanceCount
+    ParameterValue: 5
+"""
+    info, desc = check_success(capsys, tmpdir, config)
+    # check AWS specific info
+    assert info['type'] == 'cloudformation'
+    assert 'stack_name' in info
+    assert 'region' in info['provider']
+    assert 'access_key_id' in info['provider']
+    assert 'secret_access_key' in info['provider']
+    assert info['ssh']['key_name'] == 'foobar'
+    assert info['ssh']['delete_with_stack'] is True
+    assert info['ssh']['private_key'] == MOCK_SSH_KEY_DATA
+    assert info['ssh']['user'] == 'core'
+    # check that description is updated with info
+    assert 'stack_name' in desc
+
+
+def test_no_files_specified(tmpdir, mocked_aws_cf_simple):
+    """Ensure typical usage works without specifying config and info file paths
+    """
+    with tmpdir.as_cwd():
+        config_path = tmpdir.join('config.yaml')
+        config_path.write(mocked_aws_cf_simple)
+        assert main(['create']) == 0
+        assert main(['wait']) == 0
+        assert main(['describe']) == 0
+        assert main(['pytest']) == 0
+        assert main(['delete']) == 0
+
+
+def test_noop():
+    """Ensure docopt exit (displays usage)
+    """
+    with pytest.raises(DocoptExit):
+        main([])
+    with pytest.raises(DocoptExit):
+        main(['foobar'])
+
+
+def test_conflicting_path(tmpdir, mocked_aws_cf_simple):
+    """Ensure default cluster info path is never overwritten
+    by launching successive clusters
+    """
+    with tmpdir.as_cwd():
+        tmpdir.join('config.yaml').write(mocked_aws_cf_simple)
+        assert main(['create']) == 0
+        assert main(['create']) == 1
+
+
+def test_missing_input(tmpdir):
+    """No files are provided so any operation should fail
+    """
+    with tmpdir.as_cwd():
+        for cmd in ['create', 'wait', 'describe', 'delete', 'pytest']:
+            with pytest.raises(FileNotFoundError):
+                main([cmd])
+
+
+def mock_stack_not_found(*args):
+    raise Exception('Mock stack was not found!!!')
+
+
+def test_missing_aws_stack(mocked_aws_cf_simple, monkeypatch):
+    """ Tests that clean and appropriate errors will be raised
+    """
+    monkeypatch.setattr(test_util.aws.CfStack, '__init__', mock_stack_not_found)
+    config = yaml.safe_load(mocked_aws_cf_simple)
+    aws_launcher = get_launcher(config['type'], config['provider_info'])
+
+    def check_stack_error(cmd, args):
+        with pytest.raises(LauncherError) as exinfo:
+            getattr(aws_launcher, cmd)(*args)
+        assert exinfo.value.error == 'StackNotFound'
+
+    info = aws_launcher.create(config)
+    check_stack_error('wait', (info,))
+    check_stack_error('describe', (info,))
+    check_stack_error('delete', (info,))
+    check_stack_error('test', (info, 'py.test'))
+
+
+@pytest.mark.usefixtures('mocked_aws_cf_simple')
+def test_aws_ssh_key_handling(mocked_ssh_key_path):
+    provider_info = {
+        'region': 'us-west-2',
+        'access_key_id': 'foo',
+        'secret_access_key': 'bar'}
+    aws_launcher = get_launcher('cloudformation', provider_info)
+    # Test most minimal config (nothing given and key is generated)
+    ssh_info = aws_launcher.ssh_from_config({'stack_name': 'foo'})
+    expected_ssh_info = {
+        'delete_with_stack': True,
+        'key_name': 'foo',
+        'private_key': MOCK_SSH_KEY_DATA,
+        'user': None}
+    assert ssh_info == expected_ssh_info
+    # Test KeyName in provided parameters and private key provided for testing
+    ssh_info = aws_launcher.ssh_from_config({
+        'stack_name': 'foo',
+        'parameters': [{'ParameterKey': 'KeyName', 'ParameterValue': MOCK_KEY_NAME}],
+        'ssh_info': {'private_key_path': mocked_ssh_key_path}})
+    expected_ssh_info = {
+        'delete_with_stack': False,
+        'key_name': MOCK_KEY_NAME,
+        'private_key': MOCK_SSH_KEY_DATA,
+        'user': None}
+    assert ssh_info == expected_ssh_info
+    # Test key_name provided by ssh_info and not paramaters
+    ssh_info = aws_launcher.ssh_from_config({
+        'stack_name': 'foo',
+        'ssh_info': {
+            'key_name': MOCK_KEY_NAME,
+            'private_key_path': mocked_ssh_key_path}})
+    expected_ssh_info = {
+        'delete_with_stack': False,
+        'key_name': MOCK_KEY_NAME,
+        'private_key': MOCK_SSH_KEY_DATA,
+        'user': None}
+    assert ssh_info == expected_ssh_info
+    # Test private_key given, but no key_name to link against
+    with pytest.raises(LauncherError):
+        aws_launcher.ssh_from_config({
+            'stack_name': 'foo',
+            'ssh_info': {'private_key_path': mocked_ssh_key_path}})
+    # Test redundant fields assigned
+    with pytest.raises(LauncherError):
+        aws_launcher.ssh_from_config({
+            'stack_name': 'foo',
+            'ssh_info': {'key_name': MOCK_KEY_NAME},
+            'parameters': [{'ParameterKey': 'KeyName', 'ParameterValue': MOCK_KEY_NAME}]})

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
 deps =
   dnspython
   pytest
+  PyYAML
   webtest
   webtest-aiohttp==1.1.0
 commands=


### PR DESCRIPTION
Initial implementation of DC/OS Launch Utility
-only covers launching generic AWS CF simple templates. Can technically launch any generic cloudformation template, but it all features will only work for a simple deployment
-Covers create, wait, describe, test, and delete
-test optionally takes command line args for interactively working on tests

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
