### PR TITLE
Updated Mesos to include a new cherry-picked commit

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "1e264ece1a69837d0b5da5e397852424f9b4a3eb",
+      "ref": "f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8e8c70a71b2849ee37d3c6b9f396ceaac73369e",
-    "ref_origin" : "dcos-mesos-master-35ce5042"
+    "ref": "7721304186f7193e63e04f581b7b7c2f709fc8c6",
+    "ref_origin" : "dcos-mesos-master-testing-8dcef9c6"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
The [cherry-pick](https://github.com/mesosphere/mesos/commit/def16a8e17373a244bb5d8f637898a82d2551ad1) we apply to the Mesos web UI is updated in this PR to adjust paths for the Mesos logo and for the agent's `/metrics/snapshot` endpoint. The new cherry-pick commit can be viewed [here](https://github.com/mesosphere/mesos/commit/6dedb08f58f6a4db4bbe3f42da7aee224b10a716).

If the tests pass with this PR, we can merge this into pull/977 before merging.