### PR TITLE
exhibitor: extract libraries to somewhere that isn't noexec

### DIFF
--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -10,6 +10,8 @@ RestartSec=5
 # Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
 RuntimeDirectory=dcos_exhibitor
+# Make ZooKeeper not write JNA libraries to /tmp, which can be noexec
+Environment=SERVER_JVMFLAGS=-Djna.tmpdir=/run/dcos_exhibitor
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -49,6 +49,7 @@ exhibitor_cmdline = [
     '-Djava.util.prefs.userRoot=/var/lib/dcos/exhibitor/',
     '-Duser.home=/var/lib/dcos/exhibitor/',
     '-Duser.dir=/var/lib/dcos/exhibitor/',
+    '-Djna.tmpdir=/run/dcos_exhibitor',
     '-jar', '$PKG_PATH/usr/exhibitor/exhibitor.jar',
     '--port', '8181',
     '--defaultconfig', '/run/dcos_exhibitor/exhibitor_defaults.conf',


### PR DESCRIPTION
exhibitor: extract libraries to somewhere that isn't noexec, like /tmp.
