### PR TITLE
[WIP]: Updated Mesos version to master with pods cmd hc support.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "069450374b8e020f4209f1f75647969daff1e4f6",
-    "ref_origin" : "dcos-mesos-master-c7fc137"
+    "ref": "1579df0677cfca1ddfe7c453c2afd5d11a511ef2",
+    "ref_origin" : "default-executor-cmd-health-checks"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
**DO NOT MERGE**

This custom build of DC/OS includes a WIP Mesos build which adds CMD health check support to the default executor.