### PR TITLE
Refactor AWS Zen stack resource model

### DIFF
--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -1,52 +1,74 @@
+import logging
 import os
-from functools import partial
 
 import pytest
+import retrying
 
 import test_util.aws
 import test_util.helpers
 from test_util.helpers import retry_boto_rate_limits
 
+log = logging.getLogger(__name__)
+
 ENV_FLAG = 'ENABLE_RESILIENCY_TESTING'
 
-pytestmark = pytest.mark.skipif(
+skip_if_resiliency_not_enabled = pytest.mark.skipif(
     ENV_FLAG not in os.environ or os.environ[ENV_FLAG] != 'true',
     reason='Must explicitly enable resiliency testing with {}'.format(ENV_FLAG))
 
+skip_if_not_aws_stack = pytest.mark.skipif(
+    'AWS_STACK_NAME' not in os.environ,
+    reason='Must use an AWS Cloudformation run this test!')
+
+pytestmark = [skip_if_resiliency_not_enabled, skip_if_not_aws_stack]
+
 
 @pytest.fixture(scope='session')
-def dcos_launchpad(dcos_api_session):
-    """Interface for direct integration to dcos_launchpad hardware
-    Currently only supports AWS CF with AWS VPC coming soon
-    """
-    if 'AWS_STACK_NAME' not in os.environ:
-        # TODO(mellenburg): update when advanced templates are merged
-        pytest.skip('Must use a AWS Cloudformation to run test')
-    stack_name = os.environ['AWS_STACK_NAME']
+def boto_wrapper(dcos_api_session):
     aws_region = os.environ['AWS_REGION']
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
     aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
-    bw = test_util.aws.BotoWrapper(aws_region, aws_access_key_id, aws_secret_access_key)
-    return test_util.aws.DcosCfSimple(stack_name, bw)
+    return test_util.aws.BotoWrapper(aws_region, aws_access_key_id, aws_secret_access_key)
+
+
+@pytest.fixture(scope='session')
+def dcos_stack(boto_wrapper):
+    """ Works with either Zen or Simple cloud formations
+    """
+    stack = test_util.aws.fetch_stack(os.environ['AWS_STACK_NAME'], boto_wrapper)
+    if isinstance(stack, test_util.aws.VpcCfStack):
+        pytest.skip('Onprem Vpc not currently supported')
+    return stack
 
 
 @pytest.mark.last
-def test_agent_failure(dcos_launchpad, dcos_api_session, vip_apps):
-    # make sure the app works before starting
+def test_agent_failure(dcos_stack, boto_wrapper, dcos_api_session, vip_apps):
+    # Accessing AWS Resource objects will trigger a client describe call.
+    # As such, any method that touches AWS APIs must be wrapped to avoid
+    # CI collapse when rate limits are inevitably reached
     @retry_boto_rate_limits
-    def get_running_agents(group_name):
-        return [i for i in dcos_launchpad.get_auto_scaling_instances(group_name)
-                if i.state['Name'] == 'running']
+    def get_running_instances(instance_iter):
+        return [i for i in instance_iter if i.state['Name'] == 'running']
 
+    @retry_boto_rate_limits
+    def get_instance_ids(instance_iter):
+        return [i.instance_id for i in instance_iter]
+
+    @retry_boto_rate_limits
+    def get_private_ips(instance_iter):
+        return sorted([i.private_ip_address for i in get_running_instances(instance_iter)])
+
+    # make sure the app works before starting
     test_util.helpers.wait_for_pong(vip_apps[0][1], 120)
     test_util.helpers.wait_for_pong(vip_apps[1][1], 10)
-    agents = [i.instance_id for i in get_running_agents('PublicSlaveServerGroup') +
-              get_running_agents('SlaveServerGroup')]
+    agent_ids = get_instance_ids(
+        get_running_instances(dcos_stack.public_agent_instances) +
+        get_running_instances(dcos_stack.private_agent_instances))
 
     # Agents are in auto-scaling groups, so they will automatically be replaced
-    dcos_launchpad.boto_wrapper.client('ec2').terminate_instances(InstanceIds=agents)
-    waiter = dcos_launchpad.boto_wrapper.client('ec2').get_waiter('instance_terminated')
-    retry_boto_rate_limits(waiter.wait)(InstanceIds=agents)
+    boto_wrapper.client('ec2').terminate_instances(InstanceIds=agent_ids)
+    waiter = boto_wrapper.client('ec2').get_waiter('instance_terminated')
+    retry_boto_rate_limits(waiter.wait)(InstanceIds=agent_ids)
 
     # Tell mesos the machines are "down" and not coming up so things get rescheduled.
     down_hosts = [{'hostname': slave, 'ip': slave} for slave in dcos_api_session.all_slaves]
@@ -58,17 +80,32 @@ def test_agent_failure(dcos_launchpad, dcos_api_session, vip_apps):
         }]}).raise_for_status()
     dcos_api_session.post('/mesos/machine/down', json=down_hosts).raise_for_status()
 
