### PR TITLE
Fix the sort -V capability check

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -136,9 +136,11 @@ declare -i DISABLE_VERSION_CHECK=0
 
 # check if sort -V works
 function check_sort_capability() {
-    $( echo '1' | sort -V >/dev/null 2>&1 || exit 1 )
-    RC=$?
-    if [[ "$RC" -eq "2" ]]; then
+    $( command -v sort >/dev/null 2>&1 || exit 1 )
+    RC1=$?
+    $( echo '1' | sort -V >/dev/null 2>&1 )
+    RC2=$?
+    if [[ "$RC1" -eq "1" || "$RC2" -eq "2" ]]; then
         echo -e "${RED}Disabling version checking as sort -V is not available${NORMAL}"
         DISABLE_VERSION_CHECK=1
     fi


### PR DESCRIPTION
## High Level Description

I think its a minor bug. We would never run into this in currently supported distros. But I happened to stumble upon the logic which seems incorrect.

I believe there is a bug in the code block : 
```
     $( echo '1' | sort -V >/dev/null 2>&1 || exit 1 )
     RC=$?
     if [[ "$RC" -eq "2" ]]; then
```

Bash is confusing in that 0 is true(success) non-zero is false(failure) 

Current logic
If `sort -V` is valid, its retncode will be 0, `||` will short circuit and `$?`=0
If  `sort -V` is invalid its retncode will be 2, `||` will not short circuit and exit 1 will be executed  and `$?`=1

I think && is what was intended to be used.

New logic 

If `sort -V` is valid, its retncode will be 0, `&&` will not short circuit and exit 1 will be executed  and `$?`=1
If  `sort -V` is invalid its retncode will be 2, `&&` will short circuit and `$?`= 2

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
This succeeded so far because we only test on images with sort -V functionality so we never hit a path where we have to disable version check. I ran the modified script in an image without sort -V functionality and got version check disabled using new logic but not using old logic

  - [X ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
