### PR TITLE
Use generated SSH keys

### DIFF
--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -12,17 +12,6 @@ PUBLIC_AGENTS: integer (default=1)
 DCOS_TEMPLATE_URL: string
     The template to be used for deployment testing
 
-DCOS_STACK_NAME: string
-    Instead of providing a template, supply the name (or id) of an already
-    existing cluster
-
-DCOS_SSH_KEY_PATH: string
-    path for the SSH key to be used with a preexiting cluster.
-    Defaults to 'default_ssh_key'
-
-DCOS_ADVANCED_TEMPLATE: boolean (default:false)
-    If true, then DCOS_STACK_NAME is for a DC/OS advanced stack
-
 DCOS_HOST_OS: 'coreos' or 'centos'
     This must be set only if you are attaching to an already provisioned
     DC/OS Advanced template cluster
@@ -42,7 +31,7 @@ import sys
 import test_util.aws
 import test_util.cluster
 from gen.calc import calculate_environment_variable
-from pkgpanda.util import load_string
+from pkgpanda.util import write_string
 from test_util.helpers import random_id
 
 LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
@@ -73,21 +62,11 @@ def check_environment():
     options.host_os = os.getenv('DCOS_HOST_OS', 'coreos')
     options.agents = int(os.environ.get('AGENTS', '2'))
     options.public_agents = int(os.environ.get('PUBLIC_AGENTS', '1'))
-    options.ssh_key_path = os.getenv('DCOS_SSH_KEY_PATH', 'default_ssh_key')
 
     # Mandatory
-    options.stack_name = os.getenv('DCOS_STACK_NAME', None)
     options.template_url = os.getenv('DCOS_TEMPLATE_URL', None)
-    if not options.template_url:
-        assert options.stack_name is not None, 'if DCOS_TEMPLATE_URL is not provided, '\
-            'then DCOS_STACK_NAME must be specified'
-        advanced = os.getenv('DCOS_ADVANCED_TEMPLATE', None)
-        assert advanced is not None, 'if using DCOS_STACK_NAME, '\
-            'then DCOS_ADVANCED_TEMPLATE=[true/false] must be specified'
-        options.advanced = advanced == 'true'
-    else:
-        options.advanced = not options.template_url.endswith('single-master.cloudformation.json') and \
-            not options.template_url.endswith('multi-master.cloudformation.json')
+    options.advanced = not options.template_url.endswith('single-master.cloudformation.json') and \
+        not options.template_url.endswith('multi-master.cloudformation.json')
     # Required
     options.aws_access_key_id = calculate_environment_variable('AWS_ACCESS_KEY_ID')
     options.aws_secret_access_key = calculate_environment_variable('AWS_SECRET_ACCESS_KEY')
@@ -103,8 +82,44 @@ def check_environment():
 
 def main():
     options = check_environment()