-    # Wait for replacements
-    test_util.helpers.wait_for_len(partial(get_running_agents, 'SlaveServerGroup'), len(dcos_api_session.slaves), 600)
-    test_util.helpers.wait_for_len(
-        partial(get_running_agents, 'PublicSlaveServerGroup'), len(dcos_api_session.public_slaves), 600)
+    public_agent_count = len(dcos_api_session.public_slaves)
+    private_agent_count = len(dcos_api_session.slaves)
 
-    # Reset the dcos_api_session to have the replacement agents
-    dcos_api_session.slaves = sorted([agent.private_ip_address for agent in
-                                      get_running_agents('SlaveServerGroup')])
-    dcos_api_session.public_slaves = sorted([agent.private_ip_address for agent in
-                                             get_running_agents('PublicSlaveServerGroup')])
-    dcos_api_session.all_slaves = sorted(dcos_api_session.slaves + dcos_api_session.public_slaves)
+    @retrying.retry(
+        wait_fixed=60 * 1000,
+        retry_on_result=lambda res: res is False,
+        stop_max_delay=900 * 1000)
+    def wait_for_agents_to_refresh():
+        public_agents = get_running_instances(dcos_stack.public_agent_instances)
+        if len(public_agents) == public_agent_count:
+            dcos_api_session.public_slaves = get_private_ips(public_agents)
+        else:
+            log.info('Waiting for {} public agents. Current: {}'.format(
+                     public_agent_count, len(public_agents)))
+            return False
+        private_agents = get_running_instances(dcos_stack.private_agent_instances)
+        if len(private_agents) == private_agent_count:
+            dcos_api_session.slaves = get_private_ips(private_agents)
+        else:
+            log.info('Waiting for {} private agents. Current: {}'.format(
+                     private_agent_count, len(private_agents)))
+            return False
+        dcos_api_session.all_slaves = sorted(
+            dcos_api_session.slaves + dcos_api_session.public_slaves)
+
+    wait_for_agents_to_refresh()
 
     # verify that everything else is still working
     dcos_api_session.wait_for_dcos()

--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -1,4 +1,20 @@
-#!/usr/bin/env python3
+""" Abstractions for handling resources via Amazon Web Services (AWS) API
+
+The intention of these utilities is to allow other infrastructure to
+interact with AWS without having to understand AWS APIs. Additionally,
+this module provides helper functions for the most common queries required
+to manipulate and test a DC/OS cluster, which would be otherwise cumbersome
+to do with AWS API calls only
+
+BotoWrapper: AWS credentials and region bound to various helper methods
+CfStack: Generic representation of a CloudFormation stack
+DcosCfStack: Represents DC/OS in a simple deployment
+DcosZenCfStack: Represents DC/OS  deployed from a zen template
+MasterStack: thin wrapper for master stack in a zen template
+PrivateAgentStack: thin wrapper for public agent stack in a zen template
+PublicAgentStack: thin wrapper for public agent stack in a zen template
+VpcCfStack: Represents a homogeneous cluster of hosts with a specific AMI
+"""
 import logging
 import time
 
@@ -7,10 +23,11 @@ import retrying
 
 from test_util.helpers import Host, retry_boto_rate_limits, SshInfo
 
-LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
-logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 # AWS verbosity in debug mode overwhelms meaningful logging
 logging.getLogger('botocore').setLevel(logging.INFO)
+logging.getLogger('boto3').setLevel(logging.INFO)
+logging.getLogger('boto3.resources.action').setLevel(logging.WARNING)
+logging.getLogger('botocore.vendored.requests.packages.urllib3').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 VPC_TEMPLATE_URL = 'https://s3.amazonaws.com/vpc-cluster-template/vpc-cluster-template.json'
@@ -33,6 +50,20 @@ def instances_to_hosts(instances):
     return [Host(i.private_ip_address, i.public_ip_address) for i in instances]
 
 
