### PR TITLE
Support for Oracle Enterprise Linux

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -360,8 +360,15 @@ if ([ x$dist == 'xcoreos' ]); then
   exit 0
 fi
 
-if ([ x$dist != 'xrhel' ] && [ x$dist != 'xcentos' ]); then
-  echo "$dist is not supported. Only RHEL and CentOS are supported" >&2
+if ([ x$dist != 'xrhel' ] && [ x$dist != 'xcentos' ] && [ x$dist != 'xol' ]); then
+  echo "$dist is not supported. Only RHEL, CentOS and Oracle Enterprise Linux are supported" >&2
+  exit 0
+fi
+
+kernel_version=`uname -r`
+
+if ([ x$dist != 'xol' ] && [ kernel_version == *"uek"* ]); then
+  echo "Unbreakable Enterprise Kernel is not supported on Oracle Enterprise Linux. Switch to the other Kernel" >&2
   exit 0
 fi
 


### PR DESCRIPTION
## High Level Description

DCOS can be installed on Oracle Enterprise Linux 7.2 and 7.3(Fork of RHEL 7.2/7.3) if booted from kernel-3.10.0-514.el7 which ships along with the default kernel kernel-uek-4.1.12-61.1.18.el7uek