### PR TITLE
Grab rex ray with updated aws-go-sdk

### DIFF
--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/rexray.git",
-    "ref": "1816ee3868550e07b90f00f57bfd7f737235cd93",
-    "ref_origin": "v0.3.3-dcos"
+    "ref": "7454cbaca89a015c6eff1f38d9279baf98a06f26",
+    "ref_origin": "new-aws-go-sdk"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/rexray.git",
-    "ref": "7454cbaca89a015c6eff1f38d9279baf98a06f26",
-    "ref_origin": "new-aws-go-sdk"
+    "ref": "7a5c745d117156a57429bb48514576b684588235",
+    "ref_origin": "v0.3.3-dcos"
   }
 }


### PR DESCRIPTION
## High Level Description

Bumps rexray to support govcloud regions

## Related Issues

- https://jira.mesosphere.com/browse/DCOS-11335

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This relies on the current rexray tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/rexray/compare/1816ee3868550e07b90f00f57bfd7f737235cd93...7a5c745d117156a57429bb48514576b684588235
  - [ ] Test Results: N/A
  - [ ] Code Coverage (if available): N/A
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).