### PR TITLE
Document missing exhibitor ports

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -31,6 +31,8 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 1050: dcos-3dt
  - 1801: dcos-oauth
  - 2181: dcos-exhibitor
+ - 2888: dcos-exhibitor
+ - 3888: dcos-exhibitor
  - 5050: dcos-mesos-master
  - 7070: dcos-cosmos
  - 8080: dcos-marathon


### PR DESCRIPTION
Not sure if these are missing ports or weren't documented because they don't need to be exposed or aren't actually used...

This list, dcos.io, and docs.mesosphere.com all say different things. So it's hard to tell which is correct.

2888 & 3888 are used here:
https://github.com/dcos/dcos/blob/master/packages/exhibitor/extra/start_exhibitor.py

Feel free to correct me...

