### PR TITLE
Bump signal service timeout to 15 seconds

### DIFF
--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -2,8 +2,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "40a23b4dcba6b3053379235a96bc3ac53996e146",
-    "ref_origin": "1.3.0"
+    "ref": "5f64585fe945480aa1b3c363fa7e5d6c0f9878d7",
+    "ref_origin": "1.4.0"
   },
   "username": "dcos_signal"
 }


### PR DESCRIPTION
## High Level Description

Bumps signal service requests timeout to 15 seconds to compensate for services that might be requesting data from API's not native to a DC/OS cluster (in example, Cosmos reaches out to S3, which is prone to variable lag). 

## Related Issues

https://jira.mesosphere.com/browse/DCOS-12267

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-signal/compare/40a23b4dcba6b3053379235a96bc3ac53996e146...5f64585fe945480aa1b3c363fa7e5d6c0f9878d7
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-signal-service-pulls/121/console
  - [x] Code Coverage (if available): 
```
➜  dcos-signal malnick/DCOS-12267 ✓ make test
+test
go test github.com/dcos/dcos-signal github.com/dcos/dcos-signal/config github.com/dcos/dcos-signal/signal -v -cover
?       github.com/dcos/dcos-signal     [no test files]
time="2017-02-14T17:13:30-08:00" level=warning msg="Service account not detected, continuing with out secure requests." 
=== RUN   TestDefaultConfig
--- PASS: TestDefaultConfig (0.00s)
=== RUN   TestFlagParsing
--- PASS: TestFlagParsing (0.00s)
=== RUN   TestGetClusterID
--- PASS: TestGetClusterID (0.00s)
=== RUN   TestGetExternalConfig
--- PASS: TestGetExternalConfig (0.00s)
=== RUN   TestTryLoadingCert
--- PASS: TestTryLoadingCert (0.00s)
PASS
coverage: 48.0% of statements
ok      github.com/dcos/dcos-signal/config      0.005s  coverage: 48.0% of statements
time="2017-02-14T17:13:31-08:00" level=warning msg="Service account not detected, continuing with out secure requests." 
=== RUN   TestCosmosTrack
time="2017-02-14T17:13:31-08:00" level=warning msg="REPORT:\n&{Packages:[{AppID:fooPackage}]}" 
--- PASS: TestCosmosTrack (0.00s)
=== RUN   TestDiagnosticsTrack
--- PASS: TestDiagnosticsTrack (0.00s)
=== RUN   TestPullHealthReport
--- PASS: TestPullHealthReport (0.00s)
=== RUN   TestMakeReporters
--- PASS: TestMakeReporters (0.00s)
=== RUN   TestCreateUnitTotalKey
--- PASS: TestCreateUnitTotalKey (0.00s)
=== RUN   TestCreateUnitUnhealthyKey
--- PASS: TestCreateUnitUnhealthyKey (0.00s)
=== RUN   TestCreateSegmentClient
--- PASS: TestCreateSegmentClient (0.00s)
=== RUN   TestExecuteTester
{
    "foo": {
        "event": ""
    }
}--- PASS: TestExecuteTester (0.00s)
PASS
coverage: 37.8% of statements
ok      github.com/dcos/dcos-signal/signal      0.005s  coverage: 37.8% of statements
```
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
