### PR TITLE
mesos-dns bugfixes and truncate bit disable

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -90,7 +90,8 @@ package:
         "timeout": 5,
         "listener": "0.0.0.0",
         "email": "root.mesos-dns.mesos",
-        "IPSources": {{ mesos_dns_ip_sources }}
+        "IPSources": {{ mesos_dns_ip_sources }},
+        "SetTruncateBit": false
       }
   - path: /etc_master/minuteman.config.d/master.config
     content: |

--- a/packages/mesos-dns/build
+++ b/packages/mesos-dns/build
@@ -1,12 +1,17 @@
-#!/bin/bash
-set -x
+#!/bin/bash -xe
+
+export GOPATH=/pkg:$GOPATH
+export PATH=/pkg/bin:$PATH
+
+mkdir -p /pkg/src/github.com/mesosphere
+mv /pkg/src/mesos-dns /pkg/src/github.com/mesosphere/
+cd /pkg/src/github.com/mesosphere/mesos-dns
+go install -v ./...
 
 mkdir -p $PKG_PATH/bin
-cp /pkg/src/mesos-dns/mesos-dns-*-amd64 $PKG_PATH/bin/mesos-dns
-chmod 755 $PKG_PATH/bin/mesos-dns
+cp -v /pkg/bin/mesos-dns $PKG_PATH/bin
 
 # Create the service file
 service="$PKG_PATH/dcos.target.wants_master/dcos-mesos-dns.service"
 mkdir -p "$(dirname "$service")"
 cp /pkg/extra/dcos-mesos-dns.service "$service"
-

--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -1,10 +1,10 @@
 {
-  "sources": {
-    "mesos-dns": {
-      "kind": "url",
-      "url": "https://github.com/mesosphere/mesos-dns/releases/download/v0.6.0/mesos-dns-v0.6.0-linux-amd64",
-      "sha1": "da98d671ca743ab44aa876b65d4e08db22b8c4d3"
-    }
+  "docker": "golang:1.7",
+  "single_source" : {
+    "kind": "git",
+    "git": "https://github.com/mesosphere/mesos-dns.git",
+    "ref": "919851a158ba71aee4de145dc0a7f90cc68d0902",
+    "ref_origin": "master"
   },
   "username": "dcos_mesos_dns"
 }


### PR DESCRIPTION
## High Level Description

Update mesos-dns to build instead of downloading a binary.

Fix race between mesos-dns serving empty data (NXDOMAINs) and polling state.json at startup.

Updates mesos-dns to HEAD, bringing in a couple of commits from the last few months.

Also included code that disables setting the truncate bit and config change to activate it.

## Related Issues

  - [DCOS-10809](https://mesosphere.atlassian.net/browse/DCOS-10809): DNS unavailable during DC/OS 1.8.5 upgrade
 - [DCOS-13193](https://mesosphere.atlassian.net/browse/DCOS-13193): Review EDNS fixes, merge to master if needed
 - [DCOS-13507](https://mesosphere.atlassian.net/browse/DCOS-13507): build mesos-dns in DC/OS build instead of pulling from CI

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated: [change log](https://github.com/mesosphere/mesos-dns/compare/43cd0620400449b70ee52883e94ec1c38f84b1ac...c8eb70e77f1f0ee8fa590421a89a665abc726192)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-mesos-dns-pulls/159/
  - [x] Code Coverage https://jenkins.mesosphere.com/service/jenkins/job/public-mesos-dns-pulls/159/