### PR TITLE
Change the default build image to Ubuntu 16

### DIFF
--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -4,7 +4,7 @@ mkdir -p "$PKG_PATH/lib/"
 mkdir -p "$PKG_PATH/usr/"
 
 cp -rp /pkg/src/cosmos/cosmos-*-one-jar.jar "${PKG_PATH}/usr/cosmos.jar"
-sudo chmod -R o+r "${PKG_PATH}/usr"
+chmod -R o+r "${PKG_PATH}/usr"
 
 cosmos_service="${PKG_PATH}/dcos.target.wants_master/dcos-cosmos.service"
 mkdir -p $(dirname "$cosmos_service")

--- a/packages/libevent/build
+++ b/packages/libevent/build
@@ -3,8 +3,12 @@
 mkdir -p build
 pushd build
 
+export CFLAGS=-I/opt/mesosphere/include
+export LDFLAGS="-L/opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
+export CPPFLAGS=-I/opt/mesosphere/include
+
 cd /pkg/src/libevent
 ./autogen.sh
-LDFLAGS="-L/opt/mesosphere/active/openssl/lib" ./configure --prefix="$PKG_PATH"
+./configure --prefix="$PKG_PATH"
 make
 make install

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -4,7 +4,7 @@ mkdir -p "$PKG_PATH/usr/"
 
 cp -rp /pkg/src/marathon/target/scala-2.11/marathon-assembly-*.jar "$PKG_PATH/usr/marathon.jar"
 
-sudo chmod -R o+r "$PKG_PATH/usr"
+chmod -R o+r "$PKG_PATH/usr"
 
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")

--- a/packages/python/build
+++ b/packages/python/build
@@ -5,7 +5,7 @@ pushd build
 
 export CFLAGS=-I/opt/mesosphere/include
 export LDFLAGS="-L/opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
-export CXXFLAGS=-I/opt/mesosphere/include
+export CPPFLAGS=-I/opt/mesosphere/include
 
 /pkg/src/python/configure --enable-shared --prefix="$PKG_PATH" --enable-ipv6 --with-threads --with-computed-gotos
 make -j$NUM_CORES

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get -qq update && apt-get -y install \
   scala \
   unzip \
   wget \
+  xutils-dev \
   xz-utils \
   zlib1g-dev
 

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.4
+FROM ubuntu:16.04
 MAINTAINER help@dcos.io
 
 RUN apt-get -qq update && apt-get -y install \
@@ -10,7 +10,8 @@ RUN apt-get -qq update && apt-get -y install \
   default-jdk \
   default-jre \
   dpkg-dev \
-  gcc \
+  g++-4.8 \
+  gcc-4.8 \
   gettext-base \
   git \
   gzip \
@@ -22,7 +23,7 @@ RUN apt-get -qq update && apt-get -y install \
   libsasl2-dev \
   libsvn-dev \
   libtool \
-  linux-headers-3.19.0-21-generic \
+  linux-headers-4.4.0-45-generic \
   make \
   maven \
   patch \

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qq update && apt-get -y install \
   libcurl4-openssl-dev \
   libnl-3-dev \
   libnl-genl-3-dev \
+  libpcre++-dev \
   libpopt-dev \
   libsasl2-dev \
   libsvn-dev \

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -39,4 +39,7 @@ RUN apt-get -qq update && apt-get -y install \
   xz-utils \
   zlib1g-dev
 
+ENV CC=/usr/bin/gcc-4.8
+ENV CXX=/usr/bin/g++-4.8
+
 RUN pip install awscli

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -5,35 +5,36 @@ RUN apt-get -qq update && apt-get -y install \
   autoconf \
   automake \
   cmake \
-  make \
-  gcc \
   cpp \
-  patch \
-  python-dev \
-  python-pip \
-  git \
-  libtool \
+  curl \
   default-jdk \
   default-jre \
-  gzip \
-  zlib1g-dev \
-  libcurl4-openssl-dev \
-  python-setuptools \
   dpkg-dev \
-  libsasl2-dev \
-  maven \
+  gcc \
+  gettext-base \
+  git \
+  gzip \
   libapr1-dev \
-  libsvn-dev \
-  ruby \
-  curl \
-  wget \
-  scala \
-  xz-utils \
-  libpopt-dev \
+  libcurl4-openssl-dev \
   libnl-3-dev \
   libnl-genl-3-dev \
+  libpopt-dev \
+  libsasl2-dev \
+  libsvn-dev \
+  libtool \
   linux-headers-3.19.0-21-generic \
+  make \
+  maven \
+  patch \
   pkg-config \
-  gettext-base \
-  unzip
+  python-dev \
+  python-pip \
+  python-setuptools \
+  ruby \
+  scala \
+  unzip \
+  wget \
+  xz-utils \
+  zlib1g-dev
+
 RUN pip install awscli


### PR DESCRIPTION
This PR does:
- Alphabetizes the list of dependencies in the Dockerfile
- Bumps the base image from `ubuntu:14.04.4` to `ubuntu:16.04`
  - Changes `gcc` to `gcc-4.8` and `g++-4.8` (the same version that is currently being used) and set `CC` and `CXX` environment variables appropriately.
  - Bumps the package for `linux-headers` to match the updated kernel
  - Add `libpcre++-dev` dependency for adminrouter/nginx (the installed library is placed in the same location as before)
  - Add `xutils-dev` dependency for the `makedepend` utility
- `s/CXXFLAGS/CPPFLAGS/` in the main Python build, needed to find and build the `_ssl` module
- Removed extraneous `sudo`s from the Cosmos and Marathon build scripts
