### PR TITLE
Debugging API changes in Mesos

### DIFF
--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -1,112 +1,135 @@
+import json
 import logging
 import uuid
 
 import requests
 
 from test_util.marathon import get_test_app
+from test_util.recordio import Decoder, Encoder
+
+
+# Wrapper to post, log, and validate return status
+def post(url, headers, json=None, data=None, stream=False):
+    r = requests.post(url, headers=headers, json=json, data=data, stream=stream)
+    logging.info(
+        'Got %s with POST request to %s with headers %s and json data %s.',
+        r.status_code,
+        url,
+        headers,
+        json
+    )
+    assert r.status_code == 200
+    return r
+
+
+# Creates and yields the initial ATTACH_CONTAINER_INPUT message, then a data message,
+# then an empty data chunk to indicate end-of-stream.
+def input_streamer(nested_container_id):
+    encoder = Encoder(lambda s: bytes(json.dumps(s, ensure_ascii=False), "UTF-8"))
+    message = {
+        'type': 'ATTACH_CONTAINER_INPUT',
+        'attach_container_input': {
+            'type': 'CONTAINER_ID',
+            'container_id': nested_container_id}}
+    yield encoder.encode(message)
+
+    message['attach_container_input'] = {
+        'type': 'PROCESS_IO',
+        'process_io': {
+            'type': 'DATA',
+            'data': {'type': 'STDIN', 'data': 'meow'}}}
+    yield encoder.encode(message)
+
+    # Place an empty string to indicate EOF to the server and push
+    # 'None' to our queue to indicate that we are done processing input.
+    message['attach_container_input']['process_io']['data']['data'] = ''
+    yield encoder.encode(message)
 
 
 def test_if_marathon_app_can_be_debugged(cluster):
-    def post(url, data):
-        r = requests.post(url, json=data)
-        logging.info(
-            'Got %s with POST request to %s with %s. Response: \n%s',
-            r.status_code,
-            url,
-            data,
-            r.text
-        )
-        assert r.status_code == 200
-
-    def find_container_id(state, app_id):
-        if 'frameworks' in state:
-            for framework in state['frameworks']:
-                # TODO: Skip anything that's not Marathon
-                if 'tasks' in framework:
-                    for task in framework['tasks']:
-                        if 'id' in task and app_id in task['id']:
-                            if 'statuses' in task and 'container_status' in task['statuses'][0]:
-                                if 'container_id' in task['statuses'][0]['container_status']:
-                                    container_status = task['statuses'][0]['container_status']
-                                    if 'container_id' in container_status:
-                                        if 'value' in container_status['container_id']:
-                                            return container_status['container_id']['value']
-
-    def find_agent_id(state, app_id):
-        if 'frameworks' in state:
-            for framework in state['frameworks']:
-                # TODO: Skip anything that's not Marathon
-                if 'tasks' in framework:
-                    for task in framework['tasks']:
-                        if 'id' in task and app_id in task['id']:
-                            if 'slave_id' in task:
-                                return task['slave_id']
-
-    def find_agent_hostname(state, agent_id):
-        if 'slaves' in state:
-            for agent in state['slaves']:
-                if 'id' in agent and agent['id'] == agent_id and 'hostname' in agent:
-                    return agent['hostname']
-
     # Launch a basic marathon app (no image), so we can debug into it!
+    # Cannot use deploy_and_cleanup because we must attach to a running app/task/container.
     app, test_uuid = get_test_app()
-    test_app_id = 'integration-test-{}'.format(test_uuid)
+    app_id = 'integration-test-{}'.format(test_uuid)
     cluster.marathon.deploy_app(app)
 
-    # Find the agent_id and container_id from master state
+    # Fetch the mesos master state once the task is running
     master_state_url = 'http://{}:{}/state'.format(cluster.masters[0], 5050)
     r = requests.get(master_state_url)
