### PR TITLE
Bump Docker 1.13.1 in CentOS 7 AMI

### DIFF
--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -51,11 +51,11 @@ echo ">>> Removing tty requirement for sudo"
 sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 
 echo ">>> Install Docker"
-curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-1.11.2-1.el7.centos.x86_64.rpm \
-  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.11.2-1.el7.centos.x86_64.rpm
-curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-selinux-1.11.2-1.el7.centos.noarch.rpm \
-  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-1.11.2-1.el7.centos.noarch.rpm
-rpm -i /tmp/docker*.rpm || true
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-1.13.1-1.el7.centos.x86_64.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.13.1-1.el7.centos.x86_64.rpm
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-selinux-1.13.1-1.el7.centos.noarch.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-1.13.1-1.el7.centos.noarch.rpm
+yum -y localinstall /tmp/docker*.rpm || true
 systemctl enable docker
 
 echo ">>> Creating docker group"
@@ -71,7 +71,7 @@ StartLimitInterval=0
 RestartSec=15
 ExecStartPre=-/sbin/ip link del docker0
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --graph=/var/lib/docker --storage-driver=overlay
+ExecStart=/usr/bin/dockerd --graph=/var/lib/docker --storage-driver=overlay
 EOF
 
 echo ">>> Adding group [nogroup]"


### PR DESCRIPTION
## High Level Description

Bump Docker 1.13.1 in the CentOS AMI

I tested deploying a cluster using the advanced templates and running an nginx Docker container via Marathon.

Switched from `rpm -i` to `yum localinstall` to have it automatically install dependencies without the need to manually maintain a package list.

New dependency in Docker 1.13.1:
```
libseccomp.so.2()(64bit) is needed by docker-engine-1.13.1-1.el7.centos.x86_64
```