### PR TITLE
bump dcos-ui and dcos-installer-ui packages.

### DIFF
--- a/packages/dcos-installer-ui/buildinfo.json
+++ b/packages/dcos-installer-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-installer-ui.git",
-    "ref": "16682dd1f4a2322e4dbe06079447825dcb08c723",
-    "ref_origin": "release/1.7"
+    "ref": "27c79846d24b1ceefd7c7f8dc66d9520d63aa338",
+    "ref_origin": "release/1.8"
   }
 }

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "e0e3bccd63182cd1e4d3eac54f89565940db82fd",
+    "ref": "5f0581092de53fb52d50b535c965c7456b902c6a",
     "ref_origin": "release/1.8"
   }
 }

--- a/tests/test_installer_backend.py
+++ b/tests/test_installer_backend.py
@@ -44,7 +44,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.9-dev',
+        'version': '1.8.7',
         'variant': 'some-variant'
     }
 


### PR DESCRIPTION
* Removes timeout for /login endpoint
* Removes security dropdown from installer UI.