-    logging.info('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
+    logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
     assert r.status_code == 200
     state = r.json()
 
-    container_id = find_container_id(state, test_app_id)
-    agent_id = find_agent_id(state, test_app_id)
-    agent_hostname = find_agent_hostname(state, agent_id)
+    # Find the agent_id and container_id from master state
+    container_id = None
+    agent_id = None
+    for framework in state['frameworks']:
+        for task in framework['tasks']:
+            if app_id in task['id']:
+                container_id = task['statuses'][0]['container_status']['container_id']['value']
+                agent_id = task['slave_id']
+    if container_id is None:
+        raise Exception('Container ID not found for instance of app_id {}'.format(app_id))
+    if agent_id is None:
+        raise Exception('Agent ID not found for instance of app_id {}'.format(app_id))
+
+    # Find hostname and URL from agent_id
+    agent_hostname = None
+    for agent in state['slaves']:
+        if agent['id'] == agent_id:
+            agent_hostname = agent['hostname']
+    if agent_hostname is None:
+        raise Exception('Agent hostname not found for agent_id {}'.format(agent_id))
     agent_v1_url = 'http://{}:{}/api/v1'.format(agent_hostname, 5051)
-    logging.info('Located %s with containerID %s on agent %s', test_app_id, container_id, agent_hostname)
+    logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
 
-    # Attach to output stream of container
-    container_id_data = {'value': '%s' % container_id}
-    attach_out_data = {'type': 'ATTACH_CONTAINER_OUTPUT', 'attach_container_output': {}}
-    attach_out_data['attach_container_output']['container_id'] = container_id_data
-    logging.info('Making POST call to %s with: %s', agent_v1_url, attach_out_data)
-    # r = post(agent_v1_url, attach_out_data)
-    # logging.info('For %s call, got %s response: \n%s', attach_out_data['type'], r.status_code, r.text)
-    # assert r.status_code == 200
-    # TODO: verify some output
+    # Prepare nested container id data
+    nested_container_id = {
+        'value': 'debug-%s' % str(uuid.uuid4()),
+        'parent': {'value': '%s' % container_id}}
 
-    # Prepare nested container id
-    nested_container_id = {'value': 'debug-%s' % str(uuid.uuid4())}
-    nested_container_id['parent'] = container_id_data
-    logging.info('Creating nested container session: %s', nested_container_id)
+    # Launch debug session and attach to output stream of debug container
+    output_headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json+recordio',
+        'Connection': 'keep-alive'
+    }
+    lncs_data = {
+        'type': 'LAUNCH_NESTED_CONTAINER_SESSION',
+        'launch_nested_container_session': {
+            'command': {'value': 'cat'},
+            'container_id': nested_container_id}}
+    launch_output = post(agent_v1_url, output_headers, json=lncs_data, stream=True)
 
-    # Prepare POST json with nested_container_id for each call
-    lncs_data = {'type': 'LAUNCH_NESTED_CONTAINER_SESSION', 'launch_nested_container_session': {}}
-    lncs_data['launch_nested_container_session']['command'] = {'value': 'echo echo'}
-    lncs_data['launch_nested_container_session']['container_id'] = nested_container_id
-    attach_in_data = {'type': 'ATTACH_CONTAINER_INPUT', 'attach_container_input': {}}
-    attach_in_data['attach_container_input']['type'] = 'CONTAINER_ID'
-    attach_in_data['attach_container_input']['container_id'] = nested_container_id
-    # attach_out_data = {'type': 'ATTACH_CONTAINER_OUTPUT', 'attach_container_output': {}}
-    attach_out_data['attach_container_output']['container_id'] = nested_container_id
+    # Attach to output stream of nested container
+    attach_out_data = {
+        'type': 'ATTACH_CONTAINER_OUTPUT',
+        'attach_container_output': {'container_id': nested_container_id}}
+    attached_output = post(agent_v1_url, output_headers, json=attach_out_data, stream=True)
 
