### PR TITLE
Bump Mesos SHA to recent master

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "1e264ece1a69837d0b5da5e397852424f9b4a3eb",
+      "ref": "f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8e8c70a71b2849ee37d3c6b9f396ceaac73369e",
-    "ref_origin" : "dcos-mesos-master-35ce5042"
+    "ref": "d6e2a1e50d47a218adab62ca363a7ca3be129055",
+    "ref_origin" : "dcos-mesos-master-30d6edb"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
This Mesos bump includes all the commits in the official Mesos 1.1.0 tag, the fixes for [MESOS-6465](https://issues.apache.org/jira/browse/MESOS-6465) (task_id -> container_id mapping in state.json), as well as "code-complete" for Debugging (I/O switchboard, AttachContainerInput/Output and LNCSession, authz, etc.).

# Component checklist:
 - [X] Change Log from dcos `master`: https://github.com/mesosphere/mesos/compare/dcos-mesos-master-35ce5042...mesosphere:dcos-mesos-master-30d6edb
 - [x] Test Results: https://mesosphere.slack.com/messages/core-ci/ 
    - OSS Mesos: https://teamcity.mesosphere.io/viewLog.html?buildId=502519&tab=report_project134_Results
 - [ ] Code Coverage: N/A, but coverity runs on Apache Mesos regularly

# Highlights from changelog:
```
30d6edb Fixed container-logger subprocess environment setup.
8dcef9c Added Mesos logo to the list of files installed for the web UI.
a567345 Made the IO Switchboard wait for the reader to signal before exiting.
57d986c Used agent environment variables for I/O switchboard.
77b16d8 Added authorization support when attaching to container input/output.
be45c94 Added support for 'ATTACH_CONTAINER_INPUT' call to the io switchboard.
fd142a0 Supported TTY in I/O switchboard.
0e0fc46 Added API handler for LAUNCH_NESTED_CONTAINER_SESSION.
dcf0f1c Added support to handle ATTACH_CONTAINER_OUPUT in the io switchbaord.
19296e0 Added authorization actions for Nested Container and Debug API.
7e472c3 Added the v1 \`ATTACH_CONTAINER_INPUT\` call handler on the agent.
d536a13 Added API handler for ATTACH_CONTAINER_OUTPUT.
9d73fe7 Added a level of indirection for logger through an IO Switchboard.
d4ba90f Added new parameter for user to ContainerLogger's prepare function.
a030970 Added ContainerStatus.container_id to JSON endpoints.
```

# Issues blocked by this:
[DCOS-9722](https://mesosphere.atlassian.net/browse/DCOS-9722) Update UI to use Logging API instead of Files API
[DCOS-11245](https://mesosphere.atlassian.net/browse/DCOS-11245) `dcos task log` should work with logging API & nested containers (pods)
[DCOS-9569](https://mesosphere.atlassian.net/browse/DCOS-9569) Implement the `dcos task exec` command
[DCOS-11251](https://mesosphere.atlassian.net/browse/DCOS-DCOS-11251) OSS Mesos changes for Container Attach/Exec and the entire rest of the Debugging Epic

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not.
_Tests for enabling new Mesos features are coming in the PRs that enable them. #1042 for rlimit and #1031 for the debugging API_
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)