### PR TITLE
Add dcos-launch support for AWS advanced clusters

### DIFF
--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -1,52 +1,74 @@
+import logging
 import os
-from functools import partial
 
 import pytest
+import retrying
 
 import test_util.aws
 import test_util.helpers
 from test_util.helpers import retry_boto_rate_limits
 
+log = logging.getLogger(__name__)
+
 ENV_FLAG = 'ENABLE_RESILIENCY_TESTING'
 
-pytestmark = pytest.mark.skipif(
+skip_if_resiliency_not_enabled = pytest.mark.skipif(
     ENV_FLAG not in os.environ or os.environ[ENV_FLAG] != 'true',
     reason='Must explicitly enable resiliency testing with {}'.format(ENV_FLAG))
 
+skip_if_not_aws_stack = pytest.mark.skipif(
+    'AWS_STACK_NAME' not in os.environ,
+    reason='Must use an AWS Cloudformation run this test!')
+
+pytestmark = [skip_if_resiliency_not_enabled, skip_if_not_aws_stack]
+
 
 @pytest.fixture(scope='session')
-def dcos_launchpad(dcos_api_session):
-    """Interface for direct integration to dcos_launchpad hardware
-    Currently only supports AWS CF with AWS VPC coming soon
-    """
-    if 'AWS_STACK_NAME' not in os.environ:
-        # TODO(mellenburg): update when advanced templates are merged
-        pytest.skip('Must use a AWS Cloudformation to run test')
-    stack_name = os.environ['AWS_STACK_NAME']
+def boto_wrapper(dcos_api_session):
     aws_region = os.environ['AWS_REGION']
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
     aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
-    bw = test_util.aws.BotoWrapper(aws_region, aws_access_key_id, aws_secret_access_key)
-    return test_util.aws.DcosCfSimple(stack_name, bw)
+    return test_util.aws.BotoWrapper(aws_region, aws_access_key_id, aws_secret_access_key)
+
+
+@pytest.fixture(scope='session')
+def dcos_stack(boto_wrapper):
+    """ Works with either Zen or Simple cloud formations
+    """
+    stack = test_util.aws.fetch_stack(os.environ['AWS_STACK_NAME'], boto_wrapper)
+    if isinstance(stack, test_util.aws.VpcCfStack):
+        pytest.skip('Onprem Vpc not currently supported')
+    return stack
 
 
 @pytest.mark.last
-def test_agent_failure(dcos_launchpad, dcos_api_session, vip_apps):
-    # make sure the app works before starting
+def test_agent_failure(dcos_stack, boto_wrapper, dcos_api_session, vip_apps):
+    # Accessing AWS Resource objects will trigger a client describe call.
+    # As such, any method that touches AWS APIs must be wrapped to avoid
+    # CI collapse when rate limits are inevitably reached
     @retry_boto_rate_limits
-    def get_running_agents(group_name):
-        return [i for i in dcos_launchpad.get_auto_scaling_instances(group_name)
-                if i.state['Name'] == 'running']
+    def get_running_instances(instance_iter):
+        return [i for i in instance_iter if i.state['Name'] == 'running']
 
+    @retry_boto_rate_limits
+    def get_instance_ids(instance_iter):
+        return [i.instance_id for i in instance_iter]
+
+    @retry_boto_rate_limits
+    def get_private_ips(instance_iter):
+        return sorted([i.private_ip_address for i in get_running_instances(instance_iter)])
+
+    # make sure the app works before starting
     test_util.helpers.wait_for_pong(vip_apps[0][1], 120)
     test_util.helpers.wait_for_pong(vip_apps[1][1], 10)
-    agents = [i.instance_id for i in get_running_agents('PublicSlaveServerGroup') +
-              get_running_agents('SlaveServerGroup')]
+    agent_ids = get_instance_ids(
+        get_running_instances(dcos_stack.public_agent_instances) +
+        get_running_instances(dcos_stack.private_agent_instances))
 
     # Agents are in auto-scaling groups, so they will automatically be replaced
-    dcos_launchpad.boto_wrapper.client('ec2').terminate_instances(InstanceIds=agents)
-    waiter = dcos_launchpad.boto_wrapper.client('ec2').get_waiter('instance_terminated')
-    retry_boto_rate_limits(waiter.wait)(InstanceIds=agents)
+    boto_wrapper.client('ec2').terminate_instances(InstanceIds=agent_ids)
+    waiter = boto_wrapper.client('ec2').get_waiter('instance_terminated')
+    retry_boto_rate_limits(waiter.wait)(InstanceIds=agent_ids)
 
     # Tell mesos the machines are "down" and not coming up so things get rescheduled.
     down_hosts = [{'hostname': slave, 'ip': slave} for slave in dcos_api_session.all_slaves]
@@ -58,17 +80,32 @@ def test_agent_failure(dcos_launchpad, dcos_api_session, vip_apps):
         }]}).raise_for_status()
     dcos_api_session.post('/mesos/machine/down', json=down_hosts).raise_for_status()
 
-    # Wait for replacements
-    test_util.helpers.wait_for_len(partial(get_running_agents, 'SlaveServerGroup'), len(dcos_api_session.slaves), 600)
-    test_util.helpers.wait_for_len(
-        partial(get_running_agents, 'PublicSlaveServerGroup'), len(dcos_api_session.public_slaves), 600)
+    public_agent_count = len(dcos_api_session.public_slaves)
+    private_agent_count = len(dcos_api_session.slaves)
 
-    # Reset the dcos_api_session to have the replacement agents
-    dcos_api_session.slaves = sorted([agent.private_ip_address for agent in
-                                      get_running_agents('SlaveServerGroup')])
-    dcos_api_session.public_slaves = sorted([agent.private_ip_address for agent in
-                                             get_running_agents('PublicSlaveServerGroup')])
-    dcos_api_session.all_slaves = sorted(dcos_api_session.slaves + dcos_api_session.public_slaves)
+    @retrying.retry(
+        wait_fixed=60 * 1000,
+        retry_on_result=lambda res: res is False,
+        stop_max_delay=900 * 1000)
+    def wait_for_agents_to_refresh():
+        public_agents = get_running_instances(dcos_stack.public_agent_instances)
+        if len(public_agents) == public_agent_count:
+            dcos_api_session.public_slaves = get_private_ips(public_agents)
+        else:
+            log.info('Waiting for {} public agents. Current: {}'.format(
+                     public_agent_count, len(public_agents)))
+            return False
+        private_agents = get_running_instances(dcos_stack.private_agent_instances)
+        if len(private_agents) == private_agent_count:
+            dcos_api_session.slaves = get_private_ips(private_agents)
+        else:
+            log.info('Waiting for {} private agents. Current: {}'.format(
+                     private_agent_count, len(private_agents)))
+            return False
+        dcos_api_session.all_slaves = sorted(
+            dcos_api_session.slaves + dcos_api_session.public_slaves)
+
+    wait_for_agents_to_refresh()
 
     # verify that everything else is still working
     dcos_api_session.wait_for_dcos()

--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -1,4 +1,20 @@
-#!/usr/bin/env python3
+""" Abstractions for handling resources via Amazon Web Services (AWS) API
+
+The intention of these utilities is to allow other infrastructure to
+interact with AWS without having to understand AWS APIs. Additionally,
+this module provides helper functions for the most common queries required
+to manipulate and test a DC/OS cluster, which would be otherwise cumbersome
+to do with AWS API calls only
+
+BotoWrapper: AWS credentials and region bound to various helper methods
+CfStack: Generic representation of a CloudFormation stack
+DcosCfStack: Represents DC/OS in a simple deployment
+DcosZenCfStack: Represents DC/OS  deployed from a zen template
+MasterStack: thin wrapper for master stack in a zen template
+PrivateAgentStack: thin wrapper for public agent stack in a zen template
+PublicAgentStack: thin wrapper for public agent stack in a zen template
+VpcCfStack: Represents a homogeneous cluster of hosts with a specific AMI
+"""
 import logging
 import time
 
