### PR TITLE
AdminRouter: Add tests for Marathon svcapps caching

### DIFF
--- a/packages/adminrouter/extra/src/master/cache.lua
+++ b/packages/adminrouter/extra/src/master/cache.lua
@@ -114,7 +114,7 @@ local function fetch_and_store_marathon_apps()
        local appId = app["id"]
        local labels = app["labels"]
        if not labels then
-          ngx.log(ngx.NOTICE, "Labels not found in app '" .. appId .. "': " .. err)
+          ngx.log(ngx.NOTICE, "Labels not found in app '" .. appId .. "'")
           goto continue
        end
 
@@ -133,12 +133,14 @@ local function fetch_and_store_marathon_apps()
           goto continue
        end
 
-       -- Lua arrays default starting index is 1 not the 0 of marathon
-       local portIdx = tonumber(portIdx) + 1
+       local portIdx = tonumber(portIdx)
        if not portIdx then
           ngx.log(ngx.NOTICE, "Cannot convert port to number for app '" .. appId .. "'")
           goto continue
        end
+
+       -- Lua arrays default starting index is 1 not the 0 of marathon
+       portIdx = portIdx + 1
 
        local tasks = app["tasks"]
 
@@ -177,7 +179,7 @@ local function fetch_and_store_marathon_apps()
 
        local port = ports[portIdx]
        if not port then
-          ngx.log(ngx.NOTICE, "Cannot find port at port index '" .. portIdx .. "' for app '" .. appId .. "'")
+          ngx.log(ngx.NOTICE, "Cannot find port at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
           goto continue
        end
 


### PR DESCRIPTION
## High Level Description

Adds new AR unit test that exercises Marathon apps caching

Original PR: https://github.com/dcos/adminrouter/pull/55

## Related Issues

  - [DCOS-14066](https://jira.mesosphere.com/browse/DCOS-14066) Admin Router: add tests for Marathon svcapps caching

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]