### PR TITLE
Suppress exhibitor migration script stdout during upgrade

### DIFF
--- a/dcos_installer/upgrade.py
+++ b/dcos_installer/upgrade.py
@@ -74,7 +74,7 @@ pkgpanda activate --no-block {{ cluster_packages }}
 # check if we are on a master node
 if [ -f /etc/mesosphere/roles/master ]; then
    # run exhibitor migration script here
-   until dcos-shell dcos-exhibitor-migrate-perform
+   until dcos-shell dcos-exhibitor-migrate-perform > /dev/null
    do
         status=$?
         case $status in


### PR DESCRIPTION
## High Level Description

This prevents the upgrade script from printing scary-looking messages when the Exhibitor API isn't available, which is expected immediately following an upgrade.

## Related Issues

 - [DCOS-14046](https://jira.mesosphere.com/browse/DCOS-14046) Upgrade Procedure for 1.9 Findings

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]