### PR TITLE
[WIP] mesos-dns: bump for updated github.com/miekg/dns

### DIFF
--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos-dns.git",
-    "ref": "919851a158ba71aee4de145dc0a7f90cc68d0902",
+    "ref": "0f80f27b98de5652be10a3109ffa22e3c2ec9bb9",
     "ref_origin": "master"
   },
   "username": "dcos_mesos_dns"


### PR DESCRIPTION
## High Level Description

The current version of `mesos-dns` compresses various record types that should not be compressed. Most notably it compresses SRV records. This used to be compliant behaviour but more recent RFCs disallowed doing to.

This PR bumps `mesos-dns` to the following commit where it updated its `github.com/miekg/dns` dependency where this non-compliant behaviour has been fixed:

```
commit 0f80f27b98de5652be10a3109ffa22e3c2ec9bb9
Merge: 919851a faf3e39
Author: Albert Strasheim <fullung@gmail.com>
Date:   Wed Feb 1 14:54:45 2017 -0800

    Merge pull request #493 from mesosphere/gpaul/bump-github-com-miekg-dns

    Bump github.com/miekg/dns to 99f84ae56e75126dd77e5de4fae2ea034a468ca1
```

## Related Issues

  - [DCOS-13590](https://jira.mesosphere.com/browse/DCOS-13590) mesos-dns compresses SRV records

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changes](https://github.com/mesosphere/mesos-dns/compare/919851a158ba71aee4de145dc0a7f90cc68d0902...0f80f27b98de5652be10a3109ffa22e3c2ec9bb9), [reviewed here](https://github.com/mesosphere/mesos-dns/pull/493)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-mesos-dns-pulls/172/console
  - [ ] Code Coverage (if available): [link to code coverage report]
___