### PR TITLE
packages/mesos-dns: bump to bf08ab7

### DIFF
--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos-dns.git",
-    "ref": "919851a158ba71aee4de145dc0a7f90cc68d0902",
+    "ref": "bf08ab7017207b7d7924462cfbaf7b952155a53e",
     "ref_origin": "master"
   },
   "username": "dcos_mesos_dns"


### PR DESCRIPTION
## High Level Description

The DNS library that is used in mesos-dns has a bug where certain record types are being compressed when they should not be. This has been fixed in that library and this PR updates mesos-dns to a version that includes the fix. 

## Related Issues

  - [DCOS-13590](https://jira.mesosphere.com/browse/DCOS-13590) mesos-dns compresses SRV records

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: A test was not added to DC/OS but was added to the upstream dns library: https://github.com/miekg/dns/blob/75229eecb7af00b2736e93b779a78429dcb19472/dns_test.go#L313
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/mesos-dns/compare/0f80f27b98de5652be10a3109ffa22e3c2ec9bb9...bf08ab7017207b7d7924462cfbaf7b952155a53e
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
