### PR TITLE
Remove redundant SSH name / prefix from ssh modules

### DIFF
--- a/dcos_installer/async_server.py
+++ b/dcos_installer/async_server.py
@@ -15,7 +15,7 @@ import pkgpanda.util
 from dcos_installer import backend
 from dcos_installer.config import Config, make_default_config_if_needed
 from dcos_installer.constants import CONFIG_PATH, IP_DETECT_PATH, SSH_KEY_PATH, STATE_DIR
-from ssh.ssh_runner import Node
+from ssh.runner import Node
 
 
 log = logging.getLogger()

--- a/dcos_installer/prettyprint.py
+++ b/dcos_installer/prettyprint.py
@@ -17,13 +17,13 @@ class PrettyPrint():
 
     """
     def __init__(self, output):
-        self.ssh_out = output
+        self.output = output
         self.fail_hosts = []
         self.success_hosts = []
         self.preflight = False
 
     def beautify(self, mode='print_data_basic'):
-        self.failed_data, self.success_data = self.find_data(self.ssh_out)
+        self.failed_data, self.success_data = self.find_data(self.output)
         getattr(self, mode)()
         return self.failed_data, self.success_data
 
@@ -109,4 +109,4 @@ class PrettyPrint():
                     log.debug('          {}'.format(line))
 
     def print_json(self):
-        pprint.pprint(json.dumps(self.ssh_out))
+        pprint.pprint(json.dumps(self.output))

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -7,18 +7,18 @@ This library implements a SSH runner capable of running multiple SSH processes f
 
 ```python
 ssh = SSHRunner()
-ssh.ssh_user = 'ubuntu'
-ssh.ssh_key_path = '/home/ubuntu/key.pem'
+ssh.user = 'ubuntu'
+ssh.key_path = '/home/ubuntu/key.pem'
 ssh.targets = ['127.0.0.1', '127.0.0.2']
 ssh.log_directory = '/tmp'
 ssh.use_cache = False
 
-ssh_out = ssh.execute_cmd('hostname')
+output = ssh.execute_cmd('hostname')
 
 copy_out = ssh.copy_cmd('/tmp/file.txt', '/tmp')
 copy_recursive_out = ssh.copy_cmd('/usr', '/', recursive=True)
 
-print(ssh_out)
+print(output)
 print(copy_out)
 print(copy_recursive_out)
 ```
@@ -27,10 +27,10 @@ print(copy_recursive_out)
 
 #### Parameters
 
-##### `.ssh_user` *string*
+##### `.user` *string*
 The user to SSH to the remote target as.
 
-##### `.ssh_key_path` *string*
+##### `.key_path` *string*
 The path to the private key.
 
 ##### `.targets` *list*
@@ -58,16 +58,16 @@ The pretty printer provides a nice way to print colored output for success and f
 
 ```python
 from ssh.prettyprint import SSHPrettyPrint
-ssh_out = ssh.execute_cmd('hostname')
+output = ssh.execute_cmd('hostname')
 
-pretty_out = SSHPrettyPrint(ssh_out)
-ssh_out.beautify()
+pretty_out = SSHPrettyPrint(output)
+output.beautify()
 ```
 
 #### Parameters
 
-##### `.ssh_out` *dictionary* *output from SSHRunner*
-Pass the output from SSHRunner to .ssh_out.
+##### `.output` *dictionary* *output from SSHRunner*
+Pass the output from SSHRunner to .output.
 
 ##### `.beautify()` *None*
 Print the output from SSHRunner in a pretty way :)

--- a/ssh/tunnel.py
+++ b/ssh/tunnel.py
@@ -2,7 +2,7 @@
 Module for creating persistent SSH connections for use with synchronous
 commands. Typically, tunnels should be invoked as a context manager to
 ensure proper cleanup. E.G.:
-with SSHTunnel(*args, **kwargs) as tunnel:
+with Tunnel(*args, **kwargs) as tunnel:
     tunnel.write_to_remote('/usr/local/usrpath/testfile.txt', 'test_file.txt')
     tunnel.remote_cmd(['cat', 'test_file.txt'])
 """
@@ -15,27 +15,27 @@ logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class SSHTunnel():
+class Tunnel():
 
