### PR TITLE
merged minuteman sys.config into navstar sys.config

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "52d6c144b334e23faa6237c1e06dbd125272f6c3",
+      "ref": "4ef753e175a93adc597827aa28a836e43b8ccf3d",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
High level description including:
 - What does this change enable

Merges sys.config from minuteman into navstar.  This change was missing from https://github.com/dcos/dcos/pull/1010

 - What bugs does this change fix

Due to the missing config minuteman doesn't submit network metrics.  Fails networking_api integration tests in EE

 - High-Level how things changed

# Issues

[DCOS-11299](https://mesosphere.atlassian.net/browse/DCOS-11299)
...

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not

dcos enterprise test_network_api_service.py

 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: <link>
https://github.com/dcos/navstar/compare/52d6c144b334e23faa6237c1e06dbd125272f6c3...4ef753e175a93adc597827aa28a836e43b8ccf3d
 - [x] Test Results: <link>
https://circleci.com/gh/dcos/navstar/260
 - [x] Code Coverage: <link>
https://codecov.io/gh/dcos/navstar/tree/4ef753e175a93adc597827aa28a836e43b8ccf3d

