### PR TITLE
openssl: bump to 1.0.2k

### DIFF
--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2j.tar.gz",
-    "sha1": "bdfbdb416942f666865fa48fe13c2d0e588df54f"
+    "url": "https://openssl.org/source/openssl-1.0.2k.tar.gz",
+    "sha1": "5f26a624479c51847ebd2f22bb9f84b3b44dcb44"
   }
 }


### PR DESCRIPTION
## High Level Description

This bumps OpenSSL to version 1.0.2k (released on January 26th).
https://www.openssl.org/news/cl102.txt
https://mta.openssl.org/pipermail/openssl-announce/2017-January/000091.html

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

  - [x] Change log from the last version integrated: https://www.openssl.org/news/cl102.txt
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
