### PR TITLE
dcos-log: remove bootstrap

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -71,8 +71,6 @@ bootstrappers = {
     'dcos-minuteman': noop,
     'dcos-navstar': noop,
     'dcos-spartan': noop,
-    'dcos-log-master': noop,
-    'dcos-log-agent': noop,
 }
 
 

--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "c2c3ce9ab8236cd4cb47bb62a1bf8464360c5871",
+    "ref": "86c5cb00c6942a9008b0c345c810137c93fa89b4",
     "ref_origin": "master"
   },
   "username": "dcos_log",

--- a/packages/dcos-log/extra/dcos-log-agent.service
+++ b/packages/dcos-log/extra/dcos-log-agent.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=DC/OS Log service agent: DC/OS logging service
 [Service]
-PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-log.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-log-extra.env
@@ -9,5 +8,4 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 User=dcos_log
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-log-agent
-ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH} 
+ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}

--- a/packages/dcos-log/extra/dcos-log-master.service
+++ b/packages/dcos-log/extra/dcos-log-master.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=DC/OS Log service master: DC/OS logging service
 [Service]
-PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-log.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-log-extra.env
@@ -9,5 +8,4 @@ Restart=always
 StartLimitInterval=0
 RestartSec=5
 User=dcos_log
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-log-master
 ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}


### PR DESCRIPTION
no bootstrap required anymore for dcos-logs in upstream

High level description including:
 - Bump dcos-log
 - Remove the bootstrap from dcos-log

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: https://github.com/dcos/dcos-log/pull/28 https://github.com/dcos/dcos-go/pull/21
 - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/dcos-log%20pull%20requests/71/
 - [x] Code Coverage: https://jenkins.mesosphere.com/service/jenkins/job/dcos-log%20pull%20requests/71/

