### PR TITLE
 Launch prereqs

### DIFF
--- a/test_util/runner.py
+++ b/test_util/runner.py
@@ -4,10 +4,8 @@ Note: ssh_user must be able to use docker without sudo privileges
 """
 import logging
 import sys
-from os.path import join
 from subprocess import CalledProcessError
 
-from pkgpanda.util import write_string
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
@@ -15,14 +13,13 @@ log = logging.getLogger(__name__)
 
 
 def integration_test(
-        tunnel, test_dir,
+        tunnel,
         dcos_dns, master_list, agent_list, public_agent_list,
-        aws_access_key_id='', aws_secret_access_key='', region='', add_env=None,
-        pytest_cmd='py.test -vv -s -rs'):
+        aws_access_key_id='', aws_secret_access_key='', region='',
+        test_cmd='py.test'):
     """Runs integration test on host
 
     Args:
-        test_dir: directory to leave test_wrapper.sh
         dcos_dns: string representing IP of DCOS DNS host
         master_list: string of comma separated master addresses
         agent_list: string of comma separated agent addresses
@@ -30,15 +27,14 @@ def integration_test(
         aws_access_key_id: needed for REXRAY tests
         aws_secret_access_key: needed for REXRAY tests
         region: string indicating AWS region in which cluster is running
-        add_env: a python dict with any number of key=value assignments to be passed to
-            the test environment
-        pytest_cmd: string representing command for py.test
+        test_cmd: string to be passed to dcos-shell using
+            /opt/mesosphere/active/dcos-integration-test as the working dir
 
     Returns:
-        exit code corresponding to test_cmd run
+        exit code from last test command
 
     """
-    test_env = [
+    required_test_env = [
         'DCOS_DNS_ADDRESS=http://' + dcos_dns,
         'MASTER_HOSTS=' + ','.join(master_list),
         'PUBLIC_MASTER_HOSTS=' + ','.join(master_list),
@@ -47,34 +43,20 @@ def integration_test(
         'AWS_ACCESS_KEY_ID=' + aws_access_key_id,
         'AWS_SECRET_ACCESS_KEY=' + aws_secret_access_key,
         'AWS_REGION=' + region]
-    if add_env:
-        for key, value in add_env.items():
-            extra_env = key + '=' + value
-            test_env.append(extra_env)
 
-    test_env_str = ''.join(['export ' + e + '\n' for e in test_env])
+    pytest_form = """'source /opt/mesosphere/environment.export &&
+cd /opt/mesosphere/active/dcos-integration-test &&
+{env} {cmd}'"""
 
-    test_boilerplate = """#!/bin/bash
-{env}
-cd /opt/mesosphere/active/dcos-integration-test
-/opt/mesosphere/bin/dcos-shell {cmd}
-"""
+    preflight_cmd_str = pytest_form.format(env=' '.join(required_test_env), cmd='py.test --collect-only')
+    test_cmd_str = pytest_form.format(env=' '.join(required_test_env), cmd=test_cmd)
 
-    write_string('test_preflight.sh', test_boilerplate.format(
-        env=test_env_str, cmd='py.test -rs -vv --collect-only'))
-    write_string('test_wrapper.sh', test_boilerplate.format(
-        env=test_env_str, cmd=pytest_cmd))
-
-    pretest_path = join(test_dir, 'test_preflight.sh')
     log.info('Running integration test setup check...')
-    tunnel.write_to_remote('test_preflight.sh', pretest_path)
-    tunnel.remote_cmd(['bash', pretest_path], stdout=sys.stdout.buffer)
+    tunnel.remote_cmd(['bash', '-c', preflight_cmd_str], stdout=sys.stdout.buffer)
 
-    wrapper_path = join(test_dir, 'test_wrapper.sh')
     log.info('Running integration test...')
-    tunnel.write_to_remote('test_wrapper.sh', wrapper_path)
     try:
-        tunnel.remote_cmd(['bash', wrapper_path], stdout=sys.stdout.buffer)
+        tunnel.remote_cmd(['bash', '-c', test_cmd_str], stdout=sys.stdout.buffer)
     except CalledProcessError as e:
         return e.returncode
     return 0

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -39,6 +39,7 @@ import uuid
 
 import test_util.aws
 import test_util.cluster
+from pkgpanda.util import load_string
 from test_util.cluster_api import ClusterApi
 from test_util.helpers import CI_AUTH_JSON, DcosUser
 from test_util.marathon import TEST_APP_NAME_FMT
@@ -109,7 +110,7 @@ def main():
     num_public_agents = int(os.getenv('PUBLIC_AGENTS', '1'))
     stack_name = 'upgrade-test-' + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
 
-    pytest_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -s -rs ' + os.getenv('CI_FLAGS', ''))
+    test_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -s -rs ' + os.getenv('CI_FLAGS', ''))
 
     stable_installer_url = os.environ['STABLE_INSTALLER_URL']
     installer_url = os.environ['INSTALLER_URL']
@@ -132,7 +133,7 @@ def main():
     cluster = test_util.cluster.Cluster.from_vpc(
         vpc,
         ssh_info,
-        ssh_key_path=os.getenv('DCOS_SSH_KEY_PATH', 'default_ssh_key'),
+        ssh_key=load_string(os.getenv('DCOS_SSH_KEY_PATH', 'default_ssh_key')),
         num_masters=num_masters,
         num_agents=num_agents,
         num_public_agents=num_public_agents,
@@ -183,7 +184,7 @@ def main():
             task_info_before_upgrade.last_success_time + task_info_before_upgrade.health_check_interval), \
         "Invalid health-check for the task in the upgraded cluster."
 
-    result = test_util.cluster.run_integration_tests(cluster, pytest_cmd=pytest_cmd)
+    result = test_util.cluster.run_integration_tests(cluster, test_cmd=test_cmd)
 
     if result == 0:
         log.info("Test successsful! Deleting VPC if provided in this run...")


### PR DESCRIPTION
- no longer pass ssh_key_path, but rather the key contents
  ssh/tunnel.py now handles creating a temp key file with the
  correct permissions (and cleans it up)
- safer passing of AWS parameters by casting to str
- no longer need to write to remote host in order to test;
  now, everything is injected as a command
- removes unused code in ssh/tunnel.py
- removes unused code in test_util/installer_api_test.py
- no longer pass add_env separately in internals

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not (N/A this PR removes cruft)
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
