### PR TITLE
packages: set open file limits in systemd config files

### DIFF
--- a/gen/azure/cloud-config.yaml
+++ b/gen/azure/cloud-config.yaml
@@ -19,6 +19,7 @@ root:
       Restart=always
       StartLimitInterval=0
       RestartSec=15
+      LimitNOFILE=16384
       ExecStartPre=-/sbin/ip link del docker0
       ExecStart=
       ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay

--- a/packages/3dt/build
+++ b/packages/3dt/build
@@ -30,6 +30,7 @@ EnvironmentFile=/opt/mesosphere/environment
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 User=dcos_3dt
 ExecStart=/opt/mesosphere/bin/3dt -endpoint-config ${PKG_PATH}/endpoints_config.json -agent-port 61001
 EOF
@@ -42,6 +43,7 @@ EnvironmentFile=/opt/mesosphere/environment
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 PermissionsStartOnly=True
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-3dt
 User=dcos_3dt

--- a/packages/adminrouter/extra/dcos-adminrouter-agent.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent.service
@@ -5,6 +5,7 @@ Description=Admin Router Agent: A high performance web server and a reverse prox
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 Type=forking
 PIDFile=$PKG_PATH/nginx/logs/nginx.pid

--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -5,6 +5,7 @@ Description=Admin Router Master: A high performance web server and a reverse pro
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 Type=forking
 PIDFile=$PKG_PATH/nginx/logs/nginx.pid

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -17,6 +17,7 @@ Description=Package Service: DC/OS Packaging API
 Restart=always
 StartLimitInterval=0
 RestartSec=15
+LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/dcos-history/extra/dcos-history.service
+++ b/packages/dcos-history/extra/dcos-history.service
@@ -6,6 +6,7 @@ PermissionsStartOnly=True
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-history.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-history-extras.env

--- a/packages/dcos-log/extra/dcos-log-agent.service
+++ b/packages/dcos-log/extra/dcos-log-agent.service
@@ -7,5 +7,6 @@ EnvironmentFile=-/opt/mesosphere/etc/dcos-log-extra.env
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 User=dcos_log
 ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}

--- a/packages/dcos-log/extra/dcos-log-master.service
+++ b/packages/dcos-log/extra/dcos-log-master.service
@@ -7,5 +7,6 @@ EnvironmentFile=-/opt/mesosphere/etc/dcos-log-extra.env
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 User=dcos_log
 ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}

--- a/packages/dcos-metrics/extra/dcos-metrics-agent.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-agent.service
@@ -3,6 +3,7 @@ Description=Metrics Agent Service: DC/OS Metrics Agent Service for Application, 
 [Service]
 Restart=always
 RestartSec=5
+LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_metrics
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/dcos-metrics/extra/dcos-metrics-master.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-master.service
@@ -3,6 +3,7 @@ Description=Metrics Master Service: DC/OS Metrics Master Service for Host Level 
 [Service]
 Restart=always
 RestartSec=5
+LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_metrics
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/dcos-oauth/extra/dcos-oauth.service
+++ b/packages/dcos-oauth/extra/dcos-oauth.service
@@ -6,6 +6,7 @@ User=dcos_oauth
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/proxy.env

--- a/packages/dcos-signal/extra/dcos-signal.service
+++ b/packages/dcos-signal/extra/dcos-signal.service
@@ -4,6 +4,7 @@ Description=Signal: DC/OS Telemetry and Tracking Service
 Type=simple
 Restart=on-failure
 RestartSec=20
+LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_signal
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/docker-gc/extra/dcos-docker-gc.service
+++ b/packages/docker-gc/extra/dcos-docker-gc.service
@@ -4,6 +4,7 @@ Description=Docker GC: Periodically Garbate Collect Docker Containers using spot
 Type=simple
 Restart=on-failure
 RestartSec=20
+LimitNOFILE=16384
 User=dcos_docker_gc
 ConditionPathExists=/opt/mesosphere/etc/docker_gc_enabled
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -22,6 +22,7 @@ User=dcos_epmd
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=${PKG_PATH}/bin/epmd -port 61420

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -7,6 +7,7 @@ StandardError=journal
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 # Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
 RuntimeDirectory=dcos_exhibitor

