### PR TITLE
Add log-level control for dcos-launch

### DIFF
--- a/gen/build_deploy/bash/dcos-launch.spec
+++ b/gen/build_deploy/bash/dcos-launch.spec
@@ -4,7 +4,7 @@
 #   - data must be decalared explicitly if not a .py file
 #   - Building will suck up the local SSL .so and package it
 #     with the final exe. Ensure build system has OpenSSL 1.0.2g or greater
-a = Analysis(['test_util/launch.py'],
+a = Analysis(['test_util/launch_cli.py'],
              hiddenimports=['html.parser'],
              datas=[('gen/ip-detect/*.sh', 'gen/ip-detect/')])
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
             'pkgpanda=pkgpanda.cli:main',
             'mkpanda=pkgpanda.build.cli:main',
             'dcos_installer=dcos_installer.cli:main',
-            'dcos-launch=test_util.launch:main',
+            'dcos-launch=test_util.launch_cli:main',
             'dcos-exhibitor-migrate-status=dcos_installer.exhibitor_migrate:status',
             'dcos-exhibitor-migrate-perform=dcos_installer.exhibitor_migrate:perform',
         ],
@@ -101,9 +101,6 @@ setup(
         'pkgpanda': [
             'docker/dcos-builder/Dockerfile'
         ],
-        'test_util': [
-            'launch.py'
-        ]
     },
     zip_safe=False
 )

--- a/ssh/tunnel.py
+++ b/ssh/tunnel.py
@@ -16,8 +16,6 @@ from typing import Optional
 
 from pkgpanda.util import write_string
 
-LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
-logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -7,10 +7,8 @@ import retrying
 
 from test_util.helpers import Host, retry_boto_rate_limits, SshInfo
 
-LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
-logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
 # AWS verbosity in debug mode overwhelms meaningful logging
-logging.getLogger('botocore').setLevel(logging.INFO)
+
 log = logging.getLogger(__name__)
 
 VPC_TEMPLATE_URL = 'https://s3.amazonaws.com/vpc-cluster-template/vpc-cluster-template.json'