-    # Launch debug session
-    r = post(agent_v1_url, lncs_data)
-    logging.info('For %s call, got %s response: \n%s', lncs_data['type'], r.status_code, r.text)
-    assert r.status_code == 200
-    # TODO: verify more of the response contents?
+    # Attach to input stream of debug container and stream a message
+    input_headers = {
+        'Content-Type': 'application/json+recordio',
+        'Accept': 'application/json',
+        'Connection': 'keep-alive',
+        'Transfer-Encoding': 'chunked'
+    }
+    post(agent_v1_url, input_headers, data=input_streamer(nested_container_id))
 
-    # Attach to output stream of debug container
-    # r = post(agent_v1_url, attach_out_data)
-    # logging.info('For %s call, got %s response: \n%s', attach_out_data['type'], r.status_code, r.text)
-    # assert r.status_code == 200
-    # TODO: verify some output
+    # Verify the streamed output from the launch session
+    decoder = Decoder(lambda s: json.loads(s.decode("UTF-8")))
+    for chunk in launch_output.iter_content():
+        for r in decoder.decode(chunk):
+            if r['type'] == 'DATA':
+                logging.debug('Extracted data chunk: %s', r['data'])
+                assert r['data']['data'] == 'meow', 'Output did not match expected'
 
-    # Attach to input stream of debug container
-    # r = post(agent_v1_url, attach_in_data)
-    # logging.info('For %s call, got %s response: \n%s', attach_in_data['type'], r.status_code, r.text)
-    # assert r.status_code == 200
-    # TODO: input something and verify it
+    # Verify the message from the attached output stream
+    for chunk in attached_output.iter_content():
+        for r in decoder.decode(chunk):
+            if r['type'] == 'DATA':
+                logging.debug('Extracted data chunk: %s', r['data'])
+                assert r['data']['data'] == 'meow', 'Output did not match expected'
 
