### PR TITLE
Restrict access to /run/dcos unix socket files

### DIFF
--- a/packages/3dt/extra/dcos-3dt-agent.service
+++ b/packages/3dt/extra/dcos-3dt-agent.service
@@ -9,6 +9,9 @@ StartLimitInterval=0
 RestartSec=5
 LimitNOFILE=16384
 PermissionsStartOnly=True
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-3dt-agent
 User=dcos_3dt
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-3dt-agent
 ExecStart=/opt/mesosphere/bin/3dt --3dt-config ${DCOS_3DT_CONFIG_PATH}
+Sockets=dcos-3dt.socket

--- a/packages/3dt/extra/dcos-3dt-master.service
+++ b/packages/3dt/extra/dcos-3dt-master.service
@@ -9,6 +9,9 @@ StartLimitInterval=0
 RestartSec=5
 LimitNOFILE=16384
 PermissionsStartOnly=True
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-3dt-master
 User=dcos_3dt
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-3dt-master
 ExecStart=/opt/mesosphere/bin/3dt --3dt-config ${DCOS_3DT_CONFIG_PATH}
+Sockets=dcos-3dt.socket

--- a/packages/3dt/extra/dcos-3dt.socket
+++ b/packages/3dt/extra/dcos-3dt.socket
@@ -1,4 +1,8 @@
 [Unit]
 Description=DC/OS Diagnostics (3DT) Agent Socket: socket for DC/OS Diagnostics Agent
+
 [Socket]
 ListenStream=/run/dcos/3dt.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -1,5 +1,6 @@
 {
   "docker": "dcos/dcos-builder:adminrouter_dockerdir-latest",
   "requires": ["openssl"],
-  "sources": {}
+  "sources": {},
+  "username": "dcos_adminrouter"
 }

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -123,6 +123,9 @@ RUN echo "nameserver 127.0.0.1" > /etc/resolv.conf
 RUN echo "nameserver 8.8.8.8\nnameserver 8.8.4.4\n" > /etc/resolv.conf.dnsmasq
 COPY ./hosts.dnsmasq /etc/hosts.dnsmasq
 
+# Workers run as the dcos_adminrouter group.
+RUN groupadd --system dcos_adminrouter
+
 WORKDIR $AR_BIN_DIR/nginx/conf/
 
 CMD ["/bin/bash"]

--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -2,6 +2,7 @@ PyJWT==1.4.2
 cryptography>=1.3.4
 flake8
 ipdb
+psutil
 pylint
 pyroute2==0.4.11
 pytest-mccabe

--- a/packages/adminrouter/extra/src/common/main.conf
+++ b/packages/adminrouter/extra/src/common/main.conf
@@ -25,3 +25,7 @@ env CACHE_REFRESH_LOCK_TIMEOUT;
 events {
     worker_connections 1024;
 }
+
+# Run worker processes in dcos_adminrouter group to
+# restrict access to unix socket files.
+user nobody dcos_adminrouter;

--- a/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
@@ -417,6 +417,10 @@ class ManagedSubprocess(abc.ABC):
         return self.__class__.__name__
 
     @property
+    def pid(self):
+        return self._process.pid
+
+    @property
     def stdout(self):
         """Return stdout file descriptor of this process"""
         assert_msg = "`{}` process must be initialized first".format(self.id)

--- a/packages/adminrouter/extra/src/test-harness/tests/conftest.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/conftest.py
@@ -193,7 +193,21 @@ def master_ar_process(nginx_class):
     need to start AR with different env vars or AR type (master/agent). So the
     idea is to give it 'module' scope and thus have the same AR instance for
     all the tests in given test file unless some greater flexibility is required
-    and the nginx_class fixture is used directly.
+    and the nginx_class fixture or master_ar_process_pertest fixture is used.
+    .
+    """
+    nginx = nginx_class(role="master")
+    nginx.start()
+
+    yield nginx
+
+    nginx.stop()
+
+
+@pytest.fixture()
+def master_ar_process_pertest(nginx_class):
+    """An AR process instance fixture for situations where need to trade off
+       tests speed for having a per-test AR instance
     """
     nginx = nginx_class(role="master")
     nginx.start()
@@ -207,6 +221,20 @@ def master_ar_process(nginx_class):
 def agent_ar_process(nginx_class):
     """
     Same as `master_ar_process` fixture except for the fact that it starts 'agent'
