### PR TITLE
response.body -> response.content. Response.body never existed

### DIFF
--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -225,7 +225,7 @@ class Marathon(ApiClient):
         timeout = 120
 
         r = self.post('v2/pods', json=pod_definition)
-        assert r.ok, 'status_code: {} body: {}'.format(r.status_code, r.body)
+        assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
         logging.info('Response from marathon: {}'.format(repr(r.json())))
 
         @retrying.retry(wait_fixed=2000, stop_max_delay=timeout * 1000,
@@ -267,7 +267,7 @@ class Marathon(ApiClient):
                         retry_on_exception=lambda x: False)
         def _destroy_pod_complete(deployment_id):
             r = self.get('v2/deployments')
-            assert r.ok, 'status_code: {} body: {}'.format(r.status_code, r.body)
+            assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
             for deployment in r.json():
                 if deployment_id == deployment.get('id'):
@@ -277,7 +277,7 @@ class Marathon(ApiClient):
             return True
 
         r = self.delete('v2/pods' + pod_id)
-        assert r.ok, 'status_code: {} body: {}'.format(r.status_code, r.body)
+        assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
         try:
             _destroy_pod_complete(r.headers['Marathon-Deployment-Id'])


### PR DESCRIPTION
I'd accidentally had people use r.body instead of r.content for getting the body
of the http request for debug info. Since this isn't normally executed code it
snuck through. A recent other PR though hit one of these asserts and got the bad
output.

response.content: http://docs.python-requests.org/en/master/user/quickstart/#binary-response-content

Sample old behavior / assertion
```
    def deploy_pod(self, pod_definition):
        """Deploy a pod to marathon

            This function deploys an a pod and then waits for marathon to
            aknowledge it's successfull creation or fails the test.

            It waits until all the instances reach tasksRunning and then tasksHealthy state.

            Args:
                pod_definition: a dict with pod definition as specified in
                                Marathon API
                check_health: wait until Marathon reports tasks as healthy before
                              returning
            Returns:
                Scaling instance count
            """
        timeout = 120

        r = self.post('v2/pods', json=pod_definition)
>       assert r.ok, 'status_code: {} body: {}'.format(r.status_code, r.body)
E       AttributeError: 'Response' object has no attribute 'body'
```
# Issues
N/A

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not: no good way to test the negative case here, follows the docs for what the code should actually be.
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)