### PR TITLE
update marathon to 1.3.8 for dc/os 1.8.8

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.3.7/marathon-1.3.7.tgz",
-    "sha1": "d7b17c806038796312228114fe98cfb096726567"
+    "url": "https://downloads.mesosphere.com/marathon/v1.3.8/marathon-1.3.8.tgz",
+    "sha1": "bfb852fd82022c647a14ccf84c4812026d20ff6a"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.3.6/marathon-1.3.6.tgz",
-    "sha1": "0d6a3f0abd4188cbb7d9d64e729f16489cb9bc6f"
+    "url": "https://downloads.mesosphere.com/marathon/v1.3.7/marathon-1.3.7.tgz",
+    "sha1": "d7b17c806038796312228114fe98cfb096726567"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
High level description including:
 - Bug fix release for Marathon. We discovered a serious migration issue in migration to 1.1.5.

# Issues

- Fixes [Issue 4854](https://github.com/mesosphere/marathon/issues/4854) Cannot start marathon (1.4.0-RC3) with `default_accepted_resource_roles = *`
- Fixes [Issue 4637](https://github.com/mesosphere/marathon/issues/4637) Fixes #4637 Allow filtering SSE events by types
- Fixes [Pull 4927](https://github.com/mesosphere/marathon/pull/4927) Parse JSON event only once before broadcast
- Fixes [Pull 4711](https://github.com/mesosphere/marathon/pull/4711) Added a MigrationTo1_1 class to handle broken app groups
- Fixes [Issue 4968](https://github.com/mesosphere/marathon/pull/4968) Prevent Migration if the StorageVersion is too new (#4968) (Jason Gilanfarr)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

If this is a component/package update, include

 - [x] Change Log from last: https://github.com/mesosphere/marathon/releases/tag/v1.3.7 and https://github.com/mesosphere/marathon/releases/tag/v1.3.8
 - [x] Test Results: https://teamcity.mesosphere.io/viewType.html?buildTypeId=Oss_Marathon_Packages&branch_Oss_Marathon=v1.3.7&tab=buildTypeStatusDiv
 - [x] Code Coverage: currently not published

