### PR TITLE
bump exhibitor SHA to fc44d4fe0e612381646a4738a1a898867b2086d8t

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "7d39834f55988e21f2d7ce2c0b67847cb4a55dab",
+      "ref": "fc44d4fe0e612381646a4738a1a898867b2086d8",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
High level description including:
 - What does this change enable
Allows exhibitor to function under high load.
 - What bugs does this change fix
This fixes an issue where exhibitor leaked / opened too many file descriptors under load.

 - High-Level how things changed
Configure the Jetty Server to use non-blocking I/O for accepting new connections and limit the number of pending requests.

# Issues
[DCOS-558](https://dcosjira.atlassian.net/browse/DCOS-558)
...

# Checklist

 - [ ] Included a test which will fail if code is reverted but test is not
This behaviour emerges from an exhibitor node under load and would be very tricky to build a reliable test for. The effect can be checked by running 
```
while true; do sudo bash -c 'ulimit -n 10000; ab -n 100000 -c 4096 -s 1 http://172.17.0.2:8181/exhibitor/v1/cluster/status'; done
```
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: [Limit number of active requests](https://github.com/dcos/exhibitor/commit/fc44d4fe0e612381646a4738a1a898867b2086d8)
 - [ ] Test Results: <link>
 - [ ] Code Coverage: <link>





Bumps exhibitor to include https://github.com/dcos/exhibitor/pull/7