@@ -7,10 +23,11 @@ import retrying
 
 from test_util.helpers import Host, retry_boto_rate_limits, SshInfo
 
-LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
-logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 # AWS verbosity in debug mode overwhelms meaningful logging
 logging.getLogger('botocore').setLevel(logging.INFO)
+logging.getLogger('boto3').setLevel(logging.INFO)
+logging.getLogger('boto3.resources.action').setLevel(logging.WARNING)
+logging.getLogger('botocore.vendored.requests.packages.urllib3').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 VPC_TEMPLATE_URL = 'https://s3.amazonaws.com/vpc-cluster-template/vpc-cluster-template.json'
@@ -33,6 +50,20 @@ def instances_to_hosts(instances):
     return [Host(i.private_ip_address, i.public_ip_address) for i in instances]
 
 
+def fetch_stack(stack_name, boto_wrapper):
+    log.debug('Attemping to fetch AWS Stack: {}'.format(stack_name))
+    stack = boto_wrapper.resource('cloudformation').Stack(stack_name)
+    for resource in stack.resource_summaries.all():
+        if resource.logical_resource_id == 'MasterStack':
+            log.debug('Using Zen DC/OS Cloudformation interface')
+            return DcosZenCfStack(stack_name, boto_wrapper)
+        if resource.logical_resource_id == 'MasterServerGroup':
+            log.debug('Using Basic DC/OS Cloudformation interface')
+            return DcosCfStack(stack_name, boto_wrapper)
+    log.debug('Using VPC Cloudformation interface')
+    return VpcCfStack(stack_name, boto_wrapper)
+
+
 class BotoWrapper():
     def __init__(self, region, aws_access_key_id, aws_secret_access_key):
         self.region = region
@@ -48,10 +79,12 @@ class BotoWrapper():
     def create_key_pair(self, key_name):
         """Returns private key of newly generated pair
         """
+        log.info('Creating KeyPair: {}'.format(key_name))
         key = self.client('ec2').create_key_pair(KeyName=key_name)
         return key['KeyMaterial']
 
     def delete_key_pair(self, key_name):
+        log.info('Deleting KeyPair: {}'.format(key_name))
         self.resource('ec2').KeyPair(key_name).delete()
 
     def create_stack(self, name, template_url, parameters, deploy_timeout=60):
@@ -59,7 +92,7 @@ class BotoWrapper():
         Does simple casting of strings or numbers
         Starts stack creation if validation is successful
         """
-        log.info('Requesting AWS CloudFormation...')
+        log.info('Requesting AWS CloudFormation: {}'.format(name))
         self.resource('cloudformation').create_stack(
             StackName=name,
             TemplateURL=template_url,
@@ -71,12 +104,66 @@ class BotoWrapper():
             Parameters=[{str(k): str(v) for k, v in p.items()} for p in parameters])
         return CfStack(name, self)
 
+    def create_vpc_tagged(self, cidr, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new VPC...')
+        vpc_id = ec2.create_vpc(CidrBlock=cidr, InstanceTenancy='default')['Vpc']['VpcId']
+        ec2.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
+        ec2.create_tags(Resources=[vpc_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        log.info('Created VPC with ID: {}'.format(vpc_id))
+        return vpc_id
+
+    def create_internet_gateway_tagged(self, vpc_id, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new InternetGateway...')
+        gateway_id = ec2.create_internet_gateway()['InternetGateway']['InternetGatewayId']
+        ec2.attach_internet_gateway(InternetGatewayId=gateway_id, VpcId=vpc_id)
+        ec2.create_tags(Resources=[gateway_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        log.info('Created internet gateway with ID: {}'.format(gateway_id))
+        return gateway_id
+
+    def create_subnet_tagged(self, vpc_id, cidr, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new Subnet...')
+        subnet_id = ec2.create_subnet(VpcId=vpc_id, CidrBlock=cidr)['Subnet']['SubnetId']
+        ec2.create_tags(Resources=[subnet_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        ec2.get_waiter('subnet_available').wait(SubnetIds=[subnet_id])
+        log.info('Created subnet with ID: {}'.format(subnet_id))
+        return subnet_id
+
+    def delete_subnet(self, subnet_id):
+        log.info('Deleting subnet: {}'.format(subnet_id))
+        self.client('ec2').delete_subnet(SubnetId=subnet_id)
+
+    def delete_internet_gateway(self, gateway_id):
+        ig = self.resource('ec2').InternetGateway(gateway_id)
+        for vpc in ig.attachments:
+            vpc_id = vpc['VpcId']
+            log.info('Detaching gateway {} from vpc {}'.format(gateway_id, vpc_id))
+            ig.detach_from_vpc(VpcId=vpc_id)
+        log.info('Deleting internet gateway: {}'.format(gateway_id))
+        ig.delete()
+
+    def delete_vpc(self, vpc_id):
+        log.info('Deleting vpc: {}'.format(vpc_id))
+        self.client('ec2').delete_vpc(VpcId=vpc_id)
+
+    @retry_boto_rate_limits
+    def get_auto_scaling_instances(self, asg_physical_resource_id):
+        """ Returns instance objects as described here:
+        http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#instance
+        """
+        ec2 = self.resource('ec2')
+        return [ec2.Instance(i['InstanceId']) for asg in self.client('autoscaling').
+                describe_auto_scaling_groups(
+                    AutoScalingGroupNames=[asg_physical_resource_id])
+                ['AutoScalingGroups'] for i in asg['Instances']]
+
 
 class CfStack:
     def __init__(self, stack_name, boto_wrapper):
         self.boto_wrapper = boto_wrapper
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(stack_name)
-        self._host_cache = {}
 
     def wait_for_status_change(self, state_1, state_2, wait_before_poll_min, timeout=60 * 60):
         """
@@ -112,26 +199,33 @@ class CfStack:
                 for event in self.get_stack_events():
                     log.error('Stack Events: {}'.format(event))
                 raise Exception('StackStatus changed unexpectedly to: {}'.format(stack_status))
+            log.info('Continuing to wait...')
             return False
         wait_loop()
 
+    def wait_for_complete(self, wait_before_poll_min=0):
+        status = self.get_stack_details()['StackStatus']
+        if status.endswith('_COMPLETE'):
+            return
+        elif status.endswith('_IN_PROGRESS'):
+            self.wait_for_status_change(
+                status, status.replace('IN_PROGRESS', 'COMPLETE'),
+                wait_before_poll_min)
+        else:
+            raise Exception('AWS Stack has entered unexpected state: {}'.format(status))
+
     @retry_boto_rate_limits
     def get_stack_details(self):
