### PR TITLE
Set LIBPROCESS_PORT for marathon and metronome

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -38,6 +38,8 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 8181: dcos-exhibitor
  - 9990: dcos-cosmos
  - 15055: dcos-history-service
+ - 15101: dcos-marathon libprocess
+ - 15201: dcos-metronome libprocess
 
 ### UDP
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -587,6 +587,7 @@ package:
   - path: /etc_master/marathon
     content: |
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
+      LIBPROCESS_PORT=15101
 {% switch dcos_overlay_enable %}
 {% case "true" %}
       MARATHON_CMD_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
@@ -608,6 +609,7 @@ package:
       METRONOME_MESOS_MASTER_URL=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       METRONOME_PLAY_SERVER_HTTP_PORT=9000
       METRONOME_MESOS_USER=root
+      LIBPROCESS_PORT=15201
   - path: /etc/extra_master_addresses
     content: |
 {% switch master_discovery %}


### PR DESCRIPTION
Set LIBPROCESS_PORT for marathon (15101) and metronome (15102) in the dcos-config.yaml explicitly. Update the admin-port documentation.


# Issues
[DCOS-12706](https://mesosphere.atlassian.net/browse/DCOS-12706)