### PR TITLE
Rename cluster -> dcos_api_session

### DIFF
--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -1,14 +1,14 @@
 """This file has only one function: to provide a correctly configured
-ClusterApi object that will be injected into the pytest 'cluster' fixture
-via the make_cluster_fixture() method
+ClusterApi object that will be injected into the pytest 'dcos_api_session' fixture
+via the make_dcos_api_session_fixture() method
 """
 from test_util.cluster_api import ClusterApi, get_args_from_env
 from test_util.helpers import CI_AUTH_JSON, DcosUser
 
 
-def make_cluster_fixture():
+def make_session_fixture():
     args = get_args_from_env()
     args['web_auth_default_user'] = DcosUser(CI_AUTH_JSON)
-    cluster_api = ClusterApi(**args)
-    cluster_api.wait_for_dcos()
-    return cluster_api
+    dcos_api_session = ClusterApi(**args)
+    dcos_api_session.wait_for_dcos()
+    return dcos_api_session

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from cluster_fixture import make_cluster_fixture
+from api_session_fixture import make_session_fixture
 
 from test_util.marathon import get_test_app
 
@@ -32,7 +32,7 @@ def pytest_collection_modifyitems(session, config, items):
 
 
 @pytest.fixture
-def vip_apps(cluster):
+def vip_apps(dcos_api_session):
     vip1 = '6.6.6.1:6661'
     test_app1, _ = get_test_app()
     test_app1['portDefinitions'][0]['labels'] = {
@@ -41,11 +41,11 @@ def vip_apps(cluster):
     test_app2['portDefinitions'][0]['labels'] = {
         'VIP_0': 'foobarbaz:5432'}
     vip2 = 'foobarbaz.marathon.l4lb.thisdcos.directory:5432'
-    with cluster.marathon.deploy_and_cleanup(test_app1):
-        with cluster.marathon.deploy_and_cleanup(test_app2):
+    with dcos_api_session.marathon.deploy_and_cleanup(test_app1):
+        with dcos_api_session.marathon.deploy_and_cleanup(test_app2):
             yield ((test_app1, vip1), (test_app2, vip2))
 
 
 @pytest.fixture(scope='session')
-def cluster():
-    return make_cluster_fixture()
+def dcos_api_session():
+    return make_session_fixture()

--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(scope='session')
-def dcos_launchpad(cluster):
+def dcos_launchpad(dcos_api_session):
     """Interface for direct integration to dcos_launchpad hardware
     Currently only supports AWS CF with AWS VPC coming soon
     """
@@ -31,7 +31,7 @@ def dcos_launchpad(cluster):
 
 
 @pytest.mark.last
-def test_agent_failure(dcos_launchpad, cluster, vip_apps):
+def test_agent_failure(dcos_launchpad, dcos_api_session, vip_apps):
     # make sure the app works before starting
     @retry_boto_rate_limits
     def get_running_agents(group_name):
@@ -49,29 +49,29 @@ def test_agent_failure(dcos_launchpad, cluster, vip_apps):
     retry_boto_rate_limits(waiter.wait)(InstanceIds=agents)
 
     # Tell mesos the machines are "down" and not coming up so things get rescheduled.
-    down_hosts = [{'hostname': slave, 'ip': slave} for slave in cluster.all_slaves]
-    cluster.post(
+    down_hosts = [{'hostname': slave, 'ip': slave} for slave in dcos_api_session.all_slaves]
+    dcos_api_session.post(
         '/mesos/maintenance/schedule',
         json={'windows': [{
             'machine_ids': down_hosts,
             'unavailability': {'start': {'nanoseconds': 0}}
         }]}).raise_for_status()
-    cluster.post('/mesos/machine/down', json=down_hosts).raise_for_status()
+    dcos_api_session.post('/mesos/machine/down', json=down_hosts).raise_for_status()
 
     # Wait for replacements
-    test_util.helpers.wait_for_len(partial(get_running_agents, 'SlaveServerGroup'), len(cluster.slaves), 600)
+    test_util.helpers.wait_for_len(partial(get_running_agents, 'SlaveServerGroup'), len(dcos_api_session.slaves), 600)
     test_util.helpers.wait_for_len(
-        partial(get_running_agents, 'PublicSlaveServerGroup'), len(cluster.public_slaves), 600)
+        partial(get_running_agents, 'PublicSlaveServerGroup'), len(dcos_api_session.public_slaves), 600)
 
-    # Reset the cluster to have the replacement agents
-    cluster.slaves = sorted([agent.private_ip_address for agent in
-                             get_running_agents('SlaveServerGroup')])
-    cluster.public_slaves = sorted([agent.private_ip_address for agent in
-                                    get_running_agents('PublicSlaveServerGroup')])
-    cluster.all_slaves = sorted(cluster.slaves + cluster.public_slaves)
+    # Reset the dcos_api_session to have the replacement agents
+    dcos_api_session.slaves = sorted([agent.private_ip_address for agent in
+                                      get_running_agents('SlaveServerGroup')])
+    dcos_api_session.public_slaves = sorted([agent.private_ip_address for agent in
+                                             get_running_agents('PublicSlaveServerGroup')])
+    dcos_api_session.all_slaves = sorted(dcos_api_session.slaves + dcos_api_session.public_slaves)
 
     # verify that everything else is still working
-    cluster.wait_for_dcos()
+    dcos_api_session.wait_for_dcos()
     # finally verify that the app is again running somewhere with its VIPs
     # Give marathon five minutes to deploy both the apps
     test_util.helpers.wait_for_pong(vip_apps[0][1], 300)

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -3,7 +3,7 @@ import uuid
 from test_util.marathon import get_test_app, get_test_app_in_docker
 
 
-def test_if_marathon_app_can_be_deployed(cluster):
+def test_if_marathon_app_can_be_deployed(dcos_api_session):
     """Marathon app deployment integration test
 
     This test verifies that marathon app can be deployed, and that service points
@@ -17,19 +17,19 @@ def test_if_marathon_app_can_be_deployed(cluster):
     "GET /test_uuid" request is issued to the app. If the returned UUID matches
     the one assigned to test - test succeeds.
     """
-    cluster.marathon.deploy_test_app_and_check(*get_test_app())
+    dcos_api_session.marathon.deploy_test_app_and_check(*get_test_app())
 
 
-def test_if_docker_app_can_be_deployed(cluster):
+def test_if_docker_app_can_be_deployed(dcos_api_session):
     """Marathon app inside docker deployment integration test.
 
     Verifies that a marathon app inside of a docker daemon container can be
     deployed and accessed as expected.
     """
-    cluster.marathon.deploy_test_app_and_check(*get_test_app_in_docker(ip_per_container=False))
+    dcos_api_session.marathon.deploy_test_app_and_check(*get_test_app_in_docker(ip_per_container=False))
 
 
-def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
+def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(dcos_api_session):
     """Marathon app deployment integration test using the Mesos Containerizer
 
     This test verifies that a Marathon app using the Mesos containerizer with
@@ -56,10 +56,10 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(cluster):
             'mode': 'RO'
         }]
     }
-    cluster.marathon.deploy_test_app_and_check(app, test_uuid)
+    dcos_api_session.marathon.deploy_test_app_and_check(app, test_uuid)
 
 
-def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(cluster):
+def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_session):
     """Marathon pods deployment integration test using the Mesos Containerizer
 
     This test verifies that a Marathon pods can be deployed.
@@ -89,12 +89,12 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(cluster):
         'networks': [{'mode': 'host'}]
     }
 
