### PR TITLE
Adding mergebot configs to dcos/dcos.

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -1,0 +1,6 @@
+{
+   "integrate": false,
+   "ship-it": false,
+   "test": false,
+   "bump-ee": true
+}

--- a/owners.json
+++ b/owners.json
@@ -1,0 +1,8 @@
+{
+  "amitaekbote": {"slack": "amitaekbote"},
+  "branden": {"slack": "branden"},
+  "lingmann": {"slack": "jeremy"},
+  "mellenburg": {"slack": "mellenburg"},
+  "orsenthil" : {"slack": "skumaran"},
+  "spahl": {"slack": "seb"}
+}


### PR DESCRIPTION
## High Level Description

Adding mergebot config files to DCOS.

* This currently has orsenthil in owners.  I like to do a couple of the dcos -> dcos-enterprise bump before adding more owners.

*  This only has enterprise bump feature enabled for dcos/dcos repo. Once this feature is working properly, we can slowly enable other mergebot features.

The mergebot webhook should be added to the dcos repo after these changes are merged in (  ref: [internal wiki](https://mesosphere.atlassian.net/wiki/display/DCOS/Mesosphere+Mergebot) ).


