### PR TITLE
Grab latest fix to package describe and install

### DIFF
--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.3.0-SNAPSHOT-154-refs_heads_master-ab3cba08fc/cosmos-server-0.3.0-SNAPSHOT-154-refs_heads_master-ab3cba08fc-one-jar.jar",
-    "sha1": "869648a327aef95c7f84bab49da9814d7b144ac3"
+    "url": "https://downloads.dcos.io/cosmos/0.3.0-SNAPSHOT-165-refs_heads_master-3bd27057a6/cosmos-server-0.3.0-SNAPSHOT-165-refs_heads_master-3bd27057a6-one-jar.jar",
+    "sha1": "cf69602d06f80b0632f7d504ee13cb6634297a76"
   },
   "username": "dcos_cosmos",
   "state_directory": true


### PR DESCRIPTION
High level description including:
 - What does this change enable
 - What bugs does this change fix
 - High-Level how things changed

# Issues

[DCOS-12411](https://mesosphere.atlassian.net/browse/DCOS-12411)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not:
  1. https://github.com/dcos/cosmos/commit/da39604cdacbc4f79c84f397ec7fc0d14b83c47c#diff-c51a7c12e1cf4f27093f6f1caf7b54b4
  1. https://teamcity.mesosphere.io/viewQueued.html?itemId=520272
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

- [x] Change Log from last:
 -  Return postInstallNotes instead of uninstall notes ([#560](https://github.com/dcos/cosmos/pull/560)) 
 - Make sure that we set None to false for selected and framework ([#559](https://github.com/dcos/cosmos/pull/559))
 - Add ServiceAlreadyStarted error ([#557](https://github.com/dcos/cosmos/pull/557))
 - Fix package ordering ([#558](https://github.com/dcos/cosmos/pull/558))
 - Remove appId field from ServiceStartRequest ([#555](https://github.com/dcos/cosmos/pull/555))
 - Integration tests for /service/start ([#552](https://github.com/dcos/cosmos/pull/552))
- [x] Test Results: Cosmos integration tests pass.
- [ ] Code Coverage: