### PR TITLE
Updated Mesos and Mesos modules packages to accommodate interface change

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "1e264ece1a69837d0b5da5e397852424f9b4a3eb",
+      "ref": "f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8e8c70a71b2849ee37d3c6b9f396ceaac73369e",
-    "ref_origin" : "dcos-mesos-master-35ce5042"
+    "ref": "e40789f993fd136367a9f32cf76785a998e8c1ad",
+    "ref_origin" : "dcos-pkg-builder-mesos-1fc0551d"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
[This commit](https://github.com/apache/mesos/commit/d4ba90fac3b8d0507d8d952c413730b78c8be4ee) changed a module interface which breaks the mesos-modules package. This PR does the following:
* Updates the Mesos package to include the breaking interface change
* Updates the mesos-modules package to include the fix for this interface change