### PR TITLE
Remove variable pass through for items found locally

### DIFF
--- a/packages/dcos-integration-test/extra/cluster_fixture.py
+++ b/packages/dcos-integration-test/extra/cluster_fixture.py
@@ -2,7 +2,6 @@
 ClusterApi object that will be injected into the pytest 'cluster' fixture
 via the make_cluster_fixture() method
 """
-
 from test_util.cluster_api import ClusterApi, get_args_from_env
 from test_util.helpers import CI_AUTH_JSON, DcosUser
 

--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -19,13 +19,13 @@ def dcos_launchpad(cluster):
     """Interface for direct integration to dcos_launchpad hardware
     Currently only supports AWS CF with AWS VPC coming soon
     """
-    if cluster.provider != 'aws':
+    if 'AWS_STACK_NAME' not in os.environ:
         # TODO(mellenburg): update when advanced templates are merged
-        pytest.skip('Must be AWS CF to run test')
+        pytest.skip('Must use a AWS Cloudformation to run test')
+    stack_name = os.environ['AWS_STACK_NAME']
+    aws_region = os.environ['AWS_REGION']
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
     aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
-    aws_region = os.environ['AWS_REGION']
-    stack_name = os.environ['AWS_STACK_NAME']
     bw = test_util.aws.BotoWrapper(aws_region, aws_access_key_id, aws_secret_access_key)
     return test_util.aws.DcosCfSimple(stack_name, bw)
 

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -1,19 +1,25 @@
+import subprocess
+
 import pytest
 
 
 @pytest.fixture(scope='module')
-def auth_cluster(cluster):
-    if not cluster.auth_enabled:
-        pytest.skip("Skipped because not running against cluster with auth.")
-    return cluster
+def noauth_cluster(cluster):
+    return cluster.get_user_session(None)
 
 
-@pytest.fixture(scope='module')
-def noauth_cluster(auth_cluster):
-    return auth_cluster.get_user_session(None)
+def auth_enabled():
+    out = subprocess.check_output([
+        '/bin/bash', '-c',
+        'source /opt/mesosphere/etc/adminrouter.env && echo $ADMINROUTER_ACTIVATE_AUTH_MODULE']).\
+        decode().strip('\n')
+    assert out in ['true', 'false'], 'Unknown ADMINROUTER_ACTIVATE_AUTH_MODULE state: {}'.format(out)
+    return out == 'true'
 
 
-def test_adminrouter_access_control_enforcement(auth_cluster, noauth_cluster):
+@pytest.mark.skipif(not auth_enabled(),
+                    reason='Can only test adminrouter enforcement if auth is enabled')
+def test_adminrouter_access_control_enforcement(cluster, noauth_cluster):
     r = noauth_cluster.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')
@@ -27,24 +33,24 @@ def test_adminrouter_access_control_enforcement(auth_cluster, noauth_cluster):
     for path in ('/mesos_dns/v1/config', '/service/marathon/', '/mesos/'):
         r = noauth_cluster.get(path)
         assert r.status_code == 401
-        r = auth_cluster.get(path)
+        r = cluster.get(path)
         assert r.status_code == 200
 
     # Test authentication with auth cookie instead of Authorization header.
     authcookie = {
-        'dcos-acs-auth-cookie': auth_cluster.web_auth_default_user.auth_cookie}
+        'dcos-acs-auth-cookie': cluster.web_auth_default_user.auth_cookie}
     r = noauth_cluster.get(
         '/service/marathon/',
         cookies=authcookie)
     assert r.status_code == 200
 
 
-def test_logout(auth_cluster):
+def test_logout(cluster):
     """Test logout endpoint. It's a soft logout, instructing
     the user agent to delete the authentication cookie, i.e. this test
     does not have side effects on other tests.
     """
-    r = auth_cluster.get('/acs/api/v1/auth/logout')
+    r = cluster.get('/acs/api/v1/auth/logout')
     cookieheader = r.headers['set-cookie']
     assert 'dcos-acs-auth-cookie=;' in cookieheader or 'dcos-acs-auth-cookie="";' in cookieheader
     assert 'expires' in cookieheader.lower()

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -9,6 +9,8 @@ import kazoo.client
 import pytest
 import requests
 
+from test_helpers import dcos_config
+
 
 @pytest.mark.first
 def test_cluster_is_up(cluster):
@@ -112,7 +114,7 @@ def test_signal_service(cluster):
 
     # Generic properties which are the same between all tracks
     generic_properties = {
-        'provider': cluster.provider,
+        'provider': dcos_config['provider'],
         'source': 'cluster',
         'clusterId': cluster_id,
         'customerKey': customer_key,

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -1,0 +1,3 @@
+from pkgpanda.util import load_json
+
+dcos_config = load_json('/opt/mesosphere/etc/expanded.config.json')

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -4,6 +4,8 @@ import pytest
 import requests
 import retrying
 
+from test_helpers import dcos_config
+
 from test_util.marathon import get_test_app, get_test_app_in_docker
 
 MESOS_DNS_ENTRY_UPDATE_TIMEOUT = 60  # in seconds
@@ -161,7 +163,7 @@ def test_if_search_is_working(cluster):
         expected_error = {'error': '[Errno -2] Name or service not known'}
 
         # Check that result matches expectations for this cluster
-        if cluster.dns_search_set:
+        if dcos_config['dns_search']:
             assert r_data['search_hit_leader'] in cluster.masters
             assert r_data['always_hit_leader'] in cluster.masters
             assert r_data['always_miss'] == expected_error

--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -62,9 +62,7 @@ def get_value(template_parameter):
 
 
 def get_test_config():
-    # Currently tests only pass with auth disabled, TEST_ADD_ENV_DCOS_AUTH_ENABLED=true
-    # can be set in the environment to override this
-    add_env = {'DCOS_AUTH_ENABLED': 'false'}
+    add_env = {}
     prefix = 'TEST_ADD_ENV_'
     for k, v in os.environ.items():
         if k.startswith(prefix):
@@ -184,8 +182,6 @@ def main():
                 master_list=ip_buckets['master'],
                 agent_list=ip_buckets['private'],
                 public_agent_list=ip_buckets['public'],
-                provider='azure',
-                test_dns_search=False,
                 add_env=get_test_config(),
                 pytest_cmd=os.getenv('DCOS_PYTEST_CMD', "py.test -vv -s -rs -m 'not ccm' ") + os.getenv('CI_FLAGS', ''))
         test_successful = True

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -91,9 +91,6 @@ export PUBLIC_MASTER_HOSTS=$MASTER_HOSTS
 export SLAVE_HOSTS=192.168.65.111,192.168.65.121
 export PUBLIC_SLAVE_HOSTS=192.168.65.60
 export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
-export DNS_SEARCH=true
-export DCOS_AUTH_ENABLED=false
-export DCOS_PROVIDER=onprem
 export DCOS_DEFAULT_OS_USER=root
 cd /opt/mesosphere/active/dcos-integration-test
 /opt/mesosphere/bin/dcos-shell py.test -vv -s -rs -m "not ccm" ${CI_FLAGS:-}

--- a/test_util/runner.py
+++ b/test_util/runner.py
@@ -17,8 +17,6 @@ log = logging.getLogger(__name__)
 def integration_test(
         tunnel, test_dir,
         dcos_dns, master_list, agent_list, public_agent_list,
-        provider,
-        test_dns_search=True,
         aws_access_key_id='', aws_secret_access_key='', region='', add_env=None,
         pytest_cmd='py.test -vv -s -rs'):
     """Runs integration test on host