+def fetch_stack(stack_name, boto_wrapper):
+    log.debug('Attemping to fetch AWS Stack: {}'.format(stack_name))
+    stack = boto_wrapper.resource('cloudformation').Stack(stack_name)
+    for resource in stack.resource_summaries.all():
+        if resource.logical_resource_id == 'MasterStack':
+            log.debug('Using Zen DC/OS Cloudformation interface')
+            return DcosZenCfStack(stack_name, boto_wrapper)
+        if resource.logical_resource_id == 'MasterServerGroup':
+            log.debug('Using Basic DC/OS Cloudformation interface')
+            return DcosCfStack(stack_name, boto_wrapper)
+    log.debug('Using VPC Cloudformation interface')
+    return VpcCfStack(stack_name, boto_wrapper)
+
+
 class BotoWrapper():
     def __init__(self, region, aws_access_key_id, aws_secret_access_key):
         self.region = region
@@ -48,10 +79,12 @@ class BotoWrapper():
     def create_key_pair(self, key_name):
         """Returns private key of newly generated pair
         """
+        log.info('Creating KeyPair: {}'.format(key_name))
         key = self.client('ec2').create_key_pair(KeyName=key_name)
         return key['KeyMaterial']
 
     def delete_key_pair(self, key_name):
+        log.info('Deleting KeyPair: {}'.format(key_name))
         self.resource('ec2').KeyPair(key_name).delete()
 
     def create_stack(self, name, template_url, parameters, deploy_timeout=60):
@@ -59,7 +92,7 @@ class BotoWrapper():
         Does simple casting of strings or numbers
         Starts stack creation if validation is successful
         """
-        log.info('Requesting AWS CloudFormation...')
+        log.info('Requesting AWS CloudFormation: {}'.format(name))
         self.resource('cloudformation').create_stack(
             StackName=name,
             TemplateURL=template_url,
@@ -71,12 +104,66 @@ class BotoWrapper():
             Parameters=[{str(k): str(v) for k, v in p.items()} for p in parameters])
         return CfStack(name, self)
 
+    def create_vpc_tagged(self, cidr, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new VPC...')
+        vpc_id = ec2.create_vpc(CidrBlock=cidr, InstanceTenancy='default')['Vpc']['VpcId']
+        ec2.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
+        ec2.create_tags(Resources=[vpc_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        log.info('Created VPC with ID: {}'.format(vpc_id))
+        return vpc_id
+
+    def create_internet_gateway_tagged(self, vpc_id, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new InternetGateway...')
+        gateway_id = ec2.create_internet_gateway()['InternetGateway']['InternetGatewayId']
+        ec2.attach_internet_gateway(InternetGatewayId=gateway_id, VpcId=vpc_id)
+        ec2.create_tags(Resources=[gateway_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        log.info('Created internet gateway with ID: {}'.format(gateway_id))
+        return gateway_id
+
+    def create_subnet_tagged(self, vpc_id, cidr, name_tag):
+        ec2 = self.client('ec2')
+        log.info('Creating new Subnet...')
+        subnet_id = ec2.create_subnet(VpcId=vpc_id, CidrBlock=cidr)['Subnet']['SubnetId']
+        ec2.create_tags(Resources=[subnet_id], Tags=[{'Key': 'Name', 'Value': name_tag}])
+        ec2.get_waiter('subnet_available').wait(SubnetIds=[subnet_id])
+        log.info('Created subnet with ID: {}'.format(subnet_id))
+        return subnet_id
+
+    def delete_subnet(self, subnet_id):
+        log.info('Deleting subnet: {}'.format(subnet_id))
+        self.client('ec2').delete_subnet(SubnetId=subnet_id)
+
+    def delete_internet_gateway(self, gateway_id):
+        ig = self.resource('ec2').InternetGateway(gateway_id)
+        for vpc in ig.attachments:
+            vpc_id = vpc['VpcId']
+            log.info('Detaching gateway {} from vpc {}'.format(gateway_id, vpc_id))
+            ig.detach_from_vpc(VpcId=vpc_id)
+        log.info('Deleting internet gateway: {}'.format(gateway_id))
+        ig.delete()
+
+    def delete_vpc(self, vpc_id):
+        log.info('Deleting vpc: {}'.format(vpc_id))
+        self.client('ec2').delete_vpc(VpcId=vpc_id)
+
+    @retry_boto_rate_limits
+    def get_auto_scaling_instances(self, asg_physical_resource_id):
+        """ Returns instance objects as described here:
+        http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#instance
+        """
+        ec2 = self.resource('ec2')
+        return [ec2.Instance(i['InstanceId']) for asg in self.client('autoscaling').
+                describe_auto_scaling_groups(
+                    AutoScalingGroupNames=[asg_physical_resource_id])
+                ['AutoScalingGroups'] for i in asg['Instances']]
+
 
 class CfStack:
     def __init__(self, stack_name, boto_wrapper):
         self.boto_wrapper = boto_wrapper
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(stack_name)
-        self._host_cache = {}
 
     def wait_for_status_change(self, state_1, state_2, wait_before_poll_min, timeout=60 * 60):
         """
