### PR TITLE
Make oauth_available always derived, even for cloud templates, optionally from oauth_enabled

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -51,7 +51,6 @@ aws_base_source = Source(entry={
         'master_external_loadbalancer': '{ "Fn::GetAtt" : [ "ElasticLoadBalancer", "DNSName" ] }',
         # template variable for the generating advanced template cloud configs
         'cloud_config': '{{ cloud_config }}',
-        'oauth_available': 'true',
         'oauth_enabled': '{ "Ref" : "OAuthEnabled" }',
         'rexray_config_preset': 'aws'
     }

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -53,7 +53,6 @@ azure_base_source = Source(entry={
         'slave_cloud_config': '{{ slave_cloud_config }}',
         'slave_public_cloud_config': '{{ slave_public_cloud_config }}',
         'oauth_enabled': "[[[variables('oauthEnabled')]]]",
-        'oauth_available': 'true'
     }
 })
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -261,7 +261,14 @@ def validate_dcos_overlay_network(dcos_overlay_network):
 
 
 def calculate_oauth_available(oauth_enabled):
-    return oauth_enabled
+    if oauth_enabled in ["[[[variables('oauthEnabled')]]]", '{ "Ref" : "OAuthEnabled" }']:
+        return 'true'
+    elif oauth_enabled == 'false':
+        return 'false'
+    elif oauth_enabled == 'true':
+        return 'true'
+    else:
+        raise AssertionError("Invaild value for oauth_enabled: {}".format(oauth_enabled))
 
 
 def validate_num_masters(num_masters):

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -492,7 +492,8 @@ class Resolver:
             raise CalculatorError("{} must be calculated, but was explicitly set in the "
                                   "configuration. Remove it from the configuration.").format(resolvable.name)
         if len(feasible) > 1:
-            raise CalculatorError("Internal error: Multiple ways to set {}.".format(resolvable.name))
+            raise CalculatorError("Internal error: Multiple ways to set {}. setters: {}".format(
+                resolvable.name, feasible))
 
         setter = feasible[0]
 


### PR DESCRIPTION
This allows downstreams to overwrite the value for oauth_available if they would like for the cloud templates. They used to be able to do this because of how dictionary overwriting worked, but with the use of "Sources" it stopped being possible. This changes the functionality back to how it was originally designed to work.

# Issues

[DCOS-11894](https://dcosjira.atlassian.net/browse/DCOS-11894)

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not. Hard to integration test at the moment (no existing infrastructure). Hand tested with a downstream taking advantage of it.
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)