### PR TITLE
Set default vm.max_map_count and vm.swappiness for frameworks

### DIFF
--- a/packages/dcos-integration-test/extra/test_sysctl.py
+++ b/packages/dcos-integration-test/extra/test_sysctl.py
@@ -1,0 +1,37 @@
+import subprocess
+import uuid
+
+
+def test_if_default_systctls_are_set(dcos_api_session):
+    """This test verifies that default sysctls are set for tasks.
+
+    We use a `mesos-execute` to check for the values to make sure any task from
+    any framework would be affected by default.
+    The job then examines the default sysctls, and returns a failure if another
+    value is found."""
+
+    name = 'test-sysctl-{}'.format(uuid.uuid4().hex)
+
+    test_command = ('test "$(/usr/sbin/sysctl vm.swappiness)" = '
+                    '"vm.swappiness = 1"'
+                    ' && test "$(/usr/sbin/sysctl vm.max_map_count)" = '
+                    '"vm.max_map_count = 262144"')
+
+    argv = [
+        '/opt/mesosphere/bin/mesos-execute',
+        '--master=leader.mesos:5050',
+        '--name={}'.format(name),
+        '--command={}'.format(test_command),
+        '--shell=true',
+        '--env={"LC_ALL":"C"}']
+
+    output = subprocess.check_output(
+        argv,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True)
+
+    expected_output = \
+        "Received status update TASK_FINISHED for task '{name}'".format(
+            name=name)
+
+    assert expected_output in output

--- a/packages/dcos-integration-test/extra/test_sysctl.py
+++ b/packages/dcos-integration-test/extra/test_sysctl.py
@@ -10,9 +10,9 @@ def test_if_default_systctls_are_set(dcos_api_session):
     The job then examines the default sysctls, and returns a failure if another
     value is found."""
 
-    test_command = ('test "$(/usr/sbin/sysctl vm.swappiness)" = '
+    test_command = ('test "$(/sbin/sysctl vm.swappiness)" = '
                     '"vm.swappiness = 1"'
-                    ' && test "$(/usr/sbin/sysctl vm.max_map_count)" = '
+                    ' && test "$(/sbin/sysctl vm.max_map_count)" = '
                     '"vm.max_map_count = 262144"')
 
     argv = [

--- a/packages/dcos-integration-test/extra/test_sysctl.py
+++ b/packages/dcos-integration-test/extra/test_sysctl.py
@@ -10,8 +10,6 @@ def test_if_default_systctls_are_set(dcos_api_session):
     The job then examines the default sysctls, and returns a failure if another
     value is found."""
 
-    name = 'test-sysctl-{}'.format(uuid.uuid4().hex)
-
     test_command = ('test "$(/usr/sbin/sysctl vm.swappiness)" = '
                     '"vm.swappiness = 1"'
                     ' && test "$(/usr/sbin/sysctl vm.max_map_count)" = '
@@ -20,18 +18,22 @@ def test_if_default_systctls_are_set(dcos_api_session):
     argv = [
         '/opt/mesosphere/bin/mesos-execute',
         '--master=leader.mesos:5050',
-        '--name={}'.format(name),
         '--command={}'.format(test_command),
         '--shell=true',
         '--env={"LC_ALL":"C"}']
 
-    output = subprocess.check_output(
-        argv,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True)
+    def run_and_check(argv):
+        name = 'test-sysctl-{}'.format(uuid.uuid4().hex)
+        output = subprocess.check_output(
+            argv + ['--name={}'.format(name)],
+            stderr=subprocess.STDOUT,
+            universal_newlines=True)
 
-    expected_output = \
-        "Received status update TASK_FINISHED for task '{name}'".format(
-            name=name)
+        expected_output = \
+            "Received status update TASK_FINISHED for task '{name}'".format(
+                name=name)
 
-    assert expected_output in output
+        assert expected_output in output
+
+    run_and_check(argv)
+    run_and_check(argv + ['--role=slave_public'])

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,5 +10,15 @@
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
   },
-  "state_directory": true
+  "state_directory": true,
+  "sysctl": {
+      "dcos-mesos-slave": {
+          "vm.max_map_count": 262144,
+          "vm.swappiness": 1
+      },
+      "dcos-mesos-slave-public": {
+          "vm.max_map_count": 262144,
+          "vm.swappiness": 1
+      }
+  }
 }


### PR DESCRIPTION
## High Level Description

Set default vm.max_map_count and vm.swappiness for frameworks like elasticsearch

## Related Issues

- [DCOS-10611](https://mesosphere.atlassian.net/browse/DCOS-10611) Swappiness and MMap Settings

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___