### PR TITLE
DCOS-595: Stop writing zookeeper log to a file

### DIFF
--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -100,17 +100,14 @@ auto-manage-instances-fixed-ensemble-size={zookeeper_cluster_size}
 ))
 
 write_str('/var/lib/dcos/exhibitor/conf/log4j.properties', """
-log4j.rootLogger=INFO, journal, console
+log4j.rootLogger=INFO, journal
 
-log4j.appender.journal=de.bwaldvogel.log4j.SystemdJournalAppender
+log4j.appender.journal=de.bwaldvogel.log4j.SystemdJournalAppenderWithLayout
 log4j.appender.journal.logStacktrace=true
 log4j.appender.journal.logThreadName=true
 log4j.appender.journal.logLoggerName=true
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.Threshold=INFO
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+log4j.appender.journal.layout=org.apache.log4j.PatternLayout
+log4j.appender.journal.layout.ConversionPattern=%-5p [%t:%C{1}@%L] - %m%n
 """)
 
 # Add backend specific arguments


### PR DESCRIPTION
## High Level Description

Currently Zookeeper writes its logs to the `/var/lib/dcos/exhibitor/zookeeper/zookeeper.out` file and also to the `journald` service. Since the file isn't managed by any logrotation service it grows unbounded and can fill up disk. This patch links `/var/lib/dcos/exhibitor/zookeeper/zookeeper.out` to a `/dev/null` to prevent filling up disk. Users should use `journald` service to examine `zookeeper` and `exhibitor` logs. Part of the patch is also setting explicitly where the log file exists so it won't happen that location will change in future releases without controlling it.

## Related Issues

  - [DCOS-595](https://dcosjira.atlassian.net/browse/DCOS-595) DC/OS Zookeeper does not log manage.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
