### PR TITLE
bump 3dt

### DIFF
--- a/packages/3dt/build
+++ b/packages/3dt/build
@@ -8,9 +8,6 @@ make install
 # Copy the build from the bin to the correct place
 cp -r /pkg/bin/ "$PKG_PATH"
 
-# Copy the snapshot config file
-cp -v /pkg/src/github.com/dcos/3dt/endpoints_config.json $PKG_PATH/
-
 master_service=${PKG_PATH}/dcos.target.wants_master/dcos-3dt.service
 slave_service=${PKG_PATH}/dcos.target.wants_slave/dcos-3dt.service
 slave_public_service=${PKG_PATH}/dcos.target.wants_slave_public/dcos-3dt.service

--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "0c0ffc7d66e6396d64723ad26f7615164edfe3ce",
+    "ref": "6a8f0afddf5f99ac0796a6bea394c47d86253ef2",
     "ref_origin": "master"
   },
   "username": "dcos_3dt",

--- a/packages/dcos-integration-test/extra/test_3dt.py
+++ b/packages/dcos-integration-test/extra/test_3dt.py
@@ -483,14 +483,11 @@ def test_3dt_bundle_create(dcos_api_session):
     assert bundles[0] == create_response['extra']['bundle_name']
 
 
-def verify_unit_response(zip_ext_file):
+def verify_unit_response(zip_ext_file, min_lines):
     assert isinstance(zip_ext_file, zipfile.ZipExtFile)
     unit_output = gzip.decompress(zip_ext_file.read())
-
-    # TODO: This seems like a really fragile string to be searching for. This might need to be changed for
-    # different localizations.
-    assert 'Hint: You are currently not seeing messages from other users and the system' not in str(unit_output), (
-        '3dt does not have permission to run `journalctl`')
+    assert len(unit_output.decode().split('\n')) >= min_lines, 'Expect at least {} lines. Full unit output {}'.format(
+        min_lines, unit_output)
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
@@ -598,7 +595,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
                 # make sure systemd unit output is correct and does not contain error message
                 gzipped_unit_output = z.open(master_folder + 'dcos-mesos-master.service.gz')
-                verify_unit_response(gzipped_unit_output)
+                verify_unit_response(gzipped_unit_output, 100)
 
                 for expected_master_file in expected_master_files:
                     expected_file = master_folder + expected_master_file
@@ -615,7 +612,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
                 # make sure systemd unit output is correct and does not contain error message
                 gzipped_unit_output = z.open(agent_folder + 'dcos-mesos-slave.service.gz')
-                verify_unit_response(gzipped_unit_output)
+                verify_unit_response(gzipped_unit_output, 100)
 
                 for expected_agent_file in expected_agent_files:
                     expected_file = agent_folder + expected_agent_file
@@ -632,7 +629,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
                 # make sure systemd unit output is correct and does not contain error message
                 gzipped_unit_output = z.open(agent_public_folder + 'dcos-mesos-slave-public.service.gz')
-                verify_unit_response(gzipped_unit_output)
+                verify_unit_response(gzipped_unit_output, 100)
 
                 for expected_public_agent_file in expected_public_agent_files:
                     expected_file = agent_public_folder + expected_public_agent_file


### PR DESCRIPTION
## High Level Description

Bump 3dt sha to include a fix for DCOS-14190. 3dt will limit to ~ last 50 lines of systemd logs instead of 24 hours.

This PR also includes an integration test update. The function `verify_unit_response` will validate the minimum number of lines in the response. Since we cannot be sure what's the right value, we assume 100 lines should be good enough for a brand new cluster. We also removed the hardcoded line `Hint: You are currently not seeing messages from other users and the system` since we are not shelling out to journalctl anymore. Latest 3dt uses dcos-log journal reader library to read the logs natively.

## Related Issues

  - [DCOS-14190](https://jira.mesosphere.com/browse/DCOS-14190)

## Checklist for all PR's

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [3dt](https://github.com/dcos/3dt/compare/c764a5426f99f6a89a36ecc2cd21ecfcfe8cf60d...6a8f0afddf5f99ac0796a6bea394c47d86253ef2)
  - [X] Test Results: [jenkins#299](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-3dt-pulls/299/)
  - [X] Code Coverage (if available): [jenkins#299](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-3dt-pulls/299/)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
