### PR TITLE
Convert acs deploy to generic utilities

### DIFF
--- a/test_util/azure.py
+++ b/test_util/azure.py
@@ -1,26 +1,29 @@
+""" This module is intended to allow deploying of arbitrary Azure Resource
+Manager templates. For more information on how to configure and interpret these
+templates, see:
+
+https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates
+"""
 import contextlib
+import copy
 import logging
 import re
-from typing import Union
 
-import azure.common.credentials
+import requests
+import retrying
+from azure.common.credentials import ServicePrincipalCredentials
 from azure.common.exceptions import CloudError
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource.resources import ResourceManagementClient
 from azure.mgmt.resource.resources.models import (DeploymentMode,
                                                   DeploymentProperties,
-                                                  ResourceGroup, TemplateLink)
-from retrying import retry
+                                                  ResourceGroup)
 
 from test_util.helpers import lazy_property
 
-
-# Very noisy loggers that do not help much in debug mode
-logging.getLogger("msrest").setLevel(logging.INFO)
-logging.getLogger("requests_oauthlib").setLevel(logging.INFO)
 log = logging.getLogger(__name__)
 
-# This interface is designed to only use a single deployment
+# This interface is designed to only use a single deployment.
 # Being as the azure interface is based around resource groups, deriving
 # deployment name from group names makes it easier to attach to creating deploys
 DEPLOYMENT_NAME = '{}-Deployment'
@@ -35,14 +38,97 @@ def validate_hostname_prefix(prefix):
     assert re.match('^[a-z][a-z0-9-]{1,61}[a-z0-9]$', prefix), 'Invalid DNS prefix: {}'.format(prefix)
 
 
+def check_json_object(obj):
+    """ Simple check to fill in the map for automatic parameter casting
+    JSON objects must be represented as dict at this level
+    """
+    assert isinstance(obj, dict), 'Invalid JSON object: {}'.format(obj)
+    return obj
+
+
+def check_array(arr):
+    """ Simple check to fill in the map for automatic parameter casting
+    JSON arrays must be represented as lists at this level
+    """
+    assert isinstance(arr, list), 'Invalid array: {}'.format(arr)
+    return arr
+
+
 class AzureWrapper:
