### PR TITLE
Add a static value for the agent `--launcher_dir` flag.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -395,6 +395,7 @@ package:
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/
       MESOS_WORK_DIR=/var/lib/mesos/slave
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
+      MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
       MESOS_CGROUPS_ENABLE_CFS=true

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -252,7 +252,6 @@ class VpcClusterUpgradeTest:
             # See this issue for why we check for a difference:
             # https://issues.apache.org/jira/browse/MESOS-1718
             self.task_state_start = self.get_master_task_state(dcos_api, self.tasks_start[0])
-            log.debug('Test app state at start:\n' + pprint.pformat(self.task_state_start))
 
     def verify_apps_state(self, dcos_api: DcosApiSession, dns_app: dict):
         with logger.scope("verify apps state"):
@@ -268,13 +267,12 @@ class VpcClusterUpgradeTest:
                         "test_upgrade_vpc.marathon_app_tasks_survive_upgrade",
                         details="expected: {}\nactual:   {}".format(self.tasks_start, tasks_end))
 
-            def test_task_state_remains_consistent():
+            def test_mesos_task_state_remains_consistent():
                 # Verify that the "state" of the task does not change.
-                task_state_end = get_master_task_state(dcos_api, self.tasks_start[0])
-                log.debug('Test app state at end:\n' + pprint.pformat(task_state_end))
+                task_state_end = self.get_master_task_state(dcos_api, self.tasks_start[0])
                 if not self.task_state_start == task_state_end:
                     self.teamcity_msg.testFailed(
-                        "test_upgrade_vpc.test_task_state_remains_consistent",
+                        "test_upgrade_vpc.test_mesos_task_state_remains_consistent",
                         details="expected: {}\nactual:   {}".format(self.task_state_start, task_state_end))
 
             def test_app_dns_survive_upgrade():
@@ -296,7 +294,10 @@ class VpcClusterUpgradeTest:
                     self.teamcity_msg.testFailed("test_upgrade_vpc.test_app_dns_survive_upgrade", details=err_msg)
 
             self.log_test("test_upgrade_vpc.marathon_app_tasks_survive_upgrade", marathon_app_tasks_survive_upgrade)
-            self.log_test("test_upgrade_vpc.test_task_state_remains_consistent", test_task_state_remains_consistent)
+            self.log_test(
+                "test_upgrade_vpc.test_mesos_task_state_remains_consistent",
+                test_mesos_task_state_remains_consistent
+            )
             self.log_test("test_upgrade_vpc.test_app_dns_survive_upgrade", test_app_dns_survive_upgrade)
 
     def run_test(self) -> int:


### PR DESCRIPTION
Currently, all command tasks will become "over-committed" by 0.1 CPUs
and 32 MB of memory, per task, after an upgrade.  This is because the
agent generates the ExecutorInfo for command tasks with this slight
over-committment of resources.

The agent determines whether an executor is a command executor by
comparing the executor's path with its own `--launcher_dir`.  Because
the `--launcher_dir` changes (by a SHA in the path) during every upgrade,
all command executors will be considered "custom" executors after an
upgrade.  The agent will report executor resources to the master for
non-command executors only.

## Related Issues

  - [DCOS-13672](https://jira.mesosphere.com/browse/DCOS-13672) Mesos Reports Over allocated CPU during Upgrade

## Checklist for all PR's

  - [ ] Potentially update `test_util/test_upgrade_vpc.py` to check for exact resource match after an upgrade.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)