### PR TITLE
Switch remaining pieces to Python 3.5

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 # Create a python virtual environment to install the DC/OS tools to
-python3.4 -m venv /tmp/dcos_build_venv
+python3.5 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_teamcity
+++ b/build_teamcity
@@ -25,7 +25,7 @@ rm -rf wheelhouse/
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-virtualenv --always-copy --python=python3.4 build/env
+python3.5 -m venv --clear --copies build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ testpaths =
   packages/dcos-history/extra/
   tests
 
-[testenv:py34-syntax]
+[testenv:py35-syntax]
 passenv =
     TEAMCITY_VERSION
 deps =
@@ -34,7 +34,7 @@ deps =
 commands =
   flake8 --verbose
 
-[testenv:py34-unittests]
+[testenv:py35-unittests]
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
@@ -57,7 +57,11 @@ deps =
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 
-[testenv:py34-pkgpanda-build]
+# pkgpanda build tests are kept separate from the rest because they take a while
+# (lots of calls to docker). They also currently assume that they're run with a
+# specific working directory (something that should be fixed).
+[testenv:py35-pkgpanda-build]
+>>>>>>> 174e0f9... Switch remaining pieces to Python 3.5
 passenv =
   TEAMCITY_VERSION
 deps=
@@ -87,7 +91,7 @@ changedir=pkgpanda/tests/integration_tests
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 
-[testenv:py34-bootstrap]
+[testenv:py35-bootstrap]
 passenv =
   TEAMCITY_VERSION
 deps=


### PR DESCRIPTION
Allow 1.8.7 builds by switching python tooling to match current CI python
