### PR TITLE
Added POSIX rlimits support to Mesos.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -362,7 +362,7 @@ def calculate_config_yaml(user_arguments):
 
 def calculate_mesos_isolation(enable_gpu_isolation):
     isolators = ('cgroups/cpu,cgroups/mem,disk/du,network/cni,filesystem/linux,'
-                 'docker/runtime,docker/volume,volume/sandbox_path')
+                 'docker/runtime,docker/volume,volume/sandbox_path,posix/rlimits')
     if enable_gpu_isolation == 'true':
         isolators += ',cgroups/devices,gpu/nvidia'
     return isolators

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "1e264ece1a69837d0b5da5e397852424f9b4a3eb",
+      "ref": "f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8e8c70a71b2849ee37d3c6b9f396ceaac73369e",
-    "ref_origin" : "dcos-mesos-master-35ce5042"
+    "ref": "837ef1bf28ddc763e2b9d3586075afe56128d011",
+    "ref_origin" : "dcos-mesos-master-a567345"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "837ef1bf28ddc763e2b9d3586075afe56128d011",
-    "ref_origin" : "dcos-mesos-master-a567345"
+    "ref": "d6e2a1e50d47a218adab62ca363a7ca3be129055",
+    "ref_origin" : "dcos-mesos-master-30d6edb"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Added 'posix/rlimits' to default Mesos isolator list.

This isolator enables the POSIX rlimits support in Mesos. It allows
frameworks to change the default resource limits (both hard and soft)
for their containers, similar to Docker `--ulimit` flag.

Some data services like Elastic Search or Cassandra typically require
a higher than normal resource limit for their containers, and will do
a check during startup to see if those limits are set properly. This
support in Mesos will unblock them running on DC/OS.

This isolator only affects the launch path of the container. If no
framework is using this feature, adding this isolator to the isolator
list will be a no-op.

# Issues

[MESOS-6402](https://issues.apache.org/jira/browse/MESOS-6402)

