### PR TITLE
gen: Add the concept of a Resolvable, Resolve config per-Target

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -103,14 +103,14 @@ class Config():
 
         if include_ssh:
             sources.append(ssh.validate.source)
-            targets.append(ssh.validate.target)
+            targets.append(ssh.validate.get_target())
 
-        messages = gen.internals.validate_configuration(sources, targets, user_arguments)
+        resolver = gen.internals.resolve_configuration(sources, targets, user_arguments)
         # TODO(cmaloney): kill this function and make the API return the structured
         # results api as was always intended rather than the flattened / lossy other
         # format. This will be an  API incompatible change. The messages format was
         # specifically so that there wouldn't be this sort of API incompatibility.
-        return normalize_config_validation(messages)
+        return normalize_config_validation(resolver.status_dict)
 
     def do_gen_configure(self):
         return gen.generate(self.as_gen_format())

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -27,20 +27,8 @@ def check_duplicates(items: list):
         ', '.join('{} appears {} times'.format(*item) for item in duplicates.items()))
 
 
-# TODO (cmaloney): Python 3.5, add checking valid_values is Iterable[str]
-def validate_one_of(val: str, valid_values) -> None:
-    """Test if object `val` is a member of container `valid_values`.
-    Raise a AssertionError if it is not a member. The exception message contains
-    both, the representation (__repr__) of `val` as well as the representation
-    of all items in `valid_values`.
-    """
-    if val not in valid_values:
-        options_string = ', '.join("'{}'".format(v) for v in valid_values)
-        raise AssertionError("Must be one of {}. Got '{}'.".format(options_string, val))
-
-
 def validate_true_false(val) -> None:
-    validate_one_of(val, ['true', 'false'])
+    gen.internals.validate_one_of(val, ['true', 'false'])
 
 
 def validate_int_in_range(value, low, high):
@@ -382,7 +370,7 @@ def calculate_mesos_isolation(enable_gpu_isolation):
 
 
 def validate_os_type(os_type):
-    validate_one_of(os_type, ['coreos', 'el7'])
+    gen.internals.validate_one_of(os_type, ['coreos', 'el7'])
 
 
 def validate_bootstrap_tmp_dir(bootstrap_tmp_dir):

--- a/gen/test_internals.py
+++ b/gen/test_internals.py
@@ -1,0 +1,97 @@
+import pytest
+
+import gen.internals
+from gen.exceptions import ValidationError
+
+
+def sample_fn_small():
+    pass
+
+
+def sample_fn_normal(foo):
+    pass
+
+
+def sample_fn_big(foo, bar, baz, ping=None, pong="magic"):
+    pass
+
+
+def test_get_function_parameters():
+    get_function_parameters = gen.internals.get_function_parameters
+
+    assert get_function_parameters(sample_fn_small) == set()
+    assert get_function_parameters(sample_fn_normal) == {'foo'}
+    assert get_function_parameters(sample_fn_big) == {'foo', 'bar', 'baz', 'ping', 'pong'}
+    assert get_function_parameters(lambda x: x) == {'x'}
+    assert get_function_parameters(lambda x, y, a, b: sample_fn_normal(x)) == {'x', 'y', 'a', 'b'}
+
+
+def test_validate_arguments_strings():
+    validate_arguments_strings = gen.internals.validate_arguments_strings
+
+    validate_arguments_strings(dict())
+    validate_arguments_strings({'a': 'b'})
+    validate_arguments_strings({'a': 'b', 'c': 'd', 'e': 'f'})
+
+    # TODO(cmaloney): Validate the error message contains all error keys.
+    with pytest.raises(ValidationError):
+        validate_arguments_strings({'a': {'b': 'c'}})
+
+    with pytest.raises(ValidationError):
+        validate_arguments_strings({'a': 1})
+
+    with pytest.raises(ValidationError):
+        validate_arguments_strings({1: 'a'})
+
+    with pytest.raises(ValidationError):
+        validate_arguments_strings({'a': 'b', 'c': 1})
+
+    with pytest.raises(ValidationError):
+        validate_arguments_strings({'a': None})
+
+
+def validate_a(a):
+    assert a == 'a_str'
+
+
+def test_resolve_simple():
+    Scope = gen.internals.Scope
+    Source = gen.internals.Source
+    Target = gen.internals.Target
+
+    test_source = Source({
+        'validate': [validate_a],
+        'default': {
+            'a': 'a_str',
+            'd': 'd_1',
+        },
+        'must': {
+            'b': 'b_str'
+        },
+        'conditional': {
+            'd': {
+                'd_1': {
+                    'must': {
+                        'd_1_b': 'd_1_b_str'
+                    }
+                },
+                'd_2': {
+                    'must': {
+                        'd_2_b': 'd_2_b_str'
+                    }
+                }
+            }
+        }
+    })
+
+    test_target = Target(
+        {'a', 'b', 'c'},
+        {'d': Scope(
+            'd', {
+                'd_1': Target({'d_1_a', 'd_1_b'}),
+                'd_2': Target({'d_2_a', 'd_2_b'})
+            })})
+
+    resolver = gen.internals.resolve_configuration([test_source], [test_target], {'c': 'c_str', 'd_1_a': 'd_1_a_str'})
+    print(resolver)
+    assert resolver.status_dict == {'status': 'ok'}

