### PR TITLE
Added DC/OS integration tests for UCR.

### DIFF
--- a/packages/dcos-integration-test/extra/test_ucr.py
+++ b/packages/dcos-integration-test/extra/test_ucr.py
@@ -1,0 +1,203 @@
+import uuid
+
+from test_util.marathon import get_test_app
+
+
+def test_if_ucr_app_can_be_deployed_with_image_whiteout(dcos_api_session):
+    """Marathon app deployment integration test using the Mesos Containerizer.
+
+    This test verifies that a marathon ucr app can execute a docker image
+    with whiteout files. Whiteouts are files with a special meaning for
+    the layered filesystem. For more details, please see:
+    https://github.com/docker/docker/blob/master/pkg/archive/whiteouts.go
+
+    Please note that the image 'mesosphere/whiteout:test' is built on top
+    of 'alpine' which is used for UCR whiteout support testing. See:
+    https://hub.docker.com/r/mesosphere/whiteout/
+    """
+    app, test_uuid = get_test_app()
+    app['container'] = {
+        'type': 'MESOS',
+        'docker': {
+            'image': 'mesosphere/whiteout:test'
+        }
+    }
+    app['cmd'] = 'while true; do sleep 1; done'
+    app['healthChecks'] = [{
+        'protocol': 'COMMAND',
+        'command': {'value': 'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'},
+        'gracePeriodSeconds': 5,
+        'intervalSeconds': 10,
+        'timeoutSeconds': 10,
+        'maxConsecutiveFailures': 3,
+    }]
+    with dcos_api_session.marathon.deploy_and_cleanup(app):
+        # Trivial app if it deploys, there is nothing else to check
+        pass
+
+
+def test_if_ucr_app_can_be_deployed_with_image_digest(dcos_api_session):
+    """Marathon app deployment integration test using the Mesos Containerizer.
+
+    This test verifies that a marathon ucr app can execute a docker image
+    by digest.
+    """
+    app, test_uuid = get_test_app()
+    app['container'] = {
+        'type': 'MESOS',
+        'docker': {
+            'image': 'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
+        }
+    }
+    app['cmd'] = 'while true; do sleep 1; done'
+    app['healthChecks'] = [{
+        'protocol': 'COMMAND',
+        'command': {'value': 'test -d $MESOS_SANDBOX'},
+        'gracePeriodSeconds': 5,
+        'intervalSeconds': 10,
+        'timeoutSeconds': 10,
+        'maxConsecutiveFailures': 3,
+    }]
+    with dcos_api_session.marathon.deploy_and_cleanup(app):
+        # Trivial app if it deploys, there is nothing else to check
+        pass
+
+
+def test_if_ucr_pods_can_be_deployed_with_image_entrypoint(dcos_api_session):
+    """Marathon pods inside ucr deployment integration test.
+
+    This test verifies that a marathon ucr pod can execute a docker image
+    default entrypoint.
+    """
+    test_uuid = uuid.uuid4().hex
+    pod_definition = {
+        'id': '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {'kind': 'fixed', 'instances': 1},
+        'environment': {'PING': 'PONG'},
+        'containers': [
+            {
+                'name': 'container1',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'mesosphere/inky'}
+            },
+            {
+                'name': 'container2',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
+                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+            }
+        ],
+        'networks': [{'mode': 'host'}]
+    }
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
+        # Trivial app if it deploys, there is nothing else to check
+        pass
+
+
+def test_if_ucr_pods_can_be_deployed_with_scratch_image(dcos_api_session):
+    """Marathon pods inside ucr deployment integration test.
+
+    This test verifies that a marathon ucr pod can execute a docker scratch
+    image. A scratch image means an image that only contains a single binary
+    and its dependencies.
+    """
+    test_uuid = uuid.uuid4().hex
+    pod_definition = {
+        'id': '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {'kind': 'fixed', 'instances': 1},
+        'environment': {'PING': 'PONG'},
+        'containers': [
+            {
+                'name': 'container1',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'hello-world'}
+            },
+            {
+                'name': 'container2',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
+                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+            }
+        ],
+        'networks': [{'mode': 'host'}]
+    }
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
+        # Trivial app if it deploys, there is nothing else to check
+        pass
+
+
+def test_if_ucr_pods_can_be_deployed_with_image_whiteout(dcos_api_session):
+    """Marathon pods inside ucr deployment integration test.
+
+    This test verifies that a marathon ucr pod can execute a docker image
+    with whiteout files. Whiteouts are files with a special meaning for
+    the layered filesystem. For more details, please see:
+    https://github.com/docker/docker/blob/master/pkg/archive/whiteouts.go
+
+    Please note that the image 'mesosphere/whiteout:test' is built on top
+    of 'alpine' which is used for UCR whiteout support testing. See:
+    https://hub.docker.com/r/mesosphere/whiteout/
+    """
+    test_uuid = uuid.uuid4().hex
+    pod_definition = {
+        'id': '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {'kind': 'fixed', 'instances': 1},
+        'environment': {'PING': 'PONG'},
+        'containers': [
+            {
+                'name': 'container1',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'mesosphere/whiteout:test'},
+                'exec': {
+                    'command': {
+                        'shell': 'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'
+                    }
+                }
+            },
+            {
+                'name': 'container2',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
+                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+            }
+        ],
+        'networks': [{'mode': 'host'}]
+    }
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
+        # Trivial app if it deploys, there is nothing else to check
+        pass
+
+
+def test_if_ucr_pods_can_be_deployed_with_image_digest(dcos_api_session):
+    """Marathon pods inside ucr deployment integration test.
+
+    This test verifies that a marathon ucr pod can execute a docker image
+    by digest.
+    """
+    test_uuid = uuid.uuid4().hex
+    pod_definition = {
+        'id': '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {'kind': 'fixed', 'instances': 1},
+        'environment': {'PING': 'PONG'},
+        'containers': [
+            {
+                'name': 'container1',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
+                },
+                'exec': {'command': {'shell': 'ls -al /'}}
+            },
+            {
+                'name': 'container2',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
+                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+            }
+        ],
+        'networks': [{'mode': 'host'}]
+    }
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
+        # Trivial app if it deploys, there is nothing else to check
+        pass


### PR DESCRIPTION
## High Level Description

This patch included new DC/OS UCR integration test for app and pods:
1) Tested image default entrypoint.
2) Tested scratch image support.
3) Tested image with whiteout files.
4) Tested image by digest.

## Related Issues

  - [CORE-869](https://jira.mesosphere.com/browse/CORE-869) Add DC/OS integration tests for UCR.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
