### PR TITLE
standardize on zookeeper connection string

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -370,7 +370,7 @@ package:
       MESOS_SLAVE_REMOVAL_RATE_LIMIT=1/20mins
       MESOS_OFFER_TIMEOUT=2mins
       MESOS_WORK_DIR=/var/lib/dcos/mesos/master
-      MESOS_ZK=zk://127.0.0.1:2181/mesos
+      MESOS_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       MESOS_WEIGHTS={{ weights }}
       MESOS_QUORUM={{ master_quorum }}
       MESOS_HOSTNAME_LOOKUP=false

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -32,7 +32,8 @@ def test_leader_election(dcos_api_session):
 def test_if_all_mesos_masters_have_registered(dcos_api_session):
     # Currently it is not possible to extract this information through Mesos'es
     # API, let's query zookeeper directly.
-    zk = kazoo.client.KazooClient(hosts=dcos_api_session.zk_hostports, read_only=True)
+    zk_hostports = 'zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181'
+    zk = kazoo.client.KazooClient(hosts=zk_hostports, read_only=True)
     master_ips = []
 
     zk.start()

--- a/packages/dcos-oauth/extra/dcos_add_user.py
+++ b/packages/dcos-oauth/extra/dcos_add_user.py
@@ -23,7 +23,7 @@ retry_policy = KazooRetry(
 
 parser = argparse.ArgumentParser()
 parser.add_argument('email')
-parser.add_argument('--zk', default='127.0.0.1:2181')
+parser.add_argument('--zk', default='zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181')
 
 args = parser.parse_args()
 email = args.email

--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -110,7 +110,7 @@ class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
         self.slaves = sorted(slaves)
         self.public_slaves = sorted(public_slaves)
         self.all_slaves = sorted(slaves + public_slaves)
-        self.zk_hostports = ','.join(':'.join([host, '2181']) for host in self.public_masters)
+        self.zk_hostports = "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
         self.default_os_user = default_os_user
         self.auth_user = auth_user
 

--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -110,7 +110,6 @@ class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
         self.slaves = sorted(slaves)
         self.public_slaves = sorted(public_slaves)
         self.all_slaves = sorted(slaves + public_slaves)
-        self.zk_hostports = "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
         self.default_os_user = default_os_user
         self.auth_user = auth_user
 


### PR DESCRIPTION
## High Level Description

Spartan supports resolving `zk-1.zk, zk-2.zk, ..., zk-5.zk` to the IPs of the running zookeeper instances. When there are fewer instances than 5, the extra hostnames resolve to those servers that are present.

This allows services to run even if their local zookeeper instance is down.

This is nothing new. This patch just does some house cleaning by replacing one or two places where the old style was still used.

## Related Issues

  - [DCOS-626](https://dcosjira.atlassian.net/browse/DCOS-626) Standardize zookeeper address string

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: there are already several tests that will fail if the connection string functionality fails.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
