### PR TITLE
Pin pycodestyle version to 2.2.0

### DIFF
--- a/flake8_dcos_lint/setup.py
+++ b/flake8_dcos_lint/setup.py
@@ -16,7 +16,7 @@ setup(
     description='flake8 plugin for custom dcos checks',
     py_modules=["check_rules", "checker"],
     install_requires=[
-        'pycodestyle',
+        'pycodestyle==2.2.0',
         'flake8',
         'flake8-import-order==0.9.2',
         'pep8-naming'


### PR DESCRIPTION
* 2.3.0 broke our builds: https://github.com/PyCQA/pycodestyle/issues/617


## Related Issues

  - [DCOS-13518](https://mesosphere.atlassian.net/browse/DCOS-13518) Pin pycodestyle, because it breaks our CI too often

## Checklist for all PR's

  - **NA** Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
