### PR TITLE
make the awk script compatible with both mawk and gawk

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -317,10 +317,10 @@ function check_all() {
             if(client_version == server_version) {
                 version = client_version
             } else {
-                split(client_version, cv, ".")
-                split(server_version, sv, ".")
+                cv_length = split(client_version, cv, ".")
+                sv_length = split(server_version, sv, ".")
 
-                y = length(cv) > length(sv) ? length(cv) : length(sv)
+                y = cv_length > sv_length ? cv_length : sv_length
 
                 for(i = 1; i <= y; i++) {
                     if(cv[i] < sv[i]) {


### PR DESCRIPTION

When installing dcos by cli, I got following error while running `bash dcos_install.sh master` 
```
# bash dcos_install.sh master
Starting DC/OS Install Process
Running preflight checks
Checking if DC/OS is already installed: PASS (Not installed)
PASS Is SELinux disabled?
awk: line 32: illegal reference to array cv
awk: line 32: illegal reference to array sv
awk: line 32: illegal reference to array cv
awk: line 32: illegal reference to array sv
Checking if docker is installed and in PATH: PASS
dcos_install.sh: line 232: $3: unbound variable
```

related code:
```
                y = length(cv) > length(sv) ? length(cv) : length(sv)
```

I found it's because that debian default installed mawk doesn't support length(ARRAY).

Then I changed like this pull request and it works.
It supports both mawk and gawk.

