### PR TITLE
Upgrade dcos-vagrant SHA for the Vagrant Integration Tests.

### DIFF
--- a/test_util/run-all
+++ b/test_util/run-all
@@ -33,7 +33,7 @@ else
 fi
 
 # Pin to just the right dcos-vagrant commit
-git -C dcos-vagrant checkout -qf 7b0b56bde93b8f2b65bb9ec50cd8a0ca932033b2
+git -C dcos-vagrant checkout -qf 2b323c4c1942e3f6d484a7375e749929356a4417
 
 cp ../dcos_generate_config.sh dcos-vagrant/dcos_generate_config.sh
 
@@ -58,6 +58,7 @@ cp VagrantConfig.yaml.example VagrantConfig.yaml
 export DCOS_INSTALL_METHOD="ssh_pull"
 export DCOS_CONFIG_PATH="etc/3_master.yaml"
 export DCOS_PRIVATE_REGISTRY="true"
+export DCOS_GENERATE_CONFIG_PATH="dcos_generate_config.sh"
 cat <<EOF > "$DCOS_CONFIG_PATH"
 ---
 cluster_name: test_cluster


### PR DESCRIPTION
This change upgrades the dcos-vagrant version to a most recent update on Dec 16, 2016.
* [dcos-vagrant-Changes](https://github.com/dcos/dcos-vagrant/compare/7b0b56bde93b8f2b65bb9ec50cd8a0ca932033b2...2b323c4c1942e3f6d484a7375e749929356a4417)

Since that update is backwards compatible no config changes in the repo were required.

Furthermore,  this was tested with

```

    root@agent1:~# vagrant --version
    Vagrant 1.9.1
    root@agent1:~# vbox-img --version
    5.1.12r112440
```

And some of the flakiness that we observe with vagrant integration tests were not observed under this configuration.