--- a/packages/logrotate/extra/dcos-logrotate-agent.service
+++ b/packages/logrotate/extra/dcos-logrotate-agent.service
@@ -2,6 +2,7 @@
 Description=Logrotate Mesos Agent: Rotate Mesos agent logs
 [Service]
 Type=simple
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/usr/bin/mkdir -p /var/log/mesos/archive
 ExecStart=$PKG_PATH/bin/logrotate -v /opt/mesosphere/etc/logrotate_agent.config -s /var/lib/dcos/mesos/logrotate_agent.status

--- a/packages/logrotate/extra/dcos-logrotate-master.service
+++ b/packages/logrotate/extra/dcos-logrotate-master.service
@@ -2,6 +2,7 @@
 Description=Logrotate Mesos Master: Rotate Mesos master logs
 [Service]
 Type=simple
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/mesos/log/archive
 ExecStart=$PKG_PATH/bin/logrotate -v /opt/mesosphere/etc/logrotate_master.config -s /var/lib/dcos/mesos/logrotate_master.status

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -18,6 +18,7 @@ User=dcos_marathon
 Restart=always
 StartLimitInterval=0
 RestartSec=15
+LimitNOFILE=16384
 PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon

--- a/packages/mesos-dns/extra/dcos-mesos-dns.service
+++ b/packages/mesos-dns/extra/dcos-mesos-dns.service
@@ -6,6 +6,7 @@ PermissionsStartOnly=true
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/mesos-dns.env
 EnvironmentFile=-/opt/mesosphere/etc/mesos-dns-extras.env

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -16,6 +16,7 @@ User=dcos_metronome
 Restart=always
 StartLimitInterval=0
 RestartSec=15
+LimitNOFILE=16384
 PermissionsStartOnly=True
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment

--- a/packages/navstar/extra/dcos-navstar.service
+++ b/packages/navstar/extra/dcos-navstar.service
@@ -5,6 +5,7 @@ Description=Navstar: A distributed systems & network overlay orchestration engin
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}/navstar
 EnvironmentFile=/opt/mesosphere/etc/navstar-erl.env
 EnvironmentFile=/opt/mesosphere/etc/check_time.env

--- a/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
+++ b/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
@@ -8,6 +8,7 @@ StandardOutput=journal
 StandardError=journal
 Restart=always
 RestartSec=5
+LimitNOFILE=16384
 Environment=PKGPANDA_HTTP_CONFIG=${PKG_PATH}/etc/pkgpanda-api.conf.py
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=/opt/mesosphere/bin/gunicorn --worker-class=sync \

--- a/packages/rexray/extra/dcos-rexray.service
+++ b/packages/rexray/extra/dcos-rexray.service
@@ -3,8 +3,9 @@ Description=REX-Ray: A vendor agnostic storage orchestration engine
 
 [Service]
 StartLimitInterval=0
-RestartSec=15
 Restart=always
+RestartSec=15
+LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 Environment=REXRAY_HOME=/
 ExecStart=__PKG_PATH__/bin/rexray start -f


### PR DESCRIPTION
## High Level Description

Of all the DC/OS services, only spartan and mesos-{master,slave,public-slave}
set file limits. In all other cases the limit defaults to whatever is the default
for the distribution. In the case of CoreOS the default soft limit is 1024.

This PR sets the default file limit of all other dcos-* services to 16384.

Ideally this kind of change should inspect a very large, very busy cluster
and set the limits accordingly.

In future, as our monitoring improves, we will collect peak usage from large
clusters and adjust the limits accordingly.

Ideally all services should run with a predictable maximum number of open files
to support far tighter limits.

## Related Issues

  - [DCOS-625](https://dcosjira.atlassian.net/browse/DCOS-625) Explicit file descriptor limits for all DC/OS services

## Checklist for all PR's

https://dcosjira.atlassian.net/browse/
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Writing tests for configuration is always tricky. The closest thing I've come across is to run sanity checks on the config files themselves. This PR defers exactly such a test to https://github.com/dcos/dcos/pull/1170
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___