### PR TITLE
Use Marathon 1.3.6

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.3.5/marathon-1.3.5.tgz",
-    "sha1": "ee6052b9de94202ecbff34aa7e10a10ee61f6566"
+    "url": "https://downloads.mesosphere.com/marathon/v1.3.6/marathon-1.3.6.tgz",
+    "sha1": "0d6a3f0abd4188cbb7d9d64e729f16489cb9bc6f"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## Changes from 1.3.5 to 1.3.6

### Fixed issues:

- When a runtime exit is requested, if the exit does not complete in less than the requested amount of time (10 seconds by default),
  now will actually kill the JVM. Previously, the timeout code did not actually work at all.
- Marathon will now terminate upon loss of leadership instead of becoming a non-master. This prevents a lot of potentially unsafe
  behavior and a watchdog will instead bring marathon back up in a clean state.
