### PR TITLE
Cleanup interfaces for passing template urls as well as resolve_configuration

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -247,7 +247,7 @@ def do_aws_cf_configure():
 
     sources, targets, _ = gen.get_dcosconfig_source_target_and_templates(gen_config, [], extra_sources)
     targets.append(get_aws_advanced_target())
-    resolver = gen.internals.resolve_configuration(sources, targets, gen_config)
+    resolver = gen.internals.resolve_configuration(sources, targets)
     # TODO(cmaloney): kill this function and make the API return the structured
     # results api as was always intended rather than the flattened / lossy other
     # format. This will be an  API incompatible change. The messages format was

--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -127,11 +127,13 @@ def calculate_base_repository_url(
 
 
 # Figure out the s3 bucket url from region + bucket + path
-# TODO(cmaloney): Allow using a CDN rather than the raw S3 url, which will allow
-# us to use this same logic for both the internal / do_create version and the
-# user dcos_generate_config.sh option.
 def calculate_cloudformation_s3_url(bootstrap_url, config_id):
     return '{}/config_id/{}'.format(bootstrap_url, config_id)
+
+
+# Figure out the s3 bucket url from region + bucket + path
+def calculate_cloudformation_s3_url_full(cloudformation_s3_url):
+    return '{}/cloudformation'.format(cloudformation_s3_url)
 
 
 def calculate_aws_template_storage_region_name(
@@ -183,8 +185,9 @@ aws_advanced_source = gen.internals.Source({
     'must': {
         'provider': 'aws',
         'cloudformation_s3_url': calculate_cloudformation_s3_url,
+        'cloudformation_s3_url_full': calculate_cloudformation_s3_url_full,
         'bootstrap_url': calculate_base_repository_url,
-        'reproducible_artifact_path': calculate_reproducible_artifact_path
+        'reproducible_artifact_path': calculate_reproducible_artifact_path,
     },
     'conditional': {
         'aws_template_upload': {
@@ -208,6 +211,7 @@ def get_aws_advanced_target():
             'aws_template_upload',
             'aws_template_storage_bucket_path_autocreate',
             'cloudformation_s3_url',
+            'cloudformation_s3_url_full',
             'provider',
             'bootstrap_url',
             'bootstrap_variant',
@@ -269,7 +273,7 @@ def do_aws_cf_configure():
     gen_config['bootstrap_url'] = full_config['bootstrap_url']
     gen_config['provider'] = full_config['provider']
     gen_config['bootstrap_id'] = full_config['bootstrap_id']
-    gen_config['cloudformation_s3_url'] = full_config['cloudformation_s3_url']
+    gen_config['cloudformation_s3_url_full'] = full_config['cloudformation_s3_url_full']
 
     # Convert the bootstrap_Variant string we have back to a bootstrap_id as used internally by all
     # the tooling (never has empty string, uses None to say "no variant")

--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -105,7 +105,7 @@ class Config():
         sources, targets, _ = gen.get_dcosconfig_source_target_and_templates(user_arguments, [], extra_sources)
         targets = targets + extra_targets
 
-        resolver = gen.internals.resolve_configuration(sources, targets, user_arguments)
+        resolver = gen.internals.resolve_configuration(sources, targets)
         # TODO(cmaloney): kill this function and make the API return the structured
         # results api as was always intended rather than the flattened / lossy other
         # format. This will be an  API incompatible change. The messages format was

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -448,7 +448,8 @@ def generate(
         arguments,
         extra_templates=list(),
         cc_package_files=list(),
-        extra_sources=list()):
+        extra_sources=list(),
+        extra_targets=list()):
     # To maintain the old API where we passed arguments rather than the new name.
     user_arguments = arguments
     arguments = None
@@ -457,7 +458,7 @@ def generate(
         user_arguments, extra_templates, extra_sources)
 
     # TODO(cmaloney): Make it so we only get out the dcosconfig target arguments not all the config target arguments.
-    resolver = gen.internals.resolve_configuration(sources, targets)
+    resolver = gen.internals.resolve_configuration(sources, targets + extra_targets)
     status = resolver.status_dict
 
     if status['status'] == 'errors':

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -19,7 +19,7 @@ import os.path
 import textwrap
 from copy import copy, deepcopy
 from tempfile import TemporaryDirectory
-from typing import Dict, List
+from typing import List
 
 import yaml
 
@@ -365,13 +365,27 @@ def validate(
         cc_package_files=list(),
         extra_sources=list()):
     sources, targets, _ = get_dcosconfig_source_target_and_templates(arguments, extra_templates, extra_sources)
-    return gen.internals.resolve_configuration(sources, targets, arguments).status_dict
+    return gen.internals.resolve_configuration(sources, targets).status_dict
+
+
+def user_arguments_to_source(user_arguments) -> gen.internals.Source:
+    """Convert all user arguments to be a gen.internals.Source"""
+
+    # Make sure all user provided arguments are strings.
+    # TODO(cmaloney): Loosen this restriction  / allow arbitrary types as long
+    # as they all have a gen specific string form.
+    gen.internals.validate_arguments_strings(user_arguments)
+
+    user_source = gen.internals.Source(is_user=True)
+    for name, value in user_arguments.items():
+        user_source.add_must(name, value)
+    return user_source
 
 
 # TODO(cmaloney): This function should disolve away like the ssh one is and just become a big
 # static dictonary or pass in / construct on the fly at the various template callsites.
 def get_dcosconfig_source_target_and_templates(
-        user_arguments: Dict[str, str],
+        user_arguments: dict,
         extra_templates: List[str],
         extra_sources: List[gen.internals.Source]):
     log.info("Generating configuration files...")
@@ -408,7 +422,7 @@ def get_dcosconfig_source_target_and_templates(
     def add_builtin(name, value):
         base_source.add_must(name, json_prettyprint(value))
 
-    sources = [base_source] + extra_sources
+    sources = [base_source, user_arguments_to_source(user_arguments)] + extra_sources
 
     # TODO(cmaloney): Hash the contents of all the templates rather than using the list of filenames
     # since the filenames might not live in this git repo, or may be locally modified.
@@ -443,7 +457,7 @@ def generate(
         user_arguments, extra_templates, extra_sources)
 
     # TODO(cmaloney): Make it so we only get out the dcosconfig target arguments not all the config target arguments.
-    resolver = gen.internals.resolve_configuration(sources, targets, user_arguments)
+    resolver = gen.internals.resolve_configuration(sources, targets)
     status = resolver.status_dict
 
     if status['status'] == 'errors':

--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -81,7 +81,7 @@
        "Infrastructure": {
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_full_s3_url }}/infra.json",
+               "TemplateURL": "{{ cloudformation_s3_url_full }}/infra.json",
                "TimeoutInMinutes": "60",
                "Parameters": {
                     "KeyName": {
@@ -109,7 +109,7 @@
            "DependsOn": ["Infrastructure"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
+               "TemplateURL": "{{ cloudformation_s3_url_full }}/{{ variant_prefix }}{{ os_type }}-advanced-master-{{ num_masters }}.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -160,7 +160,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
+               "TemplateURL": "{{ cloudformation_s3_url_full }}/{{ variant_prefix }}{{ os_type }}-advanced-pub-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"
@@ -199,7 +199,7 @@
            "DependsOn": ["Infrastructure", "MasterStack"],
            "Type": "AWS::CloudFormation::Stack",
            "Properties": {
-               "TemplateURL": "{{ cloudformation_full_s3_url }}/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
+               "TemplateURL": "{{ cloudformation_s3_url_full }}/{{ variant_prefix }}{{ os_type }}-advanced-priv-agent.json",
                "Parameters": {
                     "KeyName": {
                         "Ref": "KeyName"

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -165,10 +165,7 @@ def gen_templates(gen_arguments, arm_template, extra_sources):
         variant_cloudconfig['slave'],
         variant_cloudconfig['slave_public'])
 
-    return {
-        'arm': arm,
-        'results': results
-    }
+    return (arm, results)
 
 
 def master_list_arm_json(num_masters, varietal):
@@ -227,22 +224,22 @@ def make_template(num_masters, gen_arguments, varietal, bootstrap_variant_prefix
     master_list_source.add_must('master_list', master_list_arm_json(num_masters, varietal))
 
     if varietal == 'dcos':
-        dcos_template = gen_templates(
+        arm, results = gen_templates(
             gen_arguments,
             'azuredeploy',
             extra_sources=[master_list_source, azure_dcos_source])
     elif varietal == 'acs':
-        dcos_template = gen_templates(
+        arm, results = gen_templates(
             gen_arguments,
             'acs',
             extra_sources=[master_list_source, azure_acs_source])
     else:
         raise ValueError("Unknown Azure varietal specified")
 
-    yield {'packages': util.cluster_to_extra_packages(dcos_template['results'].cluster_packages)}
+    yield {'packages': util.cluster_to_extra_packages(results.cluster_packages)}
     yield {
         'channel_path': 'azure/{}{}-{}master.azuredeploy.json'.format(bootstrap_variant_prefix, varietal, num_masters),
-        'local_content': dcos_template['arm'],
+        'local_content': arm,
         'content_type': 'application/json; charset=utf-8'
     }
 

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -13,8 +13,6 @@ import gen
 import gen.build_deploy.util as util
 import gen.template
 import pkgpanda.build
-import release
-import release.storage
 from gen.internals import Source
 
 # TODO(cmaloney): Make it so the template only completes when services are properly up.
@@ -261,24 +259,29 @@ def do_create(tag, build_name, reproducible_artifact_path, commit, variant_argum
 
     yield {
         'channel_path': 'azure.html',
-        'local_content': gen_buttons(build_name, reproducible_artifact_path, tag, commit),
+        'local_content': gen_buttons(
+            build_name,
+            reproducible_artifact_path,
+            tag,
+            commit,
+            next(iter(variant_arguments.values()))['azure_download_url']),
         'content_type': 'text/html; charset=utf-8'
     }
 
 
-def gen_buttons(build_name, reproducible_artifact_path, tag, commit):
+def gen_buttons(build_name, reproducible_artifact_path, tag, commit, download_url):
     '''
     Generate the button page, that is, "Deploy a cluster to Azure" page
     '''
     dcos_urls = [
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
-            download_url=get_download_url(),
+            download_url=download_url,
             reproducible_artifact_path=reproducible_artifact_path,
             arm_template_name='dcos-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
     acs_urls = [
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
-            download_url=get_download_url(),
+            download_url=download_url,
             reproducible_artifact_path=reproducible_artifact_path,
             arm_template_name='acs-{}master.azuredeploy.json'.format(x)))
         for x in [1, 3, 5]]
@@ -298,29 +301,3 @@ def encode_url_as_param(s):
     s = s.encode('utf8')
     s = urllib.parse.quote_plus(s)
     return s
-
-
-def get_download_url():
-    assert release._config is not None
-    # TODO: HACK. Stashing and pulling the config from release/__init__.py
-    # is definitely not the right way to do this.
-    # See also gen/build_deploy/aws.py#get_cloudformation_s3_url
-
-    if 'storage' not in release._config:
-        raise RuntimeError("No storage section in configuration")
-
-    if 'azure' not in release._config['storage']:
-        # No azure storage, inject a fake url for now so if people want to use
-        # the azure templates they know to come look here.
-        return "https://AZURE NOT CONFIGURED, ADD A storage.azure section to " \
-            "dcos-release.config.yaml to use the Azure templates"
-
-    if 'download_url' not in release._config['storage']['azure']:
-        raise RuntimeError("No download_url section in azure configuration")
-
-    download_url = release._config['storage']['azure']['download_url']
-
-    if not download_url.endswith('/'):
-        raise RuntimeError("Azure download_url must end with a '/'")
-
-    return download_url

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -304,10 +304,9 @@ def calc_num_masters(master_list):
     return str(len(json.loads(master_list)))
 
 
-def calculate_config_id(dcos_image_commit, user_arguments, template_filenames, sources_id):
+def calculate_config_id(dcos_image_commit, template_filenames, sources_id):
     return hash_checkout({
         "commit": dcos_image_commit,
-        "user_arguments": json.loads(user_arguments),
         "template_filenames": json.loads(template_filenames),
         "sources_id": sources_id})
 

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 from contextlib import contextmanager
 from functools import partial, partialmethod
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 from gen.exceptions import ValidationError
 from pkgpanda.build import hash_checkout
@@ -232,10 +232,6 @@ class Source:
                 self.add_conditional_scope(sub_scope, conditions + [(name, value)])
 
     add_must = partialmethod(add_setter, is_optional=False, conditions=[])
-
-    def add_value_dict(self, value_dict):
-        for name, value in value_dict.items():
-            self.add_must(name, value)
 
     def remove_setters(self, scope):
         def del_setter(name):
@@ -674,11 +670,7 @@ class Resolver:
         }
 
 
-def resolve_configuration(sources: List[Source], targets: List[Target], user_arguments: Dict[str, str]):
-    # Make sure all user provided arguments are strings.
-    # TODO(cmaloney): Loosen this restriction  / allow arbitrary types as long
-    # as they all have a gen specific string form.
-    validate_arguments_strings(user_arguments)
+def resolve_configuration(sources: List[Source], targets: List[Target]):
 
     # Merge the sources into a big dictionary of setters + validators, ensuring
     # that all setters are either strings or functions.
@@ -699,10 +691,7 @@ def resolve_configuration(sources: List[Source], targets: List[Target], user_arg
     # add in extra "acceptable" parameters (SSH Config, AWS Advanced Template config, etc)
     # validate_all_arguments_match_parameters(mandatory_parameters, setters, user_arguments)
 
-    # Add in all user arguments as setters.
-    # Happens last so that they are never overwritten with replace_existing=True
     user_config = Source(is_user=True)
-    user_config.add_value_dict(user_arguments)
 
     # Merge all the seters and validate function into one uber list
     setters = copy.deepcopy(user_config.setters)

--- a/gen/test_internals.py
+++ b/gen/test_internals.py
@@ -91,12 +91,17 @@ def test_resolve_simple():
                     'd_2': Target({'d_2_a', 'd_2_b'})
                 })})
 
-    resolver = gen.internals.resolve_configuration(
-        [test_source], [get_test_target()], {'c': 'c_str', 'd_1_a': 'd_1_a_str'})
+    test_user_source = Source(is_user=True)
+    test_user_source.add_must('c', 'c_str')
+    test_user_source.add_must('d_1_a', 'd_1_a_str')
+
+    resolver = gen.internals.resolve_configuration([test_source, test_user_source], [get_test_target()])
     print(resolver)
     assert resolver.status_dict == {'status': 'ok'}
 
     # Make sure having a unset variable results in a non-ok status
-    resolver = gen.internals.resolve_configuration([test_source], [get_test_target()], {'d_1_a': 'd_1_a_str'})
+    test_partial_source = Source(is_user=True)
+    test_partial_source.add_must('d_1_a', 'd_1_a_str')
+    resolver = gen.internals.resolve_configuration([test_source, test_partial_source], [get_test_target()])
     print(resolver)
     assert resolver.status_dict == {'status': 'errors', 'errors': {}, 'unset': {'c'}}

--- a/release/test_release.py
+++ b/release/test_release.py
@@ -599,8 +599,6 @@ def mock_make_tar(result_filename, folder):
 def test_make_channel_artifacts(monkeypatch):
     logging.basicConfig(level=logging.DEBUG)
     monkeypatch.setattr('gen.build_deploy.bash.make_installer_docker', mock_make_installer_docker)
-    monkeypatch.setattr('gen.build_deploy.aws.get_cloudformation_s3_url', mock_get_cf_s3_url)
-    monkeypatch.setattr('gen.build_deploy.azure.get_download_url', mock_get_azure_download_url)
     monkeypatch.setattr('pkgpanda.util.make_tar.__code__', mock_make_tar.__code__)
 
     metadata = {
@@ -651,7 +649,9 @@ def test_make_channel_artifacts(monkeypatch):
             'aws': 'https://aws.example.com/',
             'azure': 'https://azure.example.com/'
         },
-        'repository_url': 'https://aws.example.com/r_path'
+        'repository_url': 'https://aws.example.com/r_path',
+        'cloudformation_s3_url_full': 'https://s3.foobar.com/biz/r_path/channel/commit/sha-1',
+        'azure_download_url': 'https://azure.example.com'
     }
 
     channel_artifacts = release.make_channel_artifacts(metadata)

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -68,7 +68,8 @@ def get_target():
 # and the couple places that need this can just make a trivial call directly.
 def validate_config(user_arguments):
     user_arguments = gen.stringify_configuration(user_arguments)
-    messages = gen.internals.resolve_configuration([source], [get_target()], user_arguments).status_dict
+    user_source = gen.user_arguments_to_source(user_arguments)
+    messages = gen.internals.resolve_configuration([source, user_source], [get_target()]).status_dict
     if messages['status'] == 'ok':
         return {}
 


### PR DESCRIPTION
Cleans up two of the interfaces inside of the codebase. This is work that was done as part of getting to #1009 / late binding, pulled out of that PR so it can be reviewed / land independently.

1. Make resolve_configuration operate purely on sources and targets

This makes it have a more straightforward API and moves the responsibility for
building a source out of user arguments (if that is even needed) to the various
callsites (just two of them)

2. Remove magic global passing of azure and aws storage urls

Previously these were passed by globals when we were doing a release and as arguments when we did a advanced / custom configuration template generation. Now they are always passed as arguments which are injected by release/__init__.py in the case of release for the configuration, and via the normal argument means otherwise.

3. Fixup lingering comments from #956 by replacing the namedtuple and dictionary with just returning a tuple which gets expanded when needed.

# Issues

[DCOS-10453](https://mesosphere.atlassian.net/browse/DCOS-10453)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)