### PR TITLE
exhibitor: make sure that JNA library is included for ZK subprocesses

### DIFF
--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -39,4 +39,8 @@ chmod +x "$exhibitor_start_wrapper"
 
 mkdir -p "$PKG_PATH/usr/zookeeper/build/lib/"
 cp /pkg/src/log4j/log4j-systemd-journal-appender-1.3.2.jar "$PKG_PATH/usr/zookeeper/lib/"
-cp /pkg/src/jna/jna-4.2.2.jar "$PKG_PATH/usr/zookeeper/lib/"
+# DCOS-308: Renaming "jna-4.2.2" to "log4j-jna-4.2.2.jar" will
+# make sure that Exhibitor will include JNA library to cleanupInstance ZK
+# subprocess.
+# see: https://github.com/mesosphere/exhibitor/blob/master/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java#L65
+cp /pkg/src/jna/jna-4.2.2.jar "$PKG_PATH/usr/zookeeper/lib/log4j-jna-4.2.2.jar"


### PR DESCRIPTION
## High Level Description

This PR fixes the issue of missing `JNA` library for Zookeeper purging subprocess launched by `exhibitor`.

Exhibitor periodically launches purging process that makes sure that only relevant data stay on a disk. The process is launched as a subprocess launching new `java` process. The exhibitor searches for libraries that should be included in a `classpath` for the subprocess. By predefined rules the exhibitor includes every library from `[zookeeper-home]/libs` that include `log4j` or `sfl4j` in a file name. As a result it included `log4j-systemd-journal-appender-1.3.2.jar` but not `jna-4.2.2` which is a dependency for the first library.

This patch renames final `jna-4.2.2.jar` file to `log4j-jna-4.2.2.jar` to make sure it will get included in the purging subprocess classpath.

## Related Issues

  - [DCOS-310](https://dcosjira.atlassian.net/browse/DCOS-310) java.lang.NoClassDefFoundError: com/sun/jna/Library
  - [DCOS-10020](https://mesosphere.atlassian.net/browse/DCOS-10020) Exhibitor cleanup tasks are broken [INTERNAL]

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]