### PR TITLE
Train 129

### DIFF
--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -39,4 +39,8 @@ chmod +x "$exhibitor_start_wrapper"
 
 mkdir -p "$PKG_PATH/usr/zookeeper/build/lib/"
 cp /pkg/src/log4j/log4j-systemd-journal-appender-1.3.2.jar "$PKG_PATH/usr/zookeeper/lib/"
-cp /pkg/src/jna/jna-4.2.2.jar "$PKG_PATH/usr/zookeeper/lib/"
+# DCOS-308: Renaming "jna-4.2.2" to "log4j-jna-4.2.2.jar" will
+# make sure that Exhibitor will include JNA library to cleanupInstance ZK
+# subprocess.
+# see: https://github.com/mesosphere/exhibitor/blob/master/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java#L65
+cp /pkg/src/jna/jna-4.2.2.jar "$PKG_PATH/usr/zookeeper/lib/log4j-jna-4.2.2.jar"

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-RC7/marathon-1.4.0-RC7.tgz",
-    "sha1": "4ddb6bf4b930f905a63ca33b97d9bd68e65ef029"
+    "url": "https://downloads.mesosphere.com/marathon/v1.4.0-RC8/marathon-1.4.0-RC8.tgz",
+    "sha1": "7fd803cdf15f169949b7702a5a9992f5969807ed"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

- [1229](https://github.com/dcos/dcos/pull/1229) exhibitor: make sure that JNA library is included for ZK subprocesses
- [1231](https://github.com/dcos/dcos/pull/1231) bump marathon to v1.4.0-RC8

## Related Issues

See PRs linked above.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]