### PR TITLE
Raise error to exit nicely

### DIFF
--- a/release/__init__.py
+++ b/release/__init__.py
@@ -303,7 +303,8 @@ def make_stable_artifacts(cache_repository_url):
         try:
             all_completes = do_build_packages(cache_repository_url)
         except pkgpanda.build.BuildError as ex:
-            logger.error("Building packages: {}".format(ex))
+            logger.error("Failure building package(s): {}".format(ex))
+            raise
 
     # The installer is a built bootstrap, but not a DC/OS variant. We use
     # iteration over the complete_dict to enumerate all variants a whole lot,

--- a/release/test_release.py
+++ b/release/test_release.py
@@ -8,6 +8,7 @@ import pytest
 import gen.build_deploy.aws
 import release
 import release.storage.aws
+from pkgpanda.build import BuildError
 from pkgpanda.util import variant_prefix, write_json, write_string
 
 
@@ -552,6 +553,10 @@ stable_artifacts_metadata = {
 }
 
 
+def mock_failed_build_packages(_):
+    raise BuildError('This build failed!')
+
+
 # TODO(cmaloney): Add test for do_build_packages returning multiple bootstraps
 # containing overlapping
 def test_make_stable_artifacts(monkeypatch, tmpdir):
@@ -561,6 +566,11 @@ def test_make_stable_artifacts(monkeypatch, tmpdir):
     with tmpdir.as_cwd():
         metadata = release.make_stable_artifacts("http://test")
         assert metadata == stable_artifacts_metadata
+
+    # Check that a BuildError is propogated
+    monkeypatch.setattr("release.do_build_packages", mock_failed_build_packages)
+    with pytest.raises(BuildError):
+        release.make_stable_artifacts("http://test")
 
 
 # NOTE: Implicitly tests all gen.build_deploy do_create functions since it calls them.


### PR DESCRIPTION
 - if do_build_packages fail, we get the real exception in the log stream, but it is buried under an UnboundError exception that occurs because the code tries to go forward after failing when it should have simply stopped 
- Just raise the error as was originally the case

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd]