### PR TITLE
Add compatibility option for container logs (journald, sandbox, or both).

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -163,6 +163,11 @@ def validate_mesos_log_retention_mb(mesos_log_retention_mb):
     assert int(mesos_log_retention_mb) >= 1024, "Must retain at least 1024 MB of logs"
 
 
+def validate_mesos_container_log_sink(mesos_container_log_sink):
+    assert mesos_container_log_sink in ['journald', 'logrotate', 'journald+logrotate'], \
+        "Container logs must go to 'journald', 'logrotate', or 'journald+logrotate'."
+
+
 def calculate_mesos_log_retention_count(mesos_log_retention_mb):
     # Determine how many 256 MB log chunks can be fit into the given size.
     # We assume a 90% compression factor; logs are compressed after 2 rotations.
@@ -587,6 +592,7 @@ entry = {
         'mesos_dns_ip_sources': '["host", "netinfo"]',
         'master_external_loadbalancer': '',
         'mesos_log_retention_mb': '4000',
+        'mesos_container_log_sink': 'journald+logrotate',
         'oauth_issuer_url': 'https://dcos.auth0.com/',
         'oauth_client_id': '3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m',
         'oauth_auth_redirector': 'https://auth.dcos.io',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -235,11 +235,26 @@ package:
                 "name": "com_mesosphere_mesos_JournaldLogger",
                 "parameters": [
                   {
+                    "key": "destination_type",
+                    "value": "{{ mesos_container_log_sink }}"
+                  }, {
                     "key": "companion_dir",
                     "value": "/opt/mesosphere/active/mesos-modules/bin/"
                   }, {
                     "key": "libprocess_num_worker_threads",
                     "value": "2"
+                  }, {
+                    "key": "logrotate_max_stdout_size",
+                    "value": "2MB"
+                  }, {
+                    "key": "logrotate_stdout_options",
+                    "value": "rotate 9"
+                  }, {
+                    "key": "logrotate_max_stderr_size",
+                    "value": "2MB"
+                  }, {
+                    "key": "logrotate_stderr_options",
+                    "value": "rotate 9"
                   }
                 ]
               }

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "6660b90fbbf69a15ef46d0184e36755881d6a5ae",
+      "ref": "36ce01e6cf869b4bb2bfe9e91766f984f333f742",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
# Description
This commit adds a configuration option to pipe container logs to one of 3 destinations:
* Journald
* The sandbox, with logrotation
* Or both

This change is meant to ease the upgrade process as we transition away from logging to the sandbox, in favor of journald.

NOTE: This component bump also contains changes to the overlay agent module, which now no longer blocks the Mesos agent from starting up if the module cannot start.  See the changelog for more details.

## Component Update Details
* Changelog: https://github.com/dcos/dcos-mesos-modules/compare/6660b90fbbf69a15ef46d0184e36755881d6a5ae...36ce01e6cf869b4bb2bfe9e91766f984f333f742
* Unit tests: Parameterized existing tests for the three cases.  No CI for this repository yet.
* Coverage: Not available.

# Issues

* [DCOS-12797](https://mesosphere.atlassian.net/browse/DCOS-12797)
* [DCOS-12666](https://mesosphere.atlassian.net/browse/DCOS-12666)
* [DCOS-10952](https://mesosphere.atlassian.net/browse/DCOS-10952)

# Checklist

 - [x] Merge upstream PR ( https://github.com/dcos/dcos-mesos-modules/pull/9 ) and change the package ref back to the canonical ref.
