### PR TITLE
Bump metrics to 1.0.1 [WIP]

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "da91c1dd902734512fc29c223c9259bdae79e324",
-    "ref_origin": "1.0.0-rc8"
+    "ref": "659a6a098e9d3a0851a285de0a894c566b99249d",
+    "ref_origin": "1.0.1"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High Level Description

This PR adds an updated metrics service which fixes several bugs. See tickets below for details. 

## Related Issues

 - https://jira.mesosphere.com/browse/DCOS-14186
- https://jira.mesosphere.com/browse/DCOS-12410

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log for [1.0.1 & 1.0.1-rc8](https://github.com/dcos/dcos-metrics/compare/da91c1dd902734512fc29c223c9259bdae79e324...659a6a098e9d3a0851a285de0a894c566b99249d)
  - [x] [Test Results](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/280/console)
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
