### PR TITLE
Add golang 1.7.3 to dcos base build image and use it in our golang projects

### DIFF
--- a/packages/3dt/build
+++ b/packages/3dt/build
@@ -1,5 +1,4 @@
 #!/bin/bash
-export GOPATH=$GOPATH:/pkg
 mkdir -p /pkg/src/github.com/dcos
 # Create the GOPATH for the go tool to work properly
 mv /pkg/src/3dt /pkg/src/github.com/dcos/

--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -1,6 +1,5 @@
 {
   "requires": ["exhibitor"],
-  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",

--- a/packages/dcos-oauth/build
+++ b/packages/dcos-oauth/build
@@ -1,6 +1,5 @@
 #!/bin/bash -xe
 
-export GOPATH=/pkg:$GOPATH
 mkdir -p /pkg/src/github.com/dcos
 mv /pkg/src/dcos-oauth /pkg/src/github.com/dcos/
 cd /pkg/src/github.com/dcos/dcos-oauth

--- a/packages/dcos-oauth/buildinfo.json
+++ b/packages/dcos-oauth/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.6",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-oauth.git",

--- a/packages/dcos-signal/build
+++ b/packages/dcos-signal/build
@@ -1,5 +1,4 @@
 #!/bin/bash
-export GOPATH=$GOPATH:/pkg
 mkdir -p /pkg/src/github.com/dcos
 # Create the GOPATH for the go tool to work properly
 mv /pkg/src/dcos-signal /pkg/src/github.com/dcos/

--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.6",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -qq update && apt-get -y install \
   git \
   gzip \
   libapr1-dev \
+  libc6-dev \
   libcurl4-openssl-dev \
   libnl-3-dev \
   libnl-genl-3-dev \
@@ -48,5 +49,20 @@ RUN ln -sf /usr/bin/cpp-4.8 /usr/bin/cpp && \
   ln -sf /usr/bin/gcc-nm-4.8 /usr/bin/gcc-nm && \
   ln -sf /usr/bin/gcc-ranlib-4.8 /usr/bin/gcc-ranlib && \
   ln -sf /usr/bin/gcov-4.8 /usr/bin/gcov
+
+ENV GOLANG_VERSION 1.7.3
+ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ENV GOLANG_DOWNLOAD_SHA256 508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+  && echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+  && tar -C /usr/local -xzf golang.tar.gz \
+  && rm golang.tar.gz
+
+# Set GOPATH to expected pkgpanda package path for DC/OS
+ENV GOPATH /pkg
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 RUN pip install awscli


### PR DESCRIPTION
This PR adds golang 1.7.3 to the DC/OS base build image. This supports consolidating to a single container for building (faster builds) and allowing pkgpanda packages which build many components can use a single container (see dcos-metrics service and module consolidation). 