-    with cluster.marathon.deploy_pod_and_cleanup(pod_definition):
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
         pass
 
 
-def test_octarine_http(cluster, timeout=30):
+def test_octarine_http(dcos_api_session, timeout=30):
     """
     Test if we are able to send traffic through octarine.
     """
@@ -125,10 +125,10 @@ def test_octarine_http(cluster, timeout=30):
         }]
     }
 
-    cluster.marathon.deploy_and_cleanup(app_definition)
+    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
 
 
-def test_octarine_srv(cluster, timeout=30):
+def test_octarine_srv(dcos_api_session, timeout=30):
     """
     Test resolving SRV records through octarine.
     """
@@ -172,24 +172,24 @@ def test_octarine_srv(cluster, timeout=30):
         }]
     }
 
-    cluster.marathon.deploy_and_cleanup(app_definition)
+    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
 
 
-def test_pkgpanda_api(cluster):
+def test_pkgpanda_api(dcos_api_session):
 
     def get_and_validate_package_ids(node, path):
-        r = cluster.get(node=node, path=path)
+        r = dcos_api_session.get(node=node, path=path)
         assert r.status_code == 200
         package_ids = r.json()
         assert isinstance(package_ids, list)
         for package_id in package_ids:
-            r = cluster.get(node=node, path=path + package_id)
+            r = dcos_api_session.get(node=node, path=path + package_id)
             assert r.status_code == 200
             name, version = package_id.split('--')
             assert r.json() == {'id': package_id, 'name': name, 'version': version}
         return package_ids
 
