### PR TITLE
Explicitly set JAVA_HOME for exhibitor gradle build

### DIFF
--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -12,6 +12,9 @@ ln -s "$PKG_PATH/usr/zookeeper/bin/zkCli.sh" "$PKG_PATH/bin/zkCli.sh"
 # zkCli.sh expects zkEnv.sh to be in the same directory.
 ln -s "$PKG_PATH/usr/zookeeper/bin/zkEnv.sh" "$PKG_PATH/bin/zkEnv.sh"
 
+# Explicitly set JAVA_HOME to our java package
+export JAVA_HOME="$(find /opt/mesosphere/packages -type d -name java--*)/usr/java"
+
 # Exhibitor
 
 # Generate the build artifacts and store in the local cache, to be used later


### PR DESCRIPTION
Fixes a bug where exhibitor was building with the jdk present in the base docker container, rather than the defined java pkgpanda package.


