### PR TITLE
Set LIBPROCESS_PORT for marathon and metronome

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -38,6 +38,8 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 8181: dcos-exhibitor
  - 9990: dcos-cosmos
  - 15055: dcos-history-service
+ - 15101: dcos-marathon libprocess
+ - 15201: dcos-metronome libprocess
  - 62500: Networking API
 
 ### UDP

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -481,6 +481,7 @@ package:
   - path: /etc_master/marathon
     content: |
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
+      LIBPROCESS_PORT=15101
   - path: /etc/proxy.env
 {% switch use_proxy %}
 {% case "true" %}
@@ -497,6 +498,7 @@ package:
       METRONOME_MESOS_MASTER_URL=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       METRONOME_PLAY_SERVER_HTTP_PORT=9000
       METRONOME_MESOS_USER=root
+      LIBPROCESS_PORT=15201
   - path: /etc/user.config.yaml
     content: |
 {{ config_yaml }}


### PR DESCRIPTION
Set LIBPROCESS_PORT for marathon (15101) and metronome (15102) in the dcos-config.yaml explicitly. Update the admin-port documentation.

## High Level Description

Backport of https://github.com/dcos/dcos/pull/1121

## Related Issues

https://mesosphere.atlassian.net/browse/DCOS-12706

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
