### PR TITLE
Use requests paradigms

### DIFF
--- a/packages/dcos-integration-test/extra/cluster_fixture.py
+++ b/packages/dcos-integration-test/extra/cluster_fixture.py
@@ -1,14 +1,14 @@
 """This file has only one function: to provide a correctly configured
-ClusterApi object that will be injected into the pytest 'cluster' fixture
+DcosApiSession object that will be injected into the pytest 'cluster' fixture
 via the make_cluster_fixture() method
 """
-from test_util.cluster_api import ClusterApi, get_args_from_env
-from test_util.helpers import CI_AUTH_JSON, DcosUser
+from test_util.dcos_api_session import DcosApiSession, DcosUser, get_args_from_env
+from test_util.helpers import CI_CREDENTIALS
 
 
 def make_cluster_fixture():
     args = get_args_from_env()
-    args['web_auth_default_user'] = DcosUser(CI_AUTH_JSON)
-    cluster_api = ClusterApi(**args)
+    args['auth_user'] = DcosUser(CI_CREDENTIALS)
+    cluster_api = DcosApiSession(**args)
     cluster_api.wait_for_dcos()
     return cluster_api

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -49,3 +49,8 @@ def vip_apps(cluster):
 @pytest.fixture(scope='session')
 def cluster():
     return make_cluster_fixture()
+
+
+@pytest.fixture(scope='session')
+def noauth_cluster(cluster):
+    return cluster.get_user_session(None)

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -177,13 +177,13 @@ def test_octarine_srv(cluster, timeout=30):
 
 def test_pkgpanda_api(cluster):
 
-    def get_and_validate_package_ids(node, path):
-        r = cluster.get(node=node, path=path)
+    def get_and_validate_package_ids(path, node):
+        r = cluster.get(path, node=node)
         assert r.status_code == 200
         package_ids = r.json()
         assert isinstance(package_ids, list)
         for package_id in package_ids:
-            r = cluster.get(node=node, path=path + package_id)
+            r = cluster.get(path + package_id, node=node)
             assert r.status_code == 200
             name, version = package_id.split('--')
             assert r.json() == {'id': package_id, 'name': name, 'version': version}
@@ -207,8 +207,8 @@ def test_pkgpanda_api(cluster):
                 assert package == buildinfo_package
 
     for node in cluster.masters + cluster.all_slaves:
-        package_ids = get_and_validate_package_ids(node, '/pkgpanda/repository/')
-        active_package_ids = get_and_validate_package_ids(node, '/pkgpanda/active/')
+        package_ids = get_and_validate_package_ids('pkgpanda/repository/', node)
+        active_package_ids = get_and_validate_package_ids('pkgpanda/active/', node)
 
         assert set(active_package_ids) <= set(package_ids)
         assert_packages_match_active_buildinfo(active_package_ids)

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -3,11 +3,6 @@ import subprocess
 import pytest
 
 
