### PR TITLE
Update cosmos

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -6,6 +6,7 @@ import socket
 import textwrap
 from math import floor
 from subprocess import check_output
+from urllib.parse import urlparse
 
 import yaml
 
@@ -65,6 +66,15 @@ def validate_ipv4_addresses(ips: list):
             return None
     invalid_ips = list(filter(lambda ip: try_parse_ip(ip) is None, ips))
     assert not len(invalid_ips), 'Invalid IPv4 addresses in list: {}'.format(', '.join(invalid_ips))
+
+
+def validate_url(url: str):
+    try:
+        urlparse(url)
+    except ValueError as ex:
+        raise AssertionError(
+            "Couldn't parse given value `{}` as an URL".format(url)
+        ) from ex
 
 
 def is_azure_addr(addr: str):
@@ -427,6 +437,65 @@ def calculate_cluster_docker_registry_enabled(cluster_docker_registry_url):
     return 'false' if cluster_docker_registry_url == '' else 'true'
 
 
+def validate_cosmos_config(cosmos_config):
+    """The schema for this configuration is.
+    {
+      "schema": "http://json-schema.org/draft-04/schema#",
+      "type": "object",
+      "properties": {
+        "staged_package_storage_uri": {
+          "type": "string"
+        },
+        "package_storage_uri": {
+          "type": "string"
+        }
+      }
+    }
+    """
+
+    config = validate_json_dictionary(cosmos_config)
+    expects = ['staged_package_storage_uri', 'package_storage_uri']
+    found = list(filter(lambda value: value in config, expects))
+
+    if len(found) == 0:
+        # User didn't specify any configuration; nothing to do
+        pass
+    elif len(found) == 1:
+        # User specified one parameter but not the other; fail
+        raise AssertionError(
+            'cosmos_config must be a dictionary containing both {}, or must '
+            'be left empty. Found only {}'.format(' '.join(expects), found)
+        )
+    else:
+        # User specified both parameters; make sure they are URLs
+        for value in found:
+            validate_url(config[value])
+
+
+def calculate_cosmos_staged_package_storage_uri_flag(cosmos_config):
+    config = validate_json_dictionary(cosmos_config)
+    if 'staged_package_storage_uri' in config:
+        return (
+            '-com.mesosphere.cosmos.stagedPackageStorageUri={}'.format(
+                config['staged_package_storage_uri']
+            )
+        )
+    else:
+        return ''
+
+
+def calculate_cosmos_package_storage_uri_flag(cosmos_config):
+    config = validate_json_dictionary(cosmos_config)
+    if 'package_storage_uri' in config:
+        return (
+            '-com.mesosphere.cosmos.packageStorageUri={}'.format(
+                config['package_storage_uri']
+            )
+        )
+    else:
+        return ''
+
+
 def calculate_set(parameter):
     if parameter == '':
         return 'false'
