### PR TITLE
cosmos: restrict admin and http ports to localhost

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -467,7 +467,7 @@ package:
           "http://leader.mesos:1050/system/health/v1/report?cache=0"
         ],
         "cosmos_urls": [
-          "http://leader.mesos:7070/package/list"
+          "http://127.0.0.1:7070/package/list"
         ],
         "mesos_urls": [
           "http://leader.mesos:5050/frameworks",

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -28,6 +28,8 @@ ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -classpath ${PKG_PATH}/usr/cosmos.jar \\
     com.simontuffs.onejar.Boot \\
+    -admin.port=127.0.0.1:9990 \\
+    -io.github.benwhitehead.finch.httpInterface=127.0.0.1:7070 \\
     \${COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG} \\
     \${COSMOS_PACKAGE_STORAGE_URI_FLAG}
 EOF

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -2,6 +2,7 @@ import ipaddress
 import urllib.parse
 
 import bs4
+import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 


### PR DESCRIPTION
 - What does this change enable
The Cosmos service currently runs with default options for its admin port (`0.0.0.0:9990`) and its http port (`0.0.0.0:7070`.) We should restrict Cosmos to listen on the loopback interface only.

 - What bugs does this change fix
This change prevents bypassing Admin Router via direct access to Cosmos.

# Issues

[DCOS-613](https://dcosjira.atlassian.net/browse/DCOS-613)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)