-@pytest.fixture(scope='module')
-def noauth_cluster(cluster):
-    return cluster.get_user_session(None)
-
-
 def auth_enabled():
     out = subprocess.check_output([
         '/bin/bash', '-c',
@@ -38,7 +33,7 @@ def test_adminrouter_access_control_enforcement(cluster, noauth_cluster):
 
     # Test authentication with auth cookie instead of Authorization header.
     authcookie = {
-        'dcos-acs-auth-cookie': cluster.web_auth_default_user.auth_cookie}
+        'dcos-acs-auth-cookie': cluster.auth_user.auth_cookie}
     r = noauth_cluster.get(
         '/service/marathon/',
         cookies=authcookie)

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -61,10 +61,10 @@ def test_if_all_exhibitors_are_in_sync(cluster):
 def test_mesos_agent_role_assignment(cluster):
     state_endpoint = '/state.json'
     for agent in cluster.public_slaves:
-        r = cluster.get(path=state_endpoint, node=agent, port=5051)
+        r = cluster.get(state_endpoint, host=agent, port=5051)
         assert r.json()['flags']['default_role'] == 'slave_public'
     for agent in cluster.slaves:
-        r = cluster.get(path=state_endpoint, node=agent, port=5051)
+        r = cluster.get(state_endpoint, host=agent, port=5051)
         assert r.json()['flags']['default_role'] == '*'
 
 

--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -1,17 +1,21 @@
+""" Utilities for interacting with a DC/OS instance via REST API
+
+Most DC/OS deployments will have auth enabled, so this module includes
+DcosUser and DcosAuth to be attached to a DcosApiSession. Additionally,
+it is sometimes necessary to query specific nodes within a DC/OS cluster,
+so there is ARNodeApiClientMixin to allow querying nodes without boilerplate
+to set the correct port and scheme.
+"""
 import copy
 import logging
 import os
-from urllib.parse import urlparse
+from typing import Optional
 
 import requests
 import retrying
 
-import test_util.helpers
 import test_util.marathon
-
-ADMINROUTER_PORT_MAPPING = {
-    'master': {'http': 80, 'https': 443},
-    'agent': {'http': 61001, 'https': 61002}}
+from test_util.helpers import ApiClientSession, Url
 
 
 def get_args_from_env():
@@ -30,11 +34,107 @@ def get_args_from_env():
         'public_masters': os.environ['PUBLIC_MASTER_HOSTS'].split(','),
         'slaves': os.environ['SLAVE_HOSTS'].split(','),
         'public_slaves': os.environ['PUBLIC_SLAVE_HOSTS'].split(','),
-        'default_os_user': os.getenv('DCOS_DEFAULT_OS_USER', 'root'),
-        'ca_cert_path': os.getenv('DCOS_CA_CERT_PATH', None)}
+        'default_os_user': os.getenv('DCOS_DEFAULT_OS_USER', 'root')}
 
 
-class ClusterApi(test_util.helpers.ApiClient):
+class DcosUser:
+    """A lightweight user representation for grabbing the auth info and stashing it"""
+    def __init__(self, credentials: dict):
+        self.credentials = credentials
+        self.auth_token = None
+        self.auth_cookie = None
+
+    @property
+    def auth_header(self):
+        return {'Authorization': 'token={}'.format(self.auth_token)}
+
+
+class DcosAuth(requests.auth.AuthBase):
+    def __init__(self, auth_token: str):
+        self.auth_token = auth_token
+
+    def __call__(self, request):
+        request.headers['Authorization'] = 'token={}'.format(self.auth_token)
+        return request
+
+
+class ARNodeApiClientMixin:
+    def api_request(self, method, path_extension, *, scheme=None, host=None, query=None,
+                    fragment=None, port=None, node=None, **kwargs):
+        """ Communicating with a DC/OS cluster is done by default through Admin Router.
+        Use this Mixin with an ApiClientSession that requires distinguishing between nodes.
+        Admin Router has both a master and agent process and so this wrapper accepts a
+        node argument. node must be a host in self.master or self.all_slaves. If given,
+        the request will be made to the Admin Router endpoint for that node type
+        """
+        assert self.masters
+        assert self.all_slaves
+        if node is not None:
+            assert port is None, 'node is intended to retrieve port; cannot set both simultaneously'
+            assert host is None, 'node is intended to retrieve host; cannot set both simultaneously'
+            if node in self.masters:
+                # Nothing else to do, master Admin Router uses default HTTP (80) and HTTPS (443) ports
+                pass
+            elif node in self.all_slaves:
+                scheme = scheme if scheme is not None else self.default_url.scheme
+                if scheme == 'http':
+                    port = 61001
+                if scheme == 'https':
+                    port = 61002
+            else:
+                raise Exception('Node {} is not recognized within the DC/OS cluster'.format(node))
+            host = node
+        return super().api_request(method, path_extension, scheme=scheme, host=host,
+                                   query=query, fragment=fragment, port=port, **kwargs)
+
+
+class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
+    def __init__(self, dcos_url: str, masters: list, public_masters: list,
+                 slaves: list, public_slaves: list, default_os_user: str,
+                 auth_user: Optional[DcosUser]):
+        """Proxy class for DC/OS clusters.
+
+        Args:
+            dcos_url: address for the DC/OS web UI.
+            masters: list of Mesos master advertised IP addresses.
+            public_masters: list of Mesos master IP addresses routable from
+                the local host.
+            slaves: list of Mesos slave/agent advertised IP addresses.
+            default_os_user: default user that marathon/metronome will launch tasks under
+            auth_user: use this user's auth for all requests
+                Note: user must be authenticated explicitly or call self.wait_for_dcos()
+        """
+        super().__init__(Url.from_string(dcos_url))
+        self.masters = sorted(masters)
+        self.public_masters = sorted(public_masters)
+        self.slaves = sorted(slaves)
+        self.public_slaves = sorted(public_slaves)
+        self.all_slaves = sorted(slaves + public_slaves)
+        self.zk_hostports = ','.join(':'.join([host, '2181']) for host in self.public_masters)
+        self.default_os_user = default_os_user
+        self.auth_user = auth_user
+
+        assert len(self.masters) == len(self.public_masters)
+
+    @retrying.retry(wait_fixed=2000, stop_max_delay=120 * 1000)
+    def _authenticate_default_user(self):
+        """retry default auth user because in some deployments,
+        the auth endpoint might not be routable immediately
+        after Admin Router is up. DcosUser.authenticate()
+        will raise exception if authorization fails
+        """
+        if self.auth_user is None:
+            return
+        logging.info('Attempting authentication')
+        # explicitly use a session with no user authentication for requesting auth headers
+        r = self.post('/acs/api/v1/auth/login', json=self.auth_user.credentials, auth=None)
+        r.raise_for_status()
+        logging.info('Received authentication blob: {}'.format(r.json()))
+        self.auth_user.auth_token = r.json()['token']
+        self.auth_user.auth_cookie = r.cookies['dcos-acs-auth-cookie']
+        logging.info('Authentication successful')
+        # Set requests auth
+        self.session.auth = DcosAuth(self.auth_user.auth_token)
 
     @retrying.retry(wait_fixed=1000,
                     retry_on_result=lambda ret: ret is False,
@@ -177,8 +277,7 @@ class ClusterApi(test_util.helpers.ApiClient):
 
     def wait_for_dcos(self):
         self._wait_for_adminrouter_up()
-        if self.web_auth_default_user is not None:
-            self._authenticate_default_user()
+        self._authenticate_default_user()
         self._wait_for_marathon_up()
         self._wait_for_zk_quorum()
         self._wait_for_slaves_to_join()
@@ -187,117 +286,54 @@ class ClusterApi(test_util.helpers.ApiClient):
         self._wait_for_dcos_history_data()
         self._wait_for_metronome()
 
-    @retrying.retry(wait_fixed=2000, stop_max_delay=120 * 1000)
-    def _authenticate_default_user(self):
-        """retry default auth user because in some deployments,
-        the auth endpoint might not be routable immediately
-        after adminrouter is up. DcosUser.authenticate()
-        will raise exception if authorization fails
+    def copy(self):
+        """ Create a new client session without cookies, with the authentication intact.
         """
-        self.web_auth_default_user.authenticate(self)
-        self.default_headers.update(self.web_auth_default_user.auth_header)
-
-    def __init__(self, dcos_url, masters, public_masters, slaves, public_slaves,
-                 default_os_user, web_auth_default_user=None, ca_cert_path=None):
-        """Proxy class for DC/OS clusters.
-
-        Args:
-            dcos_url: address for the DC/OS web UI.
-            masters: list of Mesos master advertised IP addresses.
-            public_masters: list of Mesos master IP addresses routable from
-                the local host.
-            slaves: list of Mesos slave/agent advertised IP addresses.
-            default_os_user: default user that marathon/metronome will launch tasks under
-            web_auth_default_user: use this user's auth for all requests
-                Note: user must be authenticated explicitly or call self.wait_for_dcos()
-            ca_cert_path: (str) optional path point to the CA cert to make requests against
-        """
-        # URL must include scheme
-        assert dcos_url.startswith('http')
-        parse_result = urlparse(dcos_url)
-        self.scheme = parse_result.scheme
-        self.dns_host = parse_result.netloc.split(':')[0]
-
-        # Make URL never end with /
-        self.dcos_url = dcos_url.rstrip('/')
-
-        super().__init__(
-            default_host_url=self.dcos_url,
-            api_base=None,
-            ca_cert_path=ca_cert_path,
-            get_node_url=self.get_node_url)
-        self.masters = sorted(masters)
-        self.public_masters = sorted(public_masters)
-        self.slaves = sorted(slaves)
-        self.public_slaves = sorted(public_slaves)
-        self.all_slaves = sorted(slaves + public_slaves)
-        self.zk_hostports = ','.join(':'.join([host, '2181']) for host in self.public_masters)
-        self.default_os_user = default_os_user
-        self.web_auth_default_user = web_auth_default_user
-
-        assert len(self.masters) == len(self.public_masters)
+        new = copy.deepcopy(self)
+        new.session.cookies.clear()
+        return new
 
     def get_user_session(self, user):
-        """Returns a copy of self with auth headers set for user
+        """Returns a copy of this client but with auth for user (can be None)
         """
-        new_session = copy.deepcopy(self)
-        # purge old auth headers
-        if self.web_auth_default_user is not None:
-            for k in self.web_auth_default_user.auth_header.keys():
-                if k in new_session.default_headers:
-                    del new_session.default_headers[k]
-        # if user is given then auth and update the headers
-        new_session.web_auth_default_user = user
+        new = self.copy()
+        new.session.auth = None
+        new.auth_user = None
         if user is not None:
-            new_session._authenticate_default_user()
-        return new_session
-
-    def get_node_url(self, node, port=None):
-        """
-        Args:
-            node: (str) the hostname of the node to be requested from, if node=None,
-                then public cluster address (see environment DCOS_DNS_ADDRESS)
-            port: (int) port to be requested at. If port=None, the default port
-                for that given node type will be used
-        Returns:
-            fully-qualified URL string for this API
-        """
-        if node in self.masters:
-            role = 'master'
-        elif node in self.all_slaves:
-            role = 'agent'
-        else:
-            raise Exception('Node {} is not recognized within the DC/OS cluster'.format(node))
-        if port is None:
-            port = ADMINROUTER_PORT_MAPPING[role][self.scheme]
-        # do not explicitly declare default ports
-        if (port == 80 and self.scheme == 'http') or (port == 443 and self.scheme == 'https'):
-            netloc = node
-        else:
-            netloc = '{}:{}'.format(node, port)
-        return '{}://{}'.format(self.scheme, netloc)
+            new.auth_user = user
+            new._authenticate_default_user()
+        return new
 
     @property
     def marathon(self):
-        marathon_client = test_util.marathon.Marathon(
-            default_host_url=self.dcos_url,
+        return test_util.marathon.Marathon(
+            default_url=self.default_url.copy(path='marathon'),
             default_os_user=self.default_os_user,
-            default_headers=self.default_headers,
-            ca_cert_path=self.ca_cert_path,
-            get_node_url=self.get_node_url)
-        return marathon_client
+            session=self.copy().session)
 
     @property
     def metronome(self):
-        return self.get_client('/service/metronome/v1')
+        new = self.copy()
+        new.default_url = self.default_url.copy(path='service/metronome/v1')
+        return new
+
+    @property
+    def health(self):
+        new = self.copy()
+        new.default_url = self.default_url.copy(query='cache=0', path='system/health/v1')
+        return new
 
     @property
     def logs(self):
-        return self.get_client('/system/v1/logs')
+        new = self.copy()
+        new.default_url = self.default_url.copy(path='system/v1/logs')
+        return new
 
     @property
     def metrics(self):
-        return self.get_client('/system/v1/metrics/v0')
+        new = self.copy()
+        new.default_url = self.default_url.copy(path='/system/v1/metrics/v0')
+        return new
 
     def metronome_one_off(self, job_definition, timeout=300, ignore_failures=False):
         """Run a job on metronome and block until it returns success

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -8,6 +8,8 @@ import os
 import tempfile
 import time
 from collections import namedtuple
+from typing import Union
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 import retrying
@@ -28,107 +30,140 @@ SshInfo = namedtuple('SshInfo', ['user', 'home_dir'])
 #        "iat": 1460164974
 #    }
 
-CI_AUTH_JSON = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ'}     # noqa
+CI_CREDENTIALS = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ'}     # noqa
 
 
-def path_join(p1, p2):
+def path_join(p1: str, p2: str):
+    """Helper to ensure there is only one '/' between two strings"""
     return '{}/{}'.format(p1.rstrip('/'), p2.lstrip('/'))
 
 
-class DcosUser:
-    """A lightweight user representation."""
-    def __init__(self, auth_json):
-        self.auth_json = auth_json
-        self.auth_header = {}
-        self.auth_token = None
-        self.auth_cookie = None
+class Url:
+    """URL abstraction to allow convenient substitution of URL anatomy
+    without having to copy and dissect the entire original URL
+    """
+    def __init__(self, scheme: str, host: str, path: str, query: str,
+                 fragment: str, port: Union[str, int]):
+        """{scheme}://{host}:{port}/{path}?{query}#{fragment}
+        """
+        self.scheme = scheme
+        self.host = host
+        self.path = path
+        self.query = query
+        self.fragment = fragment
+        self.port = port
 
-    def authenticate(self, cluster):
-        logging.info('Attempting authentication')
-        # explicitly use a session with no user authentication for requesting auth headers
-        if cluster.web_auth_default_user:
-            post = cluster.get_user_session(None).post
+    @classmethod
+    def from_string(cls, url_str: str):
+        u = urlsplit(url_str)
+        if ':' in u.netloc:
+            host, port = u.netloc.split(':')
         else:
-            post = cluster.post
-        r = post('/acs/api/v1/auth/login', json=self.auth_json)
-        r.raise_for_status()
-        logging.info('Received authorization blob: {}'.format(r.json()))
-        self.auth_token = r.json()['token']
-        self.auth_header = {'Authorization': 'token={}'.format(self.auth_token)}
-        self.auth_cookie = r.cookies['dcos-acs-auth-cookie']
-        logging.info('Authentication successful')
+            host = u.netloc
+            port = None
+        return cls(u.scheme, host, u.path, u.query, u.fragment, port)
+
+    @property
+    def netloc(self):
+        return '{}:{}'.format(self.host, self.port) if self.port else self.host
+
+    def __str__(self):
+        return urlunsplit((
+            self.scheme,
+            self.netloc,
+            self.path,
+            self.query if self.query else '',
+            self.fragment if self.fragment else ''))
+
+    def copy(self, scheme=None, host=None, path=None, query=None, fragment=None, port=None):
+        """return new Url with any component replaced
+        """
+        return Url(
+            scheme if scheme is not None else self.scheme,
+            host if host is not None else self.host,
+            path if path is not None else self.path,
+            query if query is not None else self.query,
+            fragment if fragment is not None else self.fragment,
+            port if port is not None else self.port)
 
 
-class ApiClient:
+class ApiClientSession:
+    """This class functions like the requests.session interface but adds
+    a default Url and a request wrapper. This class only differs from requests.Session
+    in that the cookies are cleared after each request (but not purged from the response)
+    so that the request state may be more well-defined betweens tests sharing this object
+    """
+    def __init__(self, default_url: Url):
+        """
+        Args:
+            default_url: Url object to wihch requests can be made
+        """
+        self.default_url = default_url
+        self.session = requests.Session()
 
-    def __init__(self, default_host_url, api_base, default_headers=None, ca_cert_path=None, get_node_url=None):
-        """Client that facilitates HTTP request with a host in the cluster.
+    def api_request(self, method, path_extension, *, scheme=None, host=None, query=None,
+                    fragment=None, port=None, **kwargs):
+        """ Direct wrapper for requests.session.request. This method is kept deliberatly
+        simple so that child classes can alter this behavior without much copying
 
         Args:
+            method: the HTTP verb
+            path_extension: the extension to the path that is set as the default Url
+            scheme: scheme to be used instead of that included with self.default_url
+            host: host to be used instead of that included with self.default_url
+            query: query to be used instead of that included with self.default_url
+            fragment: fragment to be used instead of that included with self.default_url
+            port: port to be used instead of that included with self.default_url
 
-            default_host_url:   host url to make the request. For e.g, it could be master.
-            api_base:           base url of the api request. For e.g. /marathon
-            default_headers:    headers specified for the request.
-            ca_cert_path:       path to ca cert.
-            get_node_url:       callback to get the node url
+        Keyword Args:
+            **kwargs: anything that can be passed to requests.request
+
+        Returns:
+            requests.Response
         """
-        self.default_host_url = default_host_url
-        self.api_base = api_base
-        if default_headers is None:
-            default_headers = dict()
-        self.default_headers = default_headers
-        self.ca_cert_path = ca_cert_path
-        self._get_node_url = get_node_url
 
-    def api_request(self, method, path, host_url=None, node=None, port=None, **kwargs):
-        """
-        Makes a request with default headers + user auth headers if necessary
-        If self.ca_cert_path is set, this method will pass it to requests
-        Args:
-            method: (str) name of method for requests.request
-            path: see get_url()
-            host_url: override the client's default host URL
-            node: if a get_node_url function is set, node and port will be passed to this function
-                instead of setting a host_url or using the default
-            port: can be used with node with get_node_url is set
-            **kwargs: any optional arguments to be passed to requests.request
-        """
-        headers = copy.copy(self.default_headers)
+        final_path = path_join(self.default_url.path, path_extension)
 
-        # allow kwarg to override verification so client can be used generically
-        if self.ca_cert_path and 'verify' not in kwargs:
-            kwargs['verify'] = self.ca_cert_path
+        request_url = str(self.default_url.copy(
+            scheme=scheme,
+            host=host,
+            path=final_path,
+            query=query,
+            fragment=fragment,
+            port=port))
 
-        if self.api_base:
-            path = path_join(self.api_base, path)
-
-        if node is not None:
-            assert host_url is None, 'Cannot set both node ({}) and host_url ({})'.format(node, host_url)
-            assert self._get_node_url is not None, 'get_node_url function must be supplied'
-            host_url = self._get_node_url(node, port=port)
-        else:
-            host_url = host_url if host_url else self.default_host_url
-        request_url = path_join(host_url, path)
-        headers.update(kwargs.pop('headers', {}))
         logging.info('Request method {}: {}'.format(method, request_url))
-        logging.debug('Request kwargs: {}'.format(kwargs))
-        logging.debug('Request headers: {}'.format(headers))
-        return requests.request(method, request_url, headers=headers, **kwargs)
+        r = self.session.request(method, request_url, **kwargs)
+        self.session.cookies.clear()
+        return r
 
-    def get_client(self, path, default_headers=None):
-        new_client = copy.deepcopy(self)
-        if default_headers is not None:
-            new_client.default_headers.update(default_headers)
-        new_client.api_base = path_join(self.api_base, path) if self.api_base is not None else path
-        return new_client
+    @functools.wraps(api_request)
+    def get(self, *args, **kwargs):
+        return self.api_request('GET', *args, **kwargs)
 
-    get = functools.partialmethod(api_request, 'get')
-    post = functools.partialmethod(api_request, 'post')
-    put = functools.partialmethod(api_request, 'put')
-    delete = functools.partialmethod(api_request, 'delete')
-    options = functools.partialmethod(api_request, 'options')
-    head = functools.partialmethod(api_request, 'head')
-    patch = functools.partialmethod(api_request, 'patch')
+    @functools.wraps(api_request)
+    def post(self, *args, **kwargs):
+        return self.api_request('POST', *args, **kwargs)
+
+    @functools.wraps(api_request)
+    def put(self, *args, **kwargs):
+        return self.api_request('PUT', *args, **kwargs)
+
+    @functools.wraps(api_request)
+    def patch(self, *args, **kwargs):
+        return self.api_request('PATCH', *args, **kwargs)
+
+    @functools.wraps(api_request)
+    def delete(self, *args, **kwargs):
+        return self.api_request('DELETE', *args, **kwargs)
+
+    @functools.wraps(api_request)
+    def head(self, *args, **kwargs):
+        return self.api_request('HEAD', *args, **kwargs)
+
+    @functools.wraps(api_request)
+    def options(self, *args, **kwargs):
+        return self.api_request('OPTIONS', *args, **kwargs)
 
 
 def retry_boto_rate_limits(boto_fn, wait=2, timeout=60 * 60):

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -7,9 +7,8 @@ from contextlib import contextmanager
 import requests
 import retrying
 
-from test_util.helpers import ApiClient, path_join
+from test_util.helpers import ApiClientSession, path_join
 
-DEFAULT_API_BASE = 'marathon'
 TEST_APP_NAME_FMT = 'integration-test-{}'
 REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}
 