-    active_buildinfo = cluster.get('/pkgpanda/active.buildinfo.full.json').json()
+    active_buildinfo = dcos_api_session.get('/pkgpanda/active.buildinfo.full.json').json()
     active_buildinfo_packages = sorted(
         # Setup packages don't have a buildinfo.
         (package_name, info['package_version'] if info else None)
@@ -206,7 +206,7 @@ def test_pkgpanda_api(cluster):
             else:
                 assert package == buildinfo_package
 
-    for node in cluster.masters + cluster.all_slaves:
+    for node in dcos_api_session.masters + dcos_api_session.all_slaves:
         package_ids = get_and_validate_package_ids(node, '/pkgpanda/repository/')
         active_package_ids = get_and_validate_package_ids(node, '/pkgpanda/active/')
 

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -4,8 +4,8 @@ import pytest
 
 
 @pytest.fixture(scope='module')
-def noauth_cluster(cluster):
-    return cluster.get_user_session(None)
+def noauth_dcos_api_session(dcos_api_session):
+    return dcos_api_session.get_user_session(None)
 
 
 def auth_enabled():
@@ -19,8 +19,8 @@ def auth_enabled():
 
 @pytest.mark.skipif(not auth_enabled(),
                     reason='Can only test adminrouter enforcement if auth is enabled')
-def test_adminrouter_access_control_enforcement(cluster, noauth_cluster):
-    r = noauth_cluster.get('/acs/api/v1')
+def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_dcos_api_session):
+    r = noauth_dcos_api_session.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')
     # Make sure that this is UI's error page body,
@@ -31,26 +31,26 @@ def test_adminrouter_access_control_enforcement(cluster, noauth_cluster):
     # Verify that certain locations are forbidden to access
     # when not authed, but are reachable as superuser.
     for path in ('/mesos_dns/v1/config', '/service/marathon/', '/mesos/'):
-        r = noauth_cluster.get(path)
+        r = noauth_dcos_api_session.get(path)
         assert r.status_code == 401
-        r = cluster.get(path)
+        r = dcos_api_session.get(path)
         assert r.status_code == 200
 
     # Test authentication with auth cookie instead of Authorization header.
     authcookie = {
-        'dcos-acs-auth-cookie': cluster.web_auth_default_user.auth_cookie}
-    r = noauth_cluster.get(
+        'dcos-acs-auth-cookie': dcos_api_session.web_auth_default_user.auth_cookie}
+    r = noauth_dcos_api_session.get(
         '/service/marathon/',
         cookies=authcookie)
     assert r.status_code == 200
 
 
