### PR TITLE
yaml.load -> load_yaml for better error messages, simpler code

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -7,7 +7,7 @@ import yaml
 import gen
 import ssh.validate
 from gen.build_deploy.bash import onprem_source
-from pkgpanda.util import write_string
+from pkgpanda.util import load_yaml, write_string, YamlParseError
 
 log = logging.getLogger(__name__)
 
@@ -73,14 +73,15 @@ class Config():
             return {}
 
         try:
-            with open(self.config_path) as f:
-                return yaml.load(f)
+            return load_yaml(self.config_path)
         except FileNotFoundError as ex:
             raise NoConfigError(
                 "No config file found at {}. See the DC/OS documentation for the "
                 "available configuration options. You can also use the GUI web installer (--web),"
                 "which provides a guided configuration and installation for simple "
                 "deployments.".format(self.config_path)) from ex
+        except YamlParseError as ex:
+            raise NoConfigError("Unable to load configuration file. {}".format(ex)) from ex
 
     def update(self, updates):
         # TODO(cmaloney): check that the updates are all for valid keys, keep

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -218,7 +218,7 @@ def render_templates(template_dict, arguments):
                 assert len(templates) == 1
                 full_template = rendered_template
                 continue
-            template_data = yaml.load(rendered_template)
+            template_data = yaml.safe_load(rendered_template)
 
             if full_template:
                 full_template = merge_dictionaries(full_template, template_data)

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -398,7 +398,7 @@ def make_advanced_bunch(variant_args, extra_sources, template_name, cc_params):
     cc_variant = deepcopy(cloud_config)
     cc_variant = results.utils.add_units(
         cc_variant,
-        yaml.load(gen.template.parse_str(late_services).render(cc_params)),
+        yaml.safe_load(gen.template.parse_str(late_services).render(cc_params)),
         cloud_init_implementation)
 
     # Add roles
@@ -527,7 +527,7 @@ def gen_simple_template(variant_prefix, filename, arguments, extra_source):
         # Specialize the dcos-cfn-signal service
         cc_variant = results.utils.add_units(
             cc_variant,
-            yaml.load(gen.template.parse_str(late_services).render(params)))
+            yaml.safe_load(gen.template.parse_str(late_services).render(params)))
 
         # Add roles
         cc_variant = results.utils.add_roles(cc_variant, params['roles'] + ['aws'])

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -81,7 +81,7 @@ def transform(cloud_config_yaml_str):
     that ARM template parameters appear at the top level of the template and get
     substituted.
     '''
-    cc_json = json.dumps(yaml.load(cloud_config_yaml_str), sort_keys=True)
+    cc_json = json.dumps(yaml.safe_load(cloud_config_yaml_str), sort_keys=True)
     arm_list = ["[base64(concat('#cloud-config\n\n', "]
     # Find template parameters and seperate them out as seperate elements in a
     # json list.
@@ -151,11 +151,6 @@ def gen_templates(gen_arguments, arm_template, extra_sources):
     variant_cloudconfig = {}
     for variant, params in INSTANCE_GROUPS.items():
         cc_variant = deepcopy(cloud_config)
-
-        # TODO(cmaloney): Add the dcos-arm-signal service here
-        # cc_variant = results.utils.add_units(
-        #     cc_variant,
-        #     yaml.load(gen.template.parse_str(late_services).render(params)))
 
         # Add roles
         cc_variant = results.utils.add_roles(cc_variant, params['roles'] + ['azure'])

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,14 +1,13 @@
 # Various tests that don't fit into the other categories and don't make their own really.
 import json
 
-import yaml
+from pkgpanda.util import load_yaml
 
 
 # Test that user config is loadable
 # TODO(cmaloney): Validate it contains some settings we expact.
 def test_load_user_config():
-    with open("/opt/mesosphere/etc/user.config.yaml", "r") as f:
-        user_config = yaml.load(f)
+    user_config = load_yaml("/opt/mesosphere/etc/user.config.yaml")
 
     # Calculated parameters shouldn't be in the user config
     assert 'master_quorum' not in user_config

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -14,6 +14,7 @@ from subprocess import check_call
 
 import requests
 import teamcity
+import yaml
 from teamcity.messages import TeamcityServiceMessages
 
 from pkgpanda.exceptions import FetchError, ValidationError
@@ -125,6 +126,18 @@ def load_json(filename):
             return json.load(f)
     except ValueError as ex:
         raise ValueError("Invalid JSON in {0}: {1}".format(filename, ex)) from ex
+
+
+class YamlParseError(Exception):
+    pass
+
+
+def load_yaml(filename):
+    try:
+        with open(filename) as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError as ex:
+        raise YamlParseError("Invalid YAML in {}: {}".format(filename, ex)) from ex
 
 
 def make_file(name):

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -19,7 +19,6 @@ from distutils.version import LooseVersion
 from typing import Optional
 
 import pkg_resources
-import yaml
 
 import gen.build_deploy.util as util
 import pkgpanda
@@ -64,8 +63,7 @@ def expand_env_vars(config):
 
 
 def load_config(filename):
-    with open(filename) as config_file:
-        return expand_env_vars(yaml.load(config_file))
+    return expand_env_vars(pkgpanda.util.load_yaml(filename))
 
 
 def strip_locals(data):

--- a/test_util/installer_api_test.py
+++ b/test_util/installer_api_test.py
@@ -11,6 +11,7 @@ import requests
 import yaml
 from retrying import retry
 
+from pkgpanda.util import load_yaml
 from ssh.tunnel import run_scp_cmd, run_ssh_cmd, Tunnelled
 
 MAX_STAGE_TIME = int(os.getenv('INSTALLER_API_MAX_STAGE_TIME', '900'))
@@ -164,8 +165,7 @@ class DcosApiInstaller(AbstractDcosInstaller):
         if zk_host:
             payload['exhibitor_zk_hosts'] = zk_host
         if add_config_path:
-            with open(add_config_path, 'r') as fh:
-                add_config = yaml.load(fh)
+            add_config = load_yaml(add_config_path)
             payload.update(add_config)
         response = requests.post(self.url + '/api/v1/configure', headers=headers, data=json.dumps(payload))
         assert response.status_code == 200, "{} {}".format(response.status_code, response.content)
@@ -323,8 +323,7 @@ class DcosCliInstaller(AbstractDcosInstaller):
         else:
             test_config['exhibitor_storage_backend'] = 'static'
         if add_config_path:
-            with open(add_config_path, 'r') as fh:
-                add_config = yaml.load(fh)
+            add_config = load_yaml(add_config_path)
             test_config.update(add_config)
         with open('config.yaml', 'w') as config_fh:
             config_fh.write(yaml.dump(test_config))


### PR DESCRIPTION
Changes from calling yaml.load() directly to using a wrapper `load_yaml` which does a couple things
1. Makes syntax errors include the filename (re-wrap the exception with more context)
2. Make it so not everyone has to do a `with open() as f; yaml.load(f)`
3. Switch from yaml.load -> yaml.safe_load so that we're always keeping to basic yaml types / not arbitrary code.

Found during / relates to Late Binding #1009  

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)