-    cluster.marathon.destroy_app(test_app_id)
+    # Destroy the app and the task's containers now that we're done with it
+    cluster.marathon.destroy_app(app_id)

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -1,0 +1,112 @@
+import logging
+import uuid
+
+import requests
+
+from test_util.marathon import get_test_app
+
+
+def test_if_marathon_app_can_be_debugged(cluster):
+    def post(url, data):
+        r = requests.post(url, json=data)
+        logging.info(
+            'Got %s with POST request to %s with %s. Response: \n%s',
+            r.status_code,
+            url,
+            data,
+            r.text
+        )
+        assert r.status_code == 200
+
+    def find_container_id(state, app_id):
+        if 'frameworks' in state:
+            for framework in state['frameworks']:
+                # TODO: Skip anything that's not Marathon
+                if 'tasks' in framework:
+                    for task in framework['tasks']:
+                        if 'id' in task and app_id in task['id']:
+                            if 'statuses' in task and 'container_status' in task['statuses'][0]:
+                                if 'container_id' in task['statuses'][0]['container_status']:
+                                    container_status = task['statuses'][0]['container_status']
+                                    if 'container_id' in container_status:
+                                        if 'value' in container_status['container_id']:
+                                            return container_status['container_id']['value']
+
+    def find_agent_id(state, app_id):
+        if 'frameworks' in state:
+            for framework in state['frameworks']:
+                # TODO: Skip anything that's not Marathon
+                if 'tasks' in framework:
+                    for task in framework['tasks']:
+                        if 'id' in task and app_id in task['id']:
+                            if 'slave_id' in task:
+                                return task['slave_id']
+
+    def find_agent_hostname(state, agent_id):
+        if 'slaves' in state:
+            for agent in state['slaves']:
+                if 'id' in agent and agent['id'] == agent_id and 'hostname' in agent:
+                    return agent['hostname']
+
+    # Launch a basic marathon app (no image), so we can debug into it!
+    app, test_uuid = get_test_app()
+    test_app_id = 'integration-test-{}'.format(test_uuid)
+    cluster.marathon.deploy_app(app)
+
+    # Find the agent_id and container_id from master state
+    master_state_url = 'http://{}:{}/state'.format(cluster.masters[0], 5050)
+    r = requests.get(master_state_url)
+    logging.info('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
+    assert r.status_code == 200
+    state = r.json()
+
+    container_id = find_container_id(state, test_app_id)
+    agent_id = find_agent_id(state, test_app_id)
+    agent_hostname = find_agent_hostname(state, agent_id)
+    agent_v1_url = 'http://{}:{}/api/v1'.format(agent_hostname, 5051)
+    logging.info('Located %s with containerID %s on agent %s', test_app_id, container_id, agent_hostname)
+
+    # Attach to output stream of container
+    container_id_data = {'value': '%s' % container_id}
+    attach_out_data = {'type': 'ATTACH_CONTAINER_OUTPUT', 'attach_container_output': {}}
+    attach_out_data['attach_container_output']['container_id'] = container_id_data
+    logging.info('Making POST call to %s with: %s', agent_v1_url, attach_out_data)
+    # r = post(agent_v1_url, attach_out_data)
+    # logging.info('For %s call, got %s response: \n%s', attach_out_data['type'], r.status_code, r.text)
+    # assert r.status_code == 200
+    # TODO: verify some output
+
+    # Prepare nested container id
+    nested_container_id = {'value': 'debug-%s' % str(uuid.uuid4())}
+    nested_container_id['parent'] = container_id_data
+    logging.info('Creating nested container session: %s', nested_container_id)
+
+    # Prepare POST json with nested_container_id for each call
+    lncs_data = {'type': 'LAUNCH_NESTED_CONTAINER_SESSION', 'launch_nested_container_session': {}}
+    lncs_data['launch_nested_container_session']['command'] = {'value': 'echo echo'}
+    lncs_data['launch_nested_container_session']['container_id'] = nested_container_id
+    attach_in_data = {'type': 'ATTACH_CONTAINER_INPUT', 'attach_container_input': {}}
+    attach_in_data['attach_container_input']['type'] = 'CONTAINER_ID'
+    attach_in_data['attach_container_input']['container_id'] = nested_container_id
+    # attach_out_data = {'type': 'ATTACH_CONTAINER_OUTPUT', 'attach_container_output': {}}
+    attach_out_data['attach_container_output']['container_id'] = nested_container_id
+
+    # Launch debug session
+    r = post(agent_v1_url, lncs_data)
+    logging.info('For %s call, got %s response: \n%s', lncs_data['type'], r.status_code, r.text)
+    assert r.status_code == 200
+    # TODO: verify more of the response contents?
+
+    # Attach to output stream of debug container
+    # r = post(agent_v1_url, attach_out_data)
+    # logging.info('For %s call, got %s response: \n%s', attach_out_data['type'], r.status_code, r.text)
+    # assert r.status_code == 200
+    # TODO: verify some output
+
+    # Attach to input stream of debug container
+    # r = post(agent_v1_url, attach_in_data)
+    # logging.info('For %s call, got %s response: \n%s', attach_in_data['type'], r.status_code, r.text)
+    # assert r.status_code == 200
+    # TODO: input something and verify it
+
+    cluster.marathon.destroy_app(test_app_id)

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -113,16 +113,22 @@ def test_if_marathon_app_can_be_debugged(cluster):
         post(agent_v1_url, input_headers, data=input_streamer(nested_container_id))
 
         # Verify the streamed output from the launch session
+        meowed = False
         decoder = Decoder(lambda s: json.loads(s.decode("UTF-8")))
         for chunk in launch_output.iter_content():
             for r in decoder.decode(chunk):
                 if r['type'] == 'DATA':
                     logging.debug('Extracted data chunk: %s', r['data'])
                     assert r['data']['data'] == 'meow', 'Output did not match expected'
+                    meowed = True
+        assert meowed, 'Read launch output without seeing meow.'
 
+        meowed = False
         # Verify the message from the attached output stream
         for chunk in attached_output.iter_content():
             for r in decoder.decode(chunk):
                 if r['type'] == 'DATA':
                     logging.debug('Extracted data chunk: %s', r['data'])
                     assert r['data']['data'] == 'meow', 'Output did not match expected'
+                    meowed = True
+        assert meowed, 'Read output stream without seeing meow.'

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -67,18 +67,15 @@ def test_if_marathon_app_can_be_debugged(cluster):
                 if app_id in task['id']:
                     container_id = task['statuses'][0]['container_status']['container_id']['value']
                     agent_id = task['slave_id']
-        if container_id is None:
-            raise Exception('Container ID not found for instance of app_id {}'.format(app_id))
-        if agent_id is None:
-            raise Exception('Agent ID not found for instance of app_id {}'.format(app_id))
+        assert container_id is not None, 'Container ID not found for instance of app_id {}'.format(app_id)
+        assert agent_id is not None, 'Agent ID not found for instance of app_id {}'.format(app_id)
 
         # Find hostname and URL from agent_id
         agent_hostname = None
         for agent in state['slaves']:
             if agent['id'] == agent_id:
                 agent_hostname = agent['hostname']
-        if agent_hostname is None:
-            raise Exception('Agent hostname not found for agent_id {}'.format(agent_id))
+        assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(agent_id)
         agent_v1_url = 'http://{}:{}/api/v1'.format(agent_hostname, 5051)
         logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
 

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -51,85 +51,81 @@ def test_if_marathon_app_can_be_debugged(cluster):
     # Cannot use deploy_and_cleanup because we must attach to a running app/task/container.
     app, test_uuid = get_test_app()
     app_id = 'integration-test-{}'.format(test_uuid)
-    cluster.marathon.deploy_app(app)
+    with cluster.marathon.deploy_and_cleanup(app):
+        # Fetch the mesos master state once the task is running
+        master_state_url = 'http://{}:{}/state'.format(cluster.masters[0], 5050)
+        r = requests.get(master_state_url)
+        logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
+        assert r.status_code == 200
+        state = r.json()
 
-    # Fetch the mesos master state once the task is running
-    master_state_url = 'http://{}:{}/state'.format(cluster.masters[0], 5050)
-    r = requests.get(master_state_url)
-    logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
-    assert r.status_code == 200
-    state = r.json()
+        # Find the agent_id and container_id from master state
+        container_id = None
+        agent_id = None
+        for framework in state['frameworks']:
+            for task in framework['tasks']:
+                if app_id in task['id']:
+                    container_id = task['statuses'][0]['container_status']['container_id']['value']
+                    agent_id = task['slave_id']
+        if container_id is None:
+            raise Exception('Container ID not found for instance of app_id {}'.format(app_id))
+        if agent_id is None:
+            raise Exception('Agent ID not found for instance of app_id {}'.format(app_id))
 
-    # Find the agent_id and container_id from master state
-    container_id = None
-    agent_id = None
-    for framework in state['frameworks']:
-        for task in framework['tasks']:
-            if app_id in task['id']:
-                container_id = task['statuses'][0]['container_status']['container_id']['value']
-                agent_id = task['slave_id']
-    if container_id is None:
-        raise Exception('Container ID not found for instance of app_id {}'.format(app_id))
-    if agent_id is None:
-        raise Exception('Agent ID not found for instance of app_id {}'.format(app_id))
+        # Find hostname and URL from agent_id
+        agent_hostname = None
+        for agent in state['slaves']:
+            if agent['id'] == agent_id:
+                agent_hostname = agent['hostname']
+        if agent_hostname is None:
+            raise Exception('Agent hostname not found for agent_id {}'.format(agent_id))
+        agent_v1_url = 'http://{}:{}/api/v1'.format(agent_hostname, 5051)
+        logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
 
-    # Find hostname and URL from agent_id
-    agent_hostname = None
-    for agent in state['slaves']:
-        if agent['id'] == agent_id:
-            agent_hostname = agent['hostname']
-    if agent_hostname is None:
-        raise Exception('Agent hostname not found for agent_id {}'.format(agent_id))
-    agent_v1_url = 'http://{}:{}/api/v1'.format(agent_hostname, 5051)
-    logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
+        # Prepare nested container id data
+        nested_container_id = {
+            'value': 'debug-%s' % str(uuid.uuid4()),
+            'parent': {'value': '%s' % container_id}}
 
-    # Prepare nested container id data
-    nested_container_id = {
-        'value': 'debug-%s' % str(uuid.uuid4()),
-        'parent': {'value': '%s' % container_id}}
+        # Launch debug session and attach to output stream of debug container
+        output_headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json+recordio',
+            'Connection': 'keep-alive'
+        }
+        lncs_data = {
+            'type': 'LAUNCH_NESTED_CONTAINER_SESSION',
+            'launch_nested_container_session': {
+                'command': {'value': 'cat'},
+                'container_id': nested_container_id}}
+        launch_output = post(agent_v1_url, output_headers, json=lncs_data, stream=True)
 
