### PR TITLE
bump dcos-log

### DIFF
--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "86c5cb00c6942a9008b0c345c810137c93fa89b4",
+    "ref": "4cc217e0d9e131d410f2cb5480b34729b807c973",
     "ref_origin": "master"
   },
   "username": "dcos_log",


### PR DESCRIPTION
use dcos-go/dcos/http/transport

## High Level Description

Use http transport from shared library

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-log](https://github.com/dcos/dcos-log/compare/564464219e6d7b150046c84fc3e301305d3dc7af...4cc217e0d9e131d410f2cb5480b34729b807c973)
  - [X] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/dcos-log%20pull%20requests/87/console
  - [X] Code Coverage (if available): https://jenkins.mesosphere.com/service/jenkins/job/dcos-log%20pull%20requests/87/console
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