--- a/gen/test_internals.py
+++ b/gen/test_internals.py
@@ -2,6 +2,7 @@ import pytest
 
 import gen.internals
 from gen.exceptions import ValidationError
+from gen.internals import Scope, Source, Target
 
 
 def sample_fn_small():
@@ -55,9 +56,6 @@ def validate_a(a):
 
 
 def test_resolve_simple():
-    Scope = gen.internals.Scope
-    Source = gen.internals.Source
-    Target = gen.internals.Target
 
     test_source = Source({
         'validate': [validate_a],

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -51,22 +51,24 @@ source = Source({
     }
 })
 
-target = Target({
-    'ssh_user',
-    'ssh_port',
-    'ssh_key_path',
-    'master_list',
-    'agent_list',
-    'public_agent_list',
-    'ssh_parallelism',
-    'process_timeout'})
+
+def get_target():
+    return Target({
+        'ssh_user',
+        'ssh_port',
+        'ssh_key_path',
+        'master_list',
+        'agent_list',
+        'public_agent_list',
+        'ssh_parallelism',
+        'process_timeout'})
 
 
 # TODO(cmaloney): Work this API, callers until this result remapping is unnecessary
 # and the couple places that need this can just make a trivial call directly.
 def validate_config(user_arguments):
     user_arguments = gen.stringify_configuration(user_arguments)
-    messages = gen.internals.validate_configuration([source], [target], user_arguments)
+    messages = gen.internals.resolve_configuration([source], [get_target()], user_arguments).status_dict
     if messages['status'] == 'ok':
         return {}
 


### PR DESCRIPTION

 - Targets now get finalized with results. This also means they need to be constructued per-use.
 - validate_configuration() no longer exists, as resolve_configuration does exactly the same thing,
   users of validate_configuration() are migrated to just use resolve_configuration() once.
 - The per-target results aren't yet plugged into various places, that will come in a later pr
 - Introduce a notion of variables "visited" to calculate a particular variable.
 - Introduce a concept of a "Resolvable". A resolvable tracks the resolution state of a particular configuration value. (Unresolved, being resolved, error). It will eventually also include a "late resolution" (late binding) state. The introduction centralizes the logic for tracking that, and makes it harder to get wrong. Resolvables also keep track of what caused them to come into existence / get resolved.
 - Switches / sub-scopes now generate single-argument "validate" functions rather than having custom logic to validate their values when we reached the switch they were used in (See yield_implicit_validates)
 - Renames DFSArgumentCalculator to Resolver. A resolver is now only usable once, takes a set of setters (taken from a set of sources) and targets, then resolves them all at once. The goal being that the resolution of all targets produces a single, consistent / valid against eachother full final configuration. Resolver now owns / builds the status dictionary itself, and makes it accessible to callers
 - Adds a new unit test for gen internals code

Things this works towards enabling
 - Typed parameters. "Resolvables" can be focused around a type (as discovered by python type annotations on function parameters)
 - "nested" configuration. Currently all config must be one top level dictionary. In theory though we could use nested dictionaries and flatten them ({"a": {"b": {"c": "d"}}} could be accessed as `a_b_c`.
 - Late-binding. Resolvables do a much better job of tracking / keeping contained the resolution state, code which was currently spread about DFSArgumentCalculator previously. The code to track "unset" and spread it through the tree, is very similar to the code needed to track "late bound" and that property spreading / chaining through the tree.
 - "secret" / private data such as aws keys in config.yaml. Things like the AWS keys should be explicitly protected / marked so they don't show up in things like the user config.yaml inside the cluster / on every host. If anything would make them show up, that should result in an error.

# Issues

 - Late-binding configuration
 - Secrets in dcos-release.config.yaml vs. config.yaml for AWS Advanced templates
 - Enabling dcos-launch to use config.yaml

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
