### PR TITLE
flake8 plugin for dcos.

### DIFF
--- a/flake8_dcos_lint/__version__.py
+++ b/flake8_dcos_lint/__version__.py
@@ -1,0 +1,2 @@
+PLUGIN_VERSION = '0.1'
+PLUGIN_NAME = "flake8-dcos-lint"

--- a/flake8_dcos_lint/check_rules.py
+++ b/flake8_dcos_lint/check_rules.py
@@ -1,0 +1,10 @@
+import re
+
+from collections import namedtuple
+
+CheckRegex = namedtuple("CheckRegex", "regex code reason")
+
+
+regex_rules = [
+    CheckRegex(re.compile(r'assert\s(\w+\.ok)$'), "D001", "Invalid assertion of type assert <symbol>.ok found.")
+]

--- a/flake8_dcos_lint/check_rules.py
+++ b/flake8_dcos_lint/check_rules.py
@@ -6,5 +6,6 @@ CheckRegex = namedtuple("CheckRegex", "regex code reason")
 
 
 regex_rules = [
-    CheckRegex(re.compile(r'assert\s(\w+\.ok)$'), "D001", "Invalid assertion of type assert <symbol>.ok found.")
+    # Prefer asserting actual == expected, instead of asserting on .ok on a result object.
+    CheckRegex(re.compile(r'assert\s(\w+\.ok)$'), "D001", "Assertion of type assert <symbol>.ok detected.")
 ]

--- a/flake8_dcos_lint/check_rules.py
+++ b/flake8_dcos_lint/check_rules.py
@@ -7,5 +7,7 @@ CheckRegex = namedtuple("CheckRegex", "regex code reason")
 
 regex_rules = [
     # Prefer asserting actual == expected, instead of asserting on .ok on a result object.
+    # In certain a specific instance, Response object from requests library provides a `ok` short code of type bool
+    # that is not documented, and it engulfs the status code. It is better to assert .status_code value there.
     CheckRegex(re.compile(r'assert\s(\w+\.ok)$'), "D001", "Assertion of type assert <symbol>.ok detected.")
 ]

--- a/flake8_dcos_lint/checker.py
+++ b/flake8_dcos_lint/checker.py
@@ -1,0 +1,21 @@
+import pycodestyle
+
+from __version__ import PLUGIN_NAME, PLUGIN_VERSION
+from check_rules import regex_rules
+
+
+def flake8extn(func):
+    """Decorator to Specify flake8 extension details."""
+    func.version = PLUGIN_VERSION
+    func.name = PLUGIN_NAME
+    return func
+
+
+@flake8extn
+def check(physical_line):
+    if pycodestyle.noqa(physical_line):
+        return
+    for rule in regex_rules:
+        match = rule.regex.search(physical_line)
+        if match:
+            return match.start(), "{code} {reason}".format(code=rule.code, reason=rule.reason)

--- a/flake8_dcos_lint/setup.py
+++ b/flake8_dcos_lint/setup.py
@@ -1,0 +1,21 @@
+from __version__ import PLUGIN_NAME, PLUGIN_VERSION
+
+from setuptools import setup
+
+setup(
+    name=PLUGIN_NAME,
+    version=PLUGIN_VERSION,
+    description='flake8 plugin for custom dcos checks',
+    py_modules=["check_rules", "checker"],
+    install_requires=[
+        'pycodestyle',
+        'flake8',
+        'flake8-import-order==0.9.2',
+        'pep8-naming'
+    ],
+    entry_points={
+        'flake8.extension': [
+            '{} = checker:check'.format(PLUGIN_NAME),
+        ],
+    }
+)

--- a/flake8_dcos_lint/setup.py
+++ b/flake8_dcos_lint/setup.py
@@ -1,3 +1,11 @@
+"""
+flake8 plugin for dcos code base.
+
+This is flake8 extension that provides custom code quality checks for DCOS project. The syntax rules can be added as
+Regex in check_rules.py module. New plugins can be introduced by following the flake8 extension guide
+(http://flake8.pycqa.org/en/latest/plugin-development/index.html). And they will automatically be run as part of the
+syntax-check.
+"""
 from __version__ import PLUGIN_NAME, PLUGIN_VERSION
 
 from setuptools import setup

--- a/packages/dcos-integration-test/extra/test_3dt.py
+++ b/packages/dcos-integration-test/extra/test_3dt.py
@@ -24,7 +24,7 @@ def make_3dt_request(cluster):
         assert endpoint.startswith('/'), 'endpoint {} must start with /'.format(endpoint)
         endpoint = BASE_ENDPOINT_3DT + endpoint + '?cache=0'
         response = cluster.get(path=endpoint, node=ip)
-        assert response.ok
+        assert response.status_code == 200
         try:
             json_response = response.json()
             logging.info('Response: {}'.format(json_response))

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,8 @@ testpaths =
 [testenv:py35-syntax]
 passenv =
     TEAMCITY_VERSION
-deps =
-  flake8
-  flake8-import-order==0.9.2
-  pep8-naming
-
 commands =
+  pip install -e flake8_dcos_lint
   flake8 --verbose
 
 [testenv:py35-unittests]


### PR DESCRIPTION
High level description including:

* Provides ability to add custom rule checks.

# Issues

[DCOS-12408](https://mesosphere.atlassian.net/browse/DCOS-12408)
...

# Checklist

* The code style test will fail with the introduction of this plugin. Proof that the checking with rules works.
```
./packages/dcos-integration-test/extra/test_3dt.py:27:9: D001 Invalid assertion of type assert <symbol>.ok found.
```

# Example Failure

* https://teamcity.mesosphere.io/viewLog.html?buildId=517381 


