### PR TITLE
Fix: Latest stable version of CoreOS break dcos-adminrouter

### DIFF
--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -22,7 +22,7 @@ ExecStartPre=/bin/ping -c1 marathon.mesos
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 # Wait for auth backend to seed the secret key
-ExecStartPre=/usr/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
+ExecStartPre=/opt/mesosphere/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
 ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT


### PR DESCRIPTION
## High Level Description

moves to /opt/mesosphere/bin/curl, fix compatibility problem with CoreOS >1221.0.0
## Related Issues

  - [DCOS_OSS-683](https://jira.mesosphere.com/browse/DCOS_OSS-683) Latest stable version of CoreOS break dcos-adminrouter.