-def test_logout(cluster):
+def test_logout(dcos_api_session):
     """Test logout endpoint. It's a soft logout, instructing
     the user agent to delete the authentication cookie, i.e. this test
     does not have side effects on other tests.
     """
-    r = cluster.get('/acs/api/v1/auth/logout')
+    r = dcos_api_session.get('/acs/api/v1/auth/logout')
     cookieheader = r.headers['set-cookie']
     assert 'dcos-acs-auth-cookie=;' in cookieheader or 'dcos-acs-auth-cookie="";' in cookieheader
     assert 'expires' in cookieheader.lower()

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -11,15 +11,17 @@ import requests
 
 from test_helpers import dcos_config
 
+from pkgpanda.util import load_json, load_string
+
 
 @pytest.mark.first
-def test_cluster_is_up(cluster):
+def test_dcos_cluster_is_up(dcos_api_session):
     pass
 
 
-def test_leader_election(cluster):
+def test_leader_election(dcos_api_session):
     mesos_resolver = dns.resolver.Resolver()
-    mesos_resolver.nameservers = cluster.public_masters
+    mesos_resolver.nameservers = dcos_api_session.public_masters
     mesos_resolver.port = 61053
     try:
         mesos_resolver.query('leader.mesos', 'A')
@@ -27,10 +29,10 @@ def test_leader_election(cluster):
         assert False, "Cannot resolve leader.mesos"
 
 
-def test_if_all_mesos_masters_have_registered(cluster):
+def test_if_all_mesos_masters_have_registered(dcos_api_session):
     # Currently it is not possible to extract this information through Mesos'es
     # API, let's query zookeeper directly.
-    zk = kazoo.client.KazooClient(hosts=cluster.zk_hostports, read_only=True)
+    zk = kazoo.client.KazooClient(hosts=dcos_api_session.zk_hostports, read_only=True)
     master_ips = []
 
     zk.start()
@@ -41,16 +43,16 @@ def test_if_all_mesos_masters_have_registered(cluster):
         master_ips.append(master['address']['ip'])
     zk.stop()
 
-    assert sorted(master_ips) == cluster.masters
+    assert sorted(master_ips) == dcos_api_session.masters
 
 
-def test_if_all_exhibitors_are_in_sync(cluster):
-    r = cluster.get('/exhibitor/exhibitor/v1/cluster/status')
+def test_if_all_exhibitors_are_in_sync(dcos_api_session):
+    r = dcos_api_session.get('/exhibitor/exhibitor/v1/cluster/status')
     assert r.status_code == 200
 
     correct_data = sorted(r.json(), key=lambda k: k['hostname'])
 
-    for zk_ip in cluster.public_masters:
+    for zk_ip in dcos_api_session.public_masters:
         resp = requests.get('http://{}:8181/exhibitor/v1/cluster/status'.format(zk_ip))
         assert resp.status_code == 200
 
@@ -58,17 +60,17 @@ def test_if_all_exhibitors_are_in_sync(cluster):
         assert correct_data == tested_data
 
 
-def test_mesos_agent_role_assignment(cluster):
+def test_mesos_agent_role_assignment(dcos_api_session):
     state_endpoint = '/state.json'
-    for agent in cluster.public_slaves:
-        r = cluster.get(path=state_endpoint, node=agent, port=5051)
+    for agent in dcos_api_session.public_slaves:
+        r = dcos_api_session.get(path=state_endpoint, node=agent, port=5051)
         assert r.json()['flags']['default_role'] == 'slave_public'
-    for agent in cluster.slaves:
-        r = cluster.get(path=state_endpoint, node=agent, port=5051)
+    for agent in dcos_api_session.slaves:
+        r = dcos_api_session.get(path=state_endpoint, node=agent, port=5051)
         assert r.json()['flags']['default_role'] == '*'
 
 
