### PR TITLE
Turn task-level journald logging off by default.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -563,7 +563,7 @@ entry = {
         'mesos_dns_ip_sources': '["host", "netinfo"]',
         'master_external_loadbalancer': '',
         'mesos_log_retention_mb': '4000',
-        'mesos_container_log_sink': 'journald+logrotate',
+        'mesos_container_log_sink': 'logrotate',
         'oauth_issuer_url': 'https://dcos.auth0.com/',
         'oauth_client_id': '3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m',
         'oauth_auth_redirector': 'https://auth.dcos.io',


### PR DESCRIPTION
This PR is currently blocked the following tickets and should not be merged until these land:
https://jira.mesosphere.com/browse/DCOS_OSS-645
https://jira.mesosphere.com/browse/DCOS-14010

## High Level Description

We discovered a bug in journald which spikes CPU usage to 100% even under moderate load with rate-limiting turned on.

This is a known performance bug.
https://github.com/systemd/systemd/issues/5102

If we are intent on using journald in the future (which I think we are), the only way to deal with this problem is to get a patched version of journald in place that fixes the bug.

There are only 2 options for that:
(1) wait for it to get patched upstream
(2) patch it ourselves

If we wait for it to get patched upstream, there are two complications:
(1) we don't when / if this would ever happen
(2) it would likely take years for this patch to trickle down into any standard CentOS or CoreOS distributions.

If we patch it ourselves, it probably wouldn't take too much effort initially, but then we'd have the added cost of maintaining that patch and backporting it as updates to journald trickle in over time.
Either way we are stuck shipping some patched version of journald if we want to support it anytime in the near future.

This can get complicated though, because journald is intimately tied to whatever systemd version that it runs on (they are actually part of the same repo and their binaries are built together from a single make command). This suggests that we will likely need to ship a custom version of systemd as a whole (not just a simple journald binary). I really don't want to do this if we can avoid it.

I think we need to revisit what the overall goal is with funneling all our task logs through journald?

Is it for UX reasons?.
Is it so we can have easier integration with things like Splunk, Fluentd, etc.?

Maybe we can come up with an alternative to journald that satisfies our goals without it.

But for now, we need to disable journald by default in DC/OS so our users aren't subject to this bug.

## Related Issues

  - [DCOS-14021](https://jira.mesosphere.com/browse/DCOS-14021) Turn of journald by default in DC/OS.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:

This PR simply disables a feature that was previously enabled by default. There are no new tests added to ensure this functionality is supported. The existing tests should be enough.

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]