### PR TITLE
Integration Tests: Updated environment variable list explosion.

### DIFF
--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -30,10 +30,10 @@ def get_args_from_env():
 
     return {
         'dcos_url': os.environ['DCOS_DNS_ADDRESS'],
-        'masters': os.environ['MASTER_HOSTS'].split(','),
-        'public_masters': os.environ['PUBLIC_MASTER_HOSTS'].split(','),
-        'slaves': os.environ['SLAVE_HOSTS'].split(','),
-        'public_slaves': os.environ['PUBLIC_SLAVE_HOSTS'].split(','),
+        'masters': list(filter(None, os.environ['MASTER_HOSTS'].split(','))),
+        'public_masters': list(filter(None, os.environ['PUBLIC_MASTER_HOSTS'].split(','))),
+        'slaves': list(filter(None, os.environ['SLAVE_HOSTS'].split(','))),
+        'public_slaves': list(filter(None, os.environ['PUBLIC_SLAVE_HOSTS'].split(','))),
         'default_os_user': os.getenv('DCOS_DEFAULT_OS_USER', 'root')}
 
 


### PR DESCRIPTION
## High Level Description

Fixes a nit in the integration test utilities;

```python
slaves = os.environ['SLAVE_HOSTS'].split(',')
```
into
```python
slaves = list(filter(None, os.environ['SLAVE_HOSTS'].split(',')))
```
This is meant to prevent the creation of arrays with one empty element if the source string was empty.

Consider a cluster with one master and one single agent (which is public). Without this patch, the integration tests won't ever finish initializing:
- SLAVE_HOSTS is empty -> renders a list of a single empty element
- PUBLIC_SLAVE_HOSTS contains one IP -> renders a list of that IP
- `all_slaves` is calculated from `slaves + public_slaves` -> renders a list of two elements `[ , IP]` 

= Number of slaves registered remains smaller than `all_slaves` and hence the integration tests basic cluster checkup will not ever finish waiting for that "missing" slave.

## Related Issues

  - [DCOS-<number>](https://dcosjira.atlassian.net/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
  - [DCOS-<number>](https://mesosphere.atlassian.net/browse/DCOS-<number) TRACKING: dcosjira-123 Foo the Bar

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