@@ -112,26 +199,33 @@ class CfStack:
                 for event in self.get_stack_events():
                     log.error('Stack Events: {}'.format(event))
                 raise Exception('StackStatus changed unexpectedly to: {}'.format(stack_status))
+            log.info('Continuing to wait...')
             return False
         wait_loop()
 
+    def wait_for_complete(self, wait_before_poll_min=0):
+        status = self.get_stack_details()['StackStatus']
+        if status.endswith('_COMPLETE'):
+            return
+        elif status.endswith('_IN_PROGRESS'):
+            self.wait_for_status_change(
+                status, status.replace('IN_PROGRESS', 'COMPLETE'),
+                wait_before_poll_min)
+        else:
+            raise Exception('AWS Stack has entered unexpected state: {}'.format(status))
+
     @retry_boto_rate_limits
     def get_stack_details(self):
-        log.debug('Requesting stack details')
-        return self.boto_wrapper.client('cloudformation').describe_stacks(
+        details = self.boto_wrapper.client('cloudformation').describe_stacks(
             StackName=self.stack.stack_id)['Stacks'][0]
+        log.debug('Stack details: {}'.format(details))
+        return details
 
     @retry_boto_rate_limits
     def get_stack_events(self):
         log.debug('Requesting stack events')
         return self.boto_wrapper.client('cloudformation').describe_stack_events(
             StackName=self.stack.stack_id)['StackEvents']
-
-    def wait_for_stack_creation(self, wait_before_poll_min=3):
-        self.wait_for_status_change('CREATE_IN_PROGRESS', 'CREATE_COMPLETE', wait_before_poll_min)
-
-    def wait_for_stack_deletion(self, wait_before_poll_min=3):
-        self.wait_for_status_change('DELETE_IN_PROGRESS', 'DELETE_COMPLETE', wait_before_poll_min)
 
     def get_parameter(self, param):
         """Returns param if in stack parameters, else returns None
@@ -142,32 +236,51 @@ class CfStack:
         raise KeyError('Key not found in template parameters: {}. Parameters: {}'.
                        format(param, self.stack.parameters))
 
-    @retry_boto_rate_limits
-    def get_auto_scaling_instances(self, logical_id):
-        """ Get instances in ASG with logical_id. If logical_id is None, all ASGs will be used
-        Will return instance objects as described here:
-        http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#instance
+    def delete(self):
+        stack_id = self.stack.stack_id
+        log.info('Deleting stack: {}'.format(stack_id))
+        # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
+        self.stack = self.boto_wrapper.resource('cloudformation').Stack(stack_id)
+        self.stack.delete()
+        log.info('Delete successfully initiated for {}'.format(stack_id))
 
-        Note: there is no ASG resource hence the need for this method
+
+class CleanupS3BucketMixin:
+    def delete_exhibitor_s3_bucket(self):
+        """ A non-empty S3 bucket cannot be deleted, so check to
+        see if it should be emptied first. If its non-empty, but
+        has more than one item, error out as the bucket is perhaps
+        not an exhibitor bucket and the user should be alerted
         """
-        ec2 = self.boto_wrapper.resource('ec2')
-        return [ec2.Instance(i['InstanceId']) for asg in self.boto_wrapper.client('autoscaling').
-                describe_auto_scaling_groups(
-                    AutoScalingGroupNames=[self.stack.Resource(logical_id).physical_resource_id])
-                ['AutoScalingGroups'] for i in asg['Instances']]
+        try:
+            bucket = self.boto_wrapper.resource('s3').Bucket(
+                self.stack.Resource('ExhibitorS3Bucket').physical_resource_id)
+        except:
+            log.exception('Bucket could not be fetched')
+            return
+        log.info('Starting bucket {} deletion'.format(bucket))
+        all_objects = list(bucket.objects.all())
+        obj_count = len(all_objects)
+        if obj_count == 1:
+            all_objects[0].delete()
+        elif obj_count > 1:
+            raise Exception('Expected on item in Exhibitor S3 bucket but found: ' + obj_count)
+        log.info('Trying deleting bucket {} itself'.format(bucket))
+        bucket.delete()
 
-    def get_hosts_cached(self, group_name, refresh=False):
-        if refresh or group_name not in self._host_cache:
-            host_list = instances_to_hosts(self.get_auto_scaling_instances(group_name))
-            self._host_cache[group_name] = host_list
-            return host_list
-        return self._host_cache[group_name]
+    def delete(self):
+        self.delete_exhibitor_s3_bucket()
+        super().delete()
 
 
-class DcosCfSimple(CfStack):
+class DcosCfStack(CleanupS3BucketMixin, CfStack):
+    """ This abstraction will work for a simple DC/OS template.
+    A simple template has its exhibitor bucket and auto scaling groups
+    for each of the master, public agent, and private agent groups
+    """
     @classmethod
-    def create(cls, stack_name, template_url, public_agents, private_agents,
-               admin_location, key_pair_name, boto_wrapper):
+    def create(cls, stack_name: str, template_url: str, public_agents: int, private_agents: int,
+               admin_location: str, key_pair_name: str, boto_wrapper: BotoWrapper):
         parameters = {
             'KeyName': key_pair_name,
             'AdminLocation': admin_location,
@@ -178,78 +291,61 @@ class DcosCfSimple(CfStack):
         # stack.stack_name returns stack_id if Stack was created with ID
         return cls(stack.stack.stack_name, boto_wrapper), SSH_INFO['coreos']
 
-    def delete(self):
-        log.info('Starting deletion of CF stack')
-        # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
-        self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
-        self.stack.delete()
-        self.empty_and_delete_s3_bucket_from_stack()
+    @property
+    def master_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('MasterServerGroup').physical_resource_id)
 
-    def empty_and_delete_s3_bucket_from_stack(self):
-        bucket_id = self.stack.Resource('ExhibitorS3Bucket').physical_resource_id
-        s3 = self.boto_wrapper.resource('s3')
-        bucket = s3.Bucket(bucket_id)
-        log.info('Starting bucket {} deletion'.format(bucket))
-        all_objects = bucket.objects.all()
-        obj_count = len(list(all_objects))
-        if obj_count > 0:
-            assert obj_count == 1, 'Expected one object in Exhibitor S3 bucket but found: ' + str(obj_count)
-            exhibitor_object = list(all_objects)[0]
-            log.info('Trying to delete object from bucket: {}'.format(repr(exhibitor_object)))
-            exhibitor_object.delete()
-        log.info('Trying deleting bucket {} itself'.format(bucket))
-        bucket.delete()
-        log.info('Delete successfully triggered for {}'.format(self.stack.stack_name))
+    @property
+    def private_agent_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('SlaveServerGroup').physical_resource_id)
 