--- a/test_util/launch.py
+++ b/test_util/launch.py
@@ -1,39 +1,17 @@
-"""DC/OS Launch
-
-Usage:
-  dcos-launch create [--config-path=<path> --info-path=<path>]
-  dcos-launch wait [--info-path=<path>]
-  dcos-launch describe [--info-path=<path>]
-  dcos-launch pytest [--info-path=<path> --env=<envlist>] [--] [<pytest_extras>]...
-  dcos-launch delete [--info-path=<path>]
-
-Commands:
-  create    Reads the file given by --config-path, creates the cluster described therein
-            and finally dumps a JSON file to the path given in --info-path which can then
-            be used with the wait, describe, and delete calls.
-  wait      Block until the cluster is up and running.
-  describe  Return additional information about the composition of the cluster.
-  pytest    Runs integration test suite on cluster. Can optionally supply options and arguments to pytest
-  delete    Destroying the provided cluster deployment.
-
-Options:
-  --config-path=<path>  Path for config to create cluster from [default: config.yaml].
-  --info-path=<path>    JSON file output by create and consumed by wait, describe,
-                        and delete [default: cluster_info.json].
-  --env=<envlist>       Specifies a comma-delimited list of environment variables to be
-                        passed from the local environment into the test environment.
+""" Utilities to provide a turn-key deployments of DC/OS clusters, wait
+for their deployment to finish, describe the cluster topology, run the
+integration tests, and finally delete the cluster.
 """
 import abc
 import copy
-import os
-import sys
-
-from docopt import docopt
+import logging
 
 import ssh.tunnel
 import test_util.runner
-from pkgpanda.util import json_prettyprint, load_json, load_string, load_yaml, write_json, YamlParseError
+from pkgpanda.util import load_string
 from test_util.aws import BotoWrapper, DcosCfSimple
+
+log = logging.getLogger(__name__)
 
 
 class LauncherError(Exception):
@@ -68,6 +46,7 @@ class AbstractLauncher(metaclass=abc.ABCMeta):
 class AwsCloudformationLauncher(AbstractLauncher):
     def __init__(self, boto_wrapper):
         self.boto_wrapper = boto_wrapper
+        log.debug('Using AWS Cloudformation Launcher')
 
     def create(self, config):
         check_keys(config, ['stack_name', 'template_url'])
@@ -232,61 +211,3 @@ def check_keys(user_dict, key_list):
     if len(missing) > 0:
         raise LauncherError('MissingInput', 'The following keys were required but '
                             'not provided: {}'.format(repr(missing)))
-
-
-def do_main(args):
-    if args['create']:
-        info_path = args['--info-path']
-        if os.path.exists(info_path):
-            raise LauncherError('InputConflict', 'Target info path already exists!')
-        config = load_yaml(args['--config-path'])
-        check_keys(config, ['type', 'provider_info', 'this_is_a_temporary_config_format_do_not_put_in_production'])
-        write_json(info_path, get_launcher(config['type'], config['provider_info']).create(config))
-        return 0
-
-    info = load_json(args['--info-path'])
-    check_keys(info, ['type', 'provider'])
-    launcher = get_launcher(info['type'], info['provider'])
-
-    if args['wait']:
-        launcher.wait(info)
-        print('Cluster is ready!')
-        return 0
-
-    if args['describe']:
-        print(json_prettyprint(launcher.describe(info)))
-        return 0
-
-    if args['pytest']:
-        test_cmd = 'py.test'
-        if args['--env'] is not None:
-            if '=' in args['--env']:
-                # User is attempting to do an assigment with the option
-                raise LauncherError('OptionError', "The '--env' option can only pass through environment variables "
-                                    "from the current environment. Set variables according to the shell being used.")
-            var_list = args['--env'].split(',')
-            check_keys(os.environ, var_list)
-            test_cmd = ' '.join(['{}={}'.format(e, os.environ[e]) for e in var_list]) + ' ' + test_cmd
-        if len(args['<pytest_extras>']) > 0:
-            test_cmd += ' ' + ' '.join(args['<pytest_extras>'])
-        launcher.test(info, test_cmd)
-        return 0
-
-    if args['delete']:
-        launcher.delete(info)
-        return 0
-
-
-def main(argv=None):
-    args = docopt(__doc__, argv=argv, version='DC/OS Launch v.0.1')
-
-    try:
-        return do_main(args)
-    except (LauncherError, YamlParseError) as ex:
-        print('DC/OS Launch encountered an error!')
-        print(repr(ex))
-        return 1
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/test_util/launch_cli.py
+++ b/test_util/launch_cli.py
@@ -1,0 +1,123 @@
+"""DC/OS Launch
+
+Usage:
+  dcos-launch create [-L LEVEL -c PATH -i PATH]
+  dcos-launch wait [-L LEVEL -i PATH]
+  dcos-launch describe [-L LEVEL -i PATH]
+  dcos-launch pytest [-L LEVEL -i PATH -e LIST] [--] [<pytest_extras>]...
+  dcos-launch delete [-L LEVEL -i PATH]
+
+Commands:
+  create    Reads the file given by --config-path, creates the cluster
+              described therein and finally dumps a JSON file to the path
+              given in --info-path which can then be used with the wait,
+              describe, pytest, and delete calls.
+  wait      Block until the cluster is up and running.
+  describe  Return additional information about the composition of the cluster.
+  pytest    Runs integration test suite on cluster. Can optionally supply
+              options and arguments to pytest
+  delete    Destroying the provided cluster deployment.
+
+Options:
+  -c PATH --config-path=PATH
+            Path for config to create cluster from [default: config.yaml].
+  -i PATH --info-path=PATH
+            JSON file output by create and consumed by wait, describe,
+            and delete [default: cluster_info.json].
+  -e LIST --env=LIST
+            Specifies a comma-delimited list of environment variables to be
+            passed from the local environment into the test environment.
+  -L LEVEL --log-level=LEVEL
+            One of: critical, error, warning, info, debug, and trace
+            [default: info].
+"""
+import logging
+import os
+import sys
+
+from docopt import docopt
+
+from pkgpanda.util import json_prettyprint, load_json, load_yaml, write_json, YamlParseError
+from test_util.launch import check_keys, get_launcher, LauncherError
+
+LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
+
+
+def _handle_logging(log_level_str):
+    if log_level_str == 'CRITICAL':
+        log_level = logging.CRITICAL
+    elif log_level_str == 'ERROR':
+        log_level = logging.ERROR
+    elif log_level_str == 'WARNING':
+        log_level = logging.WARNING
+    elif log_level_str == 'INFO':
+        log_level = logging.INFO
+    elif log_level_str == 'DEBUG' or log_level_str == 'TRACE':
+        log_level = logging.DEBUG
+    else:
+        raise LauncherError('InvalidOption', '{} is not a valid log level'.format(log_level_str))
+    logging.basicConfig(format=LOGGING_FORMAT, level=log_level)
+    if log_level_str in ('TRACE', 'CRITICAL'):
+        return
+    # now dampen the loud loggers
+    for module in ['botocore', 'boto3']:
+        logging.getLogger(module).setLevel(log_level + 10)
+
+
+def do_main(args):
+    _handle_logging(args['--log-level'].upper())
+    if args['create']:
+        info_path = args['--info-path']
+        if os.path.exists(info_path):
+            raise LauncherError('InputConflict', 'Target info path already exists!')
+        config = load_yaml(args['--config-path'])
+        check_keys(config, ['type', 'provider_info', 'this_is_a_temporary_config_format_do_not_put_in_production'])
+        write_json(info_path, get_launcher(config['type'], config['provider_info']).create(config))
+        return 0
+
+    info = load_json(args['--info-path'])
+    check_keys(info, ['type', 'provider'])
+    launcher = get_launcher(info['type'], info['provider'])
+
+    if args['wait']:
+        launcher.wait(info)
+        print('Cluster is ready!')
+        return 0
+
+    if args['describe']:
+        print(json_prettyprint(launcher.describe(info)))
+        return 0
+
+    if args['pytest']:
+        test_cmd = 'py.test'
+        if args['--env'] is not None:
+            if '=' in args['--env']:
+                # User is attempting to do an assigment with the option
+                raise LauncherError('OptionError', "The '--env' option can only pass through environment variables "
+                                    "from the current environment. Set variables according to the shell being used.")
+            var_list = args['--env'].split(',')
+            check_keys(os.environ, var_list)
+            test_cmd = ' '.join(['{}={}'.format(e, os.environ[e]) for e in var_list]) + ' ' + test_cmd
+        if len(args['<pytest_extras>']) > 0:
+            test_cmd += ' ' + ' '.join(args['<pytest_extras>'])
+        launcher.test(info, test_cmd)
+        return 0
+
+    if args['delete']:
+        launcher.delete(info)
+        return 0
+
+
+def main(argv=None):
+    args = docopt(__doc__, argv=argv, version='DC/OS Launch v.0.1')
+
+    try:
+        return do_main(args)
+    except (LauncherError, YamlParseError) as ex:
+        print('DC/OS Launch encountered an error!')
+        print(repr(ex))
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test_util/runner.py
+++ b/test_util/runner.py
@@ -6,9 +6,6 @@ import logging
 import sys
 from subprocess import CalledProcessError
 
-
-LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
-logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
 log = logging.getLogger(__name__)
 
 

--- a/test_util/test_launch.py
+++ b/test_util/test_launch.py
@@ -9,7 +9,7 @@ import ssh.tunnel
 import test_util
 from pkgpanda.util import load_json
 from test_util.helpers import Host
-from test_util.launch import get_launcher, LauncherError, main
+from test_util.launch_cli import get_launcher, LauncherError, main
 
 MOCK_SSH_KEY_DATA = 'ssh_key_data'
 MOCK_KEY_NAME = 'my_key_name'


### PR DESCRIPTION
- suppresses select libraries to prevent obfuscation
- adds truncated options for existing long-name options
- moves CLI code to its own module