### PR TITLE
Bump dcos-metrics to 1.0.0-rc4

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "4878133571598d7b7b966297b4fca52f327d2224",
-    "ref_origin": "1.0.0-rc3"
+    "ref": "7afcfebfba457bff890931c8daf1ecfe1513441d",
+    "ref_origin": "1.0.0-rc4"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
Bump dcos-metrics to 1.0.0-rc4 to resolve an issue fetching the framework principal.

# Issues

N/A

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: https://github.com/dcos/dcos-metrics/compare/1.0.0-rc3...1.0.0-rc4
 - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/72/
 - [x] Code Coverage: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/72/cobertura/