-    def get_master_ips(self, refresh=False):
-        return self.get_hosts_cached('MasterServerGroup', refresh=refresh)
+    @property
+    def public_agent_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PublicSlaveServerGroup').physical_resource_id)
 
-    def get_public_agent_ips(self, refresh=False):
-        return self.get_hosts_cached('PublicSlaveServerGroup', refresh=refresh)
+    def get_master_ips(self):
+        return instances_to_hosts(self.master_instances)
 
-    def get_private_agent_ips(self, refresh=False):
-        return self.get_hosts_cached('SlaveServerGroup', refresh=refresh)
+    def get_private_agent_ips(self):
+        return instances_to_hosts(self.private_agent_instances)
+
+    def get_public_agent_ips(self):
+        return instances_to_hosts(self.public_agent_instances)
 
 
-class DcosCfAdvanced(CfStack):
+class MasterStack(CleanupS3BucketMixin, CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('MasterServerGroup').physical_resource_id)
+
+
+class PrivateAgentStack(CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PrivateAgentServerGroup').physical_resource_id)
+
+
+class PublicAgentStack(CfStack):
+    @property
+    def instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('PublicAgentServerGroup').physical_resource_id)
+
+
+class DcosZenCfStack(CfStack):
+    """Zen stacks are stacks that have the masters, infra, public agents, and private
+    agents split into resources stacks under one zen stack
+    """
     @classmethod
     def create(cls, stack_name, boto_wrapper, template_url,
                public_agents, private_agents, key_pair_name,
                private_agent_type, public_agent_type, master_type,
-               vpc_cidr='10.0.0.0/16', public_subnet_cidr='10.0.128.0/20',
-               private_subnet_cidr='10.0.0.0/17',
-               gateway=None, vpc=None, private_subnet=None, public_subnet=None):
-        ec2 = boto_wrapper.client('ec2')
-        if not vpc:
-            log.info('Creating new VPC...')
-            vpc = ec2.create_vpc(CidrBlock=vpc_cidr, InstanceTenancy='default')['Vpc']['VpcId']
-            ec2.get_waiter('vpc_available').wait(VpcIds=[vpc])
-            ec2.create_tags(Resources=[vpc], Tags=[{'Key': 'Name', 'Value': stack_name}])
-        log.info('Using VPC with ID: ' + vpc)
-
-        if not gateway:
-            log.info('Creating new InternetGateway...')
-            gateway = ec2.create_internet_gateway()['InternetGateway']['InternetGatewayId']
-            ec2.attach_internet_gateway(InternetGatewayId=gateway, VpcId=vpc)
-            ec2.create_tags(Resources=[gateway], Tags=[{'Key': 'Name', 'Value': stack_name}])
-        log.info('Using InternetGateway with ID: ' + gateway)
-
-        def _make_subnet(cidr, suffix):
-            subnet = ec2.create_subnet(VpcId=vpc, CidrBlock=cidr)['Subnet']['SubnetId']
-            ec2.create_tags(Resources=[private_subnet], Tags=[{'Key': 'Name', 'Value': stack_name + '-' + suffix}])
-            ec2.get_waiter('subnet_available').wait(SubnetIds=[subnet])
-            return subnet
-
-        if not private_subnet:
-            log.info('Creating new PrivateSubnet...')
-            private_subnet = _make_subnet(private_subnet_cidr, 'private')
-        log.info('Using PrivateSubnet with ID: ' + private_subnet)
-
-        if not public_subnet:
-            log.info('Creating new PublicSubnet...')
-            public_subnet = _make_subnet(public_subnet_cidr, 'public')
-        log.info('Using PublicSubnet with ID: ' + public_subnet)
-
+               gateway, vpc, private_subnet, public_subnet):
         parameters = {
             'KeyName': key_pair_name,
             'Vpc': vpc,
@@ -272,38 +368,50 @@ class DcosCfAdvanced(CfStack):
             raise
         return cls(stack.stack.stack_name, boto_wrapper), ssh_info
 
-    def delete(self, delete_vpc=False):
-        log.info('Starting deletion of CF Advanced stack')
-        vpc_id = self.get_parameter('Vpc')
+    def __init__(self, stack_name, boto_wrapper):
+        super().__init__(stack_name, boto_wrapper)
+        self.master_stack = MasterStack(
+            self.stack.Resource('MasterStack').physical_resource_id, self.boto_wrapper)
+        self.private_agent_stack = PrivateAgentStack(
+            self.stack.Resource('PrivateAgentStack').physical_resource_id, self.boto_wrapper)
+        self.public_agent_stack = PublicAgentStack(
+            self.stack.Resource('PublicAgentStack').physical_resource_id, self.boto_wrapper)
+        self.infrastructure = CfStack(self.stack.Resource('Infrastructure').physical_resource_id, self.boto_wrapper)
+
+    def delete(self):
+        log.info('Starting deletion of Zen CF stack')
         # boto stacks become unusable after deletion (e.g. status/info checks) if name-based
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
-        log.info('Deleting Infrastructure Stack')
-        infrastack = DcosCfSimple(self.get_resource_stack('Infrastructure').stack.stack_id, self.boto_wrapper)
-        infrastack.delete()
-        log.info('Deleting Master Stack')
-        self.get_resource_stack('MasterStack').stack.delete()
-        log.info('Deleting Private Agent Stack')
-        self.get_resource_stack('PrivateAgentStack').stack.delete()
-        log.info('Deleting Public Agent Stack')
-        self.get_resource_stack('PublicAgentStack').stack.delete()
-        self.stack.delete()
-        if delete_vpc:
-            self.wait_for_stack_deletion()
-            self.boto_wrapper.resource('ec2').Vpc(vpc_id).delete()
+        # These resources might have failed to create or been removed prior, except their
+        # failures and log it out
+        for s in [self.infrastructure, self.master_stack, self.private_agent_stack,
+                  self.public_agent_stack]:
+            try:
+                s.delete()
+            except:
+                log.exception('Delete encountered an error!')
+        super().delete()
 
-    def get_master_ips(self, refresh=False):
-        return self.get_resource_stack('MasterStack').get_hosts_cached('MasterServerGroup', refresh=refresh)
+    @property
+    def master_instances(self):
+        yield from self.master_stack.instances
 
-    def get_private_agent_ips(self, refresh=False):
-        return self.get_resource_stack('PrivateAgentStack').get_hosts_cached('PrivateAgentServerGroup', refresh=refresh)
+    @property
+    def private_agent_instances(self):
+        yield from self.private_agent_stack.instances
 
-    def get_public_agent_ips(self, refresh=False):
-        return self.get_resource_stack('PublicAgentStack').get_hosts_cached('PublicAgentServerGroup', refresh=refresh)
+    @property
+    def public_agent_instances(self):
+        yield from self.public_agent_stack.instances
 
-    def get_resource_stack(self, resource_name):
-        """Returns a CfStack for a given resource
-        """
-        return CfStack(self.stack.Resource(resource_name).physical_resource_id, self.boto_wrapper)
+    def get_master_ips(self):
+        return instances_to_hosts(self.master_instances)
+
+    def get_private_agent_ips(self):
+        return instances_to_hosts(self.private_agent_instances)
+
+    def get_public_agent_ips(self):
+        return instances_to_hosts(self.public_agent_instances)
 
 
 class VpcCfStack(CfStack):
@@ -326,10 +434,15 @@ class VpcCfStack(CfStack):
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.stack.stack_id)
         self.stack.delete()
 