-    # Launch debug session and attach to output stream of debug container
-    output_headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json+recordio',
-        'Connection': 'keep-alive'
-    }
-    lncs_data = {
-        'type': 'LAUNCH_NESTED_CONTAINER_SESSION',
-        'launch_nested_container_session': {
-            'command': {'value': 'cat'},
-            'container_id': nested_container_id}}
-    launch_output = post(agent_v1_url, output_headers, json=lncs_data, stream=True)
+        # Attach to output stream of nested container
+        attach_out_data = {
+            'type': 'ATTACH_CONTAINER_OUTPUT',
+            'attach_container_output': {'container_id': nested_container_id}}
+        attached_output = post(agent_v1_url, output_headers, json=attach_out_data, stream=True)
 
-    # Attach to output stream of nested container
-    attach_out_data = {
-        'type': 'ATTACH_CONTAINER_OUTPUT',
-        'attach_container_output': {'container_id': nested_container_id}}
-    attached_output = post(agent_v1_url, output_headers, json=attach_out_data, stream=True)
+        # Attach to input stream of debug container and stream a message
+        input_headers = {
+            'Content-Type': 'application/json+recordio',
+            'Accept': 'application/json',
+            'Connection': 'keep-alive',
+            'Transfer-Encoding': 'chunked'
+        }
+        post(agent_v1_url, input_headers, data=input_streamer(nested_container_id))
 
