### PR TITLE
Update AWS AMI Base OS to CentOS 7.3.1611

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## Changelog
 
+### 2017-02-22
+
+#### dcos-centos7-201702221655
+
+Base (source) AMI:
+* ami-c5af54a5
+
+DC/OS AMI's:
+* ap-northeast-1:ami-2ea9e149
+* ap-northeast-2:ami-98ec3cf6
+* ap-south-1:ami-8ccdbce3
+* ap-southeast-1:ami-e9d5648a
+* ap-southeast-2:ami-f99c9c9a
+* ca-central-1:ami-7279c416
+* eu-central-1:ami-1b13d974
+* eu-west-1:ami-57240931
+* eu-west-2:ami-2b2e3b4f
+* sa-east-1:ami-a60f69ca
+* us-east-1:ami-6a1bca7c
+* us-east-2:ami-34a08551
+* us-west-1:ami-4eebb42e
+* us-west-2:ami-71961611
+
+#### dcos-centos7-201702221615
+
+Base (source) AMI:
+* ami-7dff411c
+
+DC/OS AMI's:
+* us-gov-west-1: ami-f34df792
+
 ### 2016-08-30
 
 * Fix intermittent issue with Docker 1.11.2 startup where a small percentage of agents (~5%) fail to start.

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -2,8 +2,10 @@
 set -o errexit -o nounset -o pipefail
 
 echo ">>> Kernel: $(uname -r)"
-echo ">>> Updating system"
-yum -y update
+echo ">>> Updating system to 7.3.1611"
+sed -i -e 's/^mirrorlist=/#mirrorlist=/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
+yum -y --releasever=7.3.1611 update
+sed -i -e 's/^#mirrorlist=/mirrorlist=/' -e 's/^baseurl=/#baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
 
 echo ">>> Disabling SELinux"
 sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
@@ -87,6 +89,7 @@ rm -f /var/run/utmp
 >/var/log/btmp
 
 echo ">>> Remove temporary files"
+yum clean all
 rm -rf /tmp/* /var/tmp/*
 
 echo ">>> Remove ssh client directories"

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -127,43 +127,43 @@ region_to_ami_map = {
     'ap-northeast-1': {
         'coreos': 'ami-965899f7',
         'stable': 'ami-965899f7',
-        'el7': 'ami-264f8747',
+        'el7': 'ami-2ea9e149',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-3120fe52',
         'stable': 'ami-3120fe52',
-        'el7': 'ami-0765bd64',
+        'el7': 'ami-e9d5648a',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-b1291dd2',
         'stable': 'ami-b1291dd2',
-        'el7': 'ami-3f1a2c5c',
+        'el7': 'ami-f99c9c9a',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-3ae31555',
         'stable': 'ami-3ae31555',
-        'el7': 'ami-846e9eeb',
+        'el7': 'ami-1b13d974',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-b7cba3c4',
         'stable': 'ami-b7cba3c4',
-        'el7': 'ami-250c7f56',
+        'el7': 'ami-57240931',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-61e3750d',
         'stable': 'ami-61e3750d',
-        'el7': 'ami-0e019062',
+        'el7': 'ami-a60f69ca',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-6d138f7a',
         'stable': 'ami-6d138f7a',
-        'el7': 'ami-47096750',
+        'el7': 'ami-6a1bca7c',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
@@ -175,13 +175,13 @@ region_to_ami_map = {
     'us-west-1': {
         'coreos': 'ami-ee57148e',
         'stable': 'ami-ee57148e',
-        'el7': 'ami-e4afe284',
+        'el7': 'ami-4eebb42e',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-dc6ba3bc',
         'stable': 'ami-dc6ba3bc',
-        'el7': 'ami-ab07d1cb',
+        'el7': 'ami-71961611',
         'natami': 'ami-bb69128b'
     }
 }


### PR DESCRIPTION
## High Level Description

* Update the AWS AMI to CentOS 7.3
* Ensure we don't blindly update to untested versions

## Related Issues

  - [DCOS_OSS-655](https://jira.mesosphere.com/browse/DCOS_OSS-655) Create CentOS 7.3 AMI's and update CFN.


To keep the change small I only updated existing regions with the new AMI image. We need a separate issue to add additional regions including CoreOS images. The AMI has been build for all currently existing regions however and the AMI names can be found in the `CHANGELOG.md`.