### PR TITLE
Cleanup request checking

### DIFF
--- a/test_util/cluster_api.py
+++ b/test_util/cluster_api.py
@@ -367,7 +367,7 @@ class ClusterApi(test_util.helpers.ApiClient):
                         retry_on_exception=lambda x: False)
         def wait_for_completion():
             r = self.metronome.get('jobs/' + job_id, params={'embed': 'history'})
-            assert r.ok
+            r.raise_for_status()
             out = r.json()
             if not ignore_failures and (out['history']['failureCount'] != 0):
                 raise Exception('Metronome job failed!: ' + repr(out))
@@ -378,11 +378,11 @@ class ClusterApi(test_util.helpers.ApiClient):
             return True
         logging.info('Creating metronome job: ' + repr(job_definition))
         r = self.metronome.post('jobs', json=job_definition)
-        assert r.ok, r.json()
+        r.raise_for_status()
         logging.info('Starting metronome job')
         r = self.metronome.post('jobs/{}/runs'.format(job_id))
-        assert r.ok, r.json()
+        r.raise_for_status()
         wait_for_completion()
         logging.info('Deleting metronome one-off')
         r = self.metronome.delete('jobs/' + job_id)
-        assert r.ok
+        r.raise_for_status()

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -40,7 +40,6 @@ class DcosUser:
         r = post('/acs/api/v1/auth/login', json=self.auth_json)
         r.raise_for_status()
         logging.info('Received authorization blob: {}'.format(r.json()))
-        assert r.ok, 'Authentication failed with status_code: {}'.format(r.status_code)
         self.auth_token = r.json()['token']
         self.auth_header = {'Authorization': 'token={}'.format(self.auth_token)}
         self.auth_cookie = r.cookies['dcos-acs-auth-cookie']
@@ -137,7 +136,7 @@ def wait_for_pong(url, timeout):
     def ping_app():
         logging.info('Attempting to ping test application')
         r = requests.get('http://{}/ping'.format(url), timeout=10)
-        assert r.ok, 'Bad response from test server: ' + str(r.status_code)
+        r.raise_for_status()
         assert r.json() == {"pong": True}, 'Unexpected response from server: ' + repr(r.json())
     ping_app()
 

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -7,10 +7,10 @@ from contextlib import contextmanager
 import requests
 import retrying
 
-import test_util.helpers
+from test_util.helpers import ApiClient, path_join
 
 DEFAULT_API_BASE = 'marathon'
-TEST_APP_NAME_FMT = '/integration-test-{}'
+TEST_APP_NAME_FMT = 'integration-test-{}'
 REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}
 
 
@@ -80,7 +80,7 @@ def get_test_app_in_docker(ip_per_container):
     return app, test_uuid
 
 
-class Marathon(test_util.helpers.ApiClient):
+class Marathon(ApiClient):
     def __init__(self, default_host_url, default_os_user='root', api_base=DEFAULT_API_BASE,
                  default_headers=None, ca_cert_path=None):
         if default_headers is None:
@@ -155,7 +155,7 @@ class Marathon(test_util.helpers.ApiClient):
         """
         r = self.post('v2/apps', json=app_definition)
         logging.info('Response from marathon: {}'.format(repr(r.json())))
-        assert r.ok
+        r.raise_for_status()
 
         @retrying.retry(wait_fixed=1000, stop_max_delay=timeout * 1000,
                         retry_on_result=lambda ret: ret is None,
@@ -167,8 +167,8 @@ class Marathon(test_util.helpers.ApiClient):
             req_params = (('embed', 'apps.lastTaskFailure'),
                           ('embed', 'apps.counts'))
 
-            r = self.get('v2/apps' + app_id, params=req_params)
-            assert r.ok
+            r = self.get(path_join('v2/apps', app_id), params=req_params)
+            r.raise_for_status()
 
             data = r.json()
 
@@ -219,7 +219,7 @@ class Marathon(test_util.helpers.ApiClient):
                         retry_on_exception=lambda x: False)
         def _destroy_complete(deployment_id):
             r = self.get('v2/deployments')
-            assert r.ok
+            r.raise_for_status()
 
             for deployment in r.json():
                 if deployment_id == deployment.get('id'):
@@ -228,8 +228,8 @@ class Marathon(test_util.helpers.ApiClient):
             logging.info('Application destroyed')
             return True
 
-        r = self.delete('v2/apps' + app_name)
-        assert r.ok
+        r = self.delete(path_join('v2/apps', app_name))
+        r.raise_for_status()
 
         try:
             _destroy_complete(r.json()['deploymentId'])


### PR DESCRIPTION
assert r.ok is a very uninformative check to make. Rather just use
r.raise_for_status()

additionally, this utility requires app names to start with '/' so just they can be queried, which makes for confusing errors if you successfully launch an app with a name that doesn't start with '/'