### PR TITLE
Add missing from to re-raise, fix unset variables leading to an assertion

### DIFF
--- a/gen/internals.py
+++ b/gen/internals.py
@@ -595,7 +595,7 @@ class Resolver:
     @property
     def status_dict(self):
         assert self._resolved, "Can't retrieve status dictionary until configuration has been resolved"
-        if not self._errors:
+        if not self._errors and not self._unset:
             return {'status': 'ok'}
 
         # Defer multi-key validation errors and noramlize them to be single-key

--- a/gen/template.py
+++ b/gen/template.py
@@ -317,8 +317,8 @@ class Template():
         def get_argument(name):
             try:
                 return arguments[name]
-            except KeyError:
-                raise UnsetParameter("Unset parameter {}".format(name), name)
+            except KeyError as ex:
+                raise UnsetParameter("Unset parameter {}".format(name), name) from ex
 
         def render_ast(ast):
             rendered = ""

--- a/gen/test_internals.py
+++ b/gen/test_internals.py
@@ -82,14 +82,21 @@ def test_resolve_simple():
         }
     })
 
-    test_target = Target(
-        {'a', 'b', 'c'},
-        {'d': Scope(
-            'd', {
-                'd_1': Target({'d_1_a', 'd_1_b'}),
-                'd_2': Target({'d_2_a', 'd_2_b'})
-            })})
+    def get_test_target():
+        return Target(
+            {'a', 'b', 'c'},
+            {'d': Scope(
+                'd', {
+                    'd_1': Target({'d_1_a', 'd_1_b'}),
+                    'd_2': Target({'d_2_a', 'd_2_b'})
+                })})
 
-    resolver = gen.internals.resolve_configuration([test_source], [test_target], {'c': 'c_str', 'd_1_a': 'd_1_a_str'})
+    resolver = gen.internals.resolve_configuration(
+        [test_source], [get_test_target()], {'c': 'c_str', 'd_1_a': 'd_1_a_str'})
     print(resolver)
     assert resolver.status_dict == {'status': 'ok'}
+
+    # Make sure having a unset variable results in a non-ok status
+    resolver = gen.internals.resolve_configuration([test_source], [get_test_target()], {'d_1_a': 'd_1_a_str'})
+    print(resolver)
+    assert resolver.status_dict == {'status': 'errors', 'errors': {}, 'unset': {'c'}}


### PR DESCRIPTION
 - Add missing `from` to raise
 - If there are unset variables, then that means the resolver is in an "Error" state. This wasn't happening, which resulted in weird `is_resolved` assertion failures when variables were unset rather than a ValidationError being raised.

# Issues

Found working towards late binding

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
