### PR TITLE
Fix logrotate source URL

### DIFF
--- a/packages/logrotate/buildinfo.json
+++ b/packages/logrotate/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source": {
     "kind": "url_extract",
-    "url": "https://fedorahosted.org/releases/l/o/logrotate/logrotate-3.9.1.tar.gz",
+    "url": "http://pkgs.fedoraproject.org/repo/pkgs/logrotate/logrotate-3.9.1.tar.gz/4492b145b6d542e4a2f41e77fa199ab0/logrotate-3.9.1.tar.gz",
     "sha1": "7ba734cd1ffa7198b66edc4bca17a28ea8999386"
   }
 }


### PR DESCRIPTION
## High Level Description

DC/OS currently can't be build as fedorahosted was retired three days ago.
See https://fedoraproject.org/wiki/Infrastructure/Fedorahosted-retirement
