### PR TITLE
Provide an Ability to give AWS Stack name prefix.

### DIFF
--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -277,6 +277,7 @@ class DcosCfStack(CleanupS3BucketMixin, CfStack):
     @classmethod
     def create(cls, stack_name: str, template_url: str, public_agents: int, private_agents: int,
                admin_location: str, key_pair_name: str, boto_wrapper: BotoWrapper):
+
         parameters = {
             'KeyName': key_pair_name,
             'AdminLocation': admin_location,

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -206,6 +206,7 @@ class VpcClusterUpgradeTest:
                  config_yaml_override_install: str, config_yaml_override_upgrade: str,
                  dcos_api_session_factory_install: VpcClusterUpgradeTestDcosApiSessionFactory,
                  dcos_api_session_factory_upgrade: VpcClusterUpgradeTestDcosApiSessionFactory):
+
         self.dcos_api_session_factory_install = dcos_api_session_factory_install
         self.dcos_api_session_factory_upgrade = dcos_api_session_factory_upgrade
         self.num_masters = num_masters
@@ -361,7 +362,9 @@ class VpcClusterUpgradeTest:
             self.log_test("test_upgrade_vpc.test_app_dns_survive_upgrade", test_app_dns_survive_upgrade)
 
     def run_test(self) -> int:
-        stack_name = 'dcos-ci-test-upgrade-' + random_id(10)
+        stack_suffix = os.getenv("CF_STACK_NAME_SUFFIX", "open-upgrade")
+        stack_name = "dcos-ci-test-{stack_suffix}-{random_id}".format(
+            stack_suffix=stack_suffix, random_id=random_id(10))
 
         test_id = uuid.uuid4().hex
         healthcheck_app_id = TEST_APP_NAME_FMT.format('healthcheck-' + test_id)


### PR DESCRIPTION
## High Level Description

Since Upgrade Integration Tests are inherited and used in Enterprise tests too, it will be good to know the stacks that were launched for enterprise vs the cloudformation stacks that were launched for open.


## Related Issues

- https://jira.mesosphere.com/browse/DCOS-13979 

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