-        log.debug('Requesting stack details')
-        return self.boto_wrapper.client('cloudformation').describe_stacks(
+        details = self.boto_wrapper.client('cloudformation').describe_stacks(
             StackName=self.stack.stack_id)['Stacks'][0]
+        log.debug('Stack details: {}'.format(details))
+        return details
 
     @retry_boto_rate_limits
     def get_stack_events(self):
         log.debug('Requesting stack events')
         return self.boto_wrapper.client('cloudformation').describe_stack_events(
             StackName=self.stack.stack_id)['StackEvents']
-
-    def wait_for_stack_creation(self, wait_before_poll_min=3):
-        self.wait_for_status_change('CREATE_IN_PROGRESS', 'CREATE_COMPLETE', wait_before_poll_min)
-
-    def wait_for_stack_deletion(self, wait_before_poll_min=3):
-        self.wait_for_status_change('DELETE_IN_PROGRESS', 'DELETE_COMPLETE', wait_before_poll_min)
 
     def get_parameter(self, param):
         """Returns param if in stack parameters, else returns None
@@ -142,32 +236,51 @@ class CfStack:
         raise KeyError('Key not found in template parameters: {}. Parameters: {}'.
                        format(param, self.stack.parameters))
 
-    @retry_boto_rate_limits
-    def get_auto_scaling_instances(self, logical_id):
-        """ Get instances in ASG with logical_id. If logical_id is None, all ASGs will be used
-        Will return instance objects as described here:
-        http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#instance
+    def delete(self):
+        stack_id = self.stack.stack_id
+        log.info('Deleting stack: {}'.format(stack_id))
+        # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
+        self.stack = self.boto_wrapper.resource('cloudformation').Stack(stack_id)
+        self.stack.delete()
+        log.info('Delete successfully initiated for {}'.format(stack_id))
 
-        Note: there is no ASG resource hence the need for this method
+
+class CleanupS3BucketMixin:
+    def delete_exhibitor_s3_bucket(self):
+        """ A non-empty S3 bucket cannot be deleted, so check to
+        see if it should be emptied first. If its non-empty, but
+        has more than one item, error out as the bucket is perhaps
+        not an exhibitor bucket and the user should be alerted
         """
-        ec2 = self.boto_wrapper.resource('ec2')
-        return [ec2.Instance(i['InstanceId']) for asg in self.boto_wrapper.client('autoscaling').
-                describe_auto_scaling_groups(
-                    AutoScalingGroupNames=[self.stack.Resource(logical_id).physical_resource_id])
-                ['AutoScalingGroups'] for i in asg['Instances']]
+        try:
+            bucket = self.boto_wrapper.resource('s3').Bucket(
+                self.stack.Resource('ExhibitorS3Bucket').physical_resource_id)
+        except:
+            log.exception('Bucket could not be fetched')
+            return
+        log.info('Starting bucket {} deletion'.format(bucket))
+        all_objects = list(bucket.objects.all())
+        obj_count = len(all_objects)
+        if obj_count == 1:
+            all_objects[0].delete()
+        elif obj_count > 1:
+            raise Exception('Expected on item in Exhibitor S3 bucket but found: ' + obj_count)
+        log.info('Trying deleting bucket {} itself'.format(bucket))
+        bucket.delete()
 
-    def get_hosts_cached(self, group_name, refresh=False):
-        if refresh or group_name not in self._host_cache:
-            host_list = instances_to_hosts(self.get_auto_scaling_instances(group_name))
-            self._host_cache[group_name] = host_list
-            return host_list
-        return self._host_cache[group_name]
+    def delete(self):
+        self.delete_exhibitor_s3_bucket()
+        super().delete()
 
 
-class DcosCfSimple(CfStack):
+class DcosCfStack(CleanupS3BucketMixin, CfStack):
+    """ This abstraction will work for a simple DC/OS template.
+    A simple template has its exhibitor bucket and auto scaling groups
+    for each of the master, public agent, and private agent groups
+    """
     @classmethod
-    def create(cls, stack_name, template_url, public_agents, private_agents,
-               admin_location, key_pair_name, boto_wrapper):
+    def create(cls, stack_name: str, template_url: str, public_agents: int, private_agents: int,
+               admin_location: str, key_pair_name: str, boto_wrapper: BotoWrapper):
         parameters = {
             'KeyName': key_pair_name,
             'AdminLocation': admin_location,
@@ -178,78 +291,61 @@ class DcosCfSimple(CfStack):
         # stack.stack_name returns stack_id if Stack was created with ID
         return cls(stack.stack.stack_name, boto_wrapper), SSH_INFO['coreos']
 
-    def delete(self):
-        log.info('Starting deletion of CF stack')
-        # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
-        self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
-        self.stack.delete()
-        self.empty_and_delete_s3_bucket_from_stack()
+    @property
+    def master_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('MasterServerGroup').physical_resource_id)
 
-    def empty_and_delete_s3_bucket_from_stack(self):
-        bucket_id = self.stack.Resource('ExhibitorS3Bucket').physical_resource_id
-        s3 = self.boto_wrapper.resource('s3')
-        bucket = s3.Bucket(bucket_id)
-        log.info('Starting bucket {} deletion'.format(bucket))
-        all_objects = bucket.objects.all()
-        obj_count = len(list(all_objects))
-        if obj_count > 0:
-            assert obj_count == 1, 'Expected one object in Exhibitor S3 bucket but found: ' + str(obj_count)
-            exhibitor_object = list(all_objects)[0]
-            log.info('Trying to delete object from bucket: {}'.format(repr(exhibitor_object)))
-            exhibitor_object.delete()
-        log.info('Trying deleting bucket {} itself'.format(bucket))
-        bucket.delete()
-        log.info('Delete successfully triggered for {}'.format(self.stack.stack_name))
+    @property
+    def private_agent_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('SlaveServerGroup').physical_resource_id)
 
-    def get_master_ips(self, refresh=False):
-        return self.get_hosts_cached('MasterServerGroup', refresh=refresh)
+    @property
+    def public_agent_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PublicSlaveServerGroup').physical_resource_id)
 
-    def get_public_agent_ips(self, refresh=False):
-        return self.get_hosts_cached('PublicSlaveServerGroup', refresh=refresh)
+    def get_master_ips(self):
+        return instances_to_hosts(self.master_instances)
 
