### PR TITLE
Various CentOS 7 AMI fixes and improvements.

### DIFF
--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -8,9 +8,9 @@ function usage {
 cat <<USAGE
  USAGE: $(basename "$0") <device> <mount_location>
 
-  This script will partition, format, and persistently mount the device to the specified location.
+  This script will format, and persistently mount the device to the specified location.
   It is intended to run as an early systemd unit (local-fs-pre.target) on AWS to set up EBS volumes.
-  It will only execute if <device> is not yet partitioned.
+  It will only execute if <device> doesn't already contain a filesystem.
 
  EXAMPLES:
 
@@ -35,29 +35,22 @@ function main {
     exit 1
   fi
 
-  echo "Waiting for $device to come online"
-  until test -b "$device"; do sleep 1; done
-  partition=${device}1
-  if [[ ! -b "$partition" ]]
+  echo -n "Waiting for $device to come online"
+  until test -b "$device"; do sleep 1; echo -n .; done
+  echo
+  local formated
+  mkfs.xfs $device > /dev/null 2>&1 && formated=true || formated=false
+  if [ "$formated" = true ]
   then
-    echo "Partition $partition not detected: creating partitions"
-    parted -s -a optimal "$device" -- \
-      mklabel gpt \
-      mkpart primary xfs 1 -1
-    partprobe "$device" > /dev/null 2>&1 || :
-    echo "Waiting for $partition to be detected by the Kernel"
-    until test -b "$partition"; do sleep 1; done
-    echo "Formatting: $partition"
-    mkfs.xfs "$partition" > /dev/null
-    echo "Setting up partition mount"
+    echo "Setting up device mount"
     mkdir -p "$mount_location"
-    fstab="$partition $mount_location xfs defaults 0 2"
+    fstab="$device $mount_location xfs defaults 0 2"
     echo "Adding entry to fstab: $fstab"
     echo "$fstab" >> /etc/fstab
     if [ "$mount_location" = "/var/log" ]; then
-      echo "Preparing $partition by migrating logs from $mount_location"
+      echo "Preparing $device by migrating logs from $mount_location"
       mkdir -p /var/log-prep
-      mount "$partition" /var/log-prep
+      mount $device /var/log-prep
       mkdir -p /var/log-prep/journal
       systemctl is-active chronyd > /dev/null && systemctl stop chronyd || :
       systemctl is-active tuned > /dev/null && systemctl stop tuned || :
@@ -68,17 +61,19 @@ function main {
       rmdir /var/log-prep
       rm -rf /var/log
       mkdir -p /var/log
-      echo "Mounting: $partition to $mount_location"
-      until grep ^$partition /etc/mtab > /dev/null; do sleep 1; mount "$mount_location"; done
+      echo -n "Mounting: $device to $mount_location"
+      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location"; done
+      echo
       systemctl restart systemd-journald || :
       systemctl is-enabled tuned > /dev/null && systemctl start tuned || :
       systemctl is-enabled chronyd > /dev/null && systemctl start chronyd || :
     else
-      echo "Mounting: $partition to $mount_location"
-      until grep ^$partition /etc/mtab > /dev/null; do sleep 1; mount "$mount_location"; done
+      echo -n "Mounting: $device to $mount_location"
+      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location"; done
+      echo
     fi
   else
-    echo "Partition $partition detected: no action taken"
+    echo "Device $device contains a filesystem: no action taken"
     exit
   fi
 }

--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -5,18 +5,23 @@ export device=${1:-}
 export mount_location=${2:-}
 
 function usage {
-cat <<USAGE
- USAGE: $(basename "$0") <device> <mount_location>
+cat <<EOUSAGE
+USAGE: $(basename "$0") <device> <mount_location>
 
-  This script will format, and persistently mount the device to the specified location.
-  It is intended to run as an early systemd unit (local-fs-pre.target) on AWS to set up EBS volumes.
-  It will only execute if <device> doesn't already contain a filesystem.
+ This script will format, and persistently mount the device to the specified
+ location. It is intended to run as an early systemd unit (local-fs-pre.target)
+ on AWS to set up EBS volumes.
 
- EXAMPLES:
+ If <mount_location> is /var/log the script will migrate existing data to the
+ new filesystem.
 
-  $(basename "$0") /dev/xvde /dcos/volume1
+ It will only execute if <device> doesn't already contain a filesystem.
 
-USAGE
+EXAMPLES:
+
+ $(basename "$0") /dev/xvde /dcos/volume1
+
+EOUSAGE
 }
 
 for i in "$@"

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -43,10 +43,6 @@ systemctl enable dcos_vol_setup
 echo ">>> Disable rsyslog"
 systemctl disable rsyslog
 
-echo ">>> Set journald limits"
-mkdir -p /etc/systemd/journald.conf.d/
-echo -e "[Journal]\nRateLimitBurst=15000\nRateLimitInterval=30s\nSystemMaxUse=10G" > /etc/systemd/journald.conf.d/dcos-el7.conf
-
 echo ">>> Removing tty requirement for sudo"
 sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -43,6 +43,10 @@ systemctl enable dcos_vol_setup
 echo ">>> Disable rsyslog"
 systemctl disable rsyslog
 
+echo ">>> Set journald limits"
+mkdir -p /etc/systemd/journald.conf.d/
+echo -e "[Journal]\nSystemMaxUse=15G" > /etc/systemd/journald.conf.d/dcos-el7-ami.conf
+
 echo ">>> Removing tty requirement for sudo"
 sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -22,17 +22,49 @@
       {
         "device_name": "/dev/sde",
         "volume_type": "gp2",
-        "volume_size": 20,
+        "volume_size": 50,
         "delete_on_termination": true
       },
       {
         "device_name": "/dev/sdf",
         "volume_type": "gp2",
-        "volume_size": 20,
+        "volume_size": 100,
         "delete_on_termination": true
       },
       {
         "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdh",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      }
+    ],
+    "launch_block_device_mappings": [
+      {
+        "device_name": "/dev/sde",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdf",
+        "volume_type": "gp2",
+        "volume_size": 100,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdh",
         "volume_type": "gp2",
         "volume_size": 20,
         "delete_on_termination": true


### PR DESCRIPTION
This modifies default packer settings and supporting scripts for the CentOS 7 AMI.

The current CentOS 7 AMI uses 8GB on / of which 4GB is in use by the OS and DC/OS. On our prod cluster's leader the remaining 4GB were filled with /var/log data within a day.

This PR:
- fixes a race in `dcos_vol_setup.sh` where the Kernel could sometimes take longer to pick up the newly created partition than it takes the script to proceed with `mkfs.xfs` (`dcos_vol_setup.sh[689]: /dev/xvdf1: No such file or directory`).
- makes the `partprobe` call optional. The script sometimes fails right now because the new partition is being picked up before the partprobe call and make the device busy (`Error: Error informing the kernel about modifications to partition /dev/xvde1 -- Device or resource busy.`). Since the partition previously doesn't exist, if xfs is able to format it we're all good. However when spinning up large clusters (100 nodes+) in my tests I would sometimes but rarely run into a situation where the partition blockdevice (e.g. /dev/xvde1) exists but mkfs.xfs fails and actually required a node reboot before the partition was usable. To fix this we will have to refactor the entire volume setup mechanism to one where we prepare the volumes, detect if they require a reboot, reboot the node if needed and then resume the formating and mounting. That's however beyond the scope of this PR. The way it's behaving now already increases reliability of volume setup drastically. Whereas previously out of 50 nodes ~5-10 wouldn't have all four EBS volumes mounted it's now only one or none.
- ensures we actually mount the newly created filesystem instead of `mount -a`
- adds a 20G partition at /var/log
- turns off rsyslog (/var/log/messages)
- turns on persistent systemd journal (mkdir /var/log/journal)
- allows for 10G of the 20G in /var/log to be used by the journal
- increases the journald per service rate limit to 15k/30s (500/s) up from 1000/30s (33/s)
- raises the /var/lib/docker partition 20G -> 100G to make it better suited for production use
- raises /var/lib/mesos and /dcos/volume0 20G -> 50G
- removes the tty requirement for sudo
- adds `nfs-utils` package so nodes are AWS EFS ready
- cleans up some `yum` syntax (officially the order is `yum [options] [command] ...` even though reverting command and options works)
- cleans up an `rm` typo

The storage changes increase the cost per node by $0,53/day on current GP2 EBS volumes but make the image more prod usable imho. I can remove those though if not wanted.
