### PR TITLE
Changed some package urls to https instead of http.

### DIFF
--- a/packages/curl/buildinfo.json
+++ b/packages/curl/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["openssl", "python-requests"],
   "single_source": {
     "kind": "url_extract",
-    "url": "http://curl.haxx.se/download/curl-7.48.0.tar.gz",
+    "url": "https://curl.haxx.se/download/curl-7.48.0.tar.gz",
     "sha1": "eac95625b849408362cf6edb0bc9489da317ba30"
   }
 }

--- a/packages/ncurses/buildinfo.json
+++ b/packages/ncurses/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "http://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz",
+    "url": "https://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz",
     "sha1": "acd606135a5124905da770803c05f1f20dd3b21c"
   }
 }

--- a/packages/strace/buildinfo.json
+++ b/packages/strace/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source": {
     "kind": "url_extract",
-    "url": "http://downloads.mesosphere.com/strace/strace-4.10.tar.xz",
+    "url": "https://downloads.mesosphere.com/strace/strace-4.10.tar.xz",
     "sha1": "5c3ec4c5a9eeb440d7ec70514923c2e7e7f9ab6c"
   }
 }

--- a/packages/toybox/buildinfo.json
+++ b/packages/toybox/buildinfo.json
@@ -3,7 +3,7 @@
   "sources": {
     "toybox": {
       "kind": "url_extract",
-      "url": "http://landley.net/toybox/downloads/toybox-0.7.0.tar.gz",
+      "url": "https://landley.net/toybox/downloads/toybox-0.7.0.tar.gz",
       "sha1": "154846f3faa7fa00f48b408f607fe85f36bb349e"
     }
   }


### PR DESCRIPTION
Five packages were fetched over HTTP instead of HTTPS. The SHA still gets checked, but this is a bit better. Confirmed all of these were served over HTTPS as well.

High level description including:
- What does this change enable
- What bugs does this change fix
- High-Level how things changed
# Issues

[DCOS-<number>](https://dcosjira.atlassian.net/browse/DCOS-<number)
...
# Checklist
- [ ] Included a test which will fail if code is reverted but test is not
- [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include
- [ ] Change Log from last: <link>
- [ ] Test Results: <link>
- [ ] Code Coverage: <link>
