### PR TITLE
set MARATHON_DEFAULT_NETWORK_NAME to the name of the default dcos overlay network

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -232,6 +232,20 @@ def validate_oauth_enabled(oauth_enabled):
     validate_true_false(oauth_enabled)
 
 
+def validate_network_default_name(dcos_overlay_network_default_name, dcos_overlay_network):
+    try:
+        overlay_network = json.loads(dcos_overlay_network)
+    except ValueError:
+        # TODO(cmaloney): This is not the right form to do this
+        assert False, "Provided input was not valid JSON: {}".format(dcos_overlay_network)
+
+    overlay_names = map(lambda overlay: overlay['name'], overlay_network['overlays'])
+
+    if dcos_overlay_network_default_name not in overlay_names:
+        assert False, "Default overlay network name does not reference a defined overlay network: {}".format(
+            dcos_overlay_network_default_name)
+
+
 def validate_dcos_overlay_network(dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
@@ -533,6 +547,8 @@ entry = {
         lambda master_dns_bindall: validate_true_false(master_dns_bindall),
         validate_os_type,
         validate_dcos_overlay_network,
+        lambda dcos_overlay_network_default_name, dcos_overlay_network:
+            validate_network_default_name(dcos_overlay_network_default_name, dcos_overlay_network),
         lambda dcos_overlay_enable: validate_true_false(dcos_overlay_enable),
         lambda dcos_overlay_mtu: validate_int_in_range(dcos_overlay_mtu, 552, None),
         lambda dcos_overlay_config_attempts: validate_int_in_range(dcos_overlay_config_attempts, 0, 10),

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -512,6 +512,9 @@ def validate_exhibitor_storage_master_discovery(master_discovery, exhibitor_stor
             "`master_http_load_balancer` then exhibitor_storage_backend must not be static."
 
 
+__dcos_overlay_network_default_name = 'dcos'
+
+
 entry = {
     'validate': [
         validate_num_masters,
@@ -588,11 +591,12 @@ entry = {
             'vtep_subnet': '44.128.0.0/20',
             'vtep_mac_oui': '70:B3:D5:00:00:00',
             'overlays': [{
-                'name': 'dcos',
+                'name': __dcos_overlay_network_default_name,
                 'subnet': '9.0.0.0/8',
                 'prefix': 24
             }]
         }),
+        'dcos_overlay_network_default_name': __dcos_overlay_network_default_name,
         'dcos_remove_dockercfg_enable': "false",
         'minuteman_min_named_ip': '11.0.0.0',
         'minuteman_max_named_ip': '11.255.255.255',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -235,23 +235,22 @@ def validate_oauth_enabled(oauth_enabled):
 def validate_network_default_name(dcos_overlay_network_default_name, dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
-    except ValueError:
-        # TODO(cmaloney): This is not the right form to do this
-        assert False, "Provided input was not valid JSON: {}".format(dcos_overlay_network)
+    except ValueError as ex:
+        raise AssertionError("Provided input was not valid JSON: {}".format(dcos_overlay_network)) from ex
 
     overlay_names = map(lambda overlay: overlay['name'], overlay_network['overlays'])
 
-    if dcos_overlay_network_default_name not in overlay_names:
-        assert False, "Default overlay network name does not reference a defined overlay network: {}".format(
-            dcos_overlay_network_default_name)
+    assert dcos_overlay_network_default_name in overlay_names, (
+        "Default overlay network name does not reference a defined overlay network: {}".format(
+            dcos_overlay_network_default_name))
 
 
 def validate_dcos_overlay_network(dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
-    except ValueError:
-        # TODO(cmaloney): This is not the right form to do this
-        assert False, "Provided input was not valid JSON: {}".format(dcos_overlay_network)
+    except ValueError as ex:
+        raise AssertionError("Provided input was not valid JSON: {}".format(dcos_overlay_network)) from ex
+
     # Check the VTEP IP, VTEP MAC keys are present in the overlay
     # configuration
     assert 'vtep_subnet' in overlay_network.keys(), (
@@ -260,10 +259,9 @@ def validate_dcos_overlay_network(dcos_overlay_network):
     try:
         ipaddress.ip_network(overlay_network['vtep_subnet'])
     except ValueError as ex:
-        # TODO(cmaloney): This is incorrect currently.
-        assert False, (
-            "Incorrect value for vtep_subnet. Only IPv4 "
-            "values are allowed: {}".format(ex))
+        raise AssertionError(
+            "Incorrect value for vtep_subnet: {}."
+            " Only IPv4 values are allowed".format(overlay_network['vtep_subnet'])) from ex
 
     assert 'vtep_mac_oui' in overlay_network.keys(), (
         'Missing "vtep_mac_oui" in overlay configuration {}'.format(overlay_network))
@@ -274,14 +272,14 @@ def validate_dcos_overlay_network(dcos_overlay_network):
         'We need at least one overlay network configuration {}'.format(overlay_network))
 
     for overlay in overlay_network['overlays']:
-        if (len(overlay['name']) > 13):
-            assert False, "Overlay name cannot exceed 13 characters:{}".format(overlay['name'])
+        assert (len(overlay['name']) <= 13), (
+            "Overlay name cannot exceed 13 characters:{}".format(overlay['name']))
         try:
             ipaddress.ip_network(overlay['subnet'])
         except ValueError as ex:
-            assert False, (
-                "Incorrect value for vtep_subnet. Only IPv4 "
-                "values are allowed: {}".format(ex))
+            raise AssertionError(
+                "Incorrect value for vtep_subnet {}."
+                " Only IPv4 values are allowed".format(overlay['subnet'])) from ex
 
 
 def calculate_oauth_available(oauth_enabled):

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -528,7 +528,7 @@ package:
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
 {% switch dcos_overlay_enable %}
 {% case "true" %}
-      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network }}
+      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
 {% case "false" %}
 {% endswitch %}
   - path: /etc/proxy.env

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -528,7 +528,7 @@ package:
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
 {% switch dcos_overlay_enable %}
 {% case "true" %}
-      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
+      MARATHON_CMD_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
 {% case "false" %}
 {% endswitch %}
   - path: /etc/proxy.env

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -526,6 +526,11 @@ package:
   - path: /etc_master/marathon
     content: |
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
+{% switch dcos_overlay_enable %}
+{% case "true" %}
+      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network }}
+{% case "false" %}
+{% endswitch %}
   - path: /etc/proxy.env
 {% switch use_proxy %}
 {% case "true" %}

--- a/gen/test_validation.py
+++ b/gen/test_validation.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 import pkg_resources
 import pytest
@@ -171,5 +172,22 @@ def test_exhibitor_storage_master_discovery():
         ['exhibitor_storage_backend', 'master_discovery'],
         msg_master_discovery,
         unset={'exhibitor_address', 'num_masters'})
+
+
+def test_validate_default_overlay_network_name():
+    msg = "Default overlay network name does not reference a defined overlay network: foo"
+    validate_error_multikey(
+        {'dcos_overlay_network': json.dumps({
+            'vtep_subnet': '44.128.0.0/20',
+            'vtep_mac_oui': '70:B3:D5:00:00:00',
+            'overlays': [{
+                'name': 'bar',
+                'subnet': '1.1.1.0/24',
+                'prefix': 24
+            }],
+        }), 'dcos_overlay_network_default_name': 'foo'},
+        ['dcos_overlay_network_default_name', 'dcos_overlay_network'],
+        msg)
+
 
 # TODO(cmaloney): Add tests that specific config leads to specific files in specific places at install time.

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -23,13 +23,11 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
-EnvironmentFile=-/var/lib/dcos/marathon/optional.flags.marathon
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=-/bin/bash -c '[ -n "\$MARATHON_DEFAULT_NETWORK_NAME" ] && echo OPTFLAG_DEFAULT_NETWORK_NAME=\\"--default_network_name \$MARATHON_DEFAULT_NETWORK_NAME\\" > /var/lib/dcos/marathon/optional.flags.marathon'
 ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -jar "$PKG_PATH/usr/marathon.jar" \\
@@ -46,5 +44,5 @@ ExecStart=/opt/mesosphere/bin/java \\
     --mesos_leader_ui_url "/mesos" \\
     --enable_features "vips,task_killing,external_volumes,gpu_resources" \\
     --mesos_authentication_principal "dcos_marathon" \\
-    --mesos_user "root" \$OPTFLAG_DEFAULT_NETWORK_NAME
+    --mesos_user "root"
 EOF

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -23,11 +23,13 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+EnvironmentFile=-/var/lib/dcos/marathon/optional.flags.marathon
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
+ExecStartPre=/bin/bash -c 'echo "OPTFLAG_DEFAULT_NETWORK_NAME=\${MARATHON_DEFAULT_NETWORK_NAME:+--default_network_name \$MARATHON_DEFAULT_NETWORK_NAME}" > /var/lib/dcos/marathon/optional.flags.marathon'
 ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -jar "$PKG_PATH/usr/marathon.jar" \\
@@ -44,5 +46,5 @@ ExecStart=/opt/mesosphere/bin/java \\
     --mesos_leader_ui_url "/mesos" \\
     --enable_features "vips,task_killing,external_volumes,gpu_resources" \\
     --mesos_authentication_principal "dcos_marathon" \\
-    --mesos_user "root"
+    --mesos_user "root" \$OPTFLAG_DEFAULT_NETWORK_NAME
 EOF

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -29,7 +29,7 @@ ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=/bin/bash -c 'echo "OPTFLAG_DEFAULT_NETWORK_NAME=\${MARATHON_DEFAULT_NETWORK_NAME:+--default_network_name \$MARATHON_DEFAULT_NETWORK_NAME}" > /var/lib/dcos/marathon/optional.flags.marathon'
+ExecStartPre=-/bin/bash -c '[ -n "\$MARATHON_DEFAULT_NETWORK_NAME" ] && echo OPTFLAG_DEFAULT_NETWORK_NAME=\\"--default_network_name \$MARATHON_DEFAULT_NETWORK_NAME\\" > /var/lib/dcos/marathon/optional.flags.marathon'
 ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -jar "$PKG_PATH/usr/marathon.jar" \\


### PR DESCRIPTION
Bug fix: Marathon should be configured with the name of the default dcos overlay network when overlay networking has been configured at install time.