+    nginx instead of `master`.
+    """
+    nginx = nginx_class(role="agent")
+    nginx.start()
+
+    yield nginx
+
+    nginx.stop()
+
+
+@pytest.fixture()
+def agent_ar_process_pertest(nginx_class):
+    """
+    Same as `master_ar_process_pertest` fixture except for the fact that it starts 'agent'
     nginx instead of `master`.
     """
     nginx = nginx_class(role="agent")

--- a/packages/adminrouter/extra/src/test-harness/tests/test_common.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_common.py
@@ -1,0 +1,27 @@
+import grp
+
+import psutil
+import pytest
+
+
+# A hack to be able to parameterize a test with multiple fixtures.
+# https://github.com/pytest-dev/pytest/issues/349#issuecomment-189370273
+@pytest.fixture(
+    params=[
+        'agent_ar_process_pertest',
+        'master_ar_process_pertest'
+    ])
+def ar_process(request):
+    return request.getfuncargvalue(request.param)
+
+
+class TestNginxWorkersGroup:
+    def test_if_nginx_workers_on_master_have_correct_group(
+            self, ar_process):
+        gid = grp.getgrnam('dcos_adminrouter').gr_gid
+        for proc in psutil.process_iter():
+            if proc.pid == ar_process.pid:
+                if proc.children():
+                    for child in proc.children():
+                        effective_gid = child.gids()[1]
+                        assert gid == effective_gid, "Process not running as dcos_adminrouter"

--- a/packages/dcos-log/extra/dcos-log-agent.service
+++ b/packages/dcos-log/extra/dcos-log-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=DC/OS Log Agent: exposes agent node, component, and container (task) logs
+
 [Service]
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-log.env
@@ -9,4 +10,7 @@ StartLimitInterval=0
 RestartSec=5
 LimitNOFILE=16384
 User=dcos_log
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
 ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}
+Sockets=dcos-log-agent.socket

--- a/packages/dcos-log/extra/dcos-log-master.service
+++ b/packages/dcos-log/extra/dcos-log-master.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=DC/OS Log Master: exposes master node and component logs
+
 [Service]
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-log.env
@@ -9,4 +10,7 @@ StartLimitInterval=0
 RestartSec=5
 LimitNOFILE=16384
 User=dcos_log
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
 ExecStart=/opt/mesosphere/bin/dcos-log -config ${DCOS_LOG_CONFIG_PATH}
+Sockets=dcos-log-master.socket

--- a/packages/dcos-log/extra/dcos-log.socket
+++ b/packages/dcos-log/extra/dcos-log.socket
@@ -1,4 +1,8 @@
 [Unit]
 Description=DC/OS Log Socket: socket for DC/OS Log service
+
 [Socket]
 ListenStream=/run/dcos/dcos-log.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/dcos-metrics/extra/dcos-metrics-agent.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-agent.service
@@ -6,9 +6,12 @@ RestartSec=5
 LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_metrics
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-metrics.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-metrics-extra.env
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metrics-agent
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 ExecStart=/opt/mesosphere/bin/dcos-metrics -role agent -config ${DCOS_METRICS_CONFIG_PATH}
+Sockets=dcos-metrics-agent.socket

--- a/packages/dcos-metrics/extra/dcos-metrics-agent.socket
+++ b/packages/dcos-metrics/extra/dcos-metrics-agent.socket
@@ -2,3 +2,6 @@
 Description=DC/OS Metrics Agent Socket: socket for DC/OS Metrics Agent service
 [Socket]
 ListenStream=/run/dcos/dcos-metrics-agent.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/dcos-metrics/extra/dcos-metrics-master.service
+++ b/packages/dcos-metrics/extra/dcos-metrics-master.service
@@ -6,9 +6,12 @@ RestartSec=5
 LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_metrics
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-metrics.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-metrics-extra.env
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metrics-master
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 ExecStart=/opt/mesosphere/bin/dcos-metrics -role master -config ${DCOS_METRICS_CONFIG_PATH}
+Sockets=dcos-metrics-master.socket

--- a/packages/dcos-metrics/extra/dcos-metrics-master.socket
+++ b/packages/dcos-metrics/extra/dcos-metrics-master.socket
@@ -2,3 +2,6 @@
 Description=DC/OS Metrics Master Socket: socket for DC/OS Metrics Master service
 [Socket]
 ListenStream=/run/dcos/dcos-metrics-master.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
+++ b/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
@@ -8,6 +8,10 @@ StandardError=journal
 Restart=always
 RestartSec=5
 LimitNOFILE=16384
+User=root
+Group=root
+# Explicitly allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
 Environment=PKGPANDA_HTTP_CONFIG=${PKG_PATH}/etc/pkgpanda-api.conf.py
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=${PKG_PATH}/pkgpanda-api/bin/pkgpanda-api.sh
@@ -19,3 +23,4 @@ ExecStart=${PKG_PATH}/pkgpanda-api/bin/pkgpanda-api.sh
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=30
+Sockets=dcos-pkgpanda-api.socket

--- a/packages/pkgpanda-api/extra/dcos-pkgpanda-api.socket
+++ b/packages/pkgpanda-api/extra/dcos-pkgpanda-api.socket
@@ -3,3 +3,6 @@ Description=DC/OS Component Package Manager (Pkgpanda) Socket: socket for DC/OS 
 
 [Socket]
 ListenStream=/run/dcos/pkgpanda-api.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/pkgpanda-api/extra/pkgpanda-api.sh
+++ b/packages/pkgpanda-api/extra/pkgpanda-api.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -xe
 
+# Wait for dcos-pkgpanda-api.socket to create the socket file so we don't
+# create one with the wrong ownership and permissions below.
+test -S /run/dcos/pkgpanda-api.sock
+
 exec /opt/mesosphere/bin/gunicorn --worker-class=sync \
     --workers=1 \
     --threads=10 \

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -516,7 +516,7 @@ class UserManagement:
                 "User {} exists with current UID {}, however he should be assigned to group {} with {} UID, please "
                 "check `buildinfo.json`".format(username, user.pw_gid, group_name, group.gr_gid))
 
-    def add_user(self, username, group):
+    def add_user(self, username, groupname):
         UserManagement.validate_username(username)
 
         if not self._manage_users:
@@ -524,7 +524,7 @@ class UserManagement:
 
         # Check if the user already exists and exit.
         try:
-            UserManagement.validate_user_group(username, group)
+            UserManagement.validate_user_group(username, groupname)
             self._users.add(username)
             return
         except KeyError as ex:
@@ -545,10 +545,13 @@ class UserManagement:
             '-c', 'DCOS System User',
         ]
 
-        if group is not None:
-            UserManagement.validate_group(group)
+        # A group matching the username will be created by the adduser command.
+        # Any other group that the user is added to needs to exist prior to executing the
+        # adduser command.
+        if groupname is not None and groupname != username:
+            UserManagement.validate_group(groupname)
             add_user_cmd += [
-                '-g', group
+                '-g', groupname
             ]
 
         add_user_cmd += [username]


### PR DESCRIPTION
Unix sockets that are managed by systemd default to having mode 0666. This is a hole in our security. 

This PR

- restricts access to socket files to the `root` user and members of the `dcos_adminrouter` group.
- patches pkgpanda so it doesn't complain if the group specified in the `buildinfo.json` doesn't exist already on condition that it matches the username of the user being created. That group would be created as part of creating the user anyway, but now we can be explicit about the fact in our `buildinfo.json` files.
- adds the `dcos_adminrouter` supplementary group to the service systemd units.
- sets the group adminrouter worker processes run as to `dcos_adminrouter`.


## Related Issues

  - [DCOS-14113](https://jira.mesosphere.com/browse/DCOS-14113) adminrouter: run worker processes with groups 'dcos_adminrouter'
  - [DCOS-14081](https://jira.mesosphere.com/browse/DCOS-14081) Bypass authentication in 3dt on agents/masters
  - [DCOS-14084](https://jira.mesosphere.com/browse/DCOS-14084) Bypass authentication in dcos-log on agents/masters
  - [DCOS-14085](https://jira.mesosphere.com/browse/DCOS-14085) Bypass authentication in dcos-metrics on agents/masters
  - [DCOS-14087](https://jira.mesosphere.com/browse/DCOS-14087) Bypass authentication in pkgpanda-http-api on agents/masters, gain root.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
