### PR TITLE
exhibitor: write JNA libraries to somewhere that isn't noexec

### DIFF
--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -12,6 +12,7 @@ MountFlags=private
 RuntimeDirectory=dcos_exhibitor
 # On some systems /tmp is mounted as noexec. Make zookeeper write its JNA
 # libraries to a path we control instead. See DCOS-11056
+Environment=JNA_TMP_DIR=/var/lib/dcos/exhibitor/tmp
 Environment=SERVER_JVMFLAGS=-Djna.tmpdir=/var/lib/dcos/exhibitor/tmp
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -10,6 +10,8 @@ RestartSec=5
 # Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
 RuntimeDirectory=dcos_exhibitor
+# Make ZooKeeper not write JNA libraries to /tmp, which can be noexec
+Environment=SERVER_JVMFLAGS=-Djna.tmpdir=/run/dcos_exhibitor
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -10,8 +10,9 @@ RestartSec=5
 # Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
 RuntimeDirectory=dcos_exhibitor
-# Make ZooKeeper not write JNA libraries to /tmp, which can be noexec
-Environment=SERVER_JVMFLAGS=-Djna.tmpdir=/run/dcos_exhibitor
+# On some systems /tmp is mounted as noexec. Make zookeeper write its JNA
+# libraries to a path we control instead. See DCOS-11056
+Environment=SERVER_JVMFLAGS=-Djna.tmpdir=/var/lib/dcos/exhibitor/tmp
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -41,6 +41,11 @@ detected_ip = invoke_detect_ip()
 # Make the zk conf directory (exhibitor assumes the dir exists)
 check_call(['mkdir', '-p', '/var/lib/dcos/exhibitor/conf/', '/var/lib/dcos/exhibitor/zookeeper/transactions'])
 
+# On some systems /tmp is mounted as noexec. Make zookeeper write its JNA
+# libraries to a path we control instead. See DCOS-11056
+jna_tmpdir = '/var/lib/dcos/exhibitor/tmp'
+check_call(['mkdir', '-p', jna_tmpdir])
+
 # TODO(cmaloney): Move exhibitor_defaults to a temp runtime conf dir.
 # Base for building up the command line
 exhibitor_cmdline = [
@@ -49,7 +54,7 @@ exhibitor_cmdline = [
     '-Djava.util.prefs.userRoot=/var/lib/dcos/exhibitor/',
     '-Duser.home=/var/lib/dcos/exhibitor/',
     '-Duser.dir=/var/lib/dcos/exhibitor/',
-    '-Djna.tmpdir=/run/dcos_exhibitor',
+    '-Djna.tmpdir=%s' % jna_tmpdir,
     '-jar', '$PKG_PATH/usr/exhibitor/exhibitor.jar',
     '--port', '8181',
     '--defaultconfig', '/run/dcos_exhibitor/exhibitor_defaults.conf',

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -43,7 +43,7 @@ check_call(['mkdir', '-p', '/var/lib/dcos/exhibitor/conf/', '/var/lib/dcos/exhib
 
 # On some systems /tmp is mounted as noexec. Make zookeeper write its JNA
 # libraries to a path we control instead. See DCOS-11056
-jna_tmpdir = '/var/lib/dcos/exhibitor/tmp'
+jna_tmpdir = get_var_assert_set('JNA_TMP_DIR')
 check_call(['mkdir', '-p', jna_tmpdir])
 
 # TODO(cmaloney): Move exhibitor_defaults to a temp runtime conf dir.

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -49,6 +49,7 @@ exhibitor_cmdline = [
     '-Djava.util.prefs.userRoot=/var/lib/dcos/exhibitor/',
     '-Duser.home=/var/lib/dcos/exhibitor/',
     '-Duser.dir=/var/lib/dcos/exhibitor/',
+    '-Djna.tmpdir=/run/dcos_exhibitor',
     '-jar', '$PKG_PATH/usr/exhibitor/exhibitor.jar',
     '--port', '8181',
     '--defaultconfig', '/run/dcos_exhibitor/exhibitor_defaults.conf',


### PR DESCRIPTION
## High Level Description

By default the JNA tmpdir is set to `/tmp`. This conflicts with some standard security policies that dictate that `/tmp` should be mounted as `noexec`.

@alberts's first thought is to use `/run`, but that is mounted `noexec` by default on Ubuntu 16.04 LTS, too.

We should set the JNA tmpdir to somewhere we control: `/var/lib/dcos/exhibitor/tmp` seems like a good option.

## Related Issues

  - [DCOS-634](https://dcosjira.atlassian.net/browse/DCOS-634) zookepeer should not write JNA libraries to /tmp
  - [DCOS-11056](https://mesosphere.atlassian.net/browse/DCOS-11056) The requirment of mounting /tmp without `noexec` flag conflicts with security policies that some customers have

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a config change - if it doesn't work zookeeper doesn't start and we'll notice.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
