### PR TITLE
Update RexRay to 0.8.2

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -6,7 +6,6 @@ The following is a list of ports used by internal DC/OS services, and their corr
 
 ### TCP
 
- - 61003: dcos-rexray (default)
  - 61053: dcos-mesos-dns
  - 61420: dcos-epmd
  - 61421: dcos-minuteman

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -622,13 +622,11 @@ entry = {
             'rexray': {
                 'loglevel': 'info',
                 'modules': {
-                    'default-admin': {
-                        'host': 'tcp://127.0.0.1:61003'
-                    },
                     'default-docker': {
                         'disabled': True
                     }
-                }
+                },
+                'service': 'vfs'
             }
         }),
         'enable_gpu_isolation': 'true',
@@ -692,15 +690,16 @@ entry = {
                         # Use IAM Instance Profile for auth.
                         'rexray': {
                             'loglevel': 'info',
-                            'modules': {
-                                'default-admin': {
-                                    'host': 'tcp://127.0.0.1:61003'
-                                }
-                            },
-                            'storageDrivers': ['ec2'],
-                            'volume': {
-                                'unmount': {
-                                    'ignoreusedcount': True
+                            'service': 'ebs'
+                        },
+                        'libstorage': {
+                            'integration': {
+                                'volume': {
+                                    'operations': {
+                                        'unmount': {
+                                            'ignoreusedcount': True
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/packages/dvdcli/build
+++ b/packages/dvdcli/build
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
-mkdir -p $PKG_PATH/bin/
-tar -xf /pkg/src/dvdcli/dvdcli-Linux-x86_64-0.1.0.tar.gz -C $PKG_PATH/bin/
+srcdir=$GOPATH/src/github.com/codedellemc/dvdcli
+mkdir -p $(dirname $srcdir)
+ln -s /pkg/src/dvdcli $srcdir
+cd $srcdir
+
+make
+
+mkdir -p $PKG_PATH/bin
+mv $GOPATH/bin/dvdcli $PKG_PATH/bin

--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -1,7 +1,9 @@
 {
-  "single_source": {
-    "kind": "url",
-    "url": "https://downloads.dcos.io/pkgpanda-artifact-cache/dvdcli-Linux-x86_64-0.1.0.tar.gz",
-    "sha1": "a0d7757939eefdf1ad28bc44919cdba5b6310528"
+  "docker": "golang:1.7",
+  "single_source" : {
+    "kind": "git",
+    "git": "https://github.com/codedellemc/dvdcli.git",
+    "ref": "7e3650924cc6671b8cb6655301ba3e872ae46f2d",
+    "ref_origin": "master"
   }
 }

--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,13 +9,12 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/emccode/rexray
+srcdir=$GOPATH/src/github.com/codedellemc/rexray
 mkdir -p $(dirname $srcdir)
 ln -s /pkg/src/rexray $srcdir
-
 cd $srcdir
 
-echo "...building rexray..."
-mkdir -p $PKG_PATH/bin/
-make build-linux-amd64 OFFLINE=1
-mv .build/bin/Linux-x86_64/rexray $PKG_PATH/bin/
+DGOOS=linux make
+
+mkdir -p $PKG_PATH/bin
+mv $GOPATH/bin/rexray $PKG_PATH/bin

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,9 +1,9 @@
 {
-  "docker": "golang:1.6",
+  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/dcos/rexray.git",
-    "ref": "7a5c745d117156a57429bb48514576b684588235",
-    "ref_origin": "v0.3.3-dcos"
+    "git": "https://github.com/codedellemc/rexray.git",
+    "ref": "38c16d3b3e82eb1ed0502fbf6877a72d0f777c46",
+    "ref_origin": "master"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/rexray.git",
-    "ref": "38c16d3b3e82eb1ed0502fbf6877a72d0f777c46",
+    "ref": "7b6be36e0c3b9d69e59f87ebb0098d56a74467db",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description

This pull request update the RexRay version of DC/OS from 0.3.3 to 0.8.2 ([Changelog](https://github.com/codedellemc/rexray/releases/tag/v0.8.2)). This last new version introduce support of Ceph/RDB storage which can be very useful on DC/OS.
Also because the actual RexRay version on DC/OS is pretty old.

Also, in order to get working RexRay 0.8.2 we had to update dvdcli to 0.2.0. Otherwise the build wasn't passing tests.

## Related Issues

None

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] [Changelog](https://github.com/codedellemc/rexray/compare/v0.3.3...codedellemc:v0.8.2?expand=1) between 0.3.3 and 0.8.2
  - [ ] Test Results: 
  - [ ] Code Coverage (if available):