-    def get_private_agent_ips(self, refresh=False):
-        return self.get_hosts_cached('SlaveServerGroup', refresh=refresh)
+    def get_private_agent_ips(self):
+        return instances_to_hosts(self.private_agent_instances)
+
+    def get_public_agent_ips(self):
+        return instances_to_hosts(self.public_agent_instances)
 
 
-class DcosCfAdvanced(CfStack):
+class MasterStack(CleanupS3BucketMixin, CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('MasterServerGroup').physical_resource_id)
+
+
+class PrivateAgentStack(CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PrivateAgentServerGroup').physical_resource_id)
+
+
+class PublicAgentStack(CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PublicAgentServerGroup').physical_resource_id)
+
+
+class DcosZenCfStack(CfStack):
+    """Zen stacks are stacks that have the masters, infra, public agents, and private
+    agents split into resources stacks under one zen stack
+    """
     @classmethod
     def create(cls, stack_name, boto_wrapper, template_url,
                public_agents, private_agents, key_pair_name,
                private_agent_type, public_agent_type, master_type,
-               vpc_cidr='10.0.0.0/16', public_subnet_cidr='10.0.128.0/20',
-               private_subnet_cidr='10.0.0.0/17',
-               gateway=None, vpc=None, private_subnet=None, public_subnet=None):
-        ec2 = boto_wrapper.client('ec2')
-        if not vpc:
-            log.info('Creating new VPC...')
-            vpc = ec2.create_vpc(CidrBlock=vpc_cidr, InstanceTenancy='default')['Vpc']['VpcId']
-            ec2.get_waiter('vpc_available').wait(VpcIds=[vpc])
-            ec2.create_tags(Resources=[vpc], Tags=[{'Key': 'Name', 'Value': stack_name}])
-        log.info('Using VPC with ID: ' + vpc)
-
-        if not gateway:
-            log.info('Creating new InternetGateway...')
-            gateway = ec2.create_internet_gateway()['InternetGateway']['InternetGatewayId']
-            ec2.attach_internet_gateway(InternetGatewayId=gateway, VpcId=vpc)
-            ec2.create_tags(Resources=[gateway], Tags=[{'Key': 'Name', 'Value': stack_name}])
-        log.info('Using InternetGateway with ID: ' + gateway)
-
-        def _make_subnet(cidr, suffix):
-            subnet = ec2.create_subnet(VpcId=vpc, CidrBlock=cidr)['Subnet']['SubnetId']
-            ec2.create_tags(Resources=[private_subnet], Tags=[{'Key': 'Name', 'Value': stack_name + '-' + suffix}])
-            ec2.get_waiter('subnet_available').wait(SubnetIds=[subnet])
-            return subnet
-
-        if not private_subnet:
-            log.info('Creating new PrivateSubnet...')
-            private_subnet = _make_subnet(private_subnet_cidr, 'private')
-        log.info('Using PrivateSubnet with ID: ' + private_subnet)
-
-        if not public_subnet:
-            log.info('Creating new PublicSubnet...')
-            public_subnet = _make_subnet(public_subnet_cidr, 'public')
-        log.info('Using PublicSubnet with ID: ' + public_subnet)
-
+               gateway, vpc, private_subnet, public_subnet):
         parameters = {
             'KeyName': key_pair_name,
             'Vpc': vpc,
@@ -272,38 +368,50 @@ class DcosCfAdvanced(CfStack):
             raise
         return cls(stack.stack.stack_name, boto_wrapper), ssh_info
 
-    def delete(self, delete_vpc=False):
-        log.info('Starting deletion of CF Advanced stack')
-        vpc_id = self.get_parameter('Vpc')
+    def __init__(self, stack_name, boto_wrapper):
+        super().__init__(stack_name, boto_wrapper)
+        self.master_stack = MasterStack(
+            self.stack.Resource('MasterStack').physical_resource_id, self.boto_wrapper)
+        self.private_agent_stack = PrivateAgentStack(
+            self.stack.Resource('PrivateAgentStack').physical_resource_id, self.boto_wrapper)
+        self.public_agent_stack = PublicAgentStack(
+            self.stack.Resource('PublicAgentStack').physical_resource_id, self.boto_wrapper)
+        self.infrastructure = CfStack(self.stack.Resource('Infrastructure').physical_resource_id, self.boto_wrapper)
+
+    def delete(self):
+        log.info('Starting deletion of Zen CF stack')
         # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
-        log.info('Deleting Infrastructure Stack')
-        infrastack = DcosCfSimple(self.get_resource_stack('Infrastructure').stack.stack_id, self.boto_wrapper)
-        infrastack.delete()
-        log.info('Deleting Master Stack')
-        self.get_resource_stack('MasterStack').stack.delete()
-        log.info('Deleting Private Agent Stack')
-        self.get_resource_stack('PrivateAgentStack').stack.delete()
-        log.info('Deleting Public Agent Stack')
-        self.get_resource_stack('PublicAgentStack').stack.delete()
-        self.stack.delete()
-        if delete_vpc:
-            self.wait_for_stack_deletion()
-            self.boto_wrapper.resource('ec2').Vpc(vpc_id).delete()
+        # These resources might have failed to create or been removed prior, except their
+        # failures and log it out
+        for s in [self.infrastructure, self.master_stack, self.private_agent_stack,
+                  self.public_agent_stack]:
+            try:
+                s.delete()
+            except:
+                log.exception('Delete encountered an error!')
+        super().delete()
 
-    def get_master_ips(self, refresh=False):
-        return self.get_resource_stack('MasterStack').get_hosts_cached('MasterServerGroup', refresh=refresh)
+    @property
+    def master_instances(self):
+        yield from self.master_stack.instances
 
-    def get_private_agent_ips(self, refresh=False):
-        return self.get_resource_stack('PrivateAgentStack').get_hosts_cached('PrivateAgentServerGroup', refresh=refresh)
+    @property
+    def private_agent_instances(self):
+        yield from self.private_agent_stack.instances
 
-    def get_public_agent_ips(self, refresh=False):
-        return self.get_resource_stack('PublicAgentStack').get_hosts_cached('PublicAgentServerGroup', refresh=refresh)
+    @property
+    def public_agent_instances(self):
+        yield from self.public_agent_stack.instances
 
-    def get_resource_stack(self, resource_name):
-        """Returns a CfStack for a given resource
-        """
-        return CfStack(self.stack.Resource(resource_name).physical_resource_id, self.boto_wrapper)
+    def get_master_ips(self):
+        return instances_to_hosts(self.master_instances)
+
+    def get_private_agent_ips(self):
+        return instances_to_hosts(self.private_agent_instances)
+
+    def get_public_agent_ips(self):
+        return instances_to_hosts(self.public_agent_instances)
 
 
 class VpcCfStack(CfStack):
@@ -326,10 +434,15 @@ class VpcCfStack(CfStack):
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
         self.stack.delete()
 
-    def get_vpc_host_ips(self):
+    @property
+    def instances(self):
         # the vpc templates use the misleading name CentOSServerAutoScale for all deployments
         # https://mesosphere.atlassian.net/browse/DCOS-11534
-        return self.get_hosts_cached('CentOSServerAutoScale')
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('CentOSServerAutoScale').physical_resource_id)
+
+    def get_host_ips(self):
+        return instances_to_hosts(self.instances)
 
 
 SSH_INFO = {

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -141,7 +141,7 @@ class Cluster:
         num_agents,
         num_public_agents,
     ):
-        hosts = vpc.get_vpc_host_ips()
+        hosts = vpc.get_host_ips()
         logging.info('AWS provided VPC info: ' + repr(hosts))
 
         vpc_cluster = cls.from_hosts(

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -215,22 +215,6 @@ def wait_for_pong(url, timeout):
     ping_app()
 
 
-def wait_for_len(fetch_fn, target_count, timeout):
-    """Will call fetch_fn every 10s, get len() on the result and repeat until it is
-    equal to target count or timeout (in seconds) has been reached
-    """
-    @retrying.retry(wait_fixed=10000, stop_max_delay=timeout * 1000,
-                    retry_on_result=lambda res: res is False,
-                    retry_on_exception=lambda ex: False)
-    def check_for_match():
-        items = fetch_fn()
-        count = len(items)
-        logging.info('Waiting for len()=={}. Current count: {}. Items: {}'.format(target_count, count, repr(items)))
-        if count != target_count:
-            return False
-    check_for_match()
-
-
 def session_tempfile(data):
     """Writes bytes to a named temp file and returns its path
     the temp file will be removed when the interpreter exits

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -33,7 +33,7 @@ from docopt import docopt
 import ssh.tunnel
 import test_util.runner
 from pkgpanda.util import json_prettyprint, load_json, load_string, load_yaml, write_json, YamlParseError
-from test_util.aws import BotoWrapper, DcosCfSimple
+from test_util.aws import BotoWrapper, DcosCfStack
 
 
 class LauncherError(Exception):
@@ -203,7 +203,7 @@ class AwsCloudformationLauncher(AbstractLauncher):
         NOTE: only supports Simple Cloudformation currently
         """
         try:
-            return DcosCfSimple(info['stack_name'], self.boto_wrapper)
+            return DcosCfStack(info['stack_name'], self.boto_wrapper)
         except Exception as ex:
             raise LauncherError('StackNotFound', '{} is not accessible'.format(info['stack_name'])) from ex
 

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -33,7 +33,14 @@ from docopt import docopt
 import ssh.tunnel
 import test_util.runner
 from pkgpanda.util import json_prettyprint, load_json, load_string, load_yaml, write_json, YamlParseError
-from test_util.aws import BotoWrapper, DcosCfStack
+from test_util.aws import BotoWrapper, fetch_stack
+
+
+def check_keys(user_dict, key_list):
+    missing = [k for k in key_list if k not in user_dict]
+    if len(missing) > 0:
+        raise LauncherError('MissingInput', 'The following keys were required but '
+                            'not provided: {}'.format(repr(missing)))
 
 
 class LauncherError(Exception):
@@ -42,7 +49,7 @@ class LauncherError(Exception):
         self.msg = msg
 
     def __repr__(self):
-        return '{}: {}'.format(self.error, self.msg)
+        return '{}: {}'.format(self.error, self.msg if self.msg else self.__cause__)
 
 
 class AbstractLauncher(metaclass=abc.ABCMeta):
@@ -61,8 +68,26 @@ class AbstractLauncher(metaclass=abc.ABCMeta):
     def ssh_from_config(self, info):
         raise NotImplementedError()
 
-    def test(self, info):
-        raise NotImplementedError()
+    def test(self, info, test_cmd):
+        ssh_info = info['ssh']
+        try:
+            check_keys(ssh_info, ['user', 'private_key'])
+        except LauncherError:
+            print('DC/OS Launch is missing sufficient SSH info to run tests!')
+            raise
+        details = self.describe(info)
+        test_host = details['masters'][0]['public_ip']
+        with ssh.tunnel.tunnel(ssh_info['user'], ssh_info['private_key'], test_host) as test_tunnel:
+            return test_util.runner.integration_test(
+                tunnel=test_tunnel,
+                dcos_dns=test_host,
+                master_list=[m['private_ip'] for m in details['masters']],
+                agent_list=[a['private_ip'] for a in details['private_agents']],
+                public_agent_list=[a['private_ip'] for a in details['public_agents']],
+                aws_access_key_id=info['provider'].get('access_key_id'),
+                aws_secret_access_key=info['provider'].get('secret_access_key'),
+                region=info['provider'].get('region'),
+                test_cmd=test_cmd)
 
 
 class AwsCloudformationLauncher(AbstractLauncher):
@@ -70,12 +95,24 @@ class AwsCloudformationLauncher(AbstractLauncher):
         self.boto_wrapper = boto_wrapper
 
     def create(self, config):
+        """
+        Checks config and creates missing resources as necessary
+        If actual stack creation fails, then network resources
+        will be cleaned up
+
+        Note: ssh_from_config and provide_network_prereqs will mutate
+            config
+        """
         check_keys(config, ['stack_name', 'template_url'])
-        ssh_info = self.ssh_from_config(config)
-        # NOTE: even if parameters not given, ssh_from_config will add KeyName
-        # parameter to config['parameters']
-        self.boto_wrapper.create_stack(
-            config['stack_name'], config['template_url'], config['parameters'])
+        ssh_info, temp_resources = self.ssh_from_config(config)
+        if config.get('zen_helper', False):
+            temp_resources.update(self.provide_network_prereqs(config))
+        try:
+            self.boto_wrapper.create_stack(
+                config['stack_name'], config['template_url'], config['parameters'])
+        except Exception as ex:
+            self.delete_temp_resources(temp_resources)
+            raise LauncherError('ProviderError', None) from ex
         return {
             'type': 'cloudformation',
             'stack_name': config['stack_name'],
@@ -83,18 +120,51 @@ class AwsCloudformationLauncher(AbstractLauncher):
                 'region': config['provider_info']['region'],
                 'access_key_id': config['provider_info']['access_key_id'],
                 'secret_access_key': config['provider_info']['secret_access_key']},
-            'ssh': ssh_info}
+            'ssh': ssh_info,
+            'temp_resources': temp_resources}
+
+    def provide_network_prereqs(self, config):
+        parameters = config.get('parameters', list())
+        vpc_found = False
+        gateway_found = False
+        private_subnet_found = False
+        public_subnet_found = False
+        for param in parameters:
+            key = param['ParameterKey']
+            if key == 'Vpc':
+                vpc_found = True
+                vpc_id = param['ParameterValue']
+            elif key == 'InternetGateway':
+                gateway_found = True
+            elif key == 'PrivateSubnet':
+                private_subnet_found = True
+            elif key == 'PublicSubnet':
+                public_subnet_found = True
+        temp_resources = {}
+
+        if not vpc_found:
+            vpc_id = self.boto_wrapper.create_vpc_tagged('10.0.0.0/16', config['stack_name'])
+            parameters.append({'ParameterKey': 'Vpc', 'ParameterValue': vpc_id})
+            temp_resources.update({'vpc': vpc_id})
+        if not gateway_found:
+            gateway_id = self.boto_wrapper.create_internet_gateway_tagged(vpc_id, config['stack_name'])
+            parameters.append({'ParameterKey': 'InternetGateway', 'ParameterValue': gateway_id})
+            temp_resources.update({'gateway': gateway_id})
+        if not private_subnet_found:
+            private_subnet_id = self.boto_wrapper.create_subnet_tagged(
+                vpc_id, '10.0.0.0/17', config['stack_name'] + 'private')
+            parameters.append({'ParameterKey': 'PrivateSubnet', 'ParameterValue': private_subnet_id})
+            temp_resources.update({'private_subnet': private_subnet_id})
+        if not public_subnet_found:
+            public_subnet_id = self.boto_wrapper.create_subnet_tagged(
+                vpc_id, '10.0.128.0/20', config['stack_name'] + '-public')
+            parameters.append({'ParameterKey': 'PublicSubnet', 'ParameterValue': public_subnet_id})
+            temp_resources.update({'public_subnet': public_subnet_id})
+        config['parameters'] = parameters
+        return temp_resources
 
     def wait(self, info):
