### PR TITLE
Bump dcos-mesos to 1.2.0-rc2

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -4,6 +4,4 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[09975e642168a47c466e211f02a590b6e3e1e40c] Changed agent_host to expect a relative path.
 <li>[d2cf9ac1dfa0d7d2b5ebcf8f9da86190706bb5cd] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[3d042bae0431da237d2c109525ea81fe8eb9943c] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[7fdf195b5f3bb4d4a0bd155d1663a96f9eaf4da1] Fixed fetcher to not pick up environment variables it should not see.
 <li>[dc01a78680410d7fe49e096508b64e94d991471c] Updated mesos containerizer to ignore GPU isolator creation failure.
-<li>[e619e9ff2cd7e6cf0397660bd4cbfb9a5549ecbe] Fixed a bug around executor not able to use reserved resources.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "e619e9ff2cd7e6cf0397660bd4cbfb9a5549ecbe",
-    "ref_origin" : "dcos-mesos-1.2.0-rc1"
+    "ref": "dfd332085e9dec451239aa17102d912e909f8a98",
+    "ref_origin" : "dcos-mesos-1.2.0-rc2"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Bumps dcos-mesos to the official Apache Meso 1.2.0-rc2 tag to include such critical fixes as:

```
e1c11f0 Fixed fetcher to not pick up environment variables it should not see.
4683320 Fixed nested container agent flapping issue after reboot.
056978a Modified the executor driver to always relink on agent failover.
12e99f7 Fixed a bug around executor not able to use reserved resources.
d80af6c Fixed a crash on the default executor due to a failed invariant check.
7e5439d Fixed a crash on the agent when handling the SIGUSR1 signal.
e53fcaf Fixed a crash on the master upon receiving an invalid inverse offer.
```

## Related Issues

  - [CORE-864](https://jira.mesosphere.com/browse/CORE-864) Mesos masters crashing after receiving inverse offers
 - [CORE-779](https://jira.mesosphere.com/browse/CORE-779) Bump dcos-mesos to Mesos 1.2 (when ready) 

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Relying on Apache Mesos unit tests and existing (and continuously improving) dcos-integration-tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

  - [x] Change log from the last version integrated: https://github.com/mesosphere/mesos/compare/e619e9ff2cd7e6cf0397660bd4cbfb9a5549ecbe...dfd332085e9dec451239aa17102d912e909f8a98
    https://git-wip-us.apache.org/repos/asf?p=mesos.git;a=blob_plain;f=CHANGELOG;hb=1.2.0-rc2
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/391
  - [x] Code Coverage (if available): N/A