-    # Attach to input stream of debug container and stream a message
-    input_headers = {
-        'Content-Type': 'application/json+recordio',
-        'Accept': 'application/json',
-        'Connection': 'keep-alive',
-        'Transfer-Encoding': 'chunked'
-    }
-    post(agent_v1_url, input_headers, data=input_streamer(nested_container_id))
+        # Verify the streamed output from the launch session
+        decoder = Decoder(lambda s: json.loads(s.decode("UTF-8")))
+        for chunk in launch_output.iter_content():
+            for r in decoder.decode(chunk):
+                if r['type'] == 'DATA':
+                    logging.debug('Extracted data chunk: %s', r['data'])
+                    assert r['data']['data'] == 'meow', 'Output did not match expected'
 
-    # Verify the streamed output from the launch session
-    decoder = Decoder(lambda s: json.loads(s.decode("UTF-8")))
-    for chunk in launch_output.iter_content():
-        for r in decoder.decode(chunk):
-            if r['type'] == 'DATA':
-                logging.debug('Extracted data chunk: %s', r['data'])
-                assert r['data']['data'] == 'meow', 'Output did not match expected'
-
-    # Verify the message from the attached output stream
-    for chunk in attached_output.iter_content():
-        for r in decoder.decode(chunk):
-            if r['type'] == 'DATA':
-                logging.debug('Extracted data chunk: %s', r['data'])
-                assert r['data']['data'] == 'meow', 'Output did not match expected'
-
-    # Destroy the app and the task's containers now that we're done with it
-    cluster.marathon.destroy_app(app_id)
+        # Verify the message from the attached output stream
+        for chunk in attached_output.iter_content():
+            for r in decoder.decode(chunk):
+                if r['type'] == 'DATA':
+                    logging.debug('Extracted data chunk: %s', r['data'])
+                    assert r['data']['data'] == 'meow', 'Output did not match expected'

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a",
+      "ref": "6660b90fbbf69a15ef46d0184e36755881d6a5ae",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "d6e2a1e50d47a218adab62ca363a7ca3be129055",
-    "ref_origin" : "dcos-mesos-master-30d6edb"
+    "ref": "9736e0a608bc227957be4886bbe8372e23f62b7d",
+    "ref_origin" : "dcos-mesos-master-e99ea9c"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/test_util/recordio.py
+++ b/test_util/recordio.py
@@ -1,0 +1,150 @@
+"""
+Provides facilities for "Record-IO" encoding of data.
+"Record-IO" encoding allows one to encode a sequence
+of variable-length records by prefixing each record
+with its size in bytes:
+
+5\n
+hello
+6\n
+world!
+
+Note that this currently only supports record lengths
+encoded as base 10 integer values with newlines as a
+delimiter. This is to provide better language
+portability: parsing a base 10 integer is simple. Most
+other "Record-IO" implementations use a fixed-size
+header of 4 bytes to directly encode an unsigned 32 bit
+length.
+"""
+
+
+class Encoder():
+    """Encode an arbitray message type into a 'RecordIO' message.
+
+       This class encapsulates the process of encoding an
+       arbitrary message into a 'RecordIO' message. Its
+       constructor takes a serialization function of the form
+       'serialize(message)'. This serialization function is
+       responsible for knowing how to take whatever message type
+       is passed to 'encode()' and serializing it to a 'UTF-8'
+       encoded byte array.
+
+       Once 'encode(message)' is called, it will use the
+       serialization function to convert 'message' into a 'UTF-8'
+       encoded byte array, wrap it in a 'RecordIO' frame,
+       and return it.
+
+       :param serialize: a function to serialize any message
+                         passed to 'encode()' into a 'UTF-8'
+                         encoded byte array
+       :type serialize: function
+    """
+
+    def __init__(self, serialize):
+        self.serialize = serialize
+
+    def encode(self, message):
+        """Encode a message into 'RecordIO' format.
+
+        :param message: a message to serialize and then wrap in
+                        a 'RecordIO' frame.
+        :type message: object
+        :returns: a serialized message wrapped in a 'RecordIO' frame
+        :rtype: bytes
+        """
+
+        s = self.serialize(message)
+
+        if not isinstance(s, bytes):
+            raise Exception("Calling 'serialize(message)' must return a 'bytes' object")
+
+        return bytes(str(len(s)) + "\n", "UTF-8") + s
+
+
+class Decoder():
+    """Decode a 'RecordIO' message back to an arbitrary message type.
+
+       This class encapsulates the process of decoding a message
+       previously encoded with 'RecordIO' back to an arbitrary
+       message type. Its constructor takes a deserialization
+       function of the form 'deserialize(data)'. This
+       deserialization function is responsible for knowing how to
+       take a fully constructed 'RecordIO' message containing a
+       'UTF-8' encoded byte array and deserialize it back into the
+       original message type.
+
+       The 'decode(data)' message takes a 'UTF-8' encoded byte array
+       as input and buffers it across subsequent calls to
+       construct a set of fully constructed 'RecordIO' messages that
+       are decoded and returned in a list.
+
+       :param deserialize: a function to deserialize from 'RecordIO'
+                           messages built up by subsequent calls
+                           to 'decode(data)'
+       :type deserialize: function
+    """
+
+    HEADER = 0
+    RECORD = 1
+    FAILED = 2
+
+    def __init__(self, deserialize):
+        self.deserialize = deserialize
+        self.state = self.HEADER
+        self.buffer = bytes("", "UTF-8")
+        self.length = 0
+
+    def decode(self, data):
+        """Decode a 'RecordIO' formatted message to its original type.
+
+        :param data: an array of 'UTF-8' encoded bytes that make up a
+                      partial 'RecordIO' message. Subsequent calls to this
+                      function maintain state to build up a full 'RecordIO'
+                      message and decode it
+        :type data: bytes
+        :returns: a list of deserialized messages
+        :rtype: list
+        """
+
+        if not isinstance(data, bytes):
+            raise Exception("Parameter 'data' must of of type 'bytes'")
+
+        if self.state == self.FAILED:
+            raise Exception("Decoder is in a FAILED state")
+
+        records = []
+
+        for c in data:
+            if self.state == self.HEADER:
+                if c != ord('\n'):
+                    self.buffer += bytes([c])
+                    continue
+
+                try:
+                    self.length = int(self.buffer.decode("UTF-8"))
+                except Exception as exception:
+                    self.state = self.FAILED
+                    raise Exception("Failed to decode length '{buffer}': {error}"
+                                    .format(buffer=self.buffer, error=exception))
+
+                self.buffer = bytes("", "UTF-8")
+                self.state = self.RECORD
+
+                # Note that for 0 length records, we immediately decode.
+                if self.length <= 0:
+                    records.append(self.deserialize(self.buffer))
+                    self.state = self.HEADER
+
+            elif self.state == self.RECORD:
+                assert self.length
+                assert len(self.buffer) < self.length
+
+                self.buffer += bytes([c])
+
+                if len(self.buffer) == self.length:
+                    records.append(self.deserialize(self.buffer))
+                    self.buffer = bytes("", "UTF-8")
+                    self.state = self.HEADER
+
+        return records

