### PR TITLE
cosmos: restrict admin and http ports to localhost + test fix

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -467,7 +467,7 @@ package:
           "http://leader.mesos:1050/system/health/v1/report?cache=0"
         ],
         "cosmos_urls": [
-          "http://leader.mesos:7070/package/list"
+          "http://127.0.0.1:7070/package/list"
         ],
         "mesos_urls": [
           "http://leader.mesos:5050/frameworks",

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -28,6 +28,8 @@ ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
     -classpath ${PKG_PATH}/usr/cosmos.jar \\
     com.simontuffs.onejar.Boot \\
+    -admin.port=127.0.0.1:9990 \\
+    -io.github.benwhitehead.finch.httpInterface=127.0.0.1:7070 \\
     \${COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG} \\
     \${COSMOS_PACKAGE_STORAGE_URI_FLAG}
 EOF

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -2,6 +2,7 @@ import ipaddress
 import urllib.parse
 
 import bs4
+import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -320,15 +320,15 @@ def test_if_cosmos_is_only_available_locally(dcos_api_session):
     # over non-lo interfaces
     msg = "Cosmos reachable from non-lo interface"
     with pytest.raises(ConnectionError, message=msg):
-        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=7070)
+        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=7070, scheme='http')
     with pytest.raises(ConnectionError, message=msg):
-        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=9990)
+        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=9990, scheme='http')
 
     # One should be able to connect to the cosmos HTTP and admin ports at
     # 127.0.0.1:7070 and 127.0.0.1:9990.
     # Getting HTTP error codes shows that we made it all the way to
     # cosmos which is exactly what we're testing.
-    r = dcos_api_session.get('/', host="127.0.0.1", port=7070)
+    r = dcos_api_session.get('/', host="127.0.0.1", port=7070, scheme='http')
     assert r.status_code == 404
-    r = dcos_api_session.get('/', host="127.0.0.1", port=9990)
+    r = dcos_api_session.get('/', host="127.0.0.1", port=9990, scheme='http')
     assert r.status_code == 404


### PR DESCRIPTION
 - What does this change enable
The Cosmos service currently runs with default options for its admin port (`0.0.0.0:9990`) and its http port (`0.0.0.0:7070`.) We should restrict Cosmos to listen on the loopback interface only.

 - What bugs does this change fix
This change prevents bypassing Admin Router via direct access to Cosmos.

# Issues

[DCOS-613](https://dcosjira.atlassian.net/browse/DCOS-613)

# Checklist

 - [x] Included a test which will fail if code is reverted but test is not
 - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

Supercedes https://github.com/dcos/dcos/pull/1134