-        # TODO: should this support the case where the cluster is being updated?
-        cf = self.get_stack(info)
-        status = cf.get_stack_details()['StackStatus']
-        if status == 'CREATE_IN_PROGRESS':
-            cf.wait_for_stack_creation(wait_before_poll_min=0)
-        elif status == 'CREATE_COMPLETE':
-            return
-        else:
-            raise LauncherError('WaitError', 'AWS Stack has entered unexpected state: {}'.format(status))
+        self.get_stack(info).wait_for_complete()
 
     def describe(self, info):
         desc = copy.copy(info)
@@ -106,28 +176,37 @@ class AwsCloudformationLauncher(AbstractLauncher):
         return desc
 
     def delete(self, info):
-        if info['ssh']['delete_with_stack']:
-            self.boto_wrapper.delete_key_pair(info['ssh']['key_name'])
-        self.get_stack(info).delete()
+        stack = self.get_stack(info)
+        stack.delete()
+        if len(info['temp_resources']) > 0:
+            stack.wait_for_complete()
+            self.delete_temp_resources(info['temp_resources'])
+
+    def delete_temp_resources(self, temp_resources):
+        if 'key_name' in temp_resources:
+            self.boto_wrapper.delete_key_pair(temp_resources['key_name'])
+        if 'public_subnet' in temp_resources:
+            self.boto_wrapper.delete_subnet(temp_resources['public_subnet'])
+        if 'private_subnet' in temp_resources:
+            self.boto_wrapper.delete_subnet(temp_resources['private_subnet'])
+        if 'gateway' in temp_resources:
+            self.boto_wrapper.delete_internet_gateway(temp_resources['gateway'])
+        if 'vpc' in temp_resources:
+            self.boto_wrapper.delete_vpc(temp_resources['vpc'])
 
     def ssh_from_config(self, config):
         """
-        In AWS simple deploys, SSH is only used for running the integration test suite.
-        In order to use SSH with AWS, one must use an SSH key pair that was previously created
-        in and downloaded from AWS. The private key cannot be obtained after its creation, so there
-        are three supported possibilities:
-        1. User has no preset key pair and would like one to be created for just this instance.
-            The keypair will be generated and the private key and key name will be added to the
-            ssh_info of the cluster info JSON. This key will be marked in the ssh_info for deletion
-            by dcos-launch when the entire cluster is deleted. SSH user name cannot be inferred so
-            it must still be provided in the ssh_info of the config
-        2. User has a preset AWS KeyPair and no corresponding private key. Testing will not be possible
-            without the private key, so ssh_info can be completely omitted with no loss.
-        3. User has a preset AWS KeyPair and has the corresponding private key. The private key must be
-            pointed to with private_key_path in the config ssh_info along with user.
+        In order to deploy AWS instances, one must use an SSH key pair that was
+        previously created in and downloaded from AWS. The private key cannot be
+        obtained after its creation; this helper exists to remove this hassle.
 
-        Case 2 and 3 require specifying key name. The key name can be provided to dcos-launch in two ways:
-        1. Passed directly to the template like other template parameters.
+        This method will take the config dict, scan the parameters for KeyName,
+        and should KeyName not be found it generate a key and amend the config.
+        Returns two dicts: ssh_info and temporary resources. SSH user cannot be
+        inferred, so the user must still provide this explicitly via the field
+        'private_key_path'
+
+        Thus, there are 4 possible allowable scenarios:
         ---
         parameters:
           - ParameterKey: KeyName
@@ -135,17 +214,23 @@ class AwsCloudformationLauncher(AbstractLauncher):
         ssh_info:
           user: foo
           private_key_path: path_to_my_key
-        2. Provided with the other SSH paramters:
+        ### Result: nothing generated, testing possible ###
+
         ---
         ssh_info:
           user: foo
-          key_name: my_key_name
-          private_key_path: path_to_my_key
+        ### Result: key generated, testing possible ###
 
-        This method will take the config dict, determine if a key name is provided, if necessary, generate
-        the key and amend the config, and return the ssh_info for the cluster info JSON
+        ---
+        parameters:
+          - ParameterKey: KeyName
+            ParameterValue: my_key_name
+        ### Result: nothing generated, testing not possible
+
+        ---
+        ### Result: key generated, testing not possible
         """
