### PR TITLE
Upgrade testing with changes from train-108

### DIFF
--- a/packages/dcos-integration-test/extra/cluster_fixture.py
+++ b/packages/dcos-integration-test/extra/cluster_fixture.py
@@ -2,29 +2,14 @@
 ClusterApi object that will be injected into the pytest 'cluster' fixture
 via the make_cluster_fixture() method
 """
-import os
 
-from pkgpanda.util import load_json
 from test_util.cluster_api import ClusterApi, get_args_from_env
-from test_util.helpers import DcosUser
+from test_util.helpers import CI_AUTH_JSON, DcosUser
 
 
 def make_cluster_fixture():
-    # token valid until 2036 for user albert@bekstil.net
-    # {
-    #   "email": "albert@bekstil.net",
-    #   "email_verified": true,
-    #   "iss": "https://dcos.auth0.com/",
-    #   "sub": "google-oauth2|109964499011108905050",
-    #   "aud": "3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m",
-    #   "exp": 2090884974,
-    #   "iat": 1460164974
-    # }
-    auth_json = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ'}  # noqa
-    if 'DCOS_AUTH_JSON_PATH' in os.environ:
-        auth_json = load_json(os.environ['DCOS_AUTH_JSON_PATH'])
     args = get_args_from_env()
-    args['web_auth_default_user'] = DcosUser(auth_json)
+    args['web_auth_default_user'] = DcosUser(CI_AUTH_JSON)
     cluster_api = ClusterApi(**args)
     cluster_api.wait_for_dcos()
     return cluster_api

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -3,6 +3,8 @@ import logging
 import os
 import subprocess
 
+import dns.exception
+import dns.resolver
 import kazoo.client
 import pytest
 import requests
@@ -11,6 +13,16 @@ import requests
 @pytest.mark.first
 def test_cluster_is_up(cluster):
     pass
+
+
+def test_leader_election(cluster):
+    mesos_resolver = dns.resolver.Resolver()
+    mesos_resolver.nameservers = cluster.public_masters
+    mesos_resolver.port = 61053
+    try:
+        mesos_resolver.query('leader.mesos', 'A')
+    except dns.exception.DNSException:
+        assert False, "Cannot resolve leader.mesos"
 
 
 def test_if_all_mesos_masters_have_registered(cluster):

--- a/test_util/cluster_api.py
+++ b/test_util/cluster_api.py
@@ -3,8 +3,6 @@ import logging
 import os
 from urllib.parse import urlparse
 
-import dns.exception
-import dns.resolver
 import requests
 import retrying
 
@@ -131,25 +129,6 @@ class ClusterApi(test_util.helpers.ApiClient):
     @retrying.retry(wait_fixed=1000,
                     retry_on_result=lambda ret: ret is False,
                     retry_on_exception=lambda x: False)
-    def _wait_for_leader_election(self):
-        mesos_resolver = dns.resolver.Resolver()
-        mesos_resolver.nameservers = self.public_masters
-        mesos_resolver.port = 61053
-        try:
-            # Yeah, we can also put it in retry_on_exception, but
-            # this way we will loose debug messages
-            mesos_resolver.query('leader.mesos', 'A')
-        except dns.exception.DNSException as e:
-            msg = "Cannot resolve leader.mesos, error string: '{}', continuing to wait"
-            logging.info(msg.format(e))
-            return False
-        else:
-            logging.info("leader.mesos dns entry is UP!")
-            return True
-
-    @retrying.retry(wait_fixed=1000,
-                    retry_on_result=lambda ret: ret is False,
-                    retry_on_exception=lambda x: False)
     def _wait_for_adminrouter_up(self):
         try:
             # Yeah, we can also put it in retry_on_exception, but
@@ -207,7 +186,6 @@ class ClusterApi(test_util.helpers.ApiClient):
         assert r.status_code == 200
 
     def wait_for_dcos(self):
-        self._wait_for_leader_election()
         self._wait_for_adminrouter_up()
         if self.auth_enabled and self.web_auth_default_user:
             self._authenticate_default_user()

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -17,6 +17,20 @@ Host = namedtuple('Host', ['private_ip', 'public_ip'])
 SshInfo = namedtuple('SshInfo', ['user', 'home_dir'])
 
 
+# Token valid until 2036 for user albert@bekstil.net
+#    {
+#        "email": "albert@bekstil.net",
+#        "email_verified": true,
+#        "iss": "https://dcos.auth0.com/",
+#        "sub": "google-oauth2|109964499011108905050",
+#        "aud": "3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m",
+#        "exp": 2090884974,
+#        "iat": 1460164974
+#    }
+
+CI_AUTH_JSON = {'token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ'}     # noqa
+
+
 def path_join(p1, p2):
     return '{}/{}'.format(p1.rstrip('/'), p2.lstrip('/'))
 

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -81,6 +81,8 @@ def get_test_app():
 
 def get_task_info(apps, tasks):
     idx = 0    # We have a single app and a task for this test.
+    logging.info("marathon apps info {apps} ".format(apps=str(apps)))
+    logging.info("marathon tasks info {tasks}".format(tasks=str(tasks)))
 
     try:
         tasks_state = tasks["tasks"][idx]["state"]

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -28,19 +28,79 @@ DCOS_PYTEST_CMD: string(default='py.test -rs -vv ' + os.getenv('CI_FLAGS', ''))
     CI_FLAGS is ignored.
 
 """
-
+import collections
+import datetime
 import logging
 import os
 import random
 import string
 import sys