@@ -80,18 +79,12 @@ def get_test_app_in_docker(ip_per_container=False):
     return app, test_uuid
 
 
-class Marathon(ApiClient):
-    def __init__(self, default_host_url, default_os_user='root', api_base=DEFAULT_API_BASE,
-                 get_node_url=None, default_headers=None, ca_cert_path=None):
-        if default_headers is None:
-            default_headers = dict()
-        default_headers.update(REQUIRED_HEADERS)
-        super().__init__(
-            default_host_url=default_host_url,
-            api_base=api_base,
-            default_headers=default_headers,
-            get_node_url=get_node_url,
-            ca_cert_path=ca_cert_path)
+class Marathon(ApiClientSession):
+    def __init__(self, default_url, default_os_user='root', session=None):
+        super().__init__(default_url)
+        if session is not None:
+            self.session = session
+        self.session.headers.update(REQUIRED_HEADERS)
         self.default_os_user = default_os_user
 
     def deploy_test_app_and_check(self, app, test_uuid):

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -50,8 +50,8 @@ import uuid
 import test_util.aws
 import test_util.cluster
 from pkgpanda.util import load_string
-from test_util.cluster_api import ClusterApi
-from test_util.helpers import CI_AUTH_JSON, DcosUser
+from test_util.dcos_api_session import DcosApiSession, DcosUser
+from test_util.helpers import CI_CREDENTIALS
 from test_util.marathon import TEST_APP_NAME_FMT
 
 
