### PR TITLE
WIP: rm libs used by Docker during 1.7 -> 1.8 upgrade

### DIFF
--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -385,6 +385,7 @@ def upgrade_dcos(cluster, installer_url, add_config_path=None):
         tunnel.remote_cmd(curl_cmd + ['--remote-name', bootstrap_url + '/dcos_install.sh'])
 
         # Remove the old DC/OS.
+        tunnel.remote_cmd(['sudo', 'rm', '/opt/mesosphere/lib/libltdl.so.7'])
         tunnel.remote_cmd(['sudo', '-i', '/opt/mesosphere/bin/pkgpanda', 'uninstall'])
         tunnel.remote_cmd(['sudo', 'rm', '-rf', '/opt/mesosphere', '/etc/mesosphere'])
 

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -37,6 +37,7 @@ import os
 import random
 import string
 import sys
+import time
 
 import test_util.aws
 import test_util.cluster
@@ -83,7 +84,9 @@ def main():
     )
 
     # Use the CLI installer to set exhibitor_storage_backend = zookeeper.
-    test_util.cluster.install_dcos(cluster, stable_installer_url, api=False)
+    test_util.cluster.install_dcos(cluster, stable_installer_url, api=False, install_prereqs=False)
+    print('Sleeping for 5 minutes...')
+    time.sleep(5 * 60)  # Hack: wait for cluster to converge
     with cluster.ssher.tunnel(cluster.bootstrap_host) as bootstrap_host_tunnel:
         bootstrap_host_tunnel.remote_cmd(['sudo', 'rm', '-rf', cluster.ssher.home_dir + '/*'])
     test_util.cluster.upgrade_dcos(cluster, installer_url)


### PR DESCRIPTION
See https://github.com/mesosphere/dcos-docs-enterprise/pull/961