-    cf, ssh_info = provide_cluster(options)
-    cluster = test_util.cluster.Cluster.from_cloudformation(cf, ssh_info, load_string(options.ssh_key_path))
+    bw = test_util.aws.BotoWrapper(
+        region=options.aws_region,
+        aws_access_key_id=options.aws_access_key_id,
+        aws_secret_access_key=options.aws_secret_access_key)
+    stack_name = 'dcos-ci-test-cf-{}'.format(random_id(10))
+    ssh_key = bw.create_key_pair(stack_name)
+    write_string('ssh_key', ssh_key)
+    log.info('Spinning up AWS CloudFormation with ID: {}'.format(stack_name))
+    if options.advanced:
+        cf, ssh_info = test_util.aws.DcosZenCfStack.create(
+            stack_name=stack_name,
+            boto_wrapper=bw,
+            template_url=options.template_url,
+            private_agents=options.agents,
+            public_agents=options.public_agents,
+            key_pair_name=stack_name,
+            private_agent_type='m3.xlarge',
+            public_agent_type='m3.xlarge',
+            master_type='m3.xlarge',
+            vpc=options.vpc,
+            gateway=options.gateway,
+            private_subnet=options.private_subnet,
+            public_subnet=options.public_subnet)
+    else:
+        cf, ssh_info = test_util.aws.DcosCfStack.create(
+            stack_name=stack_name,
+            template_url=options.template_url,
+            private_agents=options.agents,
+            public_agents=options.public_agents,
+            admin_location='0.0.0.0/0',
+            key_pair_name=stack_name,
+            boto_wrapper=bw)
+    cf.wait_for_complete(wait_before_poll_min=5)
+    # Resiliency testing requires knowing the stack name
+    options.test_cmd = 'AWS_STACK_NAME=' + stack_name + ' ' + options.test_cmd
+
+    # hidden hook where user can supply an ssh_key for a preexisting cluster
+    cluster = test_util.cluster.Cluster.from_cloudformation(cf, ssh_info, ssh_key)
 
     result = test_util.cluster.run_integration_tests(
         cluster,
@@ -116,57 +131,12 @@ def main():
     if result == 0:
         log.info('Test successful! Deleting CloudFormation.')
         cf.delete()
+        bw.delete_key_pair(stack_name)
     else:
         logging.warning('Test exited with an error')
     if options.ci_flags:
         result = 0  # Wipe the return code so that tests can be muted in CI
     sys.exit(result)
-
-
-def provide_cluster(options):
-    bw = test_util.aws.BotoWrapper(
-        region=options.aws_region,
-        aws_access_key_id=options.aws_access_key_id,
-        aws_secret_access_key=options.aws_secret_access_key)
-    if not options.stack_name:
-        stack_name = 'CF-integration-test-{}'.format(random_id(10))
-        log.info('Spinning up AWS CloudFormation with ID: {}'.format(stack_name))
-        # TODO(mellenburg): use randomly generated keys this key is delivered by CI or user
-        if options.advanced:
-            cf, ssh_info = test_util.aws.DcosZenCfStack.create(
-                stack_name=stack_name,
-                boto_wrapper=bw,
-                template_url=options.template_url,
-                private_agents=options.agents,
-                public_agents=options.public_agents,
-                key_pair_name='default',
-                private_agent_type='m3.xlarge',
-                public_agent_type='m3.xlarge',
-                master_type='m3.xlarge',
-                vpc=options.vpc,
-                gateway=options.gateway,
-                private_subnet=options.private_subnet,
-                public_subnet=options.public_subnet)
-        else:
-            cf, ssh_info = test_util.aws.DcosCfStack.create(
-                stack_name=stack_name,
-                template_url=options.template_url,
-                private_agents=options.agents,
-                public_agents=options.public_agents,
-                admin_location='0.0.0.0/0',
-                key_pair_name='default',
-                boto_wrapper=bw)
-        cf.wait_for_complete(wait_before_poll_min=5)
-    else:
-        if options.advanced:
-            cf = test_util.aws.DcosZenCfStack(options.stack_name, bw)
-        else:
-            cf = test_util.aws.DcosCfStack(options.stack_name, bw)
-        ssh_info = test_util.aws.SSH_INFO[options.host_os]
-        stack_name = options.stack_name
-    # Resiliency testing requires knowing the stack name
-    options.test_cmd = 'AWS_STACK_NAME=' + stack_name + ' ' + options.test_cmd
-    return cf, ssh_info
 
 
 if __name__ == '__main__':

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -12,9 +12,6 @@ AGENTS: integer (default=2)
 PUBLIC_AGENTS: integer (default=1)
     The number of public agents to create from a newly created VPC.
 
-DCOS_SSH_KEY_PATH: string (default='default_ssh_key')
-    Use to set specific ssh key path. Otherwise, script will expect key at default_ssh_key
-
 INSTALLER_URL: Installer URL for the DC/OS release under test.
 
 STABLE_INSTALLER_URL: Installer URL for the latest stable DC/OS release.
@@ -51,7 +48,7 @@ from teamcity.messages import TeamcityServiceMessages
 
 import test_util.aws
 import test_util.cluster
-from pkgpanda.util import load_string, logger
+from pkgpanda.util import logger, write_string
 from test_util.dcos_api_session import DcosApiSession, DcosUser
 from test_util.helpers import CI_CREDENTIALS, marathon_app_id_to_mesos_dns_subdomain, random_id
 
@@ -148,7 +145,7 @@ class VpcClusterUpgradeTest:
                  num_masters: int, num_agents: int, num_public_agents: int,
                  stable_installer_url: str, installer_url: str,
                  aws_region: str, aws_access_key_id: str, aws_secret_access_key: str,
-                 ssh_key: str, default_os_user: str,
+                 default_os_user: str,
                  config_yaml_override_install: str, config_yaml_override_upgrade: str,
                  dcos_api_session_factory_install: VpcClusterUpgradeTestDcosApiSessionFactory,
                  dcos_api_session_factory_upgrade: VpcClusterUpgradeTestDcosApiSessionFactory):
