### PR TITLE
Replace isinstance type assertions with python 3.5 type annotations

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from typing import Optional
 
 import pkgpanda
 import ssh.utils
@@ -197,11 +198,16 @@ def _remove_host(state_file, host):
 
 
 @asyncio.coroutine
-def install_dcos(config, block=False, state_json_dir=None, hosts=None, async_delegate=None, try_remove_stale_dcos=False,
-                 **kwargs):
+def install_dcos(
+        config,
+        block=False,
+        state_json_dir=None,
+        hosts: Optional[list]=None,
+        async_delegate=None,
+        try_remove_stale_dcos=False,
+        **kwargs):
     if hosts is None:
         hosts = []
-    assert isinstance(hosts, list)
 
     # Role specific parameters
     role_params = {

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -128,7 +128,6 @@ def calculate_resolvers_str(resolvers):
     # Validation because accidentally slicing a string instead of indexing a
     # list of resolvers then finding out at cluster launch is painful.
     resolvers = json.loads(resolvers)
-    assert isinstance(resolvers, list)
     return ",".join(resolvers)
 
 

--- a/gen/template.py
+++ b/gen/template.py
@@ -15,6 +15,7 @@
 #   switch <identifier>
 #   case <string>:
 #   endswith
+from typing import Optional, Tuple
 
 from pkg_resources import resource_string
 
@@ -38,8 +39,7 @@ class SyntaxError(Exception):
 
 class Tokenizer():
 
-    def __init__(self, corpus):
-        assert isinstance(corpus, str)
+    def __init__(self, corpus: str):
         self.__corpus = corpus
         self.__to_lex = corpus
 
@@ -258,10 +258,8 @@ class Tokenizer():
 
 class Switch():
 
-    def __init__(self, identifier, cases):
-        assert isinstance(identifier, str)
+    def __init__(self, identifier: str, cases: dict):
         self.identifier = identifier
-        assert isinstance(cases, dict)
         self.cases = cases
 
     def __repr__(self):
@@ -272,12 +270,9 @@ class Switch():
 
 
 class For():
-    def __init__(self, new_var, iterable, body):
-        assert isinstance(new_var, str)
+    def __init__(self, new_var: str, iterable: str, body: list):
         self.new_var = new_var
-        assert isinstance(iterable, str)
         self.iterable = iterable
-        assert isinstance(body, list)
         self.body = body
 
     def __repr__(self):
@@ -289,12 +284,9 @@ class For():
 
 class Replacement():
 
-    def __init__(self, identifier_and_filter):
+    def __init__(self, identifier_and_filter: Tuple[str, Optional[str]]):
         self.identifier = identifier_and_filter[0]
         self.filter = identifier_and_filter[1]
-
-        assert(isinstance(self.identifier, str))
-        assert(isinstance(self.filter, str) or self.filter is None)
 
     def __repr__(self):
         return "<replacement {}{}>".format(
@@ -317,12 +309,10 @@ class UnsetMarker():
 
 class Template():
 
-    def __init__(self, ast):
-        assert isinstance(ast, list)
+    def __init__(self, ast: list):
         self.ast = ast
 
-    def render(self, arguments, filters={}):
-        assert isinstance(arguments, dict)
+    def render(self, arguments: dict, filters: dict={}):
 
         def get_argument(name):
             try:

--- a/packages/dcos-history/extra/history/statebuffer.py
+++ b/packages/dcos-history/extra/history/statebuffer.py
@@ -4,6 +4,7 @@ import os
 import threading
 from collections import deque
 from datetime import datetime, timedelta
+from typing import Optional
 
 import requests
 
@@ -104,8 +105,7 @@ class HistoryBuffer():
         # Guarantees first call after instanciation will cause update
         self.next_update = datetime.now()
 
-    def _get_datafile_name(self, timestamp):
-        assert isinstance(timestamp, datetime)
+    def _get_datafile_name(self, timestamp: datetime):
         assert timestamp.tzinfo is None
         return '{}/{}{}'.format(self.path, timestamp.isoformat(), FILE_EXT)
 
@@ -113,17 +113,15 @@ class HistoryBuffer():
         while len(self.disk_files) > self.disk_count:
             os.remove(self.disk_files.pop(0))
 
-    def add_data(self, timestamp, state):
-        assert isinstance(timestamp, datetime)
+    def add_data(self, timestamp: datetime, state):
         if timestamp >= self.next_update:
             self._update_buffer(state, storage_time=timestamp)
 
-    def _update_buffer(self, state, storage_time=None):
+    def _update_buffer(self, state, storage_time: Optional[datetime]=None):
         self.in_memory.append(state)
         self.next_update += self.update_period
 
         if storage_time and (self.disk_count > 0):
-            assert isinstance(storage_time, datetime)
             data_file = self._get_datafile_name(storage_time)
             with open(data_file, 'w') as f:
                 json.dump(state, f)

--- a/pkgpanda/actions.py
+++ b/pkgpanda/actions.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import os
 import sys
@@ -29,7 +28,6 @@ def activate_packages(install, repository, package_ids, systemd, block_systemd):
     block_systemd: if systemd, block waiting for systemd services to come up
 
     """
-    assert isinstance(package_ids, collections.Sequence)
     install.activate(repository.load_packages(package_ids))
     if systemd:
         _start_dcos_target(block_systemd)
@@ -105,8 +103,9 @@ def add_package_file(repository, package_filename):
     name = os.path.basename(package_filename)
 
     if not name.endswith(filename_suffix):
-        print("ERROR: Can only add package tarballs which have names "
-              "like {{pkg-id}}{}".format(filename_suffix))
+        raise ValidationError(
+            "ERROR: Can only add package tarballs which have names like "
+            "{{pkg-id}}{}".format(filename_suffix))
 
     pkg_id = name[:-len(filename_suffix)]
 
@@ -250,8 +249,8 @@ def _do_bootstrap(install, repository):
         print("Checking for cluster packages in:", cluster_packages_filename)
         if cluster_packages:
             if not isinstance(cluster_packages, list):
-                print('ERROR: {} should contain a JSON list of packages. Got a {}'.format(cluster_packages_filename,
-                                                                                          type(cluster_packages)))
+                raise ValidationError('{} should contain a JSON list of packages. Got a {}'.format(
+                    cluster_packages_filename, type(cluster_packages)))
             print("Loading cluster-packages: {}".format(cluster_packages))
 
             for package_id_str in cluster_packages:

--- a/pkgpanda/build/__init__.py
+++ b/pkgpanda/build/__init__.py
@@ -26,8 +26,7 @@ from pkgpanda.util import (check_forbidden_services, download_atomic, load_json,
 
 class BuildError(Exception):
     """An error while building something."""
-    def __init__(self, msg):
-        assert isinstance(msg, str)
+    def __init__(self, msg: str):
         self.msg = msg
 
     def __str__(self):
@@ -360,8 +359,7 @@ class PackageStore:
     def packages_dir(self):
         return self._packages_dir
 
-    def try_fetch_by_id(self, pkg_id):
-        assert isinstance(pkg_id, PackageId)
+    def try_fetch_by_id(self, pkg_id: PackageId):
         if self._repository_url is None:
             return False
 
@@ -656,7 +654,7 @@ def build_tree(package_store, mkbootstrap, tree_variant):
     visited = set()
     built = set()
 
-    def visit(pkg_tuple):
+    def visit(pkg_tuple: tuple):
         """Add a package and its requires to the build order.
 
         Raises AssertionError if pkg_tuple is in the set of visited packages.
@@ -665,7 +663,6 @@ def build_tree(package_store, mkbootstrap, tree_variant):
         to the build order depth-first. Then the package itself is added.
 
         """
-        assert isinstance(pkg_tuple, tuple)
 
         # Visit the node for the first (and only) time.
         assert pkg_tuple not in visited
@@ -825,7 +822,7 @@ class IdBuilder():
         return self._buildinfo
 
 
-def build(package_store, name, variant, clean_after_build, recursive=False):
+def build(package_store: PackageStore, name: str, variant, clean_after_build, recursive=False):
     msg = "Building package {} variant {}".format(name, pkgpanda.util.variant_name(variant))
     with logger.scope(msg):
         return _build(package_store, name, variant, clean_after_build, recursive)

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -15,6 +15,7 @@ import os.path
 import subprocess
 import sys
 from distutils.version import LooseVersion
+from typing import Optional
 
 import pkg_resources
 import yaml
@@ -128,13 +129,12 @@ def load_providers():
 # have all the logic about channels and repositories.
 class Repository():
 
-    def __init__(self, repository_path, channel_name, unique_id):
+    def __init__(self, repository_path, channel_name: Optional[str], unique_id):
         if not repository_path:
             raise ValueError("repository_path must be a non-empty string. channel_name may be None though.")
 
         assert not repository_path.endswith('/')
         if channel_name is not None:
-            assert isinstance(channel_name, str)
             assert len(channel_name) > 0, "For an empty channel name pass None"
             assert not channel_name.startswith('/')
             assert not channel_name.endswith('/')
@@ -346,8 +346,6 @@ def make_stable_artifacts(cache_repository_url):
 
 
 def built_resource_to_artifacts(built_resource: dict):
-    assert isinstance(built_resource, dict), built_resource
-
     # Type switch
     if 'packages' in built_resource:
         return [get_gen_package_artifact(package) for package in built_resource['packages']]

--- a/release/storage/__init__.py
+++ b/release/storage/__init__.py
@@ -88,8 +88,7 @@ class AbstractStorageProvider(metaclass=abc.ABCMeta):
 
 
 class ReadOnlyProxy(AbstractStorageProvider):
-    def __init__(self, storage_provider):
-        assert isinstance(storage_provider, AbstractStorageProvider)
+    def __init__(self, storage_provider: AbstractStorageProvider):
         self._storage_provider = storage_provider
 
     def copy(self,

--- a/release/storage/aws.py
+++ b/release/storage/aws.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import boto3
 import botocore
 
@@ -73,11 +75,11 @@ class S3StorageProvider(AbstractStorageProvider):
         new_object.copy_from(CopySource=old_path)
 
     def upload(self,
-               destination_path,
-               blob=None,
-               local_path=None,
-               no_cache=None,
-               content_type=None):
+               destination_path: str,
+               blob: Optional[bytes]=None,
+               local_path: Optional[str]=None,
+               no_cache: bool=False,
+               content_type: Optional[str]=None):
         extra_args = {}
         if no_cache:
             extra_args['CacheControl'] = 'no-cache'

--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import azure.storage.blob
 import requests
 from retrying import retry
@@ -48,11 +50,11 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
 
     @retry(stop_max_attempt_number=3)
     def upload(self,
-               destination_path,
-               blob=None,
-               local_path=None,
-               no_cache=None,
-               content_type=None):
+               destination_path: str,
+               blob: Optional[bytes]=None,
+               local_path: Optional[str]=None,
+               no_cache: bool=False,
+               content_type: Optional[str]=None):
         content_settings = azure.storage.blob.ContentSettings()
 
         if no_cache:
@@ -72,7 +74,6 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
                 max_connections=16)
         else:
             assert blob is not None
-            assert isinstance(blob, bytes)
             self.blob_service.create_blob_from_text(
                 self.container,
                 destination_path,

--- a/release/storage/local.py
+++ b/release/storage/local.py
@@ -1,5 +1,6 @@
 import os.path
 import subprocess
+from typing import Optional
 
 from release.storage import AbstractStorageProvider
 
@@ -11,8 +12,7 @@ from release.storage import AbstractStorageProvider
 class LocalStorageProvider(AbstractStorageProvider):
     name = 'local_storage_provider'
 
-    def __init__(self, path):
-        assert isinstance(path, str)
+    def __init__(self, path: str):
         assert not path.endswith('/')
         self.__storage_path = path
 
@@ -34,7 +34,13 @@ class LocalStorageProvider(AbstractStorageProvider):
     def copy(self, source_path, destination_path):
         self.__copy(self.__full_path(source_path), self.__full_path(destination_path))
 
-    def upload(self, destination_path, blob=None, local_path=None, no_cache=None, content_type=None):
+    def upload(
+            self,
+            destination_path: str,
+            blob: Optional[bytes]=None,
+            local_path: Optional[str]=None,
+            no_cache: bool=False,
+            content_type: Optional[str]=None):
         # TODO(cmaloney): Don't discard the extra no_cache / content_type. We ideally want to be
         # able to test those are set.
         destination_full_path = self.__full_path(destination_path)

--- a/ssh/runner.py
+++ b/ssh/runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import logging
 import os
 import pty
@@ -18,8 +19,7 @@ def make_slave_pty():
     os.close(master_pty)
 
 
-def parse_ip(ip):
-    assert isinstance(ip, str), 'IP should be string, {} given'.format(ip)
+def parse_ip(ip: str):
     tmp = ip.split(':')
     if len(tmp) == 2:
         return {"ip": tmp[0], "port": int(tmp[1])}
@@ -32,9 +32,8 @@ def parse_ip(ip):
 
 
 class Node():
-    def __init__(self, host, tags=dict()):
-        assert isinstance(tags, dict)
-        self.tags = tags
+    def __init__(self, host, tags: dict=dict()):
+        self.tags = copy.copy(tags)
         self.host = parse_ip(host)
         self.ip = self.host['ip']
         self.port = self.host['port']
@@ -58,9 +57,8 @@ def add_host(target):
 
 
 class MultiRunner():
-    def __init__(self, targets, async_delegate=None, user=None, key_path=None, extra_opts='',
+    def __init__(self, targets: list, async_delegate=None, user=None, key_path=None, extra_opts='',
                  process_timeout=120, parallelism=10):
-        assert isinstance(targets, list)
         # TODO(cmaloney): accept an "ssh_config" object which generates an ssh
         # config file, then add a '-F' to that temporary config file rather than
         # manually building up / adding the arguments in _get_base_args which is
@@ -174,8 +172,7 @@ class MultiRunner():
         result = yield from self.run_cmd_return_dict_async(full_cmd, host, namespace, future, stage)
         return result
 
-    def _run_chain_command(self, chain, host, chain_result):
-        assert isinstance(chain, CommandChain)
+    def _run_chain_command(self, chain: CommandChain, host, chain_result):
 
         # Prepare status json
         if self.async_delegate is not None:
@@ -252,8 +249,7 @@ class MultiRunner():
         return chain_result
 
     @asyncio.coroutine
-    def run_commands_chain_async(self, chains, block=False, state_json_dir=None, delegate_extra_params={}):
-        assert isinstance(chains, list)
+    def run_commands_chain_async(self, chains: list, block=False, state_json_dir=None, delegate_extra_params={}):
         sem = asyncio.Semaphore(self.__parallelism)
 
         if state_json_dir:

--- a/ssh/tunnel.py
+++ b/ssh/tunnel.py
@@ -10,6 +10,7 @@ import logging
 import tempfile
 from contextlib import contextmanager, ExitStack
 from subprocess import check_call, check_output, TimeoutExpired
+from typing import Optional
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
@@ -17,21 +18,18 @@ logger = logging.getLogger(__name__)
 
 
 class Tunnelled():
-    def __init__(self, base_cmd, host, target):
+    def __init__(self, base_cmd: list, host: str, target: str):
         self.base_cmd = base_cmd
         self.host = host
         self.target = target
 
-    def remote_cmd(self, cmd: list, timeout=None, stdout=None):
+    def remote_cmd(self, cmd: list, timeout: Optional[int]=None, stdout=None):
         """
         Args:
             cmd: list of strings that will be interpretted in a subprocess
             timeout: (int) number of seconds until process timesout
             stdout: file object to redirect stdout to
         """
-        if timeout:
-            assert isinstance(timeout, int), 'timeout must be an int (seconds)'
-
         run_cmd = self.base_cmd + [self.target] + cmd
         logger.debug('Running socket cmd: ' + ' '.join(run_cmd))
         try:
@@ -57,7 +55,7 @@ class Tunnelled():
 
 
 @contextmanager
-def tunnel(user, key_path, host, port=22):
+def tunnel(user: str, key_path: str, host: str, port: int=22):
     tunnel_socket = tempfile.NamedTemporaryFile()
     target = user + '@' + host
 
@@ -85,7 +83,7 @@ def tunnel(user, key_path, host, port=22):
 
 
 @contextmanager
-def tunnel_collection(user: str, key_path: str, host_names: list):
+def tunnel_collection(user, key_path, host_names: list):
     """Convenience collection of Tunnels so that users can keep
     multiple connections alive with a single self-closing context
     Args:
@@ -107,7 +105,6 @@ def tunnel_collection(user: str, key_path: str, host_names: list):
 def run_ssh_cmd(user, key_path, host, cmd, port=22, timeout=None):
     """Convenience function to do a one-off SSH command
     """
-    assert isinstance(cmd, list)
     with tunnel(user, key_path, host, port=port) as t:
         return t.remote_cmd(cmd, timeout=timeout)
 

--- a/ssh/utils.py
+++ b/ssh/utils.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import os
+from typing import Callable, Union
 
 log = logging.getLogger(__name__)
 
@@ -23,8 +24,7 @@ class CommandChain():
         self.commands_stack = []
         self.namespace = namespace
 
-    def add_execute(self, cmd, rollback=None, stage=None):
-        assert isinstance(cmd, list) or callable(cmd)
+    def add_execute(self, cmd: Union[list, Callable], rollback=None, stage=None):
         self.commands_stack.append((self.execute_flag, cmd, rollback, stage))
 
     def add_copy(self, local_path, remote_path, remote_to_local=False, recursive=False, stage=None):
@@ -34,9 +34,8 @@ class CommandChain():
         # Return all commands
         return self.commands_stack
 
-    def prepend_command(self, cmd, rollback=None, stage=None):
+    def prepend_command(self: list, cmd, rollback=None, stage=None):
         # We can specify a command to be executed before the main chain of commands, for example some setup commands
-        assert isinstance(cmd, list)
         self.commands_stack.insert(0, (self.execute_flag, cmd, rollback, stage))
 
 
@@ -156,9 +155,7 @@ class JsonDelegate(AbstractSSHLibDelegate):
 
     # When the function is invoked the json status file will be populated with a list of nodes passed as a parameter.
     # In this case a node should not be in any state and should just wait to be processed.
-    def prepare_status(self, name, nodes):
-        assert isinstance(name, str)
-        assert isinstance(nodes, list)
+    def prepare_status(self, name: str, nodes: list):
 
         json_status = self._read_json_state(name)
 


### PR DESCRIPTION
The set of things to replace was found with:
`git grep 'assert isinstance'`

The python 3.5 type hints are now expressive enough for the all of these,
through the new "typing" module. The hints will effectively do the same thing
the asserts used to.

Some type assertions still exist, particularly in cases where there are circular
references (referring to a not-defined-yet class), as well as inside gen
validation where we're explicitly trying to walk through the type.

There is a second commit here which converts two error messages which didn't actually error / abort.

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not: N/A, syntactic change / modernizing the existing code. Old tests pass.
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)