### PR TITLE
Bug DCOS-11180: upgrades navstar, spartan, minuteman

### DIFF
--- a/packages/minuteman/buildinfo.json
+++ b/packages/minuteman/buildinfo.json
@@ -4,7 +4,7 @@
     "minuteman": {
       "kind": "git",
       "git": "https://github.com/dcos/minuteman.git",
-      "ref": "c5d2ee1e31c04b6f685a1a3883404df63d8573e7",
+      "ref": "54b665a30deb8ee7c3230140273e580d98826ad7",
       "ref_origin": "master"
     }
   },

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "cd49867f102c54579ce2a92138eb6345c9890609",
+      "ref": "19d25bdd7c7c0f794c7417ecd664a896dbaad275",
       "ref_origin": "master"
     }
   }

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "5d7d46eb42f94e55a0fdc0ce9e6abad06b18cb05",
+      "ref": "2d2f9b95e3e5db84a3599d0bd13dc5025ecfb0ee",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
This patch is to upgrade navstar, spartan and minuteman to point to patches to upgrade rebar3 with the fix for relx issue#523

DCOS-11180