@@ -162,7 +159,6 @@ class VpcClusterUpgradeTest:
         self.aws_region = aws_region
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
-        self.ssh_key = ssh_key
         self.default_os_user = default_os_user
         self.config_yaml_override_install = config_yaml_override_install
         self.config_yaml_override_upgrade = config_yaml_override_upgrade
@@ -271,13 +267,19 @@ class VpcClusterUpgradeTest:
             self.log_test("test_upgrade_vpc.test_app_dns_survive_upgrade", test_app_dns_survive_upgrade)
 
     def run_test(self) -> int:
-        stack_name = 'upgrade-test-' + random_id(10)
+        stack_name = 'dcos-ci-test-upgrade-' + random_id(10)
 
         test_id = uuid.uuid4().hex
         healthcheck_app_id = TEST_APP_NAME_FMT.format('healthcheck-' + test_id)
         dns_app_id = TEST_APP_NAME_FMT.format('dns-' + test_id)
 
         with logger.scope("create vpc cf stack '{}'".format(stack_name)):
+            bw = test_util.aws.BotoWrapper(
+                region=self.aws_region,
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key)
+            ssh_key = bw.create_key_pair(stack_name)
+            write_string('ssh_key', ssh_key)
             vpc, ssh_info = test_util.aws.VpcCfStack.create(
                 stack_name=stack_name,
                 instance_type='m4.xlarge',
@@ -285,19 +287,15 @@ class VpcClusterUpgradeTest:
                 # An instance for each cluster node plus the bootstrap.
                 instance_count=(self.num_masters + self.num_agents + self.num_public_agents + 1),
                 admin_location='0.0.0.0/0',
-                key_pair_name='default',
-                boto_wrapper=test_util.aws.BotoWrapper(
-                    region=self.aws_region,
-                    aws_access_key_id=self.aws_access_key_id,
-                    aws_secret_access_key=self.aws_secret_access_key,
-                ),
+                key_pair_name=stack_name,
+                boto_wrapper=bw
             )
             vpc.wait_for_complete()
 
         cluster = test_util.cluster.Cluster.from_vpc(
             vpc,
             ssh_info,
-            ssh_key=self.ssh_key,
+            ssh_key=ssh_key,
             num_masters=self.num_masters,
             num_agents=self.num_agents,
             num_public_agents=self.num_public_agents,
@@ -361,6 +359,7 @@ class VpcClusterUpgradeTest:
         if result == 0:
             self.log.info("Test successful! Deleting VPC if provided in this run.")
             vpc.delete()
+            bw.delete_key_pair(stack_name)
         else:
             self.log.info("Test failed! VPC cluster will remain available for "
                           "debugging for 2 hour after instantiation.")
@@ -385,7 +384,6 @@ def main():
     aws_region = os.getenv('DEFAULT_AWS_REGION', 'eu-central-1')
     aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
     aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-    ssh_key = load_string(os.getenv('DCOS_SSH_KEY_PATH', 'default_ssh_key'))
 
     config_yaml_override_install = os.getenv('CONFIG_YAML_OVERRIDE_INSTALL')
     config_yaml_override_upgrade = os.getenv('CONFIG_YAML_OVERRIDE_UPGRADE')
@@ -394,7 +392,7 @@ def main():
     test = VpcClusterUpgradeTest(num_masters, num_agents, num_public_agents,
                                  stable_installer_url, installer_url,
                                  aws_region, aws_access_key_id, aws_secret_access_key,
-                                 ssh_key, "root",
+                                 "root",
                                  config_yaml_override_install, config_yaml_override_upgrade,
                                  dcos_api_session_factory, dcos_api_session_factory)
     status = test.run_test()


### PR DESCRIPTION
Emergency CI Fix

- removes usage of default key in favor of generating a new key each time
- extra keys will be garbage colected by cloud cleaner
- user can no longer specify pre-existing clusters (to aid simplicity)
- standardizes tests to start with the string 'dcos-ci-test' to allow easier resource cleanup