### PR TITLE
Adjust DC/OS UI build to properly install dependencies

### DIFF
--- a/packages/dcos-ui/build
+++ b/packages/dcos-ui/build
@@ -4,7 +4,10 @@ cd "/pkg/src/dcos-ui"
 
 npm install -g npm@3.9.1
 
-npm install
+# Run npm install with `unsafe-perm` flag to run install scripts with root
+# privileges. Without those privileges the installation will fail to write some
+# of the dependencies with the correct user/permissions.
+npm --unsafe-perm install
 
 echo "module.exports = {};" > ./src/js/config/Config.dev.js
 npm run scaffold


### PR DESCRIPTION
Add `unsafe-perm` flag to run DC/OS UI install scripts with proper privileges. Without those privileges the installation will fail to write some of the dependencies (e.g. the Marathon RAML files) with the correct user/permissions.