### PR TITLE
Fix test runner

### DIFF
--- a/test_util/runner.py
+++ b/test_util/runner.py
@@ -44,9 +44,9 @@ def integration_test(
         'AWS_SECRET_ACCESS_KEY=' + aws_secret_access_key,
         'AWS_REGION=' + region]
 
-    pytest_cmd = """'source /opt/mesosphere/environment.export &&
+    pytest_cmd = """ "source /opt/mesosphere/environment.export &&
 cd /opt/mesosphere/active/dcos-integration-test &&
-{env} {cmd}'""".format(env=' '.join(required_test_env), cmd=test_cmd)
+{env} {cmd}" """.format(env=' '.join(required_test_env), cmd=test_cmd)
 
     log.info('Running integration test...')
     try:


### PR DESCRIPTION
Currently, azure fails to run and is not counted as a failure like so:
https://teamcity.mesosphere.io/viewLog.html?buildId=538219&buildTypeId=ClosedSource_Dcos_IntegrationTests_CloudIntegrationTests_DcosOssAzureIntegrati_2&tab=buildLog#_state=271&focus=1655

This is because we need to exit nonzero in order for TeamCity to be able to mute tests. However, if no tests are run, then there is nothing for TeamCity to interpret and the test is considered passing. See https://mesosphere.atlassian.net/browse/DCOS-12772 for fixing this.

This PR will simply correct the syntax error, but extra care will need to be taken when merging until 12772 is fixed