### PR TITLE
Bump exhibitor SHA to 7d39834f55988e21f2d7ce2c0b67847cb4a55dab

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "a04453d14d49e1a3774bef235462b120e1eff3e1",
+      "ref": "7d39834f55988e21f2d7ce2c0b67847cb4a55dab",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
# High level description including:
#### What does this change enable
None
#### What bugs does this change fix
Fixes a critical bug in the exhibitor UI that can result in zookeeper never being able to restart after updating configuration.
#### High-Level how things changed
Fixed bug in UI

# Issues

[DCOS-9782](https://dcosjira.atlassian.net/browse/DCOS-9782)

Upstream PR: https://github.com/dcos/exhibitor/pull/4

