### PR TITLE
Updated the Mesos package readme.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,5 +1,6 @@
-<H2>Patches to cherry-pick from mesosphere/mesos on top of open source Apache Mesos before building in DC/OS:</h2>
-<li>[460388dfd3c20632ac3eaf767e4762a87ea007cc] Set LIBPROCESS_IP into docker container.
-<li>[5e92e2755f121d9df48dfa58520157e7cfac2f5c] Changed agent_host to expect a relative path.
-<li>[c876b36ca4cb06e7d41db44f13530b6b78ae65c2] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
-<li>[c8e8c70a71b2849ee37d3c6b9f396ceaac73369e] Revert "Fixed the broken metrics information of master in WebUI."
+<H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
+These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
+<li>[a29f006abd7b1aa43baf436f61369c5ceb9cdafc] Set LIBPROCESS_IP into docker container.
+<li>[66987805d083d16d60dcc4a92b788172224134f7] Changed agent_host to expect a relative path.
+<li>[6dedb08f58f6a4db4bbe3f42da7aee224b10a716] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[d6ac65e7631b6fcbe3fcedb60086f6f91e59cd28] Revert "Fixed the broken metrics information of master in WebUI."


### PR DESCRIPTION
This patch updates the Mesos package readme to include the latest versions of the cherry-pick commits that must be applied to open source Mesos before building in DC/OS.

This is a non-functional change.