-    def get_vpc_host_ips(self):
+    @property
+    def instances(self):
         # the vpc templates use the misleading name CentOSServerAutoScale for all deployments
         # https://mesosphere.atlassian.net/browse/DCOS-11534
-        return self.get_hosts_cached('CentOSServerAutoScale')
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('CentOSServerAutoScale').physical_resource_id)
+
+    def get_host_ips(self):
+        return instances_to_hosts(self.instances)
 
 
 SSH_INFO = {

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -141,7 +141,7 @@ class Cluster:
         num_agents,
         num_public_agents,
     ):
-        hosts = vpc.get_vpc_host_ips()
+        hosts = vpc.get_host_ips()
         logging.info('AWS provided VPC info: ' + repr(hosts))
 
         vpc_cluster = cls.from_hosts(

--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -215,22 +215,6 @@ def wait_for_pong(url, timeout):
     ping_app()
 
 
-def wait_for_len(fetch_fn, target_count, timeout):
-    """Will call fetch_fn every 10s, get len() on the result and repeat until it is
-    equal to target count or timeout (in seconds) has been reached
-    """
-    @retrying.retry(wait_fixed=10000, stop_max_delay=timeout * 1000,
-                    retry_on_result=lambda res: res is False,
-                    retry_on_exception=lambda ex: False)
-    def check_for_match():
-        items = fetch_fn()
-        count = len(items)
-        logging.info('Waiting for len()=={}. Current count: {}. Items: {}'.format(target_count, count, repr(items)))
-        if count != target_count:
-            return False
-    check_for_match()
-
-
 def session_tempfile(data):
     """Writes bytes to a named temp file and returns its path
     the temp file will be removed when the interpreter exits

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -33,7 +33,7 @@ from docopt import docopt
 import ssh.tunnel
 import test_util.runner
 from pkgpanda.util import json_prettyprint, load_json, load_string, load_yaml, write_json, YamlParseError
-from test_util.aws import BotoWrapper, DcosCfSimple
+from test_util.aws import BotoWrapper, DcosCfStack
 
 
 class LauncherError(Exception):
@@ -203,7 +203,7 @@ class AwsCloudformationLauncher(AbstractLauncher):
         NOTE: only supports Simple Cloudformation currently
         """
         try:
-            return DcosCfSimple(info['stack_name'], self.boto_wrapper)
+            return DcosCfStack(info['stack_name'], self.boto_wrapper)
         except Exception as ex:
             raise LauncherError('StackNotFound', '{} is not accessible'.format(info['stack_name'])) from ex
 

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -135,7 +135,7 @@ def provide_cluster(options):
         log.info('Spinning up AWS CloudFormation with ID: {}'.format(stack_name))
         # TODO(mellenburg): use randomly generated keys this key is delivered by CI or user
         if options.advanced:
-            cf, ssh_info = test_util.aws.DcosCfAdvanced.create(
+            cf, ssh_info = test_util.aws.DcosZenCfStack.create(
                 stack_name=stack_name,
                 boto_wrapper=bw,
                 template_url=options.template_url,
@@ -150,7 +150,7 @@ def provide_cluster(options):
                 private_subnet=options.private_subnet,
                 public_subnet=options.public_subnet)
         else:
-            cf, ssh_info = test_util.aws.DcosCfSimple.create(
+            cf, ssh_info = test_util.aws.DcosCfStack.create(
                 stack_name=stack_name,
                 template_url=options.template_url,
                 private_agents=options.agents,
@@ -158,12 +158,12 @@ def provide_cluster(options):
                 admin_location='0.0.0.0/0',
                 key_pair_name='default',
                 boto_wrapper=bw)
-        cf.wait_for_stack_creation(wait_before_poll_min=5)
+        cf.wait_for_complete(wait_before_poll_min=5)
     else:
         if options.advanced:
-            cf = test_util.aws.DcosCfAdvanced(options.stack_name, bw)
+            cf = test_util.aws.DcosZenCfStack(options.stack_name, bw)
         else:
-            cf = test_util.aws.DcosCfSimple(options.stack_name, bw)
+            cf = test_util.aws.DcosCfStack(options.stack_name, bw)
         ssh_info = test_util.aws.SSH_INFO[options.host_os]
         stack_name = options.stack_name
     # Resiliency testing requires knowing the stack name

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -172,7 +172,7 @@ def main():
             admin_location='0.0.0.0/0',
             key_pair_name='default',
             boto_wrapper=bw)
-        vpc.wait_for_stack_creation()
+        vpc.wait_for_complete()
 
         cluster = test_util.cluster.Cluster.from_vpc(
             vpc,

--- a/test_util/test_launch.py
+++ b/test_util/test_launch.py
@@ -103,14 +103,14 @@ def mocked_aws_cf_simple_backend(monkeypatch, mocked_test_runner):
     # mock wait
     monkeypatch.setattr(test_util.aws.CfStack, 'get_stack_details', lambda _: {'StackStatus': 'CREATE_COMPLETE'})
     # mock describe
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_master_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_master_ips',
                         lambda _: [Host('127.0.0.1', '12.34.56')])
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_private_agent_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_private_agent_ips',
                         lambda _: [Host('127.0.0.1', None)])
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'get_public_agent_ips',
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'get_public_agent_ips',
                         lambda _: [Host('127.0.0.1', '12.34.56')])
     # mock delete