@@ -161,15 +161,14 @@ def main():
 
     master_list = [h.private_ip for h in cluster.masters]
 
-    cluster_api = ClusterApi(
+    cluster_api = DcosApiSession(
         'http://{ip}'.format(ip=cluster.masters[0].public_ip),
         master_list,
         master_list,
         [h.private_ip for h in cluster.agents],
         [h.private_ip for h in cluster.public_agents],
-        "root",             # default_os_user
-        web_auth_default_user=DcosUser(CI_AUTH_JSON),
-        ca_cert_path=None)
+        "root",  # default_os_user
+        auth_user=DcosUser(CI_CREDENTIALS))
 
     cluster_api.wait_for_dcos()
 

--- a/test_util/test_usage.py
+++ b/test_util/test_usage.py
@@ -1,43 +1,72 @@
 """Tests for verifying key functionality of utilities
 """
 import pytest
+import requests
 
-from test_util.cluster_api import ClusterApi, get_args_from_env
-from test_util.helpers import DcosUser
+from test_util.dcos_api_session import DcosApiSession, DcosUser, get_args_from_env
 
 
 class MockResponse:
-    def __init__(self, json, cookies):
-        self.json_data = json
-        self.cookies = cookies
+    def __init__(self):
+        self.cookies = {'dcos-acs-auth-cookie': 'foo'}
 
     def raise_for_status(self):
         pass
 
     def json(self):
