### PR TITLE
Fix CI for 1.8.8

### DIFF
--- a/packages/dcos-history/extra/history/server.py
+++ b/packages/dcos-history/extra/history/server.py
@@ -4,6 +4,7 @@ import sys
 
 from flask import Flask, Response
 from flask.ext.compress import Compress
+
 from history.statebuffer import BufferCollection, BufferUpdater
 
 app = Flask(__name__)

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,5 +1,6 @@
 # Various tests that don't fit into the other categories and don't make their own really.
 import json
+
 import yaml
 
 

--- a/packages/dcos-oauth/extra/dcos_add_user.py
+++ b/packages/dcos-oauth/extra/dcos_add_user.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+
 from kazoo.client import KazooClient
 from kazoo.handlers.threading import SequentialThreadingHandler
 from kazoo.retry import KazooRetry

--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -10,6 +10,9 @@ rm -rf "$PKG_PATH/usr/zookeeper/"{src,docs,contrib}
 mkdir -p "$PKG_PATH/bin"
 ln -s "$PKG_PATH/usr/zookeeper/bin/zkCli.sh" "$PKG_PATH/bin/zkCli.sh"
 
+# Explicitly set JAVA_HOME to our java package
+export JAVA_HOME="$(find /opt/mesosphere/packages -type d -name java--*)/usr/java"
+
 # Exhibitor
 
 # Generate the build artifacts and store in the local cache, to be used later

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -35,6 +35,7 @@ def invoke_detect_ip():
             "inet_aton exited with {}. {} is not a valid IPv4 address".format(e, ip))
         sys.exit(1)
 
+
 detected_ip = invoke_detect_ip()
 
 # Make the zk conf directory (exhibitor assumes the dir exists)

--- a/pkgpanda/build/cli.py
+++ b/pkgpanda/build/cli.py
@@ -60,5 +60,6 @@ def main():
         print("ERROR: {}".format(ex))
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -750,6 +750,7 @@ class ReleaseManager():
 
         apply_storage_commands(self.__storage_providers, storage_commands)
 
+
 _config = None
 
 

--- a/release/storage/aws.py
+++ b/release/storage/aws.py
@@ -120,6 +120,7 @@ class S3StorageProvider(AbstractStorageProvider):
         for obj in self._get_objects_with_prefix(path):
             obj.delete()
 
+
 factories = {
     "s3": S3StorageProvider
 }

--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -103,6 +103,7 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
         for blob_name in self.list_recursive(path):
             self.blob_service.delete_blob(self.container, blob_name)
 
+
 factories = {
     "block_blob": AzureBlockBlobStorageProvider
 }

--- a/release/storage/http.py
+++ b/release/storage/http.py
@@ -73,6 +73,7 @@ class HttpStorageProvider(AbstractStorageProvider):
     def read_only(self):
         return True
 
+
 factories = {
     'read': HttpStorageProvider
 }

--- a/release/storage/local.py
+++ b/release/storage/local.py
@@ -75,6 +75,7 @@ class LocalStorageProvider(AbstractStorageProvider):
     def url(self):
         return 'file://' + self.__storage_path + '/'
 
+
 factories = {
     'path': LocalStorageProvider
 }

--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -208,5 +208,6 @@ def run():
         print("ERROR: Azure test deployment failed", file=sys.stderr)
         sys.exit(2)
 
+
 if __name__ == '__main__':
     run()

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -33,7 +33,7 @@ else
 fi
 
 # Pin to just the right dcos-vagrant commit
-git -C dcos-vagrant checkout -qf 7b0b56bde93b8f2b65bb9ec50cd8a0ca932033b2
+git -C dcos-vagrant checkout -qf 2b323c4c1942e3f6d484a7375e749929356a4417
 
 cp ../dcos_generate_config.sh dcos-vagrant/dcos_generate_config.sh
 
@@ -58,6 +58,7 @@ cp VagrantConfig.yaml.example VagrantConfig.yaml
 export DCOS_INSTALL_METHOD="ssh_pull"
 export DCOS_CONFIG_PATH="etc/3_master.yaml"
 export DCOS_PRIVATE_REGISTRY="true"
+export DCOS_GENERATE_CONFIG_PATH="dcos_generate_config.sh"
 cat <<EOF > "$DCOS_CONFIG_PATH"
 ---
 cluster_name: test_cluster

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -174,5 +174,6 @@ def provide_cluster(options):
     options.add_env['AWS_STACK_NAME'] = stack_name
     return cf, ssh_info
 
+
 if __name__ == '__main__':
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
   pytest
   teamcity-messages
   webtest
-  webtest-aiohttp
+  webtest-aiohttp==1.1.0
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 


### PR DESCRIPTION
Bumps dcos-vagrant, pins webtest-aiohttp, and sets exhibitor's JAVA_HOME to get the 1.8.x CI green again.