### PR TITLE
Adminrouter: Increase CACHE_MAX_AGE_SOFT_LIMIT as per DCOS_OSS-693

### DIFF
--- a/packages/adminrouter/extra/src/master/cache.lua
+++ b/packages/adminrouter/extra/src/master/cache.lua
@@ -19,7 +19,7 @@ local _CONFIG = {}
 local env_vars = {CACHE_FIRST_POLL_DELAY = 2,
                   CACHE_POLL_PERIOD = 25,
                   CACHE_EXPIRATION = 20,
-                  CACHE_MAX_AGE_SOFT_LIMIT = 35,
+                  CACHE_MAX_AGE_SOFT_LIMIT = 75,
                   CACHE_MAX_AGE_HARD_LIMIT = 259200,
                   CACHE_BACKEND_REQUEST_TIMEOUT = 10,
                   CACHE_REFRESH_LOCK_TIMEOUT = 20,


### PR DESCRIPTION
## High-Level Description

AdminRouter cache update occurs every 20-45 seconds instead of desired 25s interval. This is due to Nginx reloads interfering with update coroutines and is going to be fixed in DCOS-5809, but for now, we need to eliminate "stale cache" warning messages. They appear way too frequently in the logs even though the cache was eventually updated. 

With CACHE_MAX_AGE_SOFT_LIMIT set to 75s, there have to be at least two failed attempts to update the cache for the warning to appear.

More details can be found in the Jira issue itself.

## Related Issues

  - [DCOS_OSS-693](https://dcosjira.atlassian.net/browse/DCOS_OSS-693) Adminrouter: set CACHE_MAX_AGE_SOFT_LIMIT to 75s

## Related PRs:

https://github.com/mesosphere/dcos-enterprise/pull/657