@@ -478,7 +547,8 @@ entry = {
         lambda cluster_docker_credentials_write_to_etc: validate_true_false(cluster_docker_credentials_write_to_etc),
         lambda cluster_docker_credentials: validate_json_dictionary(cluster_docker_credentials),
         lambda aws_masters_have_public_ip: validate_true_false(aws_masters_have_public_ip),
-        validate_exhibitor_storage_master_discovery
+        validate_exhibitor_storage_master_discovery,
+        validate_cosmos_config
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -551,7 +621,8 @@ entry = {
         'cluster_docker_credentials_dcos_owned': calculate_docker_credentials_dcos_owned,
         'cluster_docker_credentials_write_to_etc': 'false',
         'cluster_docker_credentials_enabled': 'false',
-        'cluster_docker_credentials': "{}"
+        'cluster_docker_credentials': "{}",
+        'cosmos_config': '{}'
     },
     'must': {
         'custom_auth': 'false',
@@ -583,7 +654,11 @@ entry = {
         'cluster_docker_credentials_path': calculate_cluster_docker_credentials_path,
         'cluster_docker_registry_enabled': calculate_cluster_docker_registry_enabled,
         'has_master_external_loadbalancer':
-            lambda master_external_loadbalancer: calculate_set(master_external_loadbalancer)
+            lambda master_external_loadbalancer: calculate_set(master_external_loadbalancer),
+        'cosmos_staged_package_storage_uri_flag':
+            calculate_cosmos_staged_package_storage_uri_flag,
+        'cosmos_package_storage_uri_flag':
+            calculate_cosmos_package_storage_uri_flag
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -383,6 +383,10 @@ package:
         ],
         "enabled": "{{ telemetry_enabled }}"
       }
+  - path: /etc/cosmos.env
+    content: |
+      COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG={{ cosmos_staged_package_storage_uri_flag }}
+      COSMOS_PACKAGE_STORAGE_URI_FLAG={{ cosmos_package_storage_uri_flag }}
   - path: /etc/adminrouter.env
     content: |
       ADMINROUTER_ACTIVATE_AUTH_MODULE={{ adminrouter_auth_enabled }}

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -21,7 +21,13 @@ PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/proxy.env
+EnvironmentFile=/opt/mesosphere/etc/cosmos.env
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
-ExecStart=/opt/mesosphere/bin/java -Xmx2G -classpath ${PKG_PATH}/usr/cosmos.jar com.simontuffs.onejar.Boot -com.mesosphere.cosmos.dataDir=/var/lib/dcos/cosmos
+ExecStart=/opt/mesosphere/bin/java \\
+    -Xmx2G \\
+    -classpath ${PKG_PATH}/usr/cosmos.jar \\
+    com.simontuffs.onejar.Boot \\
+    \${COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG} \\
+    \${COSMOS_PACKAGE_STORAGE_URI_FLAG}
 EOF

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.2.0-4/cosmos-server-0.2.0-4-one-jar.jar",
-    "sha1": "7d659d8133a37a57c03218e3fcb7105551be3068"
+    "url": "https://downloads.dcos.io/cosmos/0.3.0-SNAPSHOT-154-refs_heads_master-ab3cba08fc/cosmos-server-0.3.0-SNAPSHOT-154-refs_heads_master-ab3cba08fc-one-jar.jar",
+    "sha1": "869648a327aef95c7f84bab49da9814d7b144ac3"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -4,6 +4,8 @@ import urllib.parse
 import bs4
 from retrying import retry
 
+from pkgpanda.util import load_json
+
 
 def test_if_dcos_ui_is_up(cluster):
     r = cluster.get('/')
@@ -142,6 +144,43 @@ def test_if_we_have_capabilities(cluster):
     )
     assert r.status_code == 200
     assert {'name': 'PACKAGE_MANAGEMENT'} in r.json()['capabilities']
+
+
+def test_cosmos_package_add(cluster):
+    r = cluster.post(
+        '/package/add',
+        headers={
+            'Accept': (
+                'application/vnd.dcos.package.add-response+json;'
+                'charset=utf-8;version=v1'
+            ),
+            'Content-Type': (
+                'application/vnd.dcos.package.add-request+json;'
+                'charset=utf-8;version=v1'
+            )
+        },
+        json={
+            'packageName': 'cassandra',
+            'packageVersion': '1.0.20-3.0.10'
+        }
+    )
+
+    user_config = load_json("/opt/mesosphere/etc/expanded.config.json")
+    if (user_config['cosmos_staged_package_storage_uri_flag'] and
+            user_config['cosmos_package_storage_uri_flag']):
+        # if the config is enabled then Cosmos should accept the request and
+        # return 202
+        assert r.status_code == 202, 'status = {}, content = {}'.format(
+            r.status_code,
+            r.content
+        )
+    else:
+        # if the config is disabled then Cosmos should accept the request and
+        # return Not Implemented 501
+        assert r.status_code == 501, 'status = {}, content = {}'.format(
+            r.status_code,
+            r.content
+        )
 
 
 def test_if_overlay_master_is_up(cluster):


### PR DESCRIPTION
High level description including:
- What does this change enable
  - Update Cosmos to support the following new endpoints
    - /package/add - Add a package to the local repository
    - /service/start - Starts a service using Marathon for the given package
  - Change the configuration generator to allow the user to optionally provide permanent store for packages. If the user configure Cosmos with this information it enables the features outlined above.
- What bugs does this change fix
  - None
- High-Level how things changed
  - See above.

# Issues

[DCOS-8992](https://dcosjira.atlassian.net/browse/DCOS-8992)

# Checklist

 - [x] There are extensive unit and CI tests in the Cosmos repo.
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include
 - This feature is integrated tested in the Cosmos CI builds. See [results](https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcosIo_Cosmos_Ci).