### PR TITLE
Update JIRA links in PR template.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@ What features does this change enable? What bugs does this change fix? High-Leve
 
 ## Related Issues
 
-  - [DCOS-<number>](https://dcosjira.atlassian.net/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
-  - [DCOS-<number>](https://mesosphere.atlassian.net/browse/DCOS-<number) TRACKING: dcosjira-123 Foo the Bar
+  - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
+  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
 
 ## Checklist for all PR's
 


### PR DESCRIPTION
We recently moved to new on-prem servers, so the old URLs:
https://dcosjira.atlassian.net/browse/DCOS
https://mesosphere.atlassian.net/browse/DCOS
won't work anymore, and instead we'll need to use
https://jira.dcos.io/browse/DCOS_OSS
https://jira.mesosphere.com/browse/DCOS

More recently, the public dcosjira projects were imported into the same JIRA instance, which means all the tickets from https://jira.dcos.io/browse/DCOS were renamed to https://jira.dcos.io/browse/DCOS_OSS (also accessible via https://jira.mesosphere.com/browse/DCOS_OSS )