### PR TITLE
Bump dcos-mesos to Apache Mesos 1.0.3-rc1

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,15 +1,18 @@
-<H2>Patches to cherry-pick from mesosphere/mesos on top of open source Apache Mesos 0.28 or later:</h2>
+<H2>Patches to cherry-pick from mesosphere/mesos on top of open source Apache Mesos</h2>
+<H3>WebUI magic for DC/OS' reverse proxy</H3>
 <li>[4f6515e6a92370a2bcd4cd1f45ef08056f45c88a] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[cfbce38cd810e221b3fd1318fdb554857ef64a1d] Changed agent_host to expect a relative path.
+<li>[c0da3d7468787edb93d4c79bcdf5d1d9e7de678a] Revert "Fixed the broken metrics information of master in WebUI."
+
+<H3>LIBPROCESS_IP workaround</H3>
 <li>[23f157a4bffad38b2829bf544e24f8d490cd7b5d] Set LIBPROCESS_IP into docker container.
 
-<H2>Patches to cherry-pick from mesosphere/mesos on top of open source Apache Mesos 1.0:</h2>
-<li>[377bb78a1ca109447201f9d0909afcd91fdc8fda] Removed `O_SYNC` from StatusUpdateManager. (landing in 1.1.0)
-<li>[e8c81c1c5684079890dae24e0dce2806aff507a7] Added flag in logrotate module to control number of libprocess threads. (landing in 1.1.0)
-<li>[e444edd6e7d45eb842fe223ac484a4bc4c1a327a] Allowed all flags load methods to specify a prefix. (landing in 1.1.0)
-<li>[3dd498d797a44593d376b4d50a33e2b8214c0dd4] Split src/openssl.hpp adding include/process/ssl/flags.hpp. (landing in 1.1.0)
-<li>[f6581f2e8fcb07074fca9e72b3134476f6fc74ab] Updated includes to follow the SSL flag split. (landing in 1.1.0)
-<li>[a22b5dd552168a8dd925682f3b349059e10fc3d3] Modified network file setup in `network/cni` isolator. (landing in 1.1.0)
-<li>[3e703af02bc309a9d6653392d02627bf3d3ce930] Updated logrotation module to use `os::pagesize()`. (landing in 1.1.0)
-<li>[1d45ba9f4f7f943d24282e0a91fb01c68815d6c3] Fixed sign comparisons in logrotate module. (landing in 1.1.0)
-<li>[b546e7544c04a6d3e0da87cd6207ae8f4d827add] Added a way to set logrotate settings per executor. (landing in 1.1.0)
+<H3>Backports from master that are landing in Mesos 1.1.0</H3>
+<li>[377bb78a1ca109447201f9d0909afcd91fdc8fda] Removed `O_SYNC` from StatusUpdateManager.
+<li>[e8c81c1c5684079890dae24e0dce2806aff507a7] Added flag in logrotate module to control number of libprocess threads.
+<li>[3dd498d797a44593d376b4d50a33e2b8214c0dd4] Split src/openssl.hpp adding include/process/ssl/flags.hpp.
+<li>[f6581f2e8fcb07074fca9e72b3134476f6fc74ab] Updated includes to follow the SSL flag split.
+<li>[a22b5dd552168a8dd925682f3b349059e10fc3d3] Modified network file setup in `network/cni` isolator.
+<li>[3e703af02bc309a9d6653392d02627bf3d3ce930] Updated logrotation module to use `os::pagesize()`.
+<li>[1d45ba9f4f7f943d24282e0a91fb01c68815d6c3] Fixed sign comparisons in logrotate module.
+<li>[b546e7544c04a6d3e0da87cd6207ae8f4d827add] Added a way to set logrotate settings per executor.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "d5746045ac740d5f28f238dc55ec95c89d2b7cd9",
-    "ref_origin" : "dcos-mesos-1.0.x-837bb4e"
+    "ref": "3d4a8d7caec7cd0239dbc40e39c8ec4d965a9a67",
+    "ref_origin" : "dcos-mesos-1.0.3-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Includes various fixes deemed worthy enough to backport to Apache Mesos 1.0.2 and 1.0.3.
Puts DC/OS 1.8.x on an official Mesos tag (more or less).

# Issues

[DCOS-11525](https://mesosphere.atlassian.net/browse/DCOS-11525) Include Mesos 1.0.3 in dcos-mesos
[DCOS-12412](https://mesosphere.atlassian.net/browse/DCOS-12412) Agents disconnected from the cluster after installing kafka service

# Checklist

 - [X] Included a test which will fail if code is reverted but test is not; extensive Mesos unit tests
 - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [X] Change Log from last: https://raw.githubusercontent.com/apache/mesos/1.0.2/CHANGELOG
    https://github.com/mesosphere/mesos/compare/dcos-mesos-1.0.x-837bb4e...mesosphere:dcos-mesos-1.0.3-rc1
 - [X] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/189/ which is the same as the [last 1.0.2 build](https://jenkins.mesosphere.com/service/jenkins//job/mesos/job/Mesos_CI-build/63/), except for the additional Clang/Mac/centos6 coverage.
 - [x] Code Coverage: N/A

