### PR TITLE
Make CalculatorError.__init__() chain arg optional

### DIFF
--- a/gen/internals.py
+++ b/gen/internals.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 from contextlib import contextmanager
 from functools import partial, partialmethod
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Tuple, Union
 
 from gen.exceptions import ValidationError
 from pkgpanda.build import hash_checkout
@@ -271,7 +271,7 @@ class Source:
 # NOTE: This exception should never escape the Resolver
 class CalculatorError(Exception):
 
-    def __init__(self, message: str, chain: Optional[list]):
+    def __init__(self, message: str, chain: list = None):
         if chain is None:
             chain = list()
         self.message = message


### PR DESCRIPTION
This restores a default value removed in de76c26a844c4f11e4794861f59bb177f32479e7.

# Issues

[DCOS-11894](https://mesosphere.atlassian.net/browse/DCOS-11894)

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)