### PR TITLE
Update dcos_generate_config.sh --help to display the right help messages

### DIFF
--- a/dcos_installer/cli.py
+++ b/dcos_installer/cli.py
@@ -155,7 +155,7 @@ dispatch_dict_simple = {
         'Run the web interface'),
     'genconf': (
         lambda args: backend.do_configure(),
-        'EXECUTING CONFIGURATION GENERATION'
+        'EXECUTING CONFIGURATION GENERATION',
         'Execute the configuration generation (genconf).'),
     'validate-config': (
         do_validate_config,
@@ -265,6 +265,7 @@ def parse_args(args):
     mutual_exc.add_argument(
         '--hash-password',
         action='append',
+        metavar='password',
         nargs='?',
         help='Hash a password and print the results to copy into a config.yaml.'
     )
@@ -272,6 +273,7 @@ def parse_args(args):
     mutual_exc.add_argument(
         '--set-superuser-password',
         action='append',
+        metavar='password',
         nargs='?',
         help='Hash the given password and store it as the superuser password in config.yaml'
     )
@@ -310,10 +312,10 @@ def parse_args(args):
 
     # Add all arg modes
     for name, value in dispatch_dict_simple.items():
-        add_mode(name, value[1])
+        add_mode(name, value[2])
 
     for name, value in dispatch_dict_aio.items():
-        add_mode(name, value[1])
+        add_mode(name, value[2])
 
     return parser.parse_args(args)
 


### PR DESCRIPTION
Main changes:
 - HASH_PASSWORD, SET_SUPERUSER_PASSWORD placeholders become `password`
 - The help for `--preflight` and the like shows the intended help string rather than the all-caps used in the display output when running.

Old:
```
usage: dcos_installer [-h] [--hash-password [HASH_PASSWORD]]
                      [--set-superuser-password [SET_SUPERUSER_PASSWORD]] [-v]
                      [--offline] [--cli-telemetry-disabled] [--version]
                      [--validate-config] [--genconf] [--web]
                      [--aws-cloudformation] [--preflight] [--postflight]
                      [--uninstall] [--install-prereqs] [--deploy]

DC/OS Install and Configuration Utility

optional arguments:
  -h, --help            show this help message and exit
  --hash-password [HASH_PASSWORD]
                        Hash a password and print the results to copy into a
                        config.yaml.
  --set-superuser-password [SET_SUPERUSER_PASSWORD]
                        Hash the given password and store it as the superuser
                        password in config.yaml
  -v, --verbose         Verbose log output (DEBUG).
  --offline             Do not install preflight prerequisites on CentOS7,
                        RHEL7 in web mode
  --cli-telemetry-disabled
                        Disable the CLI telemetry gathering for SegmentIO
  --version
  --validate-config     VALIDATING CONFIGURATION
  --genconf             EXECUTING CONFIGURATION GENERATIONExecute the
                        configuration generation (genconf).
  --web                 Starting DC/OS installer in web mode
  --aws-cloudformation  EXECUTING AWS CLOUD FORMATION TEMPLATE GENERATION
  --preflight           EXECUTING_PREFLIGHT
  --postflight          EXECUTING POSTFLIGHT
  --uninstall           EXECUTING UNINSTALL
  --install-prereqs     EXECUTING INSTALL PREREQUISITES
  --deploy              EXECUTING DC/OS INSTALLATION
```

New:
```
usage: dcos_installer [-h] [--hash-password [password]]
                      [--set-superuser-password [password]] [-v] [--offline]
                      [--cli-telemetry-disabled] [--web] [--version]
                      [--aws-cloudformation] [--genconf] [--validate-config]
                      [--preflight] [--postflight] [--install-prereqs]
                      [--uninstall] [--deploy]

DC/OS Install and Configuration Utility

optional arguments:
  -h, --help            show this help message and exit
  --hash-password [password]
                        Hash a password and print the results to copy into a
                        config.yaml.
  --set-superuser-password [password]
                        Hash the given password and store it as the superuser
                        password in config.yaml
  -v, --verbose         Verbose log output (DEBUG).
  --offline             Do not install preflight prerequisites on CentOS7,
                        RHEL7 in web mode
  --cli-telemetry-disabled
                        Disable the CLI telemetry gathering for SegmentIO
  --web                 Run the web interface
  --version             Print the DC/OS version
  --aws-cloudformation  Generate AWS Advanced AWS CloudFormation templates
                        using the provided config
  --genconf             Execute the configuration generation (genconf).
  --validate-config     Validate the configuration for executing --genconf and
                        deploy arguments in config.yaml
  --preflight           Execute the preflight checks on a series of nodes.
  --postflight          Execute postflight checks on a series of nodes.
  --install-prereqs     Execute the preflight checks on a series of nodes.
  --uninstall           Execute uninstall on target hosts.
  --deploy              Execute a deploy.
```

Thanks @mellenburg  for finding this bug

https://mesosphere.atlassian.net/browse/DCOS-10167