-    monkeypatch.setattr(test_util.aws.DcosCfSimple, 'delete', lambda _: None)
+    monkeypatch.setattr(test_util.aws.DcosCfStack, 'delete', lambda _: None)
     monkeypatch.setattr(test_util.aws.BotoWrapper, 'delete_key_pair', lambda *args: None)
     # mock config
     monkeypatch.setattr(test_util.aws.BotoWrapper, 'create_key_pair', lambda *args: MOCK_SSH_KEY_DATA)

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -242,7 +242,7 @@ def main():
             aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
         ),
     )
-    vpc.wait_for_stack_creation()
+    vpc.wait_for_complete()
     cluster = test_util.cluster.Cluster.from_vpc(
         vpc,
         ssh_info,


### PR DESCRIPTION
- Adds fetch stack helper that can automatically return the correct AWS Stack representation
- Remove most boto/aws - level logic and concentrate it entirely inside test_util/aws.py
- Refactors AwsCfAdvanced into AwsZenCfStack and turn each of the resource stacks within zen into its own class
- Note: all of the @classmethod create's in this file are essentially bits of dcos-launch and will be removed when we switch infrastructure to use dcos-launch

## Related Issues

https://mesosphere.atlassian.net/browse/DCOS-13298

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: PR is a refactor, nothing added and nothing removed. Just reworked internals and removed dead code
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)