### PR TITLE
Switch remaining pieces to Python 3.5

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 # Create a python virtual environment to install the DC/OS tools to
-python3.4 -m venv /tmp/dcos_build_venv
+python3.5 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_teamcity
+++ b/build_teamcity
@@ -25,7 +25,7 @@ rm -rf wheelhouse/
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-virtualenv --always-copy --python=python3.4 build/env
+python3.5 -m venv --clear --copies build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ testpaths =
   release
   ssh
 
-[testenv:py34-syntax]
+[testenv:py35-syntax]
 passenv =
     TEAMCITY_VERSION
 deps =
@@ -37,7 +37,7 @@ deps =
 commands =
   flake8 --verbose
 
-[testenv:py34-unittests]
+[testenv:py35-unittests]
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
@@ -63,7 +63,7 @@ commands=
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a
 # specific working directory (something that should be fixed).
-[testenv:py34-pkgpanda-build]
+[testenv:py35-pkgpanda-build]
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
@@ -74,7 +74,7 @@ changedir=pkgpanda/build/tests
 commands=
   py.test --basetemp={envtmpdir} {posargs} build_integration_test.py
 
-[testenv:py34-bootstrap]
+[testenv:py35-bootstrap]
 passenv =
   TEAMCITY_VERSION
 deps=


### PR DESCRIPTION
Switches build and unit tests to run in python 3.5 rather than python 3.4, unifying all dc/os internals and build to always be python 3.5.

This PR should help flush out remaining things that break.

# Issues

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)