### PR TITLE
Revert "Make dcos-spartan-watchdog start later rather than have a random 60 second sleep"

### DIFF
--- a/packages/spartan/extra/dcos-spartan-watchdog.service
+++ b/packages/spartan/extra/dcos-spartan-watchdog.service
@@ -9,4 +9,5 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/dns_search_config
 EnvironmentFile=-/opt/mesosphere/etc/dns_config_master
+ExecStartPre=/bin/sleep 60
 ExecStart=/opt/mesosphere/active/toybox/bin/toybox timeout -k 1m 1m /bin/bash -c "/opt/mesosphere/active/toybox/bin/toybox host ready.spartan 198.51.100.1 || /opt/mesosphere/active/toybox/bin/toybox pkill -l 9 -f spartan"

--- a/packages/spartan/extra/dcos-spartan-watchdog.timer
+++ b/packages/spartan/extra/dcos-spartan-watchdog.timer
@@ -1,5 +1,5 @@
 [Unit]
 Description=DNS Dispatcher Watchdog Timer: Periodically check is Spartan is working
 [Timer]
-OnBootSec=65sec
+OnBootSec=5sec
 OnUnitActiveSec=2min


### PR DESCRIPTION
This reverts commit ecfe9a57ac9e61e84ad84161c8854f51aa12f417.

There still isn't a good explanation _why_ sleep is better than a delay. The behavior hasn't
really been explained.

That said, this fixes the issue for one customer at present, although we still need to come up with
a reasonable reason for that and _proper_ fixes. `sleep` is rarely the correct solution to software
problems, just a band-aid...

I'm really not a fan of this, only doing it because we need a fix today.

# Issues

[DCOS-10809](https://mesosphere.atlassian.net/browse/DCOS-10809)

# Checklist

 - [ ] No: Included a test which will fail if code is reverted but test is not
 - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
