### PR TITLE
DCOS-524:install-prereqs actually doesn't disable SElinux on CentOS

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -363,7 +363,7 @@ if [ -f /opt/dcos-prereqs.installed ]; then
 fi
 
 sudo setenforce 0 && \
-sudo sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
 
 sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
 [dockerrepo]


### PR DESCRIPTION
High level description including:
 - Disable SElinux on CentOS7 when executing `sudo bash dcos_generate_config.sh --install-prereqs`
 - It can disable SElinux correctly on CentOS7
 - sed -i will break hard or symbolic links when -i is used on such a file, should add --follow-symlinks option. (https://www.gnu.org/software/sed/manual/sed.html)

# Issues

[DCOS-524](https://dcosjira.atlassian.net/browse/DCOS-524)
...

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [ ] Change Log from last: <link>
 - [ ] Test Results: <link>
 - [ ] Code Coverage: <link>


sed -i will break the link between /etc/sysconfig/selinux and /etc/selinux/config.