### PR TITLE
dcos-integration-test: use dcos_api_session in test_mesos.py

### DIFF
--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -38,11 +38,8 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
     app_id = 'integration-test-{}'.format(test_uuid)
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Fetch the mesos master state once the task is running
-        scheme = dcos_api_session.default_url.scheme
         master_ip = dcos_api_session.masters[0]
-        master_state_url = '{}://{}:{}/state'.format(scheme, master_ip, 5050)
         r = dcos_api_session.get('/state', host=master_ip, port=5050)
-        logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
         assert r.status_code == 200
         state = r.json()
 
@@ -65,7 +62,6 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
         assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(agent_id)
         logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
 
-        # Wrapper to post, log, and validate return status
         def _post_agent(url, headers, json=None, data=None, stream=False):
             r = dcos_api_session.post(
                 url,
@@ -75,13 +71,6 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
                 json=json,
                 data=data,
                 stream=stream)
-            agent_url = '{}://{}:{}/state'.format(scheme, agent_hostname, 5051)
-            logging.info(
-                'Got %s with POST request to %s with headers %s and json data %s.',
-                r.status_code,
-                agent_url,
-                headers,
-                json)
             assert r.status_code == 200
             return r
 

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -39,9 +39,9 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Fetch the mesos master state once the task is running
         scheme = dcos_api_session.default_url.scheme
-        master = dcos_api_session.masters[0]
-        master_state_url = '{}://{}:{}/state'.format(scheme, master, 5050)
-        r = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+        master_ip = dcos_api_session.masters[0]
+        master_state_url = '{}://{}:{}/state'.format(scheme, master_ip, 5050)
+        r = dcos_api_session.get('/state', host=master_ip, port=5050)
         logging.debug('Got %s with request for %s. Response: \n%s', r.status_code, master_state_url, r.text)
         assert r.status_code == 200
         state = r.json()
@@ -81,8 +81,7 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
                 r.status_code,
                 agent_url,
                 headers,
-                json
-            )
+                json)
             assert r.status_code == 200
             return r
 


### PR DESCRIPTION
## High Level Description

In Enterprise `security:strict` mode the `mesos-master` and `mesos-agent` processes check the `Authorization` header and forbids unauthorized requests. They also supports only `https`. 

This PR fixes a test by replacing direct use of the `requests` library with the recently added `dcos_api_session` fixture that provides a similar API. Requests made using this fixture have a valid `Authorization` header injected. It also chooses the scheme (ie., `http` / `https`) appropriate to the cluster's security mode.

The initial `Connection Refused` failure was due to use of `http://` instead of `https://`. Fixing that revealed what we already knew: the `mesos-master` and `mesos-agent` processes would forbid unauthorized requests.

## Related Issues

  - [DCOS-14161](https://jira.mesosphere.com/browse/DCOS-14161) Fix `test_mesos.test_if_marathon_app_can_be_debugged` test

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