@@ -28,8 +26,6 @@ def integration_test(
         dcos_dns: string representing IP of DCOS DNS host
         master_list: string of comma separated master addresses
         agent_list: string of comma separated agent addresses
-        test_dns_search: if set to True, test for deployed mesos DNS app
-        provider: (str) either onprem, aws, or azure
     Optional args:
         aws_access_key_id: needed for REXRAY tests
         aws_secret_access_key: needed for REXRAY tests
@@ -42,15 +38,12 @@ def integration_test(
         exit code corresponding to test_cmd run
 
     """
-    dns_search = 'true' if test_dns_search else 'false'
     test_env = [
         'DCOS_DNS_ADDRESS=http://' + dcos_dns,
         'MASTER_HOSTS=' + ','.join(master_list),
         'PUBLIC_MASTER_HOSTS=' + ','.join(master_list),
         'SLAVE_HOSTS=' + ','.join(agent_list),
         'PUBLIC_SLAVE_HOSTS=' + ','.join(public_agent_list),
-        'DCOS_PROVIDER=' + provider,
-        'DNS_SEARCH=' + dns_search,
         'AWS_ACCESS_KEY_ID=' + aws_access_key_id,
         'AWS_SECRET_ACCESS_KEY=' + aws_secret_access_key,
         'AWS_REGION=' + region]

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -112,7 +112,6 @@ def main():
         region=options.aws_region,
         aws_access_key_id=options.aws_access_key_id,
         aws_secret_access_key=options.aws_secret_access_key,
-        test_dns_search=False,
         add_env=options.add_env,
         pytest_cmd=options.pytest_cmd,
     )

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -213,7 +213,6 @@ def main():
     result = test_util.cluster.run_integration_tests(
         cluster,
         # Setting dns_search: mesos not currently supported in API
-        test_dns_search=(not options.use_api),
         region=DEFAULT_AWS_REGION,
         aws_access_key_id=options.aws_access_key_id,
         aws_secret_access_key=options.aws_secret_access_key,

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -149,9 +149,6 @@ def main():
         master_list,
         [h.private_ip for h in cluster.agents],
         [h.private_ip for h in cluster.public_agents],
-        False,              # dns search set.
-        cluster.provider,
-        True,               # auth_enabled
         "root",             # default_os_user
         web_auth_default_user=DcosUser(CI_AUTH_JSON),
         ca_cert_path=None)


### PR DESCRIPTION
We want to minimize the amount of input needed to run a test and these member variables serve no purpose other than passing through information that can be readily pulled from the config on the host where the test is running:
-provider
-auth_enabled
-dns_search_set

# Issues
https://mesosphere.atlassian.net/browse/DCOS-11977

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)