### PR TITLE
Use /var/lib/dcos/mesos for metrics module state path

### DIFF
--- a/packages/dcos-metrics/extra/metrics.json
+++ b/packages/dcos-metrics/extra/metrics.json
@@ -16,7 +16,7 @@
             {"key": "output_collector_chunk_size_datapoints", "value": "100"},
             {"key": "output_collector_chunk_timeout_seconds", "value": "10"},
             {"key": "state_path_dir",
-             "value": "/var/run/mesos/isolators/com_mesosphere_MetricsIsolatorModule/"}
+             "value": "/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/"}
         ]
     }]
   }]


### PR DESCRIPTION
High level description including:
- fixed the state directory of the mesos volume to go to the standard path

# Issues

n/a

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [ ] Change Log from last: n/a
 - [ ] Test Results: n/a
 - [ ] Code Coverage: n/a