+import uuid
 
 import test_util.aws
 import test_util.cluster
-
+from test_util.cluster_api import ClusterApi
+from test_util.helpers import CI_AUTH_JSON, DcosUser
+from test_util.marathon import TEST_APP_NAME_FMT
 
 logging.basicConfig(format='[%(asctime)s|%(name)s|%(levelname)s]: %(message)s', level=logging.DEBUG)
 log = logging.getLogger(__name__)
+
+
+def get_test_app():
+    app = {
+        "id": TEST_APP_NAME_FMT.format(uuid.uuid4().hex),
+        "cmd": "python3 -m http.server 8080",
+        "cpus": 0.5,
+        "mem": 32.0,
+        "instances": 1,
+        "container": {
+            "type": "DOCKER",
+            "docker": {
+                "image": "python:3",
+                "network": "BRIDGE",
+                "portMappings": [
+                    {"containerPort": 8080, "hostPort": 0}
+                ]
+            }
+        },
+        "healthChecks": [
+            {
+                "protocol": "HTTP",
+                "path": "/",
+                "portIndex": 0,
+                "gracePeriodSeconds": 5,
+                "intervalSeconds": 10,
+                "timeoutSeconds": 10,
+                "maxConsecutiveFailures": -1
+            }
+        ],
+    }
+    return app
+
+
+def get_task_info(apps, tasks):
+    idx = 0    # We have a single app and a task for this test.
+
+    try:
+        tasks_state = tasks["tasks"][idx]["state"]
+        health_check_interval = \
+            apps["apps"][idx]["healthChecks"][idx]["intervalSeconds"]
+        task_id = tasks["tasks"][idx]["id"]
+        last_success = tasks["tasks"][idx]["healthCheckResults"][idx]["lastSuccess"]
+    except IndexError as e:
+        logging.debug("Failed to get task detail: {exp}".format(exp=str(e)))
+        return None
+
+    TaskInfo = collections.namedtuple("TaskInfo", "state id health_check_interval last_success_time")
+
+    task_info = TaskInfo(
+        state=tasks_state,
+        id=task_id,
+        health_check_interval=datetime.timedelta(seconds=health_check_interval),
+        last_success_time=(datetime.datetime.strptime(last_success, "%Y-%m-%dT%H:%M:%S.%fZ")))
+
+    return task_info
 
 
 def main():
@@ -80,14 +140,57 @@ def main():
 
     # Use the CLI installer to set exhibitor_storage_backend = zookeeper.
     test_util.cluster.install_dcos(cluster, stable_installer_url, api=False)
+
+    master_list = [h.private_ip for h in cluster.masters]
+
+    cluster_api = ClusterApi(
+        'http://{ip}'.format(ip=cluster.masters[0].public_ip),
+        master_list,
+        master_list,
+        [h.private_ip for h in cluster.agents],
+        [h.private_ip for h in cluster.public_agents],
+        False,              # dns search set.
+        cluster.provider,
+        True,               # auth_enabled
+        "root",             # default_os_user
+        web_auth_default_user=DcosUser(CI_AUTH_JSON),
+        ca_cert_path=None)
+
+    cluster_api.wait_for_dcos()
+
+    # Deploy an app
+    cluster_api.marathon.deploy_app(get_test_app())
+
+    task_info_before_upgrade = get_task_info(cluster_api.marathon.get('v2/apps').json(),
+                                             cluster_api.marathon.get('v2/tasks').json())
+
+    assert task_info_before_upgrade is not None, "Unable to get task details of the cluster."
+    assert task_info_before_upgrade.state == "TASK_RUNNING", "Task is not in the running state."
+
     with cluster.ssher.tunnel(cluster.bootstrap_host) as bootstrap_host_tunnel:
         bootstrap_host_tunnel.remote_cmd(['sudo', 'rm', '-rf', cluster.ssher.home_dir + '/*'])
+
     test_util.cluster.upgrade_dcos(cluster, installer_url)
 
+    task_info_after_upgrade = get_task_info(cluster_api.marathon.get('v2/apps').json(),
+                                            cluster_api.marathon.get('v2/tasks').json())
+
+    assert task_info_after_upgrade is not None, "Unable to get the tasks details of the cluster."
+    assert task_info_after_upgrade.state == "TASK_RUNNING", "Task is not in the running state."
+
+    assert task_info_before_upgrade.id == task_info_after_upgrade.id, \
+        "Task ID before and after the upgrade did not match."
+
+    # There has happened at least one health-check in the new cluster since the last health-check in the old cluster.
+    assert (task_info_after_upgrade.last_success_time >
+            task_info_before_upgrade.last_success_time + task_info_before_upgrade.health_check_interval), \
+        "Invalid health-check for the task in the upgraded cluster."
+
     result = test_util.cluster.run_integration_tests(cluster, pytest_cmd=pytest_cmd)
+
     if result == 0:
         log.info("Test successsful! Deleting VPC if provided in this run...")
         vpc.delete()
     else:
-        log.info("Test failed! VPC will remain for debugging 1 hour from instantiation")
+        log.info("Test failed! VPC cluster will remain available for debugging for 2 hour after instantiation.")
     sys.exit(result)


### PR DESCRIPTION
**Ignore this PR**

This is for doing upgrade tests using TeamCity

* With a set of changes from https://github.com/dcos/dcos/pull/1054
* Setting `"maxConsecutiveFailures": -1` in marathon app.

This will give us the information on what caused the tasks to restart. 