-        return self.json_data
+        return {'token': 'bar'}
 
 
 @pytest.fixture
-def trivial_env(monkeypatch):
+def mock_dcos_client(monkeypatch):
     monkeypatch.setenv('DCOS_DNS_ADDRESS', 'http://mydcos.dcos')
     monkeypatch.setenv('MASTER_HOSTS', '127.0.0.1,0.0.0.0')
     monkeypatch.setenv('PUBLIC_MASTER_HOSTS', '127.0.0.1,0.0.0.0')
-    monkeypatch.setenv('SLAVE_HOSTS', '127.0.0.1,0.0.0.0')
+    monkeypatch.setenv('SLAVE_HOSTS', '127.0.0.1,123.123.123.123')
     monkeypatch.setenv('PUBLIC_SLAVE_HOSTS', '127.0.0.1,0.0.0.0')
-    monkeypatch.setenv('DNS_SEARCH', 'false')
-    monkeypatch.setenv('DCOS_PROVIDER', 'onprem')
+    # covers any request made via the ApiClientSession
+    monkeypatch.setattr(requests.Session, 'request', lambda *args, **kwargs: MockResponse())
+    monkeypatch.setattr(DcosApiSession, 'wait_for_dcos', lambda self: True)
+    args = get_args_from_env()
+    args['auth_user'] = None
+    return DcosApiSession(**args)
 
 
-def test_make_user_session(monkeypatch, trivial_env):
-    monkeypatch.setattr(ClusterApi, 'post',
-                        lambda *args, **kwargs: MockResponse({'token': 'abc'}, {'dcos-acs-auth-cookie': 'foo'}))
+def test_make_user_session(mock_dcos_client):
+    # make user session from no auth
+    cluster_none = mock_dcos_client
     user_1 = DcosUser({'foo': 'bar'})
     user_2 = DcosUser({'baz': 'qux'})