-    def __init__(self, subscription_id: str, client_id: str, client_secret: str, tenant_id: str):
-        self.credentials = azure.common.credentials.ServicePrincipalCredentials(
+    def __init__(self, location: str, subscription_id: str, client_id: str, client_secret: str, tenant_id: str):
+        self.credentials = ServicePrincipalCredentials(
             client_id=client_id,
             secret=client_secret,
             tenant=tenant_id)
         self.rmc = ResourceManagementClient(self.credentials, subscription_id)
         self.nmc = NetworkManagementClient(self.credentials, subscription_id)
+        # location is included to keep a similar model as test_util.aws.BotoWrapper
+        self.location = location
+
+    def deploy_template_to_new_resource_group(self, template_url, group_name, parameters):
+        deployment_name = DEPLOYMENT_NAME.format(group_name)
+        # Resource group must be created before validation can occur
+        if self.rmc.resource_groups.check_existence(group_name):
+            raise Exception("Group name already exists / taken: {}".format(group_name))
+        log.info('Starting resource group_creation')
+        with contextlib.ExitStack() as stack:
+            self.rmc.resource_groups.create_or_update(
+                group_name,
+                ResourceGroup(location=self.location))
+            # Ensure the resource group will be deleted if the following steps fail
+            stack.callback(self.rmc.resource_groups.delete, group_name)
+            log.info('Resource group created: {}'.format(group_name))
+            deployment_properties = self.create_deployment_properties(
+                template_url, parameters)
+            log.info('Checking with Azure to validate template deployment')
+            result = self.rmc.deployments.validate(
+                group_name, deployment_name, properties=deployment_properties)
+            if result.error:
+                log.critical('{}: {}'.format(result.error.code, result.error.message))
+                raise Exception("Template verification failed!\n{}".format(result.error))
+            log.info('Template successfully validated')
+            log.info('Starting template deployment')
+            self.rmc.deployments.create_or_update(
+                group_name, deployment_name, deployment_properties)
+            stack.pop_all()
+        log.info('Successfully started template deployment')
+
+    def create_deployment_properties(self, template_url, parameters):
+        """ Pulls the targeted template, checks parameter specs and casts
+        user provided parameters to the appropriate type. Assertion is raised
+        if there are unused parameters
+        """
+        user_parameters = copy.copy(parameters)
+        type_cast_map = {
+            'string': str,
+            'secureString': str,
+            'int': int,
+            'bool': bool,
+            'object': check_json_object,
+            'secureObject': check_json_object,
+            'array': check_array}
+        log.debug('Pulling Azure template for parameter validation...')
+        r = requests.get(template_url)
+        r.raise_for_status()
+        template = r.json()
+        if 'parameters' not in template:
+            assert user_parameters is None, 'This template does not support parameters, ' \
+                'yet parameters were supplied: {}'.format(user_parameters)
+        log.debug('Constructing DeploymentProperties from user parameters: {}'.format(parameters))
+        template_parameters = {}
+        for k, v in template['parameters'].items():
+            if k in user_parameters:
+                # All templates parameters are required to have a type field.
+                # Azure requires that parameters be provided as {key: {'value': value}}.
+                template_parameters[k] = {
+                    'value': type_cast_map[v['type']](user_parameters.pop(k))}
+        log.debug('Final template parameters: {}'.format(template_parameters))
+        if len(user_parameters) > 0:
+            raise Exception('Unrecognized template parameters were supplied: {}'.format(user_parameters))
+        return DeploymentProperties(
+            template=template,
+            mode=DeploymentMode.incremental,
+            parameters=template_parameters)
 
 
 class DcosAzureResourceGroup:
@@ -52,60 +138,26 @@ class DcosAzureResourceGroup:
 
     @classmethod
     def deploy_acs_template(
-            cls, azure_wrapper, template_uri, location, group_name,
-            public_key, master_prefix, agent_prefix, admin_name, oauth_enabled: Union[bool, str],
-            vm_size, agent_count, name_suffix, vm_diagnostics_enabled: bool):
+            cls, azure_wrapper, template_url, group_name,
+            public_key, master_prefix, agent_prefix, admin_name, oauth_enabled,
+            vm_size, agent_count, name_suffix, vm_diagnostics_enabled):
         """ Creates a new resource group and deploys a ACS DC/OS template to it
         """
         assert master_prefix != agent_prefix, 'Master and agents must have unique prefixs'
         validate_hostname_prefix(master_prefix)
         validate_hostname_prefix(agent_prefix)
 
-        deployment_name = DEPLOYMENT_NAME.format(group_name)
-
-        # Resource group must be created before validation can occur
-        if azure_wrapper.rmc.resource_groups.check_existence(group_name):
-            raise Exception("Group name already exists / taken: {}".format(group_name))
-        log.info('Starting resource group_creation')
-        with contextlib.ExitStack() as stack:
-            azure_wrapper.rmc.resource_groups.create_or_update(
-                group_name,
-                ResourceGroup(location=location))
-            stack.callback(azure_wrapper.rmc.resource_groups.delete, group_name)
-            log.info('Resource group created: {}'.format(group_name))
-
-            template_params = {
-                'sshRSAPublicKey': public_key,
-                # must be lower or validation will fail
-                'masterEndpointDNSNamePrefix': master_prefix,
-                'agentEndpointDNSNamePrefix': agent_prefix,
-                'linuxAdminUsername': admin_name,
-                'agentVMSize': vm_size,
-                'agentCount': agent_count,
-                'nameSuffix': name_suffix,
-                'oauthEnabled': repr(oauth_enabled).lower(),
-                # oauth uses string, vm diagnostic uses bool
-                'enableVMDiagnostics': vm_diagnostics_enabled}
-            log.info('Provided template parameters: {}'.format(template_params))
-            # azure requires that parameters be provided as {key: {'value': value}}
-            template_parameters = {k: {'value': v} for k, v in template_params.items()}
-            deployment_properties = DeploymentProperties(
-                template_link=TemplateLink(uri=template_uri),
-                mode=DeploymentMode.incremental,
-                parameters=template_parameters)
-            log.info('Checking with Azure to validate template deployment')
-            result = azure_wrapper.rmc.deployments.validate(
-                group_name, deployment_name, properties=deployment_properties)
-            if result.error:
-                for details in result.error.details:
-                    log.error('{}: {}'.format(details.code, details.message))
-                error_msgs = '\n'.join(['{}: {}'.format(d.code, d.message) for d in result.error.details])
-                raise Exception("Template verification failed!\n{}".format(error_msgs))
-            log.info('Template successfully validated')
-            log.info('Starting template deployment')
-            azure_wrapper.rmc.deployments.create_or_update(
-                group_name, deployment_name, deployment_properties)
-            stack.pop_all()
+        parameters = {
+            'sshRSAPublicKey': public_key,
+            'masterEndpointDNSNamePrefix': master_prefix,
+            'agentEndpointDNSNamePrefix': agent_prefix,
+            'linuxAdminUsername': admin_name,
+            'agentVMSize': vm_size,
+            'agentCount': agent_count,
+            'nameSuffix': name_suffix,
+            'oauthEnabled': oauth_enabled,
+            'enableVMDiagnostics': vm_diagnostics_enabled}
+        azure_wrapper.deploy_template_to_new_resource_group(template_url, group_name, parameters)
         return cls(group_name, azure_wrapper)
 
     def wait_for_deployment(self, timeout=45 * 60):
