### PR TITLE
bump marathon to v1.4.0-RC1

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-snap29/marathon-1.4.0-snap29.tgz",
-    "sha1": "7bd14d848976e3cdc22db05023b3120b89d8ce13"
+    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-RC1/marathon-1.4.0-RC1.tgz",
+    "sha1": "d23e5eb87acf20cf22c66bc460a064a27f2feb37"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
Upgrades Marathon to version 1.4.0-RC1 (from v1.3.x).

If this is a component/package update, include

 - [x] Change Log from last
  - https://github.com/mesosphere/marathon/releases/tag/v1.4.0-RC1
 - [x] Test Results
  - https://teamcity.mesosphere.io/viewLog.html?buildId=499190&buildTypeId=Oss_Marathon_Packages&tab=buildLog#_state=63&focus=24431


