### PR TITLE
Adminrouter: refactor cache, system API leader endpoints, history service's upstream uses leader.mesos

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -874,3 +874,16 @@ package:
   - path: /etc_master/dcos-history.env
     content: |
       STATE_SUMMARY_URI=http://leader.mesos:5050/state-summary
+  - path: /etc_master/adminrouter-listen-open.conf
+    content: |
+      listen 80 default_server;
+      listen 443 ssl default_server;
+
+      ssl_certificate common/snakeoil.crt;
+      ssl_certificate_key common/snakeoil.key;
+  - path: /etc_slave/adminrouter-listen-open.conf
+    content: |
+        listen 61001 default_server;
+  - path: /etc_slave_public/adminrouter-listen-open.conf
+    content: |
+        listen 61001 default_server;

--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -9,7 +9,7 @@
       "adminrouter": {
           "kind": "git",
           "git": "https://github.com/dcos/adminrouter.git",
-          "ref": "b687a27301a2cc00e11a7f68eccaedf20ce7dd6e",
+          "ref": "89a3099470325346193321d31409681c213de7ac",
           "ref_origin": "master"
       }
   }

--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "ebb738bc3f7db16285ac9d3e4009f07c192476ee",
+    "ref": "d292d7f5969a77910a1f6a8b9ef17bf01a92ceee",
     "ref_origin": "master"
   },
   "username": "dcos_log",


### PR DESCRIPTION
## High Level Description

This PR changes in AR:
* refactors cache, introduces CACHE_MAX_AGE_(HARD|SOFT)_LIMIT variables
* removes a couple of bugs:
  * `/agent` endpoint where the Nginx was incorrectly interpreting URLs that only contained `/agent/<agent-id>` endpoint and nothing else. Agent, in this case, was receiving original path component.
* increase logging verbosity by changing log level from notice to info
* add (marathon|mesos)-leader redirecting feature for system API (`marathon-leader.lua`)
* add `/system/v1/leader/mesos` and `/system/v1/leader/marathon` endpoints
* make all timing variables for cache configurable using ENV vars
* switch history service to `leader.mesos` upstream as per DCOS-13598
* refactor Server-Sent-Events configuration:
  * for endpoints we own (logging, metrics), we switch to `X-Accel-Buffering` header (https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering) which controls response buffering done by Nginx. This allows us to use the same location block for endpoints that both do and do not require it and leave the proxy buffering configuration to the author. This also enabled us to merge `/system/v1/agent/*` endpoints.
  * for `/agent` endpoint, we statically disable both request and response buffering to facilitate stdin/stdout redirection done by Mesos agent (used i.e. by CLI task-exec command). This has been consulted with @hatred and @klueska. It seems that Mesos agent does not care about request/response buffering outside of stdin/stdout redirection so it should be a backward-compatible change.
  * we enable HTTP/1.1 (default is HTTP/1.0) for all the endpoints that may use or use ServerSentEvent as this does not matter in non-streaming mode - we do not use upstream connection polling anyway. 
  * `chunked_transfer_encoding off` setting does not matter for ServerSentEvents and be left with default (on) value as per https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate/801629#801629
* tests for all system-api related locations as well as `/agent` one

Changes to other DC/OS components:
* bump dcos-log service in order to inlcude `X-Accel-Buffering` header changes

The system API layout in AR that we would like to use for the time being is as follows:
```
        location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.*)$ {
            include common/http-11.conf;
            include common/disable-request-response-buffering.conf;
        }

        location /system/health/v1 {
            <none>
        }

        location /system/v1/logs/v1/ {
            include common/http-11.conf;
            <relies on `X-Accel-Buffering` header>
        }

        location /system/v1/metrics/ {
            <none>
        }

        location ~ ^/system/v1/leader/mesos(?<url>.*)$ {
            include common/http-11.conf;
            <relies on `X-Accel-Buffering` header>
        }

        location ~ ^/system/v1/leader/marathon(?<url>.*)$ {
            include common/http-11.conf;
            <relies on `X-Accel-Buffering` header>
        }

        location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs/v1|/metrics/v0))(?<url>.*)$ {
            include common/http-11.conf;
            <relies on `X-Accel-Buffering` header>
        }
```
`<none>` is just a shortcut for "There is no configuration specific to Server-Sent-Events for given location block."
The `http-11.conf` file:
```
proxy_set_header Connection '';
proxy_http_version 1.1;
```
and `disable-request-response-buffering.conf` file:
```
proxy_request_buffering off;
proxy_buffering off;
proxy_cache off;
```

## Related Issues

  - [DCOS-13189](https://mesosphere.atlassian.net/browse/DCOS-13189) 
  - [DCOS-13598](https://mesosphere.atlassian.net/browse/DCOS-13598) 
  - [DCOS-11921](https://mesosphere.atlassian.net/browse/DCOS-11921) 
  - [DCOS-13918](https://mesosphere.atlassian.net/browse/DCOS-13918)

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Relevant PRs:

https://github.com/dcos/adminrouter/pull/51
https://github.com/dcos/adminrouter/pull/49
https://github.com/dcos/adminrouter/pull/48
https://github.com/dcos/adminrouter/pull/46
https://github.com/dcos/adminrouter/pull/40
https://github.com/dcos/adminrouter/pull/37
https://github.com/mesosphere/dcos-enterprise/pull/594


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (https://github.com/dcos/adminrouter/compare/b687a27301a2cc00e11a7f68eccaedf20ce7dd6e...89a3099470325346193321d31409681c213de7ac)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
