### PR TITLE
dcos-integration-test: Fix SLAVE_HOSTS and PUBLIC_SLAVE_HOSTS

### DIFF
--- a/packages/dcos-integration-test/extra/util/test_env.export
+++ b/packages/dcos-integration-test/extra/util/test_env.export
@@ -7,8 +7,8 @@
 source /opt/mesosphere/environment.export
 export MASTER_HOSTS=${MASTER_HOSTS:=`dig master.mesos +short | tr '\n' ',' | sed 's/.$//'`}
 export PUBLIC_MASTER_HOSTS=${PUBLIC_MASTER_HOSTS:=$MASTER_HOSTS}
-export SLAVE_HOSTS=${SLAVE_HOSTS:=`dig slave.mesos +short | tr '\n' ',' | sed  's/.$//'`}
-export PUBLIC_SLAVE_HOSTS=${PUBLIC_SLAVE_HOSTS:=$SLAVE_HOSTS}
+export SLAVE_HOSTS=${SLAVE_HOSTS:=`for h in $(dig slave.mesos +short); do curl -s $h:5051/state | grep '"default_role":"slave_public"' >/dev/null || printf ",$h"; done | cut -d',' -f2-`}
+export PUBLIC_SLAVE_HOSTS=${PUBLIC_SLAVE_HOSTS:=`for h in $(dig slave.mesos +short); do curl -s $h:5051/state | grep '"default_role":"slave_public"' >/dev/null && printf ",$h"; done | cut -d',' -f2-`}
 export DCOS_DNS_ADDRESS=${DCOS_DNS_ADDRESS:='http://master.mesos'}
 export DCOS_PROVIDER=${DCOS_PROVIDER:=$PROVIDER}
 export DNS_SEARCH=${DNS_SEARCH:=`(ping -c1 leader &> /dev/null && echo true) || echo false`}


### PR DESCRIPTION
## High Level Description

Previously `SLAVE_HOSTS` and `PUBLIC_SLAVE_HOSTS` both just listed all hosts, now they are set properly to private and public agents respectively.

## Related Issues

  - N/A

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