-def test_signal_service(cluster):
+def test_signal_service(dcos_api_session):
     """
     signal-service runs on an hourly timer, this test runs it as a one-off
     and pushes the results to the test_server app for easy retrieval
@@ -76,21 +78,19 @@ def test_signal_service(cluster):
     # This is due to caching done by 3DT / Signal service
     # We're going to remove this soon: https://mesosphere.atlassian.net/browse/DCOS-9050
     dcos_version = os.environ["DCOS_VERSION"]
-    signal_config = open('/opt/mesosphere/etc/dcos-signal-config.json', 'r')
-    signal_config_data = json.loads(signal_config.read())
+    signal_config_data = load_json('/opt/mesosphere/etc/dcos-signal-config.json')
     customer_key = signal_config_data.get('customer_key', '')
     enabled = signal_config_data.get('enabled', 'false')
-    cluster_id_file = open('/var/lib/dcos/cluster-id')
-    cluster_id = cluster_id_file.read().strip()
+    cluster_id = load_string('/var/lib/dcos/cluster-id').strip()
 
     if enabled == 'false':
         pytest.skip('Telemetry disabled in /opt/mesosphere/etc/dcos-signal-config.json... skipping test')
 
-    print("Version: ", dcos_version)
-    print("Customer Key: ", customer_key)
-    print("Cluster ID: ", cluster_id)
+    logging.info("Version: ", dcos_version)
+    logging.info("Customer Key: ", customer_key)
+    logging.info("Cluster ID: ", cluster_id)
 
-    direct_report = cluster.get('/system/health/v1/report?cache=0')
+    direct_report = dcos_api_session.get('/system/health/v1/report?cache=0')
     signal_results = subprocess.check_output(["/opt/mesosphere/bin/dcos-signal", "-test"], universal_newlines=True)
     r_data = json.loads(signal_results)
 
@@ -180,20 +180,22 @@ def test_signal_service(cluster):
     master_units.append('oauth-service')
 
     for unit in master_units:
-        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.masters)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(dcos_api_session.masters)
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in all_node_units:
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(
-            cluster.all_slaves + cluster.masters)
+            dcos_api_session.all_slaves + dcos_api_session.masters)
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in slave_units:
-        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(dcos_api_session.slaves)
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in public_slave_units:
-        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.public_slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] \
+            = len(dcos_api_session.public_slaves)
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
     for unit in all_slave_units:
-        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] = len(cluster.all_slaves)
+        exp_data['diagnostics']['properties']["health-unit-dcos-{}-total".format(unit)] \
+            = len(dcos_api_session.all_slaves)
         exp_data['diagnostics']['properties']["health-unit-dcos-{}-unhealthy".format(unit)] = 0
 
     def check_signal_data():

--- a/packages/dcos-integration-test/extra/test_ec2.py
+++ b/packages/dcos-integration-test/extra/test_ec2.py
@@ -6,14 +6,14 @@ import pytest
 
 
 @pytest.mark.ccm
-def test_move_external_volume_to_new_agent(cluster):
+def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 
-    If the cluster has only one agent, the volume will be detached and
+    If the dcos_api_session has only one agent, the volume will be detached and
     reattached to the same agent.
 
     """
-    hosts = cluster.slaves[0], cluster.slaves[-1]
+    hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex
     test_label = 'integration-test-move-external-volume-{}'.format(test_uuid)
     mesos_volume_path = 'volume'
@@ -76,9 +76,9 @@ def test_move_external_volume_to_new_agent(cluster):
     }
 
     try:
-        with cluster.marathon.deploy_and_cleanup(write_app, **deploy_kwargs):
+        with dcos_api_session.marathon.deploy_and_cleanup(write_app, **deploy_kwargs):
             logging.info('Successfully wrote to volume')
-        with cluster.marathon.deploy_and_cleanup(read_app, **deploy_kwargs):
+        with dcos_api_session.marathon.deploy_and_cleanup(read_app, **deploy_kwargs):
             logging.info('Successfully read from volume')
     finally:
         logging.info('Deleting volume: ' + test_label)