-        generate_key = False
+        temp_resources = {}
         key_name = None
         private_key = None
         # Native AWS parameters take precedence
@@ -154,58 +239,31 @@ class AwsCloudformationLauncher(AbstractLauncher):
                 if p['ParameterKey'] == 'KeyName':
                     key_name = p['ParameterValue']
         # check ssh_info data
-        if 'ssh_info' in config:
+        if 'ssh_info' in config and 'private_key_path' in config['ssh_info']:
             if key_name is None:
-                key_name = config['ssh_info'].get('key_name', None)
-            elif 'key_name' in config['ssh_info']:
-                raise LauncherError('ValidationError',
-                                    'Provide key name as either a parameter or in ssh_info; not both')
-            if 'private_key_path' in config['ssh_info']:
-                if key_name is None:
-                    raise LauncherError('ValidationError', 'If a private_key_path is provided, '
-                                        'then the KeyName template parameter must be set')
-                private_key = load_string(config['ssh_info']['private_key_path'])
+                raise LauncherError('ValidationError', 'If a private_key_path is provided, '
+                                    'then the KeyName template parameter must be set')
+            private_key = load_string(config['ssh_info']['private_key_path'])
         if not key_name:
             key_name = config['stack_name']
-            generate_key = True
             private_key = self.boto_wrapper.create_key_pair(key_name)
+            temp_resources['key_name'] = key_name
             cf_params = config.get('parameters', list())
             cf_params.append({'ParameterKey': 'KeyName', 'ParameterValue': key_name})
             config['parameters'] = cf_params
-        return {
-            'delete_with_stack': generate_key,
-            'private_key': private_key,
-            'key_name': key_name,
-            'user': config.get('ssh_info', dict()).get('user', None)}
-
-    def test(self, info, test_cmd):
-        ssh_info = info['ssh']
-        for param in ['user', 'private_key']:
-            if param not in ssh_info:
-                raise LauncherError('MissingInfo', 'Cluster was created without providing ssh_info: {}'.format(param))
-        details = self.describe(info)
-        test_host = details['masters'][0]['public_ip']
-        # TODO: section should be generalized for use by other pr
-        with ssh.tunnel.tunnel(ssh_info['user'], ssh_info['private_key'], test_host) as test_tunnel:
-            return test_util.runner.integration_test(
-                tunnel=test_tunnel,
-                dcos_dns=test_host,
-                master_list=[m['private_ip'] for m in details['masters']],
-                agent_list=[a['private_ip'] for a in details['private_agents']],
-                public_agent_list=[a['private_ip'] for a in details['public_agents']],
-                aws_access_key_id=info['provider']['access_key_id'],
-                aws_secret_access_key=info['provider']['secret_access_key'],
-                region=info['provider']['region'],
-                test_cmd=test_cmd)
+        user = config.get('ssh_info', dict()).get('user', None)
+        ssh_info = {'private_key': private_key, 'user': user}
+        if user is None:
+            print('Testing not possible; user must be provided under ssh_info in config YAML')
+        if private_key is None:
+            print('Testing not possible; private_key_path must be provided under ssh_info in config YAML')
+        return ssh_info, temp_resources
 
     def get_stack(self, info):
-        """Returns the correct class interface depending how the AWS CF is configured
-        NOTE: only supports Simple Cloudformation currently
-        """
         try:
-            return DcosCfStack(info['stack_name'], self.boto_wrapper)
+            return fetch_stack(info['stack_name'], self.boto_wrapper)
         except Exception as ex:
-            raise LauncherError('StackNotFound', '{} is not accessible'.format(info['stack_name'])) from ex
+            raise LauncherError('StackNotFound', None) from ex
 
 
 def get_launcher(launcher_type, provider_info):
@@ -217,21 +275,13 @@ def get_launcher(launcher_type, provider_info):
         boto_wrapper = BotoWrapper(
             provider_info['region'], provider_info['access_key_id'], provider_info['secret_access_key'])
         return AwsCloudformationLauncher(boto_wrapper)
-    else:
-        raise LauncherError('UnsupportedAction', 'Launcher type not supported: {}'.format(launcher_type))
+    raise LauncherError('UnsupportedAction', 'Launcher type not supported: {}'.format(launcher_type))
 
 
 def convert_host_list(host_list):
     """ Makes Host tuples more readable when using describe
     """
     return [{'private_ip': h.private_ip, 'public_ip': h.public_ip} for h in host_list]
-
-
-def check_keys(user_dict, key_list):
-    missing = [k for k in key_list if k not in user_dict]
-    if len(missing) > 0:
-        raise LauncherError('MissingInput', 'The following keys were required but '
-                            'not provided: {}'.format(repr(missing)))
 
 
 def do_main(args):

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -135,7 +135,7 @@ def provide_cluster(options):
         log.info('Spinning up AWS CloudFormation with ID: {}'.format(stack_name))
         # TODO(mellenburg): use randomly generated keys this key is delivered by CI or user
         if options.advanced:
