### PR TITLE
making argparse use sys.argv so it auto picks up argv[0]

### DIFF
--- a/gen/installer/bash/installer_internal_wrapper.in
+++ b/gen/installer/bash/installer_internal_wrapper.in
@@ -13,4 +13,9 @@ export DCOS_IMAGE_COMMIT={dcos_image_commit}
 export BOOTSTRAP_ID={bootstrap_id}
 export BOOTSTRAP_VARIANT={variant}
 
+# ash exec inside busybox doesn't have an equivalent to `-a` letting us set argv0
+# directly, and python also doesn't have a way of setting it, so we pass argv0
+# out of line and have it picked up by the installer
+export INSTALLER_ARGV0="dcos_generate_config.sh"
+
 exec /opt/mesosphere/bin/python3 /opt/mesosphere/bin/dcos_installer "$@"

--- a/tests/test_installer_backend.py
+++ b/tests/test_installer_backend.py
@@ -42,6 +42,7 @@ def test_password_hash():
     password = 'DcosTestingPassword!@#'
     # only reads from STDOUT
     hash_pw = subprocess.check_output(['dcos_installer', '--hash-password', password])
+    print(hash_pw)
     hash_pw = hash_pw.decode('ascii').strip('\n')
     assert passlib.hash.sha512_crypt.verify(password, hash_pw), 'Hash does not match password'
 

--- a/tests/test_installer_init.py
+++ b/tests/test_installer_init.py
@@ -5,45 +5,54 @@ from dcos_installer import cli
 
 
 def test_default_arg_parser():
-    parser = cli.parse_args([])
+    parser = cli.get_argument_parser().parse_args([])
     assert parser.verbose is False
     assert parser.port == 9000
-    assert parser.action is None
+    assert parser.action == 'genconf'
 
 
 def test_set_arg_parser():
-    parser = cli.parse_args(['-v', '-p 12345'])
+    argument_parser = cli.get_argument_parser()
+
+    def parse_args(arg_list):
+        return argument_parser.parse_args(arg_list)
+
+    parser = parse_args(['-v', '-p 12345'])
     assert parser.verbose is True
     assert parser.port == 12345
-    parser = cli.parse_args(['--web'])
+    parser = parse_args(['--web'])
     assert parser.action == 'web'
-    parser = cli.parse_args(['--genconf'])
+    parser = parse_args(['--genconf'])
     assert parser.action == 'genconf'
-    parser = cli.parse_args(['--preflight'])
+    parser = parse_args(['--preflight'])
     assert parser.action == 'preflight'
-    parser = cli.parse_args(['--postflight'])
+    parser = parse_args(['--postflight'])
     assert parser.action == 'postflight'
-    parser = cli.parse_args(['--deploy'])
+    parser = parse_args(['--deploy'])
     assert parser.action == 'deploy'
-    parser = cli.parse_args(['--validate-config'])
+    parser = parse_args(['--validate-config'])
     assert parser.action == 'validate-config'
-    parser = cli.parse_args(['--uninstall'])
+    parser = parse_args(['--uninstall'])
     assert parser.action == 'uninstall'
-    parser = cli.parse_args(['--hash-password', 'foo'])
-    assert parser.hash_password == ['foo']
-    assert parser.action is None
+    parser = parse_args(['--hash-password', 'foo'])
+    assert parser.password == 'foo'
+    assert parser.action == 'hash-password'
 
-    parser = cli.parse_args(['--set-superuser-password', 'foo'])
-    assert parser.set_superuser_password == ['foo']
-    assert parser.action is None
+    parser = parse_args(['--hash-password'])
+    assert parser.password is None
+    assert parser.action == 'hash-password'
 
-    parser = cli.parse_args(['--set-superuser-password'])
-    assert parser.set_superuser_password == [None]
-    assert parser.action is None
+    parser = parse_args(['--set-superuser-password', 'foo'])
+    assert parser.password == 'foo'
+    assert parser.action == 'set-superuser-password'
+
+    parser = parse_args(['--set-superuser-password'])
+    assert parser.password is None
+    assert parser.action == 'set-superuser-password'
 
     # Can't do two at once
     with pytest.raises(SystemExit):
-        cli.parse_args(['--validate', '--hash-password', 'foo'])
+        parse_args(['--validate', '--hash-password', 'foo'])
 
 
 def test_stringify_config():


### PR DESCRIPTION
dcos_generate_config.sh --help goes from:

```
dcos_installer <...>
```

to:

```
dcos_generate_config.sh <...>
```

Should help reduce customer confusion (dcos_installer sounds a lot like dcos_install.sh)

In order to change that, how the "password" arguments are handled was also changed to use a custom argparse action which makes a simpler to understand API for which mode they should go into (Hash the given password vs. no password given prompt for one).

# Issues

https://mesosphere.slack.com/archives/documentation/p1477923100001079

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)