### PR TITLE
Teach configuration to pass through internal load balancer DNS for certificate generation

### DIFF
--- a/gen/aws/calc.py
+++ b/gen/aws/calc.py
@@ -31,6 +31,7 @@ entry = {
         'master_cloud_config': '{{ master_cloud_config }}',
         'agent_private_cloud_config': '{{ slave_cloud_config }}',
         'agent_public_cloud_config': '{{ slave_public_cloud_config }}',
+        'master_external_load_balancer': '{ "Fn::GetAtt" : [ "ElasticLoadBalancer", "DNSName" ] }',
         # template variable for the generating advanced template cloud configs
         'cloud_config': '{{ cloud_config }}',
         'oauth_available': 'true',

--- a/gen/aws/dcos-config.yaml
+++ b/gen/aws/dcos-config.yaml
@@ -6,7 +6,3 @@ package:
       AWS_STACK_NAME={ "Ref" : "AWS::StackName" }
       AWS_IAM_MASTER_ROLE_NAME={{ master_role }}
       AWS_IAM_SLAVE_ROLE_NAME={{ agent_role }}
-  - path: /etc/aws_dnsnames
-    content: |
-      INTERNAL_MASTER_LB_DNSNAME={ "Fn::GetAtt" : [ "InternalMasterLoadBalancer", "DNSName" ] }
-      MASTER_LB_DNSNAME={ "Fn::GetAtt" : [ "ElasticLoadBalancer", "DNSName" ] }

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -432,6 +432,13 @@ def calculate_cluster_docker_registry_enabled(cluster_docker_registry_url):
     return 'false' if cluster_docker_registry_url == '' else 'true'
 
 
+def calculate_set(parameter):
+    if parameter == '':
+        return 'false'
+    else:
+        return 'true'
+
+
 __logrotate_slave_module_name = 'org_apache_mesos_LogrotateContainerLogger'
 
 
@@ -487,6 +494,7 @@ entry = {
         'auth_cookie_secure_flag': 'false',
         'master_dns_bindall': 'true',
         'mesos_dns_ip_sources': '["host", "netinfo"]',
+        'master_external_loadbalancer': '',
         'mesos_container_logger': __logrotate_slave_module_name,
         'mesos_log_retention_mb': '4000',
         'oauth_issuer_url': 'https://dcos.auth0.com/',
@@ -569,6 +577,8 @@ entry = {
         'no_proxy_final': calculate_no_proxy,
         'cluster_docker_credentials_path': calculate_cluster_docker_credentials_path,
         'cluster_docker_registry_enabled': calculate_cluster_docker_registry_enabled,
+        'has_master_external_loadbalancer':
+            lambda master_external_loadbalancer: calculate_set(master_external_loadbalancer)
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -503,6 +503,18 @@ package:
       METRONOME_MESOS_MASTER_URL=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       METRONOME_PLAY_SERVER_HTTP_PORT=9000
       METRONOME_MESOS_USER=root
+  - path: /etc/extra_master_addresses
+    content: |
+{% switch master_discovery %}
+{% case "master_http_loadbalancer" %}
+      INTERNAL_MASTER_LB_DNSNAME={{ exhibitor_address }}
+{% case "static" %}
+{% endswitch %}
+{% switch has_master_external_loadbalancer %}
+{% case "true" %}
+      MASTER_LB_DNSNAME={{ master_external_loadbalancer }}
+{% case "false" %}
+{% endswitch %}
   - path: /etc/user.config.yaml
     content: |
 {{ config_yaml }}

--- a/gen/installer/aws.py
+++ b/gen/installer/aws.py
@@ -334,7 +334,7 @@ def make_advanced_bunch(variant_args, template_name, cc_params):
         '/etc/mesos-master-provider']
 
     if cc_params['node_type'] == 'master':
-        cc_package_files.append('/etc/aws_dnsnames')
+        cc_package_files.append('/etc/extra_master_addresses')
 
     results = gen.generate(
         arguments=variant_args,
@@ -449,7 +449,7 @@ def gen_templates(arguments):
             '/etc/dns_config',
             '/etc/exhibitor',
             '/etc/mesos-master-provider',
-            '/etc/aws_dnsnames'])
+            '/etc/extra_master_addresses'])
 
     cloud_config = results.templates['cloud-config.yaml']
 

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -86,6 +86,9 @@ class Scope:
         assert isinstance(other, Scope)
         return self.name == other.name and self.cases == other.cases
 
+    def __repr__(self):
+        return "<Scope cases: {}>".format(self.cases.items())
+
 
 class Target:
 
@@ -99,7 +102,10 @@ class Target:
         self.variables.add(variable)
 
     def add_scope(self, scope: Scope):
-        self.sub_scopes[scope.name] = scope
+        if scope.name in self.sub_scopes:
+            self.sub_scopes[scope.name] += scope
+        else:
+            self.sub_scopes[scope.name] = scope
 
     def __iadd__(self, other):
         assert isinstance(other, Target), "Internal consistency error, expected Target but got {}".format(type(other))
@@ -113,6 +119,9 @@ class Target:
                 self.sub_scopes[name] = scope
 
         return self
+
+    def __repr__(self):
+        return "<Target variables: {}, sub_scopes: {}>".format(self.variables, self.sub_scopes.items())
 
     def __eq__(self, other):
         assert isinstance(other, Target)


### PR DESCRIPTION
This makes it possible to do things like issue certs properly inside the cluster
for all the addresses of a master. Previously that was only possible for AWS
clusters because the integration was AWS only.

Builds on #883, Train 91 (fixes a bug that existed before and after that train, but in a piece of code #868 reworks some)

https://mesosphere.atlassian.net/browse/DCOS-10934