### PR TITLE
Bump metrics to test new build

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -35,6 +35,18 @@ def test_metrics_node(cluster):
         """
         assert 'datapoints' in response, '"datapoints" dictionary not found'
         'in response, got {}'.format(response)
+
+        for dp in response['datapoints']:
+            assert 'name' in dp, '"name" parameter should not be empty, got {}'.format(dp)
+            if 'filesystem' in dp['name']:
+                assert 'tags' in dp, '"tags" key not found, got {}'.format(dp)
+
+                assert 'path' in dp['tags'], ('"path" tag not found for filesystem metric, '
+                                              'got {}'.format(dp))
+
+                assert len(dp['tags']['path']) > 0, ('"path" tag should not be empty for '
+                                                     'filesystem metrics, got {}'.format(dp))
+
         return True
 
     def expected_dimension_response(response):

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "7afcfebfba457bff890931c8daf1ecfe1513441d",
-    "ref_origin": "1.0.0-rc4"
+    "ref": "bafec1eb7c6a18030fbc320dfd535acdcafd2fa8",
+    "ref_origin": "malnick/DCOS-12410"
   },
   "username": "dcos_metrics"
 }

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "bafec1eb7c6a18030fbc320dfd535acdcafd2fa8",
-    "ref_origin": "malnick/DCOS-12410"
+    "ref": "ba79e8b61d92c5379e04d6659d2d8e782b4a49c5",
+    "ref_origin": "1.0.0-rc5"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High Level Description

- Adds tagging 
- Adds unit values to metrics
- Adds better metric gathering for node collector

Merged PR: https://github.com/dcos/dcos-metrics/pull/61

## Related Issues

[DCOS-12410](https://jira.mesophere.com/browse/DCOS-12410) Add unit values and arbitrary tag support

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Unit Testing Results
```
ok      github.com/dcos/dcos-metrics/util/http/helpers  0.006s
?       github.com/dcos/dcos-metrics/util/http/profiler [no test files]
github.com/dcos/dcos-metrics/collectors/framework/framework.go:67:      New                             100.0%
github.com/dcos/dcos-metrics/collectors/framework/framework.go:77:      RunFrameworkTCPListener         75.0%
github.com/dcos/dcos-metrics/collectors/framework/framework.go:102:     handleConnection                60.5%
github.com/dcos/dcos-metrics/collectors/framework/framework.go:180:     transform                       78.9%
github.com/dcos/dcos-metrics/collectors/framework/framework.go:234:     Read                            80.0%
github.com/dcos/dcos-metrics/collectors/framework/framework.go:245:     getTopic                        100.0%
github.com/dcos/dcos-metrics/collectors/framework/record.go:41:         extract                         83.9%
github.com/dcos/dcos-metrics/collectors/framework/record.go:108:        createObjectFromRecord          80.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:154:       New                             0.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:163:       RunPoller                       0.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:173:       pollMesosAgent                  0.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:193:       getContainerMetrics             100.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:209:       getAgentState                   100.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:223:       transformContainerMetrics       81.8%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:259:       getFrameworkInfoByFrameworkID   100.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:271:       getLabelsByContainerID          100.0%
github.com/dcos/dcos-metrics/collectors/mesos/agent/agent.go:289:       buildDatapoints                 65.6%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:21:                 poll                            92.3%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:41:                 addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:89:                 getNumCores                     85.7%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:109:                init                            100.0%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:116:                getCPUTimes                     100.0%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:128:                calculatePcts                   100.0%
github.com/dcos/dcos-metrics/collectors/node/cpu.go:149:                round                           100.0%
github.com/dcos/dcos-metrics/collectors/node/filesystem.go:23:          poll                            83.3%
github.com/dcos/dcos-metrics/collectors/node/filesystem.go:54:          addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/load.go:15:                poll                            88.9%
github.com/dcos/dcos-metrics/collectors/node/load.go:30:                addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/memory.go:19:              poll                            87.5%
github.com/dcos/dcos-metrics/collectors/node/memory.go:45:              addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/memory.go:100:             getMemory                       100.0%
github.com/dcos/dcos-metrics/collectors/node/memory.go:105:             getSwap                         100.0%
github.com/dcos/dcos-metrics/collectors/node/metrics.go:86:             getNodeMetrics                  75.0%
github.com/dcos/dcos-metrics/collectors/node/metrics.go:117:            thisTime                        100.0%
github.com/dcos/dcos-metrics/collectors/node/network.go:25:             poll                            88.9%
github.com/dcos/dcos-metrics/collectors/node/network.go:54:             addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/node.go:43:                New                             100.0%
github.com/dcos/dcos-metrics/collectors/node/node.go:55:                RunPoller                       0.0%
github.com/dcos/dcos-metrics/collectors/node/node.go:66:                pollHost                        0.0%
github.com/dcos/dcos-metrics/collectors/node/node.go:85:                transform                       100.0%
github.com/dcos/dcos-metrics/collectors/node/process.go:13:             poll                            83.3%
github.com/dcos/dcos-metrics/collectors/node/process.go:24:             addDatapoints                   100.0%
github.com/dcos/dcos-metrics/collectors/node/process.go:35:             getProcessCount                 75.0%
github.com/dcos/dcos-metrics/collectors/node/uptime.go:13:              poll                            83.3%
github.com/dcos/dcos-metrics/collectors/node/uptime.go:23:              addDatapoints                   100.0%
github.com/dcos/dcos-metrics/config.go:90:                              setFlags                        100.0%
github.com/dcos/dcos-metrics/config.go:97:                              loadConfig                      66.7%
github.com/dcos/dcos-metrics/config.go:110:                             getNodeInfo                     58.3%
github.com/dcos/dcos-metrics/config.go:153:                             newConfig                       100.0%
github.com/dcos/dcos-metrics/config.go:184:                             getNewConfig                    50.0%
github.com/dcos/dcos-metrics/dcos-metrics.go:33:                        main                            0.0%
github.com/dcos/dcos-metrics/dcos-metrics.go:96:                        broadcast                       0.0%
github.com/dcos/dcos-metrics/dcos-metrics.go:106:                       producerIsConfigured            100.0%
github.com/dcos/dcos-metrics/producers/http/handlers.go:27:             nodeHandler                     64.3%
github.com/dcos/dcos-metrics/producers/http/handlers.go:50:             containersHandler               57.1%
github.com/dcos/dcos-metrics/producers/http/handlers.go:73:             containerHandler                66.7%
github.com/dcos/dcos-metrics/producers/http/handlers.go:91:             containerAppHandler             70.0%
github.com/dcos/dcos-metrics/producers/http/handlers.go:110:            containerAppMetricHandler       61.9%
github.com/dcos/dcos-metrics/producers/http/handlers.go:147:            pingHandler                     100.0%
github.com/dcos/dcos-metrics/producers/http/handlers.go:160:            encode                          50.0%
github.com/dcos/dcos-metrics/producers/http/http.go:51:                 New                             100.0%
github.com/dcos/dcos-metrics/producers/http/http.go:63:                 Run                             95.7%
github.com/dcos/dcos-metrics/producers/http/http.go:123:                janitor                         100.0%
github.com/dcos/dcos-metrics/producers/http/logger.go:22:               logger                          100.0%
github.com/dcos/dcos-metrics/producers/http/router.go:23:               loadRoutes                      100.0%
github.com/dcos/dcos-metrics/producers/http/router.go:41:               newRouter                       100.0%
github.com/dcos/dcos-metrics/util/http/client/client.go:38:             Fetch                           50.0%
github.com/dcos/dcos-metrics/util/http/helpers/helpers.go:30:           loadCAPool                      81.8%
github.com/dcos/dcos-metrics/util/http/helpers/helpers.go:51:           getTransport                    88.9%
github.com/dcos/dcos-metrics/util/http/helpers/helpers.go:75:           NewMetricsClient                0.0%
total:                                                                  (statements)                    69.3%
```

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated: https://github.com/dcos/dcos-metrics/compare/1.0.0-rc4...1.0.0-rc5
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/73/
  - [x] Code Coverage (if available): [link to code coverage report]