@@ -119,9 +171,10 @@ class DcosAzureResourceGroup:
         """
         log.info('Waiting for deployment to finish')
 
-        @retry(wait_fixed=60 * 1000, stop_max_delay=timeout * 1000,
-               retry_on_result=lambda res: res is False,
-               retry_on_exception=lambda ex: isinstance(ex, CloudError))
+        @retrying.retry(
+            wait_fixed=60 * 1000, stop_max_delay=timeout * 1000,
+            retry_on_result=lambda res: res is False,
+            retry_on_exception=lambda ex: isinstance(ex, CloudError))
         def check_deployment_operations():
             deploy_state = self.azure_wrapper.rmc.deployments.get(
                 self.group_name, DEPLOYMENT_NAME.format(self.group_name)).properties.provisioning_state

--- a/test_util/test_azure.py
+++ b/test_util/test_azure.py
@@ -77,6 +77,9 @@ from test_util.runner import integration_test
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
 logging.basicConfig(format=LOGGING_FORMAT, level=logging.DEBUG)
+logging.getLogger("msrest").setLevel(logging.INFO)
+logging.getLogger("requests_oauthlib").setLevel(logging.INFO)
+logging.getLogger("requests.packages").setLevel(logging.INFO)
 log = logging.getLogger(__name__)
 
 
@@ -110,10 +113,10 @@ def check_environment():
     options.agent_prefix = os.getenv('AZURE_AGENT_PREFIX', 'test' + random_id(10).lower())
     options.master_prefix = os.getenv('AZURE_MASTER_PREFIX', 'test' + random_id(10).lower())
     options.vm_size = os.getenv('AZURE_VM_SIZE', 'Standard_D2')
-    options.num_agents = int(os.getenv('AGENTS', '2'))
+    options.num_agents = os.getenv('AGENTS', '2')
     options.name_suffix = os.getenv('AZURE_DCOS_SUFFIX', '12345')
-    options.oauth_enabled = os.getenv('AZURE_OAUTH_ENABLED', 'false') == 'true'
-    options.vm_diagnostics_enabled = os.getenv('AZURE_VM_DIAGNOSTICS_ENABLED', 'true') == 'true'
+    options.oauth_enabled = os.getenv('AZURE_OAUTH_ENABLED', 'false')
+    options.vm_diagnostics_enabled = os.getenv('AZURE_VM_DIAGNOSTICS_ENABLED', 'true')
     options.azure_cleanup = os.getenv('AZURE_CLEANUP', 'true') == 'true'
     options.ci_flags = os.getenv('CI_FLAGS', '')
 
@@ -130,14 +133,14 @@ def check_environment():
 def main():
     options = check_environment()
     aw = AzureWrapper(
+        options.location,
         options.subscription_id,
         options.client_id,
         options.client_secret,
         options.tenant_id)
     dcos_resource_group = DcosAzureResourceGroup.deploy_acs_template(
         azure_wrapper=aw,
-        template_uri=options.template_url,
-        location=options.location,
+        template_url=options.template_url,
         group_name=options.name,
         public_key=options.public_ssh_key,
         master_prefix=options.master_prefix,

--- a/test_util/test_dcos_api_session.py
+++ b/test_util/test_dcos_api_session.py
@@ -1,10 +1,10 @@
-"""Tests for verifying key functionality of utilities
+""" Verifies basic interface for the test harness employed in
+DC/OS integration tests, see: packages/dcos-integration-tests/extra
 """
 import pytest
 import requests
 
 from test_util.dcos_api_session import DcosApiSession, DcosUser, get_args_from_env
