### PR TITLE
Use resources to find instances in AWS util

### DIFF
--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -188,8 +188,7 @@ def wait_for_len(fetch_fn, target_count, timeout):
     def check_for_match():
         items = fetch_fn()
         count = len(items)
-        logging.info('Waiting for len({})=={}. Current count: {}. Items: {}'.format(
-            fetch_fn.__name__, target_count, count, repr(items)))
+        logging.info('Waiting for len()=={}. Current count: {}. Items: {}'.format(target_count, count, repr(items)))
         if count != target_count:
             return False
     check_for_match()


### PR DESCRIPTION
Using tags for finding instances in groups resulted in failures as tagging is not guaranteed at deployment time, but resources are guaranteed to be created. See: https://mesosphere.atlassian.net/browse/DCOS-11009