### PR TITLE
Enforce python 3.4 in builds

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 # Create a python virtual environment to install the DC/OS tools to
-python3 -m venv /tmp/dcos_build_venv
+python3.4 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_teamcity
+++ b/build_teamcity
@@ -25,7 +25,7 @@ rm -rf wheelhouse/
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-virtualenv --always-copy build/env
+virtualenv --always-copy --python=python3.4 build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}


### PR DESCRIPTION
We are supposed to be using 3.4 everywhere, but some things still end up being run on 3.5 and then are confused by the artifacts. This commit will enforce explicit use of python 3.4 for the build environment
(disregard branch name)