-from test_util.helpers import lazy_property
 
 
 class MockResponse:
@@ -71,34 +71,3 @@ def test_dcos_client_api(mock_dcos_client):
     cluster.head('')
     cluster.patch('')
     cluster.options('')
-
-
-class LazyClass:
-    def __init__(self):
-        self.property_called = {}
-
-    def _raise_if_called_twice(self, name):
-        """ This property can only be called once, as such it can only be a lazy property
-        or else multiple calls will raise an error
-        """
-        if self.property_called.get(name):
-            raise AssertionError('This is a lazy property and should only be evaluated exactly once')
-        self.property_called[name] = True
-        return name
-
-    @property
-    def bar(self):
-        self._raise_if_called_twice('bar')
-
-    @lazy_property
-    def foo(self):
-        self._raise_if_called_twice('foo')
-
-
-def test_lazy_property():
-    c = LazyClass()
-    c.bar  # will work because its the first call
-    with pytest.raises(AssertionError):
-        c.bar  # will fail because its a standard property
-    c.foo  # will work because its the first call
-    c.foo  # will work because function is ignored on second call

--- a/test_util/test_helpers.py
+++ b/test_util/test_helpers.py
@@ -1,4 +1,5 @@
 """Tests for test_util.helpers."""
+import pytest
 
 from test_util import helpers
 
@@ -7,3 +8,34 @@ def test_marathon_app_id_to_mesos_dns_subdomain():
     assert helpers.marathon_app_id_to_mesos_dns_subdomain('/app-1') == 'app-1'
     assert helpers.marathon_app_id_to_mesos_dns_subdomain('app-1') == 'app-1'
     assert helpers.marathon_app_id_to_mesos_dns_subdomain('/group-1/app-1') == 'app-1-group-1'
+
+
+class LazyClass:
+    def __init__(self):
+        self.property_called = {}
+
+    def _raise_if_called_twice(self, name):
+        """ This property can only be called once, as such it can only be a lazy property
+        or else multiple calls will raise an error
+        """
+        if self.property_called.get(name):
+            raise AssertionError('This is a lazy property and should only be evaluated exactly once')
+        self.property_called[name] = True
+        return name
+
+    @property
+    def bar(self):
+        self._raise_if_called_twice('bar')
+
+    @helpers.lazy_property
+    def foo(self):
+        self._raise_if_called_twice('foo')
+
+
+def test_lazy_property():
+    c = LazyClass()
+    c.bar  # will work because its the first call
+    with pytest.raises(AssertionError):
+        c.bar  # will fail because its a standard property
+    c.foo  # will work because its the first call
+    c.foo  # will work because function is ignored on second call


### PR DESCRIPTION
The current tooling only allows deploying a specific template and does a lot of custom logic. This PR breaks that logical into sensible chunks that are independent of DC/OS environment

Included in this PR is a helper function that will pull down a Azure template, parse the parameters, and then type cast the user parameters as indicated. The motivation for this is that Azure parameters are naturally JSON, so a user should be able to pass a JSON or YAML parameter specification to the azure wrapper and launch. The YAML or JSON parsers have to way to tell if a string should be a string or an integer or a boolean, and as such the user would have to explicitly detail the types for no benefit what so ever.

Edit:
PR also includes a small shuffling of unit tests relevant to the code being modified

## Related Issues
https://mesosphere.atlassian.net/browse/DCOS-13300

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A Refactor work
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)