### PR TITLE
Add space between env args and py.test

### DIFF
--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -355,7 +355,7 @@ class VpcClusterUpgradeTest:
             for k, v in os.environ.items():
                 if k.startswith(prefix):
                     add_env.append(k.replace(prefix, '') + '=' + v)
-            test_cmd = ' '.join(add_env) + 'py.test -vv -s -rs ' + os.getenv('CI_FLAGS', '')
+            test_cmd = ' '.join(add_env) + ' py.test -vv -s -rs ' + os.getenv('CI_FLAGS', '')
             result = test_util.cluster.run_integration_tests(cluster, test_cmd=test_cmd)
 
         if result == 0:


### PR DESCRIPTION
Fixes error running integration suite for upgrade tests