-    args = get_args_from_env()
-    args['web_auth_default_user'] = user_1
-    cluster_none = ClusterApi(**args)
     cluster_1 = cluster_none.get_user_session(user_1)
+    assert cluster_1.session.auth.auth_token == 'bar'
+    # Add a cookie to this session to make sure it gets cleared
+    cluster_1.session.cookies.update({'dcos-acs-auth-cookie': 'foo'})
+    # make user session from user
     cluster_2 = cluster_1.get_user_session(user_2)
-    assert cluster_1.default_headers['Authorization'] == 'token=abc'
-    assert cluster_2.default_headers['Authorization'] == 'token=abc'
+    assert cluster_2.session.auth.auth_token == 'bar'
+    # check cleared cookie
+    assert cluster_2.session.cookies.get('dcos-acs-auth-cookie') is None
+    # make no auth session from use session
+    cluster_none = cluster_2.get_user_session(None)
+    assert cluster_none.session.auth is None
+    assert len(cluster_none.session.cookies.items()) == 0
+
+
+def test_dcos_client_api(mock_dcos_client):
+    """ Tests two critical aspects of the DcosApiSession
+    1. node keyword arg is supported
+    2. all HTTP verbs work
+    """
+    args = get_args_from_env()
+    args['auth_user'] = None
+    cluster = DcosApiSession(**args)
+    # no assert necessary, just make sure that this function signatures works
+    r = cluster.get('', node='123.123.123.123')
+    r.raise_for_status()
+    cluster.get('')
+    cluster.post('')
+    cluster.put('')
+    cluster.delete('')
+    cluster.head('')
+    cluster.patch('')
+    cluster.options('')


### PR DESCRIPTION
- ApiClient was added with the intention of making it easier to handle common requests by extending all requests with some default. However, this is exactly what requests.session does (and it does it much better with less cruft)
- Also adds a Url abstration to that allows easy URL composing
- By using session, a simple BaseAuth object can be bound
- With these improvements, ApiClient only takes a Url and an optional get_node_port which is a call back for determining ports for an API that has different ports on different nodes
- ApiClient.api_request still takes the same arguments (HTTP verb, something to add to path, node=) but also accepts arbitrary default url substitutions like scheme='http' or query='last_cache=0' 


# Checklist

 - [x] Included a test which makes sure cookies are handled by get_user_session as the underlying session will automatically propagate cookies now
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)