### PR TITLE
AdminRouter: Add regression tests for X-Accel-Buffering passing

### DIFF
--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code.py
@@ -117,7 +117,7 @@ def generic_valid_user_is_permitted_test(ar, auth_header, path):
     assert resp.status_code == 200
 
 
-def generic_upstream_headers_verify_test(ar, auth_header, path):
+def generic_upstream_headers_verify_test(ar, auth_header, path, assert_headers=None):
     """Test if headers sent upstream are correct
 
     Helper function meant to simplify writing multiple tests testing the
@@ -128,6 +128,8 @@ def generic_upstream_headers_verify_test(ar, auth_header, path):
         auth_header (dict): headers dict that contains JWT. The auth data it
             contains is valid and the request should be accepted.
         path (str): path for which request should be made
+        assert_headers (dict): additional headers to test where key is the
+            asserted header name and value is expected value
     """
     url = ar.make_url_from_path(path)
     resp = requests.get(url,
@@ -137,10 +139,14 @@ def generic_upstream_headers_verify_test(ar, auth_header, path):
     assert resp.status_code == 200
 
     req_data = resp.json()
-    verify_header(req_data['headers'], 'Host', '127.0.0.1')
+
     verify_header(req_data['headers'], 'X-Forwarded-For', '127.0.0.1')
     verify_header(req_data['headers'], 'X-Forwarded-Proto', 'http')
     verify_header(req_data['headers'], 'X-Real-IP', '127.0.0.1')
+
+    if assert_headers:
+        for name, value in assert_headers.items():
+            verify_header(req_data['headers'], name, value)
 
 
 def generic_correct_upstream_dest_test(ar, auth_header, path, endpoint_id):

--- a/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
@@ -1,0 +1,61 @@
+# Copyright (C) Mesosphere, Inc. See LICENSE file for details.
+
+import copy
+
+import pytest
+
+from generic_test_code import (
+    generic_no_slash_redirect_test,
+    generic_correct_upstream_dest_test,
+    generic_correct_upstream_request_test,
+    generic_upstream_headers_verify_test,
+)
+
+pytestmark = pytest.mark.usefixtures("agent_ar_process")
+
+
+class TestLogsEndpoint():
+    def test_redirect_req_without_slash(self, agent_ar_process):
+        generic_no_slash_redirect_test(agent_ar_process, '/system/v1/logs/v1')
+
+    def test_if_request_is_sent_to_correct_upstream(self,
+                                                    agent_ar_process,
+                                                    superuser_user_header):
+
+        generic_correct_upstream_dest_test(agent_ar_process,
+                                           superuser_user_header,
+                                           '/system/v1/logs/v1/foo/bar',
+                                           'http:///run/dcos/dcos-log.sock',
+                                           )
+
+    @pytest.mark.parametrize("path_given,path_expected",
+                             [("/system/v1/logs/v1/foo/bar", "/foo/bar"),
+                              ("/system/v1/logs/v1/", "/"),
+                              ])
+    def test_if_upstream_request_is_correct(self,
+                                            agent_ar_process,
+                                            superuser_user_header,
+                                            path_given,
+                                            path_expected):
+
+        generic_correct_upstream_request_test(agent_ar_process,
+                                              superuser_user_header,
+                                              path_given,
+                                              path_expected,
+                                              http_ver="HTTP/1.1"
+                                              )
+
+    def test_if_upstream_headers_are_correct(self,
+                                             agent_ar_process,
+                                             superuser_user_header):
+
+        accel_buff_header = {"X-Accel-Buffering": "TEST"}
+
+        req_headers = copy.deepcopy(superuser_user_header)
+        req_headers.update(accel_buff_header)
+
+        generic_upstream_headers_verify_test(agent_ar_process,
+                                             req_headers,
+                                             '/system/v1/logs/v1/foo/bar',
+                                             assert_headers=accel_buff_header,
+                                             )

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -1,5 +1,7 @@
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
+import copy
+
 import pytest
 import requests
 
@@ -180,9 +182,15 @@ class TestLogsEndpoint():
                                              master_ar_process,
                                              superuser_user_header):
 
+        accel_buff_header = {"X-Accel-Buffering": "TEST"}
+
+        req_headers = copy.deepcopy(superuser_user_header)
+        req_headers.update(accel_buff_header)
+
         generic_upstream_headers_verify_test(master_ar_process,
-                                             superuser_user_header,
+                                             req_headers,
                                              '/system/v1/logs/v1/foo/bar',
+                                             assert_headers=accel_buff_header,
                                              )
 
 


### PR DESCRIPTION
## High Level Description

AdminRouter regression test that checks passing `X-Accel-Buffering` header upstream.

Original PR: https://github.com/dcos/adminrouter/pull/54

## Related Issues

  - [DCOS-14147](https://jira.mesosphere.com/browse/DCOS-14147) Add regression tests for X-Accel-Buff header bug

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]