@@ -93,6 +93,6 @@ def test_move_external_volume_to_new_agent(cluster):
                 'disk': 0,
                 'cmd': delete_cmd}}
         try:
-            cluster.metronome_one_off(delete_job)
+            dcos_api_session.metronome_one_off(delete_job)
         except Exception as ex:
             raise Exception('Failed to clean up volume {}: {}'.format(test_label, ex)) from ex

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -46,14 +46,14 @@ def input_streamer(nested_container_id):
     yield encoder.encode(message)
 
 
-def test_if_marathon_app_can_be_debugged(cluster):
+def test_if_marathon_app_can_be_debugged(dcos_api_session):
     # Launch a basic marathon app (no image), so we can debug into it!
     # Cannot use deploy_and_cleanup because we must attach to a running app/task/container.
     app, test_uuid = get_test_app()
     app_id = 'integration-test-{}'.format(test_uuid)
-    with cluster.marathon.deploy_and_cleanup(app):
+    with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Fetch the mesos master state once the task is running
-        master_state_url = 'http://{}:{}/state'.format(cluster.masters[0], 5050)
+        master_state_url = 'http://{}:{}/state'.format(dcos_api_session.masters[0], 5050)
         r = requests.get(master_state_url)
         logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
         assert r.status_code == 200

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -4,29 +4,29 @@ import retrying
 LATENCY = 60
 
 
-def test_metrics_agents_ping(cluster):
+def test_metrics_agents_ping(dcos_api_session):
     """ Test that the metrics service is up on masters.
     """
