### PR TITLE
Improve error/success message for dcos-oauth dcos_add_user.py

### DIFF
--- a/packages/dcos-oauth/extra/dcos_add_user.py
+++ b/packages/dcos-oauth/extra/dcos_add_user.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 import argparse
+import sys
 from kazoo.client import KazooClient
+from kazoo.exceptions import NodeExistsError, NoNodeException
 from kazoo.handlers.threading import SequentialThreadingHandler
 from kazoo.retry import KazooRetry
+
+
+def _error(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
 
 # Retry every .3 seconds for up to 1 second.
 retry_policy = KazooRetry(
@@ -18,13 +26,23 @@ parser.add_argument('--zk', default='127.0.0.1:2181')
 
 args = parser.parse_args()
 email = args.email
+zk_host = args.zk
 
 zk = KazooClient(
-    hosts=args.zk,
+    hosts=zk_host,
     timeout=1.0,
     handler=SequentialThreadingHandler(),
     connection_retry=retry_policy,
     command_retry=retry_policy)
-zk.start()
-zk.ensure_path("/dcos/users/")
-zk.create("/dcos/users/{}".format(email), email.encode())
+try:
+    zk.start()
+    zk.ensure_path("/dcos/users/")
+    zk.create("/dcos/users/{}".format(email), email.encode())
+    print("User {} successfully added".format(email), file=sys.stdout)
+    sys.exit(0)
+except zk.handler.timeout_exception:
+    _error("Timeout connecting to {}".format(zk_host))
+except NoNodeException:
+    _error("Unable to create base node /dcos/users/")
+except NodeExistsError:
+    _error("User {} already exists".format(email))


### PR DESCRIPTION
Improve error/success message for dcos-oauth dcos_add_user.py

* A success message will be printed to stderr and exit code 0 when adding user is successful
* An error message will be printed to stderr and exit code 1 when connection to zk times out
* An error message will be printed to stderr and exit code 1 if unable to create the `/dcos/users/` base node
* An error message will be printed to stderr and exit code 1 when attempting to add a user that already exists


[DCOS-11241](https://mesosphere.atlassian.net/browse/DCOS-11241)


## Manually tested
```
.../dcos/packages/dcos-oauth/extra> python3 dcos_add_user.py blob@mesosphere.io
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Connection dropped: socket connection error: Connection refused
Failed connecting to Zookeeper within the connection retry policy.
Timeout connecting to 127.0.0.1:2181
```
```
.../dcos/packages/dcos-oauth/extra> python3 dcos_add_user.py blob@mesosphere.io
Unable to create base node /dcos/users
```
```
.../dcos/packages/dcos-oauth/extra> python3 dcos_add_user.py blob@mesosphere.io
User blob@mesosphere.io successfully added
```
```
.../dcos/packages/dcos-oauth/extra> python3 dcos_add_user.py blob@mesosphere.io
User blob@mesosphere.io already exists
```