### PR TITLE
Upgrade Navstar & Minuteman

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -59,7 +59,7 @@ def test_ip_per_container(cluster):
 
     with cluster.marathon.deploy_and_cleanup(app_definition, check_health=True) as service_points:
         app_port = app_definition['container']['docker']['portMappings'][0]['containerPort']
-        cmd = '/opt/mesosphere/bin/curl -s -f http://{}:{}/ping'.format(service_points[1].ip, app_port)
+        cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points)()
 
 
@@ -75,5 +75,5 @@ def test_ip_per_container_with_named_vip(cluster):
     with cluster.marathon.deploy_and_cleanup(origin_app):
         proxy_app, proxy_uuid = get_test_app()
         with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
-            cmd = '/opt/mesosphere/bin/curl -s -f http://foo.marathon.l4lb.thisdcos.directory:6000/ping'
+            cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://foo.marathon.l4lb.thisdcos.directory:6000/ping'
             ensure_routable(cmd, service_points)()

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -3,7 +3,7 @@ set -x
 
 export CFLAGS="-I/opt/mesosphere/include -I/opt/mesosphere/active/ncurses/include -I/opt/mesosphere/active/openssl/include"
 export LDFLAGS="-L/opt/mesosphere/lib -L/opt/mesosphere/active/ncurses/lib -L/opt/mesosphere/active/openssl/lib -Wl,-rpath=/opt/mesosphere/active/ncurses/lib -Wl,-rpath=/opt/mesosphere/active/openssl/lib -Wl,-rpath=/opt/mesosphere/lib"
-export CXXFLAGS=CFLAGS
+export CPPFLAGS=${CFLAGS}
 
 pushd /pkg/src/erlang
 ./configure --prefix=$PKG_PATH --with-ssl=/opt/mesosphere/active/openssl --with-termcap=/opt/mesosphere/active/ncurses --enable-dirty-schedulers --disable-hipe --enable-kernel-poll

--- a/packages/minuteman/build
+++ b/packages/minuteman/build
@@ -11,26 +11,13 @@ cp -r /pkg/src/minuteman/_build/prod/rel/minuteman ${PKG_PATH}
 
 service=${PKG_PATH}/dcos.target.wants/dcos-minuteman.service
 mkdir -p $(dirname $service)
-cat <<EOF > $service
-[Unit]
-Description=Layer 4 Load Balancer: DC/OS Layer 4 Load Balancing Service
 
-[Service]
-Restart=always
-StartLimitInterval=0
-RestartSec=5
-WorkingDirectory=${PKG_PATH}/minuteman
-EnvironmentFile=/opt/mesosphere/etc/minuteman-erl.env
-EnvironmentFile=/opt/mesosphere/etc/check_time.env
-EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=-/opt/mesosphere/etc/minuteman.env
-EnvironmentFile=-/run/dcos/etc/minuteman_auth.env
-ExecStartPre=/opt/mesosphere/bin/check-time
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-minuteman
-ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
-ExecStartPre=/usr/bin/env mkdir -p /var/lib/dcos/minuteman/mnesia
-ExecStartPre=/usr/bin/env mkdir -p /var/lib/dcos/minuteman/lashup
-ExecStart=${PKG_PATH}/minuteman/bin/minuteman-env foreground
-Environment=HOME=/opt/mesosphere
-EOF
+minuteman_service=${PKG_PATH}/dcos.target.wants/dcos-minuteman.service
+mkdir -p $(dirname $minuteman_service)
+cp /pkg/extra/dcos-minuteman.service "$minuteman_service"
+
+mkdir -p $PKG_PATH/bin
+
+setup_iptables="$PKG_PATH/bin/setup_iptables.sh"
+cp /pkg/extra/setup_iptables.sh "$setup_iptables"
+chmod +x "$setup_iptables"

--- a/packages/minuteman/buildinfo.json
+++ b/packages/minuteman/buildinfo.json
@@ -4,15 +4,14 @@
     "minuteman": {
       "kind": "git",
       "git": "https://github.com/dcos/minuteman.git",
-      "ref": "54b665a30deb8ee7c3230140273e580d98826ad7",
+      "ref": "e6226c74a860d7cc1b7661862cb14f714426ba58",
       "ref_origin": "master"
     }
   },
   "sysctl": {
       "dcos-minuteman": {
-          "net.netfilter.nf_conntrack_tcp_be_liberal": "1",
-          "net.netfilter.ip_conntrack_tcp_be_liberal": "1",
-          "net.ipv4.netfilter.ip_conntrack_tcp_be_liberal": "1"
+          "net.ipv4.vs.snat_reroute": "1",
+          "net.ipv4.vs.conntrack": "1"
       }
   }
 }

