### PR TITLE
Added POSIX rlimits support to Mesos

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -369,7 +369,7 @@ def calculate_config_yaml(user_arguments):
 
 def calculate_mesos_isolation(enable_gpu_isolation):
     isolators = ('cgroups/cpu,cgroups/mem,disk/du,network/cni,filesystem/linux,'
-                 'docker/runtime,docker/volume,volume/sandbox_path,'
+                 'docker/runtime,docker/volume,volume/sandbox_path,posix/rlimits,'
                  'com_mesosphere_MetricsIsolatorModule')
     if enable_gpu_isolation == 'true':
         isolators += ',cgroups/devices,gpu/nvidia'

--- a/packages/dcos-integration-test/extra/test_rlimit.py
+++ b/packages/dcos-integration-test/extra/test_rlimit.py
@@ -1,0 +1,33 @@
+import subprocess
+import uuid
+
+
+def test_if_rlimits_can_be_used(cluster):
+    """This test verifies that rlimits can be used.
+
+    Since marathon does not support rlimits yet we use `mesos-execute` as
+    scheduler. We run a job for which we specify an unlimited `RLIMIT_CORE`.
+    The job then examines the actual limit, and returns a failure if another
+    value is found."""
+
+    name = 'test-rlimits-{}'.format(uuid.uuid4().hex)
+
+    argv = [
+        '/opt/mesosphere/bin/mesos-execute',
+        '--rlimits={"rlimits": [{"type":"RLMT_CORE"}]}',
+        '--master=leader.mesos:5050',
+        '--name={}'.format(name),
+        '--command=ulimit -c | grep -q unlimited',
+        '--shell=true',
+        '--env={"LC_ALL":"C"}']
+
+    output = subprocess.check_output(
+        argv,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True)
+
+    expected_output = \
+        "Received status update TASK_FINISHED for task '{name}'".format(
+            name=name)
+
+    assert expected_output in output


### PR DESCRIPTION
Added 'posix/rlimits' to default Mesos isolator list.

This isolator enables the POSIX rlimits support in Mesos. It allows
frameworks to change the default resource limits (both hard and soft)
for their containers, similar to Docker --ulimit flag.

Some data services like Elastic Search or Cassandra typically require
a higher than normal resource limit for their containers, and will do
a check during startup to see if those limits are set properly. This
support in Mesos will unblock them running on DC/OS.

This isolator only affects the launch path of the container. If no
framework is using this feature, adding this isolator to the isolator
list will be a no-op.

# Issues

[MESOS-6402](https://issues.apache.org/jira/browse/MESOS-6402)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [ ] Change Log from last: <link>
 - [ ] Test Results: <link>
 - [ ] Code Coverage: <link>