### PR TITLE
cluster-id for metrics agents

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/bootstrap.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/bootstrap.py
@@ -37,13 +37,17 @@ class Bootstrapper(object):
     def __exit__(self, type, value, tb):
         self.close()
 
-    def cluster_id(self, path):
+    def cluster_id(self, path, readonly=False):
         dirpath = os.path.dirname(os.path.abspath(path))
         log.info('Opening {} for locking'.format(dirpath))
         with utils.Directory(dirpath) as d:
             log.info('Taking exclusive lock on {}'.format(dirpath))
             with d.lock():
-                zkid = str(uuid.uuid4()).encode('ascii')
+                if readonly:
+                    zkid = None
+                else:
+                    zkid = str(uuid.uuid4()).encode('ascii')
+
                 zkid = self._consensus('/cluster-id', zkid, ANYONE_READ)
                 zkid = zkid.decode('ascii')
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -35,6 +35,16 @@ def dcos_signal(b, opts):
 
 
 @check_root
+def dcos_metrics_master(b, opts):
+    b.cluster_id('/var/lib/dcos/cluster-id')
+
+
+@check_root
+def dcos_metrics_agent(b, opts):
+    b.cluster_id('/var/lib/dcos/cluster-id', readonly=True)
+
+
+@check_root
 def dcos_oauth(b, opts):
     b.generate_oauth_secret('/var/lib/dcos/dcos-oauth/auth-token-secret')
 
@@ -47,8 +57,8 @@ bootstrappers = {
     'dcos-adminrouter': dcos_adminrouter,
     'dcos-signal': dcos_signal,
     'dcos-oauth': dcos_oauth,
-    'dcos-metrics-master': noop,
-    'dcos-metrics-agent': noop,
+    'dcos-metrics-master': dcos_metrics_master,
+    'dcos-metrics-agent': dcos_metrics_agent,
     'dcos-3dt': noop,
     'dcos-marathon': noop,
     'dcos-mesos-master': noop,

--- a/packages/dcos-metrics/extra/dcos-metrics-agent.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-agent.service
@@ -7,4 +7,5 @@ PermissionsStartOnly=True
 User=dcos_metrics
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metrics-agent
+ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 ExecStart=/opt/mesosphere/bin/dcos-metrics -role agent

--- a/packages/dcos-metrics/extra/dcos-metrics-master.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-master.service
@@ -7,4 +7,5 @@ PermissionsStartOnly=True
 User=dcos_metrics
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metrics-master
+ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 ExecStart=/opt/mesosphere/bin/dcos-metrics -role master


### PR DESCRIPTION
Write /var/lib/dcos/cluster-id on agents for dcos-metrics service to use

# Issues

N/A

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not: checked in systemd unit
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)