### PR TITLE
Train 116

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -526,6 +526,11 @@ package:
   - path: /etc_master/marathon
     content: |
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
+{% switch dcos_overlay_enable %}
+{% case "true" %}
+      MARATHON_CMD_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
+{% case "false" %}
+{% endswitch %}
   - path: /etc/proxy.env
 {% switch use_proxy %}
 {% case "true" %}

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -490,7 +490,7 @@ class Resolver:
         # Must be calculated but user tried to provide.
         if len(feasible) == 2 and (feasible[0].is_user or feasible[1].is_user):
             raise CalculatorError("{} must be calculated, but was explicitly set in the "
-                                  "configuration. Remove it from the configuration.").format(resolvable.name)
+                                  "configuration. Remove it from the configuration.".format(resolvable.name))
         if len(feasible) > 1:
             raise CalculatorError("Internal error: Multiple ways to set {}. setters: {}".format(
                 resolvable.name, feasible))

--- a/gen/test_validation.py
+++ b/gen/test_validation.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 import pkg_resources
 import pytest
@@ -171,5 +172,22 @@ def test_exhibitor_storage_master_discovery():
         ['exhibitor_storage_backend', 'master_discovery'],
         msg_master_discovery,
         unset={'exhibitor_address', 'num_masters'})
+
+
+def test_validate_default_overlay_network_name():
+    msg = "Default overlay network name does not reference a defined overlay network: foo"
+    validate_error_multikey(
+        {'dcos_overlay_network': json.dumps({
+            'vtep_subnet': '44.128.0.0/20',
+            'vtep_mac_oui': '70:B3:D5:00:00:00',
+            'overlays': [{
+                'name': 'bar',
+                'subnet': '1.1.1.0/24',
+                'prefix': 24
+            }],
+        }), 'dcos_overlay_network_default_name': 'foo'},
+        ['dcos_overlay_network_default_name', 'dcos_overlay_network'],
+        msg)
+
 
 # TODO(cmaloney): Add tests that specific config leads to specific files in specific places at install time.

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -33,7 +33,7 @@ else
 fi
 
 # Pin to just the right dcos-vagrant commit
-git -C dcos-vagrant checkout -qf 7b0b56bde93b8f2b65bb9ec50cd8a0ca932033b2
+git -C dcos-vagrant checkout -qf 2b323c4c1942e3f6d484a7375e749929356a4417
 
 cp ../dcos_generate_config.sh dcos-vagrant/dcos_generate_config.sh
 
@@ -58,6 +58,7 @@ cp VagrantConfig.yaml.example VagrantConfig.yaml
 export DCOS_INSTALL_METHOD="ssh_pull"
 export DCOS_CONFIG_PATH="etc/3_master.yaml"
 export DCOS_PRIVATE_REGISTRY="true"
+export DCOS_GENERATE_CONFIG_PATH="dcos_generate_config.sh"
 cat <<EOF > "$DCOS_CONFIG_PATH"
 ---
 cluster_name: test_cluster

--- a/test_util/runner.py
+++ b/test_util/runner.py
@@ -44,19 +44,13 @@ def integration_test(
         'AWS_SECRET_ACCESS_KEY=' + aws_secret_access_key,
         'AWS_REGION=' + region]
 
-    pytest_form = """'source /opt/mesosphere/environment.export &&
+    pytest_cmd = """'source /opt/mesosphere/environment.export &&
 cd /opt/mesosphere/active/dcos-integration-test &&
-{env} {cmd}'"""
-
-    preflight_cmd_str = pytest_form.format(env=' '.join(required_test_env), cmd='py.test --collect-only')
-    test_cmd_str = pytest_form.format(env=' '.join(required_test_env), cmd=test_cmd)
-
-    log.info('Running integration test setup check...')
-    tunnel.remote_cmd(['bash', '-c', preflight_cmd_str], stdout=sys.stdout.buffer)
+{env} {cmd}'""".format(env=' '.join(required_test_env), cmd=test_cmd)
 
     log.info('Running integration test...')
     try:
-        tunnel.remote_cmd(['bash', '-c', test_cmd_str], stdout=sys.stdout.buffer)
+        tunnel.remote_cmd(['bash', '-c', pytest_cmd], stdout=sys.stdout.buffer)
     except CalledProcessError as e:
         return e.returncode
     return 0


### PR DESCRIPTION
#1081 Update dcos-vagrant version to reduce flaky tests 
#912 Set MARATHON_DEFAULT_NETWORK_NAME to the name of the default dcos overlay network
#1099 Remove preflight from test runner
#1102 Fix the attribute error from dcos_generate_config.sh --aws-cloudformation