### PR TITLE
Update / rewrite Tunnel, TunnelCollection

### DIFF
--- a/ssh/test_integration.py
+++ b/ssh/test_integration.py
@@ -16,7 +16,7 @@ from retrying import retry
 
 import pkgpanda.util
 from ssh.runner import MultiRunner, Node
-from ssh.tunnel import run_scp_cmd, run_ssh_cmd, Tunnel, TunnelCollection
+from ssh.tunnel import run_scp_cmd, run_ssh_cmd, tunnel, tunnel_collection
 from ssh.utils import AbstractSSHLibDelegate, CommandChain
 
 
@@ -342,8 +342,8 @@ def test_ssh_tunnel(sshd_manager):
             'key_path': sshd_manager.key_path,
             'host': '127.0.0.1',
             'port': sshd_ports[0]}
-        with Tunnel(**tunnel_args) as tunnel:
-            tunnel_write_and_run(tunnel.write_to_remote, tunnel.remote_cmd)
+        with tunnel(**tunnel_args) as t:
+            tunnel_write_and_run(t.write_to_remote, t.remote_cmd)
 
 
 def test_ssh_tunnel_collection(sshd_manager):
@@ -352,9 +352,9 @@ def test_ssh_tunnel_collection(sshd_manager):
             'user': getpass.getuser(),
             'key_path': sshd_manager.key_path,
             'host_names': ['127.0.0.1:' + str(i) for i in sshd_ports]}
-        with TunnelCollection(**tunnel_args) as tunnels:
-            for tunnel in tunnels.tunnels:
-                tunnel_write_and_run(tunnel.write_to_remote, tunnel.remote_cmd)
+        with tunnel_collection(**tunnel_args) as tunnels:
+            for t in tunnels:
+                tunnel_write_and_run(t.write_to_remote, t.remote_cmd)
 
 
 def test_ssh_one_offs(sshd_manager):

--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -14,7 +14,7 @@ from azure.mgmt.resource.resources.models import (DeploymentMode,
 from retrying import retry
 
 import pkgpanda.util
-from ssh.tunnel import Tunnel
+from ssh.tunnel import tunnel
 from test_util.test_runner import integration_test
 
 
@@ -176,7 +176,7 @@ def main():
 
         print('Detected IP configuration: {}'.format(ip_buckets))
 
-        with Tunnel(get_value('linuxAdminUsername'), 'ssh_key', master_lb, port=2200) as t:
+        with tunnel(get_value('linuxAdminUsername'), 'ssh_key', master_lb, port=2200) as t:
             integration_test(
                 tunnel=t,
                 test_dir='/home/{}'.format(get_value('linuxAdminUsername')),

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -12,7 +12,7 @@ from retrying import retry, RetryError
 import gen.calc
 import test_util.installer_api_test
 import test_util.test_runner
-from ssh.tunnel import Tunnel, TunnelCollection
+from ssh.tunnel import tunnel, tunnel_collection
 
 
 zookeeper_docker_image = 'jplock/zookeeper'
@@ -50,13 +50,13 @@ class Ssher:
             )) from exc
 
     def tunnel(self, host):
-        return Tunnel(self.user, self.key_path, host.public_ip)
+        return tunnel(self.user, self.key_path, host.public_ip)
 
     @contextmanager
     def tunnels(self, hosts):
         hostports = [host.public_ip + ':22' for host in hosts]
-        with TunnelCollection(self.user, self.key_path, hostports) as tunnel_collection:
-            yield tunnel_collection.tunnels
+        with tunnel_collection(self.user, self.key_path, hostports) as tunnels:
+            yield tunnels
 
     def remote_cmd(self, hosts, cmd):
         with self.tunnels(hosts) as tunnels:

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -4,13 +4,14 @@ import abc
 import json
 import os
 from subprocess import CalledProcessError
+from typing import Optional
 
 import pkg_resources
 import requests
 import yaml
 from retrying import retry
 
-from ssh.tunnel import run_scp_cmd, run_ssh_cmd, Tunnel
+from ssh.tunnel import run_scp_cmd, run_ssh_cmd, Tunnelled
 
 MAX_STAGE_TIME = int(os.getenv('INSTALLER_API_MAX_STAGE_TIME', '900'))
 
@@ -21,11 +22,11 @@ class AbstractDcosInstaller(metaclass=abc.ABCMeta):
         self.offline_mode = False
 
     def setup_remote(
-            self, tunnel, installer_path, download_url,
+            self, tunnel: Optional[Tunnelled], installer_path, download_url,
             host=None, ssh_user=None, ssh_key_path=None):
         """Creates a light, system-based ssh handler
         Args:
-            tunnel: Tunnel instance to avoid recreating SSH connections.
+            tunnel: Tunneled instance to avoid recreating SSH connections.
                 If set to None, ssh_user, host, and ssh_key_path must be
                 set and one-off connections will be made
             installer_path: (str) path on host to download installer to
@@ -36,7 +37,6 @@ class AbstractDcosInstaller(metaclass=abc.ABCMeta):
         """
         self.installer_path = installer_path
         if tunnel:
-            assert isinstance(tunnel, Tunnel)
             self.tunnel = tunnel
             self.url = "http://{}:9000".format(tunnel.host)
 


### PR DESCRIPTION
 - TunnelCollection is replaced with a contextlib.ExitStack, so it has less code while keeping the same behavior, uses more standard code.
 - Tunnel class is replaced with a "contextmanager" function that yields a Tunneled object.

the Tunnel contextmanager function makes it harder to use the tunnels
incorrectly as the tunnel is only accessible inside the contextmanager / when
the contextmanager has been entered. The "Tunneled" class only has the simple
API / behavior people expect to work on things which are tunneled to.

# Issues

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


