### PR TITLE
update marathon to version 1.4.1

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.4.0/marathon-1.4.0.tgz",
-    "sha1": "96df0b797bc0e82dd42f716faa302f1c380cca18"
+    "url": "https://downloads.mesosphere.com/marathon/v1.4.1/marathon-1.4.1.tgz",
+    "sha1": "d7fa7d60e73ad35471c40703b9ca13cb08a1b966"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

marathon 1.4.0 broke `PUT` on `/v2/apps`, this is fixed within 1.4.1.

## Related Issues

  - https://github.com/mesosphere/marathon/issues/5211
  - https://github.com/mesosphere/marathon/pull/5217

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/releases/tag/v1.4.1
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=566074&tab=buildResultsDiv&buildTypeId=Oss_Marathon_Packages
  - [ ] Code Coverage (if available): n/a
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
