### PR TITLE
Add zkEnv.sh to /bin

### DIFF
--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -9,6 +9,8 @@ rm -rf "$PKG_PATH/usr/zookeeper/"{src,docs,contrib}
 
 mkdir -p "$PKG_PATH/bin"
 ln -s "$PKG_PATH/usr/zookeeper/bin/zkCli.sh" "$PKG_PATH/bin/zkCli.sh"
+# zkCli.sh expects zkEnv.sh to be in the same directory.
+ln -s "$PKG_PATH/usr/zookeeper/bin/zkEnv.sh" "$PKG_PATH/bin/zkEnv.sh"
 
 # Exhibitor
 


### PR DESCRIPTION
`zkCli.sh` expects `zkEnv.sh` to be in the same directory.

```
$ dcos-shell /opt/mesosphere/packages/exhibitor--9b89c1f1654d9f2addfb8dfaa138053d6c6a5eb7/usr/zookeeper/bin/zkCli.sh ls >/dev/null
$ echo $?
0
$ dcos-shell /opt/mesosphere/bin/zkCli.sh ls >/dev/null
/opt/mesosphere/bin/zkCli.sh: line 36: /opt/mesosphere/bin/zkEnv.sh: No
such file or directory
/opt/mesosphere/bin/zkCli.sh: line 39: : command not found
$ echo $?
127
$
```

# Issues
https://mesosphere.atlassian.net/browse/DCOS-9775

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