--- a/packages/minuteman/extra/dcos-minuteman.service
+++ b/packages/minuteman/extra/dcos-minuteman.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Layer 4 Load Balancer: DC/OS Layer 4 Load Balancing Service
+
+[Service]
+Restart=always
+StartLimitInterval=0
+RestartSec=5
+WorkingDirectory=/opt/mesosphere/active/minuteman/minuteman
+Environment=HOME=/opt/mesosphere
+EnvironmentFile=/opt/mesosphere/etc/minuteman-erl.env
+EnvironmentFile=/opt/mesosphere/etc/check_time.env
+EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=-/opt/mesosphere/etc/minuteman.env
+EnvironmentFile=-/run/dcos/etc/minuteman_auth.env
+ExecStartPre=/opt/mesosphere/bin/check-time
+ExecStartPre=/usr/bin/env modprobe ip_vs_wlc
+ExecStartPre=/opt/mesosphere/bin/setup_iptables.sh
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-minuteman
+ExecStartPre=/bin/ping -c1 ready.spartan
+ExecStartPre=/bin/ping -c1 leader.mesos
+ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/minuteman/mnesia
+ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/minuteman/lashup
+ExecStart=/opt/mesosphere/active/minuteman/minuteman/bin/minuteman-env foreground

--- a/packages/minuteman/extra/setup_iptables.sh
+++ b/packages/minuteman/extra/setup_iptables.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+# http://stackoverflow.com/questions/2870992/automatic-exit-from-bash-shell-script-on-error
+# Any subsequent(*) commands which fail will cause the shell script to exit immediately
+
+## Cleanup old minuteman (NFQUEUE) rules
+iptables --wait -D FORWARD -p tcp -m set --match-set minuteman dst,dst -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j REJECT --reject-with icmp-port-unreachable || true
+iptables --wait -D OUTPUT -p tcp -m set --match-set minuteman dst,dst -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j REJECT --reject-with icmp-port-unreachable || true
+iptables --wait -t raw -D PREROUTING -p tcp -m set --match-set minuteman dst,dst -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j NFQUEUE --queue-balance 50:58 || true
+iptables --wait -t raw -D OUTPUT -p tcp -m set --match-set minuteman dst,dst -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j NFQUEUE --queue-balance 50:58 || true
+
+RULE="POSTROUTING -m ipvs --ipvs --vdir ORIGINAL --vmethod MASQ -m comment --comment Minuteman-IPVS-IPTables-masquerade-rule -j MASQUERADE"
+
+if ! iptables --wait -t nat -C ${RULE}; then
+  echo "Minuteman IPTables Rule not found: ${RULE}"
+  echo "Inserting Rule"
+  iptables --wait -t nat -I ${RULE} && echo "Rule successfully inserted"
+else
+  echo "Minuteman IPTables rule found"
+fi
+

--- a/packages/navstar/build
+++ b/packages/navstar/build
@@ -5,7 +5,7 @@ source /opt/mesosphere/environment
 
 export CFLAGS="-I/opt/mesosphere/include -I/opt/mesosphere/active/libsodium/include"
 export LDFLAGS="-L/opt/mesosphere/lib -L/opt/mesosphere/active/libsodium/lib -Wl,-rpath=/opt/mesosphere/active/libsodium/lib"
-export CXXFLAGS=CFLAGS
+export CPPFLAGS=${CFLAGS}
 
 
 pushd /pkg/src/navstar

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "19d25bdd7c7c0f794c7417ecd664a896dbaad275",
+      "ref": "70102cf1550aa3043d61fd6ff28ad46610885c39",
       "ref_origin": "master"
     }
   }

--- a/packages/toybox/build
+++ b/packages/toybox/build
@@ -3,7 +3,7 @@ set -x
 
 export CFLAGS="-I/opt/mesosphere/include -I/opt/mesosphere/active/ncurses/include -I/opt/mesosphere/active/openssl/include"
 export LDFLAGS="-L/opt/mesosphere/lib -L/opt/mesosphere/active/ncurses/lib -L/opt/mesosphere/active/openssl/lib -Wl,-rpath=/opt/mesosphere/active/ncurses/lib -Wl,-rpath=/opt/mesosphere/active/openssl/lib -Wl,-rpath=/opt/mesosphere/lib"
-export CXXFLAGS=CFLAGS
+export CPPFLAGS=${CFLAGS}
 
 mkdir -p $PKG_PATH/bin
 


### PR DESCRIPTION
High level description including:
 - This change fixes quite a few issues with Minuteman and Navstar
 - It fixes the performance and scalability issues with Minuteman and Navstar
 - It fixes the DNS polling issues
 - It switches to the IPVS-based datapath for Minuteman

# Issues
https://mesosphere.atlassian.net/browse/DCOS-10256
https://mesosphere.atlassian.net/browse/DCOS-11667
https://mesosphere.atlassian.net/browse/DCOS-9754
https://mesosphere.atlassian.net/browse/DCOS-11024
https://mesosphere.atlassian.net/browse/DCOS-11300

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
  - This doesn't change any functionality, but merely changes the implementation of it. The existing tests are valid
 - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: 
  * https://github.com/dcos/navstar/pull/31
  * https://github.com/dcos/minuteman/pull/61
  * https://github.com/dcos/minuteman/pull/65
 - [x] Test Results: In PRs above
 - [x] Code Coverage: In PRs above


