### PR TITLE
Bump Mesos, Turn on GPU support by default.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -609,7 +609,7 @@ entry = {
                 }
             }
         }),
-        'enable_gpu_isolation': 'false',
+        'enable_gpu_isolation': 'true',
         'cluster_docker_registry_url': '',
         'cluster_docker_credentials_dcos_owned': calculate_docker_credentials_dcos_owned,
         'cluster_docker_credentials_write_to_etc': 'false',

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,7 +1,8 @@
 <H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
-<li>[c81bea7092bea8a2912237abdcab027e67c1dd91] Set LIBPROCESS_IP into docker container.
-<li>[5720037ac5921b675d59b670ecf6ea24cfbdf317] Changed agent_host to expect a relative path.
-<li>[38d4c3022e22eb98006ad50c3e9c5e115d5f14e3] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
-<li>[ffea5a593c030dbdfced57942a2ca5c6e447fcf3] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[abe6e6390612f523a3106192d719982c70c31f3e] Fixed fetcher to not pick up environment variables it should not see.
+<li>[42e4e19d0d7e54d5e361e1dd2d6afbd24d1928d1] Set LIBPROCESS_IP into docker container.
+<li>[09975e642168a47c466e211f02a590b6e3e1e40c] Changed agent_host to expect a relative path.
+<li>[d2cf9ac1dfa0d7d2b5ebcf8f9da86190706bb5cd] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[3d042bae0431da237d2c109525ea81fe8eb9943c] Revert "Fixed the broken metrics information of master in WebUI."
+<li>[7fdf195b5f3bb4d4a0bd155d1663a96f9eaf4da1] Fixed fetcher to not pick up environment variables it should not see.
+<li>[dc01a78680410d7fe49e096508b64e94d991471c] Updated mesos containerizer to ignore GPU isolator creation failure.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "abe6e6390612f523a3106192d719982c70c31f3e",
-    "ref_origin" : "dcos-mesos-master-f179400b"
+    "ref": "dc01a78680410d7fe49e096508b64e94d991471c",
+    "ref_origin" : "dcos-mesos-1.2.0-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

This PR enables GPU support in DC/OS by default.

This means that if your agents have Nvidia GPUs installed on them as well as the proper Nvidia NVML library (> 340.29) installed on them, GPUs will be offered to your frameworks as a resource by those agents.

Previously, GPU support was an install-time parameter that required *all* agents in your cluster to have the proper NVML libraries installed on them. This PR removes this restriction and turns on GPU support by default. Operators should not have to perform any extra configuration to take advantage of this feature.

One caveat to be aware of, however, is that mesos will only offer GPU resources to frameworks that *opt-in* to receive these resources. If your framework has not opted-in, it will receive *no* offers from agents that have GPUs installed on them (these agents will essentially appear not to exist in your cluster from the perspective of those frameworks). The choice to make frameworks explicitly opt-in to receive offers that contain GPUs was to keep legacy frameworks from accidentally consuming non-GPU resources on GPU-capable machines (and thus blocking GPU jobs from running).

This is not an issue for frameworks that ship with DC/OS itself, as they have all been updated to opt-in to receive GPU resources. Details about how to update your framework so that it properly opts-in for GPU resources can be found here:
https://github.com/apache/mesos/blob/master/docs/gpu-support.md#framework-capabilities

## Related Issues

https://jira.mesosphere.com/browse/DCOS-13917

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:

There is no test included, because adding an automatically triggered integration test that tests GPU functionality is not yet supported (we would need to run the integration tests on nodes equipped with GPUs). However, because this PR actually turns GPU support on by default, the real test is whether we still pass all of the already-included tests with this feature enabled (since they are run on machines without GPUs). Manual tests for making sure GPU support worked in general were performed in https://github.com/dcos/dcos/pull/766.

  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)

  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:
If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:
    
  - [X] Change log from the last mesosphere/mesos version integrated: https://github.com/mesosphere/mesos/compare/abe6e6390612f523a3106192d719982c70c31f3e...dc01a78680410d7fe49e096508b64e94d991471c

  - [X] Test Results: Verified manually
  - [ ] Code Coverage (if available): *None*