-            cf, ssh_info = test_util.aws.DcosCfAdvanced.create(
+            cf, ssh_info = test_util.aws.DcosZenCfStack.create(
                 stack_name=stack_name,
                 boto_wrapper=bw,
                 template_url=options.template_url,
@@ -150,7 +150,7 @@ def provide_cluster(options):
                 private_subnet=options.private_subnet,
                 public_subnet=options.public_subnet)
         else:
-            cf, ssh_info = test_util.aws.DcosCfSimple.create(
+            cf, ssh_info = test_util.aws.DcosCfStack.create(
                 stack_name=stack_name,
                 template_url=options.template_url,
                 private_agents=options.agents,
@@ -158,12 +158,12 @@ def provide_cluster(options):
                 admin_location='0.0.0.0/0',
                 key_pair_name='default',
                 boto_wrapper=bw)
-        cf.wait_for_stack_creation(wait_before_poll_min=5)
+        cf.wait_for_complete(wait_before_poll_min=5)
     else:
         if options.advanced:
-            cf = test_util.aws.DcosCfAdvanced(options.stack_name, bw)
+            cf = test_util.aws.DcosZenCfStack(options.stack_name, bw)
         else:
-            cf = test_util.aws.DcosCfSimple(options.stack_name, bw)
+            cf = test_util.aws.DcosCfStack(options.stack_name, bw)
         ssh_info = test_util.aws.SSH_INFO[options.host_os]
         stack_name = options.stack_name
     # Resiliency testing requires knowing the stack name

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -172,7 +172,7 @@ def main():
             admin_location='0.0.0.0/0',
             key_pair_name='default',
             boto_wrapper=bw)
-        vpc.wait_for_stack_creation()
+        vpc.wait_for_complete()
 
         cluster = test_util.cluster.Cluster.from_vpc(
             vpc,

--- a/test_util/test_launch.py
+++ b/test_util/test_launch.py
@@ -103,14 +103,14 @@ def mocked_aws_cf_simple_backend(monkeypatch, mocked_test_runner):
     # mock wait
     monkeypatch.setattr(test_util.aws.CfStack, 'get_stack_details', lambda _: {'StackStatus': 'CREATE_COMPLETE'})
     # mock describe
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_master_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_master_ips',
                         lambda _: [Host('127.0.0.1', '12.34.56')])
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_private_agent_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_private_agent_ips',
                         lambda _: [Host('127.0.0.1', None)])
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_public_agent_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_public_agent_ips',
                         lambda _: [Host('127.0.0.1', '12.34.56')])
     # mock delete
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'delete', lambda _: None)
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'delete', lambda _: None)
     monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_key_pair', lambda *args: None)
     # mock config
     monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_key_pair', lambda *args: MOCK_SSH_KEY_DATA)

--- a/test_util/test_launch.py
+++ b/test_util/test_launch.py
@@ -13,6 +13,15 @@ from test_util.launch import get_launcher, LauncherError, main
 
 MOCK_SSH_KEY_DATA = 'ssh_key_data'
 MOCK_KEY_NAME = 'my_key_name'
+MOCK_VPC_ID = 'vpc-foo-bar'
+MOCK_SUBNET_ID = 'subnet-foo-bar'
+MOCK_GATEWAY_ID = 'gateway-foo-bar'
+
+
+def magic_fn(output):
+    def accept_any_args(*args, **kwargs):
+        return output
+    return accept_any_args
 
 
 def check_cli(cmd):
@@ -84,7 +93,7 @@ def mocked_context(*args, **kwargs):
 @pytest.fixture
 def mocked_test_runner(monkeypatch):
     monkeypatch.setattr(ssh.tunnel, 'tunnel', mocked_context)
-    monkeypatch.setattr(test_util.runner, 'integration_test', lambda *args, **kwargs: 0)
+    monkeypatch.setattr(test_util.runner, 'integration_test', magic_fn(0))
 
 
 @pytest.fixture
@@ -98,22 +107,25 @@ def mocked_ssh_key_path(tmpdir):
 def mocked_aws_cf_simple_backend(monkeypatch, mocked_test_runner):
     """Does not include SSH key mocking
     """
+    monkeypatch.setattr(test_util.aws.DcosCfStack, '__init__', magic_fn(None))
+    monkeypatch.setattr(
+        test_util.launch, 'fetch_stack', lambda stack_name, bw: test_util.aws.DcosCfStack(stack_name, bw))
     # mock create
-    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_stack', lambda *args: None)
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_stack', magic_fn(None))
     # mock wait
-    monkeypatch.setattr(test_util.aws.CfStack, 'get_stack_details', lambda _: {'StackStatus': 'CREATE_COMPLETE'})
+    monkeypatch.setattr(test_util.aws.CfStack, 'wait_for_complete', magic_fn(None))
     # mock describe
     monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_master_ips',
-                        lambda _: [Host('127.0.0.1', '12.34.56')])
+                        magic_fn([Host('127.0.0.1', '12.34.56')]))
     monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_private_agent_ips',
-                        lambda _: [Host('127.0.0.1', None)])
+                        magic_fn([Host('127.0.0.1', None)]))
     monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_public_agent_ips',
-                        lambda _: [Host('127.0.0.1', '12.34.56')])
+                        magic_fn([Host('127.0.0.1', '12.34.56')]))
     # mock delete
-    monkeypatch.setattr(test_util.aws.DcosCfStack, 'delete', lambda _: None)
-    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_key_pair', lambda *args: None)
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'delete', magic_fn(None))
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_key_pair', magic_fn(None))
     # mock config
-    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_key_pair', lambda *args: MOCK_SSH_KEY_DATA)
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_key_pair', magic_fn(MOCK_SSH_KEY_DATA))
 
 
 @pytest.fixture
@@ -153,16 +165,72 @@ def test_aws_cf_simple(capsys, tmpdir, mocked_aws_cf_simple):
     assert 'region' in info['provider']
     assert 'access_key_id' in info['provider']
     assert 'secret_access_key' in info['provider']
-    assert info['ssh']['key_name'] == 'default'
-    assert info['ssh']['delete_with_stack'] is False
     assert info['ssh']['private_key'] == MOCK_SSH_KEY_DATA
     assert info['ssh']['user'] == 'core'
     # check that description is updated with info
     assert 'stack_name' in desc
 
 