--- a/test_util/recordio.py
+++ b/test_util/recordio.py
@@ -123,16 +123,17 @@ class Decoder():
 
                 try:
                     self.length = int(self.buffer.decode("UTF-8"))
+                    assert self.length >= 0, "Negative record length '{length}'".format(length=self.length)
                 except Exception as exception:
                     self.state = self.FAILED
                     raise Exception("Failed to decode length '{buffer}': {error}"
-                                    .format(buffer=self.buffer, error=exception))
+                                    .format(buffer=self.buffer, error=exception)) from exception
 
                 self.buffer = bytes("", "UTF-8")
                 self.state = self.RECORD
 
                 # Note that for 0 length records, we immediately decode.
-                if self.length <= 0:
+                if self.length == 0:
                     records.append(self.deserialize(self.buffer))
                     self.state = self.HEADER
 


### PR DESCRIPTION
This change bumps Mesos (and mesos-modules to match) to include debugging fixes.
Also bumping AdminRouter to pickup some debugging support.
But most significant is a dcos-integration test of the new Mesos Debug API calls.

# Issues

[DCOS-9574](https://mesosphere.atlassian.net/browse/DCOS-9574)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

# Component updates:
Mesos

 - [X] Change Log from last: 
https://github.com/mesosphere/mesos/compare/dcos-mesos-master-30d6edb...mesosphere:dcos-mesos-master-e99ea9c
(mostly tests/fixes for debugging)
 - [x] Test Results: https://mesosphere.slack.com/archives/core-ci/p1481694252000143 
(3 known cmake build errors, 1 consistently failing test soon-to-be-fixed, and several known flaky tests)
 - [ ] Code Coverage: N/A

Mesos-modules

 - [X] Change Log from last: https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae 
(fix build for Mesos interface changes; log-sink module for #1000 and upgrade-fix slipped in too)
 - [ ] Test Results: N/A
 - [ ] Code Coverage: N/A

Adminrouter

 - [X] Change Log from last: https://github.com/dcos/adminrouter/compare/ae8d4d8328599d67e7ca8d9246229ff1420e792c...d44fd04d38db485145dd8c0fd839cc44c648c675 
("Disable buffering to mesos agent API and use HTTP/1.1" for debugging support)
 - [ ] Test Results: N/A
 - [ ] Code Coverage: N/A