### PR TITLE
Use Marathon 1.4.0-RC5

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-RC4/marathon-1.4.0-RC4.tgz",
-    "sha1": "69e51d7e2321ee3d7ed71e08d19b74d163078beb"
+    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-RC5/marathon-1.4.0-RC5.tgz",
+    "sha1": "1500738b2412e95cd53483119364a03294327282"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
High level description including:
- BugFix Release. See https://github.com/mesosphere/marathon/releases/tag/v1.4.0-RC5

# Issues
- Fixes [#4876](https://github.com/mesosphere/marathon/issues/4876) - Use 'openjdk:8-jdk' container image instead of 'java:8-jdk'.
- Fixes [#4874](https://github.com/mesosphere/marathon/issues/4874) - Document feature flag requirement for TASK_KILLING state.
- Fixes [#4900](https://github.com/mesosphere/marathon/issues/4900) - Do not restart already started task during leader abdication.
- Fixes [#4788](https://github.com/mesosphere/marathon/issues/4788) - Use async InstanceTracker in DeploymentActor.
- Fixes [#4897](https://github.com/mesosphere/marathon/issues/4897) - Fix kill and scale to never scale below 0.
- Fixes [#4146](https://github.com/mesosphere/marathon/issues/4146) - docker containerizer now allows relative containerPath starting with mesos 1.0.

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: https://github.com/mesosphere/marathon/releases/tag/v1.4.0-RC5
 - [x] Test Results: https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Marathon_Packages&branch_Oss_Marathon=v1.4.0-RC5
 - [ ] Code Coverage: n/a