-    for agent in cluster.slaves:
-        response = cluster.metrics.get('ping', node=agent)
+    for agent in dcos_api_session.slaves:
+        response = dcos_api_session.metrics.get('ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
         'agent.'
 
-    for agent in cluster.public_slaves:
-        response = cluster.metrics.get('ping', node=agent)
+    for agent in dcos_api_session.public_slaves:
+        response = dcos_api_session.metrics.get('ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
-def test_metrics_masters_ping(cluster):
-    for master in cluster.masters:
-        response = cluster.metrics.get('ping', node=master)
+def test_metrics_masters_ping(dcos_api_session):
+    for master in dcos_api_session.masters:
+        response = dcos_api_session.metrics.get('ping', node=master)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
-def test_metrics_node(cluster):
+def test_metrics_node(dcos_api_session):
     """Test that the '/system/v1/metrics/v0/node' endpoint returns the expected
     metrics and metric metadata.
     """
@@ -47,15 +47,13 @@ def test_metrics_node(cluster):
         assert 'cluster_id' in response['dimensions'], '"cluster_id" key not'
         'found in dimensions, got {}'.format(response)
 
-        assert response['dimensions']['cluster_id'] != "", '"expected'
-        'cluster_id to contain a value, got {}'.format(
-            response['dimensions']['cluster_id'])
+        assert response['dimensions']['cluster_id'] != "", 'expected cluster to contain a value'
 
         return True
 
     # private agents
-    for agent in cluster.slaves:
-        response = cluster.metrics.get('node', node=agent)
+    for agent in dcos_api_session.slaves:
+        response = dcos_api_session.metrics.get('node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -63,8 +61,8 @@ def test_metrics_node(cluster):
         assert expected_dimension_response(response.json())
 
     # public agents
-    for agent in cluster.public_slaves:
-        response = cluster.metrics.get('node', node=agent)
+    for agent in dcos_api_session.public_slaves:
+        response = dcos_api_session.metrics.get('node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -72,8 +70,8 @@ def test_metrics_node(cluster):
         assert expected_dimension_response(response.json())
 
     # masters
-    for master in cluster.masters:
-        response = cluster.metrics.get('node', node=master)
+    for master in dcos_api_session.masters:
+        response = dcos_api_session.metrics.get('node', node=master)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -81,7 +79,7 @@ def test_metrics_node(cluster):
         assert expected_dimension_response(response.json())
 
 
-def test_metrics_containers(cluster):
+def test_metrics_containers(dcos_api_session):
     """If there's a deployed container on the slave, iterate through them to check for
     the statsd-emitter executor. When found, query it's /app endpoint to test that
     it's sending the statsd metrics as expected.
@@ -89,19 +87,19 @@ def test_metrics_containers(cluster):
     @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
     def test_containers(app_endpoints):
         for agent in app_endpoints:
-            response = cluster.metrics.get('containers', node=agent.host)
+            response = dcos_api_session.metrics.get('containers', node=agent.host)
             if len(response.json()) > 0:
                 for c in response.json():
 
                     # Test that /containers/<id> responds with expected data
-                    container_response = cluster.metrics.get('containers/{}'.format(c), node=agent.host)
+                    container_response = dcos_api_session.metrics.get('containers/{}'.format(c), node=agent.host)
                     if container_response.status_code == 200 and 'executor_id' in container_response.json():
                         # Executor ID value is "executor_id": "statsd-emitter.a094eed0-b017-11e6-a972-b2bcad3866cb"
                         assert 'statsd-emitter' in container_response.json()['executor_id'].split('.'), 'statsd-emitter'
                         ' was not found running on any slaves.'
 
                         # Test that /app response is responding with expected data
-                        app_response = cluster.metrics.get('containers/{}/app'.format(c), node=agent.host)
+                        app_response = dcos_api_session.metrics.get('containers/{}/app'.format(c), node=agent.host)
                         if app_response.status_code == 200:
                             assert 'labels' in app_response.json(), '"labels" key not found in response.'
                             assert 'test_tag_key' in container_response.json()['labels'].items(), 'test-tag-key was not'
@@ -114,6 +112,6 @@ def test_metrics_containers(cluster):
         "mem": 128.0,
         "instances": 1
     }
-    with cluster.marathon.deploy_and_cleanup(marathon_config, check_health=False) as app:
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_config, check_health=False) as app:
         assert len(app) == 1, 'The marathon app should have been deployed exactly once.'
         test_containers(app)

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -33,7 +33,7 @@ def ensure_routable(cmd, service_points, timeout=120):
 @retrying.retry(wait_fixed=2000,
                 stop_max_delay=120 * 1000,
                 retry_on_exception=lambda x: True)
-def test_if_overlay_ok(cluster):
+def test_if_overlay_ok(dcos_api_session):
     def _check_overlay(hostname, port):
         uri = 'http://{}:{}/overlay-agent/overlay'.format(hostname, port)
         resp = requests.get(uri).json()
@@ -42,14 +42,14 @@ def test_if_overlay_ok(cluster):
         for overlay in overlays:
             assert overlay['state']['status'] == 'STATUS_OK'
 
-    for master in cluster.masters:
+    for master in dcos_api_session.masters:
         _check_overlay(master, 5050)
-    for slave in cluster.all_slaves:
+    for slave in dcos_api_session.all_slaves:
         _check_overlay(slave, 5051)
 
 
 @pytest.mark.skipif(lb_enabled(), reason='Load Balancer enabled')
-def test_if_minuteman_disabled(cluster):
+def test_if_minuteman_disabled(dcos_api_session):
     """Test to make sure minuteman is disabled"""
     data = check_output(["/usr/bin/env", "ip", "rule"])
     # Minuteman creates this ip rule: `9999: from 9.0.0.0/8 lookup 42`
@@ -58,51 +58,51 @@ def test_if_minuteman_disabled(cluster):
 
 
 @pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-def test_if_minuteman_routes_to_vip(cluster):
+def test_if_minuteman_routes_to_vip(dcos_api_session):
     """Test if we are able to connect to a task with a vip using minuteman.
     """
     origin_app, origin_uuid = get_test_app()
     origin_app['portDefinitions'][0]['labels'] = {'VIP_0': '1.2.3.4:5000'}
-    with cluster.marathon.deploy_and_cleanup(origin_app):
+    with dcos_api_session.marathon.deploy_and_cleanup(origin_app):
         proxy_app, proxy_uuid = get_test_app()
-        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
+        with dcos_api_session.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://1.2.3.4:5000/ping'
             ensure_routable(cmd, service_points)()
 
 
 @pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-def test_if_minuteman_routes_to_named_vip(cluster):
+def test_if_minuteman_routes_to_named_vip(dcos_api_session):
     """Test if we are able to connect to a task with a named vip using minuteman.
     """
 
     origin_app, origin_uuid = get_test_app()
     origin_app['portDefinitions'][0]['labels'] = {'VIP_0': 'foo:5000'}
-    with cluster.marathon.deploy_and_cleanup(origin_app):
+    with dcos_api_session.marathon.deploy_and_cleanup(origin_app):
         proxy_app, proxy_uuid = get_test_app()
-        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
+        with dcos_api_session.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://foo.marathon.l4lb.thisdcos.directory:5000/ping'
             ensure_routable(cmd, service_points)()
 
 
-def test_ip_per_container(cluster):
+def test_ip_per_container(dcos_api_session):
     """Test if we are able to connect to a task with ip-per-container mode
     """
     # Launch the test_server in ip-per-container mode
     app_definition, test_uuid = get_test_app_in_docker(ip_per_container=True)
 
-    assert len(cluster.slaves) >= 2, "IP Per Container tests require 2 private agents to work"
+    assert len(dcos_api_session.slaves) >= 2, "IP Per Container tests require 2 private agents to work"
 
     app_definition['instances'] = 2
     app_definition['constraints'] = [['hostname', 'UNIQUE']]
 
-    with cluster.marathon.deploy_and_cleanup(app_definition, check_health=True) as service_points:
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition, check_health=True) as service_points:
         app_port = app_definition['container']['docker']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points)()
 
 
 @pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-def test_ip_per_container_with_named_vip(cluster):
+def test_ip_per_container_with_named_vip(dcos_api_session):
     """Test if we are able to connect to a task with ip-per-container mode using named vip
     """
     origin_app, test_uuid = get_test_app_in_docker(ip_per_container=True)
@@ -111,8 +111,8 @@ def test_ip_per_container_with_named_vip(cluster):
     del origin_app['container']['docker']['portMappings'][0]['hostPort']
     del origin_app['healthChecks'][0]['portIndex']
 
-    with cluster.marathon.deploy_and_cleanup(origin_app):
+    with dcos_api_session.marathon.deploy_and_cleanup(origin_app):
         proxy_app, proxy_uuid = get_test_app()
-        with cluster.marathon.deploy_and_cleanup(proxy_app) as service_points:
+        with dcos_api_session.marathon.deploy_and_cleanup(proxy_app) as service_points:
             cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://foo.marathon.l4lb.thisdcos.directory:6000/ping'
             ensure_routable(cmd, service_points)()

--- a/packages/dcos-integration-test/extra/test_rlimit.py
+++ b/packages/dcos-integration-test/extra/test_rlimit.py
@@ -2,7 +2,7 @@ import subprocess
 import uuid
 
 
-def test_if_rlimits_can_be_used(cluster):
+def test_if_rlimits_can_be_used(dcos_api_session):
     """This test verifies that rlimits can be used.
 
     Since marathon does not support rlimits yet we use `mesos-execute` as


### PR DESCRIPTION
In integration tests, all tests rely upon a fixture called 'cluster'. This is extremely confusing and uninformative. Rather, it should be called what it really is a session object that wraps the DCOS/Adminrouter API

Note: This PR is only for renaming the test fixture. A functional refactor (which gives the harness a well-defined purpose) is here: https://github.com/dcos/dcos/pull/1016