### PR TITLE
Add test for hash_files_in_folder, fix several usages with absolute paths in codebase

### DIFF
--- a/pkgpanda/build/test_util.py
+++ b/pkgpanda/build/test_util.py
@@ -1,0 +1,86 @@
+import pkgpanda.build
+
+
+def test_hash_files_in_folder(tmpdir):
+    hash_files_in_folder = pkgpanda.build.hash_files_in_folder
+
+    with tmpdir.as_cwd():
+        # Empty folder
+        empty = tmpdir.join("test_empty")
+        empty.ensure(dir=True)
+        assert hash_files_in_folder(str("test_empty")) == {}
+
+        # Empty subfolder
+        empty.join("baz").ensure(dir=True)
+        assert hash_files_in_folder(str("test_empty")) == {
+            'baz': ""
+        }
+
+        # Empty folder in folder
+        # empty.join("baz").join("bang").ensure(dir=True)
+        # assert hash_files_in_folder(str("test_empty")) == {
+        #     'baz/bang': ""
+        # }
+        empty.join("baz").join("bang").join("swish").ensure(dir=True)
+        assert hash_files_in_folder(str("test_empty")) == {
+            'baz/bang/swish': ""
+        }
+
+        simple = tmpdir.join("test_simple")
+        simple.ensure(dir=True)
+        simple.join("foo").write("foo contents")
+        simple.join("bar").write("bar contents")
+        assert hash_files_in_folder(str("test_simple")) == {
+            'bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'foo': '8a44735524900cdc94460b8999b581836535470e'
+        }
+
+        # Test having subdirectories
+        baz = simple.join("baz")
+        baz.ensure(dir=True)
+        baz.join("foo").write("foo contents")
+        baz.join("foo2").write("foo contents")
+
+        assert hash_files_in_folder(str("test_simple")) == {
+            'bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo2': '8a44735524900cdc94460b8999b581836535470e'
+        }
+
+        # Test having subdirectories of subdirectories.
+        bang = baz.join("bang")
+        bang.ensure(dir=True)
+        bang.join("bar").write("bar contents")
+        bang.join("new").write("something new")
+
+        assert hash_files_in_folder("test_simple") == {
+            'bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo2': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/bang/bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'baz/bang/new': '15bc116ce980d703d62a16531b0ef5bb42fef91c'
+        }
+
+        swish = bang.join("swish")
+        swish.ensure(dir=True)
+        assert hash_files_in_folder("test_simple") == {
+            'bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo2': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/bang/bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'baz/bang/new': '15bc116ce980d703d62a16531b0ef5bb42fef91c',
+            'baz/bang/swish': ''
+        }
+        swish.join("swipe").write("swipe contents")
+        assert hash_files_in_folder("test_simple") == {
+            'bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/foo2': '8a44735524900cdc94460b8999b581836535470e',
+            'baz/bang/bar': '4acccb318abb44e0b8c4ba5e4e4a7fafa40243dd',
+            'baz/bang/new': '15bc116ce980d703d62a16531b0ef5bb42fef91c',
+            'baz/bang/swish/swipe': 'e855a8aca0e15c14144901428df7042798a622d6'
+        }

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -429,7 +429,7 @@ def make_abs(path):
 
 
 def do_build_docker(name, path):
-    path_sha = pkgpanda.build.hash_folder(path)
+    path_sha = pkgpanda.build.hash_folder_abs(path, os.path.dirname(path))
     container_name = 'dcos/dcos-builder:{}_dockerdir-{}'.format(name, path_sha)
 
     print("Attempting to pull docker:", container_name)


### PR DESCRIPTION
Add test for hash_files_in_folder, fix several usages with absolute paths in codebase
    
Absolute paths with hash_folder resulted in a non-reproducible hash since the absolute path changes from host to host (where the checkout is changes). This makes hash_folder assertion fail if it's given an absolute path, and gives a helper function which can be used to make absolute paths into relative paths by changing into the directory before running hash_folder

# Issues

[DCOS-275](https://dcosjira.atlassian.net/browse/DCOS-275)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)