### PR TITLE
Fixing the test_if_marathon_app_can_be_deployed_with_mesos_containerizer

### DIFF
--- a/packages/dcos-integration-test/extra/util/python_test_server.py
+++ b/packages/dcos-integration-test/extra/util/python_test_server.py
@@ -245,7 +245,8 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
     def _handle_operating_environment(self):
         """Gets basic operating environment info (such as running user)"""
         self._send_reply({
-            'username': getpass.getuser()
+            'username': getpass.getuser(),
+            'uid': os.getuid()
         })
 
     def do_GET(self):  # noqa: ignore=N802

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -128,7 +128,11 @@ class Marathon(ApiClient):
                 msg += "Detailed explanation of the problem: {2}"
                 raise Exception(msg.format(r.status_code, r.reason, r.text))
 
-            assert r.json() == {'username': marathon_user}
+            json_uid = r.json()['uid']
+            if marathon_user == 'root':
+                assert json_uid == 0, "App running as root should have uid 0."
+            else:
+                assert json_uid != 0, ("App running as {} should not have uid 0.".format(marathon_user))
 
     def deploy_app(self, app_definition, timeout=120, check_health=True, ignore_failed_tasks=False):
         """Deploy an app to marathon


### PR DESCRIPTION
High level description including:
 - The username being picked up earlier was wrong and caused the test to fail. This change enable the test to get the uid from the environment and use that to compare the user. 

# Issues

https://mesosphere.atlassian.net/browse/DCOS-10327

# Checklist

 - [X] Included a test which will fail if code is reverted but test is not
 - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [ ] Change Log from last: <link>
 - [ ] Test Results: https://github.com/mesosphere/dcos-enterprise/pull/499 

https://teamcity.mesosphere.io/viewLog.html?buildId=532479&buildTypeId=ClosedSource_Dcos_DcOsEnterpriseCcmDeployTestSecurityStrict&tab=buildLog
 - [ ] Code Coverage: <link>