+@pytest.fixture
+def mocked_aws_zen_cf(monkeypatch, mocked_aws_cf_simple_backend):
+    monkeypatch.setattr(test_util.aws.DcosZenCfStack, '__init__', magic_fn(None))
+    monkeypatch.setattr(
+        test_util.launch, 'fetch_stack', lambda stack_name, bw: test_util.aws.DcosZenCfStack(stack_name, bw))
+    # mock create
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_vpc_tagged', magic_fn(MOCK_VPC_ID))
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_internet_gateway_tagged', magic_fn(MOCK_GATEWAY_ID))
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_subnet_tagged', magic_fn(MOCK_SUBNET_ID))
+    # mock delete
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_subnet', magic_fn(None))
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_vpc', magic_fn(None))
+    monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_internet_gateway', magic_fn(None))
+    # mock describe
+    monkeypatch.setattr(test_util.aws.DcosZenCfStack, 'get_master_ips',
+                        magic_fn([Host('127.0.0.1', '12.34.56')]))
+    monkeypatch.setattr(test_util.aws.DcosZenCfStack, 'get_private_agent_ips',
+                        magic_fn([Host('127.0.0.1', None)]))
+    monkeypatch.setattr(test_util.aws.DcosZenCfStack, 'get_public_agent_ips',
+                        magic_fn([Host('127.0.0.1', '12.34.56')]))
+    # mock delete
+    monkeypatch.setattr(test_util.aws.DcosZenCfStack, 'delete', magic_fn(None))
+
+
+def test_aws_zen_cf(capsys, tmpdir, mocked_aws_zen_cf):
+    config = """
+---
+this_is_a_temporary_config_format_do_not_put_in_production: yes_i_agree
+type: cloudformation
+template_url: http://us-west-2.amazonaws.com/downloads
+stack_name: foobar
+zen_helper: true
+provider_info:
+  region: us-west-2
+  access_key_id: asdf09iasdf3m19238jowsfn
+  secret_access_key: asdf0asafawwa3j8ajn
+ssh_info:
+  user: core
+""".format(mocked_ssh_key_path)
+    info, desc = check_success(capsys, tmpdir, config)
+    # check AWS specific info
+    assert info['type'] == 'cloudformation'
+    assert 'stack_name' in info
+    assert 'region' in info['provider']
+    assert 'access_key_id' in info['provider']
+    assert 'secret_access_key' in info['provider']
+    assert info['temp_resources']['key_name'] == 'foobar'
+    assert info['ssh']['private_key'] == MOCK_SSH_KEY_DATA
+    assert info['ssh']['user'] == 'core'
+    # check that description is updated with info
+    assert 'stack_name' in desc
+    # check that zen helper did its job
+    assert info['temp_resources']['vpc'] == MOCK_VPC_ID
+    assert info['temp_resources']['gateway'] == MOCK_GATEWAY_ID
+    assert info['temp_resources']['private_subnet'] == MOCK_SUBNET_ID
+    assert info['temp_resources']['public_subnet'] == MOCK_SUBNET_ID
+
+
 @pytest.mark.usefixtures('mocked_aws_cf_simple')
-def test_aws_cf_simple_make_key(capsys, tmpdir):
+def test_aws_cf_make_key(capsys, tmpdir):
     """ Same mocked backend as other aws_cf_simple tests, but marginally different config
     Test that required parameters are consumed and appropriate output is generated
     """
@@ -193,8 +261,7 @@ parameters:
     assert 'region' in info['provider']
     assert 'access_key_id' in info['provider']
     assert 'secret_access_key' in info['provider']
-    assert info['ssh']['key_name'] == 'foobar'
-    assert info['ssh']['delete_with_stack'] is True
+    assert info['temp_resources']['key_name'] == 'foobar'
     assert info['ssh']['private_key'] == MOCK_SSH_KEY_DATA
     assert info['ssh']['user'] == 'core'
     # check that description is updated with info
@@ -249,7 +316,7 @@ def mock_stack_not_found(*args):
 def test_missing_aws_stack(mocked_aws_cf_simple, monkeypatch):
     """ Tests that clean and appropriate errors will be raised
     """
-    monkeypatch.setattr(test_util.aws.CfStack, '__init__', mock_stack_not_found)
+    monkeypatch.setattr(test_util.launch, 'fetch_stack', mock_stack_not_found)
     config = yaml.safe_load(mocked_aws_cf_simple)
     aws_launcher = get_launcher(config['type'], config['provider_info'])
 
@@ -272,45 +339,20 @@ def test_aws_ssh_key_handling(mocked_ssh_key_path):
         'access_key_id': 'foo',
         'secret_access_key': 'bar'}
     aws_launcher = get_launcher('cloudformation', provider_info)
-    # Test most minimal config (nothing given and key is generated)
-    ssh_info = aws_launcher.ssh_from_config({'stack_name': 'foo'})
-    expected_ssh_info = {
-        'delete_with_stack': True,
-        'key_name': 'foo',
-        'private_key': MOCK_SSH_KEY_DATA,
-        'user': None}
-    assert ssh_info == expected_ssh_info
-    # Test KeyName in provided parameters and private key provided for testing
-    ssh_info = aws_launcher.ssh_from_config({
-        'stack_name': 'foo',
+    # Test most minimal config (nothing given except stack name and key is generated)
+    test_config = {'stack_name': 'foo'}
+    ssh_info, temp_resources = aws_launcher.ssh_from_config(test_config)
+    assert ssh_info == {'private_key': MOCK_SSH_KEY_DATA, 'user': None}
+    assert temp_resources == {'key_name': 'foo'}
+    assert test_config['parameters'][0] == {'ParameterKey': 'KeyName', 'ParameterValue': 'foo'}
+    # Test KeyName in provided parameters and corresponding key is provided
+    ssh_info, temp_resources = aws_launcher.ssh_from_config({
         'parameters': [{'ParameterKey': 'KeyName', 'ParameterValue': MOCK_KEY_NAME}],
-        'ssh_info': {'private_key_path': mocked_ssh_key_path}})
-    expected_ssh_info = {
-        'delete_with_stack': False,
-        'key_name': MOCK_KEY_NAME,
-        'private_key': MOCK_SSH_KEY_DATA,
-        'user': None}
-    assert ssh_info == expected_ssh_info
-    # Test key_name provided by ssh_info and not paramaters
-    ssh_info = aws_launcher.ssh_from_config({
-        'stack_name': 'foo',
-        'ssh_info': {
-            'key_name': MOCK_KEY_NAME,
-            'private_key_path': mocked_ssh_key_path}})
-    expected_ssh_info = {
-        'delete_with_stack': False,
-        'key_name': MOCK_KEY_NAME,
-        'private_key': MOCK_SSH_KEY_DATA,
-        'user': None}
-    assert ssh_info == expected_ssh_info
-    # Test private_key given, but no key_name to link against
+        'ssh_info': {'private_key_path': mocked_ssh_key_path, 'user': 'bar'}})
+    assert ssh_info == {'private_key': MOCK_SSH_KEY_DATA, 'user': 'bar'}
+    assert temp_resources == {}
+    # Test private_key given, but no KeyName in parameters
     with pytest.raises(LauncherError):
         aws_launcher.ssh_from_config({
             'stack_name': 'foo',
             'ssh_info': {'private_key_path': mocked_ssh_key_path}})
-    # Test redundant fields assigned
-    with pytest.raises(LauncherError):
-        aws_launcher.ssh_from_config({
-            'stack_name': 'foo',
-            'ssh_info': {'key_name': MOCK_KEY_NAME},
-            'parameters': [{'ParameterKey': 'KeyName', 'ParameterValue': MOCK_KEY_NAME}]})

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -242,7 +242,7 @@ def main():
             aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
         ),
     )
-    vpc.wait_for_stack_creation()
+    vpc.wait_for_complete()
     cluster = test_util.cluster.Cluster.from_vpc(
         vpc,
         ssh_info,


### PR DESCRIPTION
In order to support launching Advanced (aka Zen) AWS templates, DC/OS Launch needed to be aware of which class representation from test_util.aws. Also, the Zen templates do not natively support turnkey deployment, so this PR also adds a helper to support exactly this case

- Clusters are determined to be either simple or zen when they are fetched via checking for the presence of resources that are exclusive between the two
- The only interface difference for a user deploying a zen stack will be in the case where the user did not follow the docs and create network resources in setup, in which case, (s)he can add a field to the config called ```zen_helper: true```
- Cleans up existing AWS test code to have more sensible classes, generators, and properties
- Simplifies key handling by removing confusing method of declaring it with ssh_info-key_name
- Dependent upon shipped PR: https://github.com/dcos/dcos/pull/1205
## Related Issues

https://mesosphere.atlassian.net/browse/DCOS-13298

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)