### PR TITLE
Disable streaming for pytest

### DIFF
--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -181,7 +181,7 @@ def main():
                 agent_list=ip_buckets['private'],
                 public_agent_list=ip_buckets['public'],
                 test_cmd=os.getenv(
-                    'DCOS_PYTEST_CMD', get_add_env() + " py.test -vv -s -rs -m 'not ccm' ") + os.getenv('CI_FLAGS', ''))
+                    'DCOS_PYTEST_CMD', get_add_env() + " py.test -vv -rs -m 'not ccm' ") + os.getenv('CI_FLAGS', ''))
         test_successful = True
     except Exception as ex:
         traceback.print_exc()

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -95,7 +95,7 @@ export PUBLIC_SLAVE_HOSTS=192.168.65.60
 export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
 export DCOS_DEFAULT_OS_USER=root
 cd /opt/mesosphere/active/dcos-integration-test
-/opt/mesosphere/bin/dcos-shell py.test -vv -s -rs -m "not ccm" ${CI_FLAGS:-}
+/opt/mesosphere/bin/dcos-shell py.test -vv -rs -m "not ccm" ${CI_FLAGS:-}
 EOF
 chmod +x test_wrapper.sh
 echo "Running integration test"

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -98,7 +98,7 @@ def check_environment():
     for k, v in os.environ.items():
         if k.startswith(prefix):
             add_env.append(k.replace(prefix, '') + '=' + v)
-    options.test_cmd = os.getenv('DCOS_PYTEST_CMD', ' '.join(add_env) + ' py.test -vv -s -rs ' + options.ci_flags)
+    options.test_cmd = os.getenv('DCOS_PYTEST_CMD', ' '.join(add_env) + ' py.test -vv -rs ' + options.ci_flags)
     return options
 
 

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -139,7 +139,7 @@ def check_environment():
     for k, v in os.environ.items():
         if k.startswith(prefix):
             add_env.append(k.replace(prefix, '') + '=' + v)
-    options.test_cmd = os.getenv('DCOS_PYTEST_CMD', ' '.join(add_env) + ' py.test -vv -s -rs ' + options.ci_flags)
+    options.test_cmd = os.getenv('DCOS_PYTEST_CMD', ' '.join(add_env) + ' py.test -vv -rs ' + options.ci_flags)
     return options
 
 

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -123,7 +123,7 @@ def main():
     num_public_agents = int(os.getenv('PUBLIC_AGENTS', '1'))
     stack_name = 'upgrade-test-' + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
 
-    test_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -s -rs ' + os.getenv('CI_FLAGS', ''))
+    test_cmd = os.getenv('DCOS_PYTEST_CMD', 'py.test -vv -rs ' + os.getenv('CI_FLAGS', ''))
 
     stable_installer_url = os.environ['STABLE_INSTALLER_URL']
     installer_url = os.environ['INSTALLER_URL']


### PR DESCRIPTION
Streaming, when combined with the teamcity plugin
causes some output to be randomly unparseable, thus
leading to some tests being ignored and unreported

