### PR TITLE
Don't expose --uninstall flag when the operation is not complete.

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -322,6 +322,8 @@ exit $RETCODE"""
     return result
 
 
+# TODO: DCOS-250 (skumaran@mesosphere.com)- Create an comprehensive DC/OS uninstall strategy.
+# This routine is currently unused and unexposed.
 @asyncio.coroutine
 def uninstall_dcos(config, block=False, state_json_dir=None, async_delegate=None, options=None):
     targets = get_full_nodes_list(config)

--- a/dcos_installer/cli.py
+++ b/dcos_installer/cli.py
@@ -83,21 +83,6 @@ def run_loop(action, options):
     return exitcode
 
 
-def tall_enough_to_ride():
-    choices_true = ['yes', 'y']
-    choices_false = ['no', 'n']
-    while True:
-        do_uninstall = input('This will uninstall DC/OS on your cluster. You may need to manually remove '
-                             '/var/lib/zookeeper in some cases after this completes, please see our documentation '
-                             'for details. Are you ABSOLUTELY sure you want to proceed? [ (y)es/(n)o ]: ')
-        if do_uninstall.lower() in choices_true:
-            return
-        elif do_uninstall.lower() in choices_false:
-            sys.exit(1)
-        else:
-            log.error('Choices are [y]es or [n]o. "{}" is not a choice'.format(do_uninstall))
-
-
 def log_warn_only():
     """Drop to warning level and down to get around gen.generate() log.info
     output"""
@@ -142,11 +127,6 @@ def do_validate_config(args):
     return 0
 
 
-def do_uninstall(*args, **kwargs):
-    tall_enough_to_ride()
-    return action_lib.uninstall_dcos(*args, **kwargs)
-
-
 dispatch_dict_simple = {
     'version': (do_version, None, 'Print the DC/OS version'),
     'web': (
@@ -183,11 +163,7 @@ dispatch_dict_aio = {
     'postflight': (
         action_lib.run_postflight,
         'EXECUTING POSTFLIGHT',
-        'Execute postflight checks on a series of nodes.'),
-    'uninstall': (
-        do_uninstall,
-        'EXECUTING UNINSTALL',
-        'Execute uninstall on target hosts.')
+        'Execute postflight checks on a series of nodes.')
 }
 
 

--- a/dcos_installer/test_cli.py
+++ b/dcos_installer/test_cli.py
@@ -32,8 +32,6 @@ def test_set_arg_parser():
     assert parser.action == 'deploy'
     parser = parse_args(['--validate-config'])
     assert parser.action == 'validate-config'
-    parser = parse_args(['--uninstall'])
-    assert parser.action == 'uninstall'
     parser = parse_args(['--hash-password', 'foo'])
     assert parser.password == 'foo'
     assert parser.action == 'hash-password'


### PR DESCRIPTION
# Issues

* [DCOS-12968](https://mesosphere.atlassian.net/browse/DCOS-12968)

# Checklist

 - [x] Reverted but test that will fail without this feature.

# Local Testing

```
$ wget https://s3-us-west-2.amazonaws.com/downloads.dcos.io/dcos/testing/pull/1123/commit/48cb7792006fc47aaf43ab66f8245be659fa4036/dcos_generate_config.sh
$ chmod +x dcos_generate_config.sh
$ ./dcos_generate_config.sh --help
DC/OS Install and Configuration Utility

optional arguments:
  -h, --help            show this help message and exit
  --hash-password [password]
                        Hash a password and print the results to copy into a
                        config.yaml.
  --set-superuser-password [password]
                        Hash the given password and store it as the superuser
                        password in config.yaml
  -v, --verbose         Verbose log output (DEBUG).
  --offline             Do not install preflight prerequisites on CentOS7,
                        RHEL7 in web mode
  --cli-telemetry-disabled
                        Disable the CLI telemetry gathering for SegmentIO
  --validate-config     Validate the configuration for executing --genconf and
                        deploy arguments in config.yaml
  --version             Print the DC/OS version
  --genconf             Execute the configuration generation (genconf).
  --web                 Run the web interface
  --aws-cloudformation  Generate AWS Advanced AWS CloudFormation templates
                        using the provided config
  --install-prereqs     Execute the preflight checks on a series of nodes.
  --postflight          Execute postflight checks on a series of nodes.
  --preflight           Execute the preflight checks on a series of nodes.
  --deploy              Execute a deploy.
```