### PR TITLE
Do not call logging.exception out of except clause

### DIFF
--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -101,9 +101,9 @@ class CfStack():
             if stack_status == state_2:
                 return True
             if stack_status != state_1:
-                log.exception('Stack Details: {}'.format(stack_details))
+                log.error('Stack Details: {}'.format(stack_details))
                 for event in self.get_stack_events():
-                    log.exception('Stack Events: {}'.format(repr(event)))
+                    log.error('Stack Events: {}'.format(event))
                 raise Exception('StackStatus changed unexpectedly to: {}'.format(stack_status))
             return False
         wait_loop()


### PR DESCRIPTION
logging.exception should never be called outside of an except loop, as it will not have an exception to pass and will make a terribly ugly stack trace as seen here:
https://teamcity.mesosphere.io/viewLog.html?buildId=458191&buildTypeId=ClosedSource_Dcos_IntegrationTests_CloudIntegrationTests_ProvisioningTestAwsDe_4&tab=buildLog#_focus=4228