-    def __init__(self, ssh_user, ssh_key_path, host, port=22):
+    def __init__(self, user, key_path, host, port=22):
         """Persistent SSH tunnel to avoid re-creating the same connection
 
         Args:
-            ssh_user: (str) user with access to host
-            ssh_key_path: (str) local path w/ permissions to ssh_user@host
+            user: (str) user with access to host
+            key_path: (str) local path w/ permissions to user@host
             host: (str) locally resolvable hostname to tunnel to
             port: (int) port to connect to host via
 
         Return:
-            established SSHTunnel that can be issued copy/cmd/close
+            established Tunnel that can be issued copy/cmd/close
         """
         self.socket_path = tempfile.NamedTemporaryFile(delete=False).name
         self.host = host
-        self.ssh_user = ssh_user
-        self.ssh_key_path = ssh_key_path
-        self.target = ssh_user + '@' + host
+        self.user = user
+        self.key_path = key_path
+        self.target = user + '@' + host
         self.port = port
-        self.ssh_cmd = [
+        self.cmd = [
             '/usr/bin/ssh',
             '-oConnectTimeout=10',
             '-oControlMaster=auto',
@@ -45,9 +45,9 @@ class SSHTunnel():
             '-oBatchMode=yes',
             '-oPasswordAuthentication=no']
 
-        start_tunnel = self.ssh_cmd + [
+        start_tunnel = self.cmd + [
             '-fnN',
-            '-i', ssh_key_path,
+            '-i', key_path,
             '-p', str(port), self.target]
         logger.debug('Starting SSH tunnel: ' + ' '.join(start_tunnel))
         check_call(start_tunnel)
@@ -69,7 +69,7 @@ class SSHTunnel():
         assert isinstance(cmd, list), 'cmd must be a list'
         if timeout:
             assert isinstance(timeout, int), 'timeout must be an int (seconds)'
-        run_cmd = self.ssh_cmd + ['-p', str(self.port), self.target] + cmd
+        run_cmd = self.cmd + ['-p', str(self.port), self.target] + cmd
         logger.debug('Running socket cmd: ' + ' '.join(run_cmd))
         try:
             if stdout:
@@ -87,25 +87,25 @@ class SSHTunnel():
             src: (str) local path representing source data
             dst: (str) destination for path
         """
-        cmd = self.ssh_cmd + ['-C', '-p', str(self.port), self.target, 'cat>' + dst]
+        cmd = self.cmd + ['-C', '-p', str(self.port), self.target, 'cat>' + dst]
         logger.debug('Running socket write: ' + ' '.join(cmd))
         with open(src, 'r') as fh:
             check_call(cmd, stdin=fh)
 
     def close(self):
-        close_tunnel = self.ssh_cmd + ['-p', str(self.port), '-O', 'exit', self.target]
+        close_tunnel = self.cmd + ['-p', str(self.port), '-O', 'exit', self.target]
         logger.debug('Closing SSH Tunnel: ' + ' '.join(close_tunnel))
         check_call(close_tunnel)
 
 
 class TunnelCollection():
 
-    def __init__(self, ssh_user, ssh_key_path, host_names):
-        """Convenience collection of SSHTunnels so that users can keep
+    def __init__(self, user, key_path, host_names):
+        """Convenience collection of Tunnels so that users can keep
         multiple connections alive with a single self-closing context
         Args:
-            ssh_user: (str) user with access to host
-            ssh_key_path: (str) local path w/ permissions to ssh_user@host
+            user: (str) user with access to host
+            key_path: (str) local path w/ permissions to user@host
             host_names: list of locally resolvable hostname:port to tunnel to
         """
         assert isinstance(host_names, list)
@@ -113,7 +113,7 @@ class TunnelCollection():
         self.tunnels = []
         for host in host_names:
             hostname, port = host.split(':')
-            self.tunnels.append(SSHTunnel(ssh_user, ssh_key_path, hostname, port=port))
+            self.tunnels.append(Tunnel(user, key_path, hostname, port=port))
         logger.debug('Successfully created TunnelCollection')
 
     def __enter__(self):
@@ -127,16 +127,16 @@ class TunnelCollection():
             tunnel.close()
 
 
-def run_ssh_cmd(ssh_user, ssh_key_path, host, cmd, port=22, timeout=None):
+def run_ssh_cmd(user, key_path, host, cmd, port=22, timeout=None):
     """Convenience function to do a one-off SSH command
     """
     assert isinstance(cmd, list)
-    with SSHTunnel(ssh_user, ssh_key_path, host, port=port) as tunnel:
+    with Tunnel(user, key_path, host, port=port) as tunnel:
         return tunnel.remote_cmd(cmd, timeout=timeout)
 
 
-def run_scp_cmd(ssh_user, ssh_key_path, host, src, dst, port=22):
+def run_scp_cmd(user, key_path, host, src, dst, port=22):
     """Convenience function to do a one-off SSH copy
     """
-    with SSHTunnel(ssh_user, ssh_key_path, host, port=port) as tunnel:
+    with Tunnel(user, key_path, host, port=port) as tunnel:
         tunnel.write_to_remote(src, dst)

--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -14,7 +14,7 @@ from azure.mgmt.resource.resources.models import (DeploymentMode,
 from retrying import retry
 
 import pkgpanda.util
-from ssh.ssh_tunnel import SSHTunnel
+from ssh.tunnel import Tunnel
 from test_util.test_runner import integration_test
 
 
@@ -176,7 +176,7 @@ def main():
 
         print('Detected IP configuration: {}'.format(ip_buckets))
 
-        with SSHTunnel(get_value('linuxAdminUsername'), 'ssh_key', master_lb, port=2200) as t:
+        with Tunnel(get_value('linuxAdminUsername'), 'ssh_key', master_lb, port=2200) as t:
             integration_test(
                 tunnel=t,
                 test_dir='/home/{}'.format(get_value('linuxAdminUsername')),

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -12,7 +12,7 @@ from retrying import retry, RetryError
 import gen.calc
 import test_util.installer_api_test
 import test_util.test_runner
-from ssh.ssh_tunnel import SSHTunnel, TunnelCollection
+from ssh.tunnel import Tunnel, TunnelCollection
 
 
 zookeeper_docker_image = 'jplock/zookeeper'
@@ -50,7 +50,7 @@ class Ssher:
             )) from exc
 
     def tunnel(self, host):
-        return SSHTunnel(self.user, self.key_path, host.public_ip)
+        return Tunnel(self.user, self.key_path, host.public_ip)
 
     @contextmanager
     def tunnels(self, hosts):

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -10,7 +10,7 @@ import requests
 import yaml
 from retrying import retry
 
-from ssh.ssh_tunnel import run_scp_cmd, run_ssh_cmd, SSHTunnel
+from ssh.tunnel import run_scp_cmd, run_ssh_cmd, Tunnel
 
 MAX_STAGE_TIME = int(os.getenv('INSTALLER_API_MAX_STAGE_TIME', '900'))
 
@@ -25,7 +25,7 @@ class AbstractDcosInstaller(metaclass=abc.ABCMeta):
             host=None, ssh_user=None, ssh_key_path=None):
         """Creates a light, system-based ssh handler
         Args:
-            tunnel: SSHTunnel instance to avoid recreating SSH connections.
+            tunnel: Tunnel instance to avoid recreating SSH connections.
                 If set to None, ssh_user, host, and ssh_key_path must be
                 set and one-off connections will be made
             installer_path: (str) path on host to download installer to
@@ -36,7 +36,7 @@ class AbstractDcosInstaller(metaclass=abc.ABCMeta):
         """
         self.installer_path = installer_path
         if tunnel:
-            assert isinstance(tunnel, SSHTunnel)
+            assert isinstance(tunnel, Tunnel)
             self.tunnel = tunnel
             self.url = "http://{}:9000".format(tunnel.host)
 


### PR DESCRIPTION
They were already living in the "ssh" namespace, having them named SSH as well
is redundant (ssh.ssh_tunnel.SSHTunnel -> ssh.tunnel.Tunnel).

This also makes their parameters "user" and "key_path" rather than "ssh_user"
and "ssh_key_path" since the context of "this is an ssh thing" is implicit in
the fact it came from the ssh library.

# Issues

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

