### PR TITLE
packages/exhibitor: bump to f6654479de96e898e7ed20a5fbef6b18ac88ff24

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "fc44d4fe0e612381646a4738a1a898867b2086d8",
+      "ref": "f6654479de96e898e7ed20a5fbef6b18ac88ff24",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
## High Level Description

In https://github.com/dcos/exhibitor/pull/7 we introduced a thread pool with a `corePoolSize` of 10. This was too low and led to slow and broken responses as 8 of the 10 threads were pinned to the Acceptor threads, leaving only two other threads to do anything.

This issue was reproducible on a 5-master cluster on GCE.

We tested a thread pool bump from 10 to 20 and confirmed that it the issue is thus resolved.  

We also bumped the request queue size to 4096 anticipating request spikes in a large cluster that boots up.

## Related Issues

  - [DCOS-14045](https://jira.mesosphere.com/browse/DCOS-14045) exhibitor requests hang/deadlock on 5-master cluster

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: no idea how to build a reproducible test for this. We don't even see it on all clusters. The fix was experimentally verified by hand on a 5-master cluster.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/exhibitor/compare/fc44d4fe0e612381646a4738a1a898867b2086d8...f6654479de96e898e7ed20a5fbef6b18ac88ff24
  - [ ] Test Results: exhibitor has no CI
  - [ ] Code Coverage (if available): exhibitor has no Code Coverage report
___
