### PR TITLE
Set adminrouter workers group

### DIFF
--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -1,5 +1,6 @@
 {
   "docker": "dcos/dcos-builder:adminrouter_dockerdir-latest",
   "requires": ["openssl"],
-  "sources": {}
+  "sources": {},
+  "username": "dcos_adminrouter"
 }

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -123,6 +123,9 @@ RUN echo "nameserver 127.0.0.1" > /etc/resolv.conf
 RUN echo "nameserver 8.8.8.8\nnameserver 8.8.4.4\n" > /etc/resolv.conf.dnsmasq
 COPY ./hosts.dnsmasq /etc/hosts.dnsmasq
 
+# Workers run as the dcos_adminrouter group.
+RUN groupadd --system dcos_adminrouter
+
 WORKDIR $AR_BIN_DIR/nginx/conf/
 
 CMD ["/bin/bash"]

--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -2,6 +2,7 @@ PyJWT==1.4.2
 cryptography>=1.3.4
 flake8
 ipdb
+psutil
 pylint
 pyroute2==0.4.11
 pytest-mccabe

--- a/packages/adminrouter/extra/src/common/main.conf
+++ b/packages/adminrouter/extra/src/common/main.conf
@@ -25,3 +25,7 @@ env CACHE_REFRESH_LOCK_TIMEOUT;
 events {
     worker_connections 1024;
 }
+
+# Run worker processes in dcos_adminrouter group to
+# restrict access to unix socket files.
+user nobody dcos_adminrouter;

--- a/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
@@ -417,6 +417,10 @@ class ManagedSubprocess(abc.ABC):
         return self.__class__.__name__
 
     @property
+    def pid(self):
+        return self._process.pid
+
+    @property
     def stdout(self):
         """Return stdout file descriptor of this process"""
         assert_msg = "`{}` process must be initialized first".format(self.id)

--- a/packages/adminrouter/extra/src/test-harness/tests/conftest.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/conftest.py
@@ -193,7 +193,21 @@ def master_ar_process(nginx_class):
     need to start AR with different env vars or AR type (master/agent). So the
     idea is to give it 'module' scope and thus have the same AR instance for
     all the tests in given test file unless some greater flexibility is required
-    and the nginx_class fixture is used directly.
+    and the nginx_class fixture or master_ar_process_pertest fixture is used.
+    .
+    """
+    nginx = nginx_class(role="master")
+    nginx.start()
+
+    yield nginx
+
+    nginx.stop()
+
+
+@pytest.fixture()
+def master_ar_process_pertest(nginx_class):
+    """An AR process instance fixture for situations where need to trade off
+       tests speed for having a per-test AR instance
     """
     nginx = nginx_class(role="master")
     nginx.start()
@@ -207,6 +221,20 @@ def master_ar_process(nginx_class):
 def agent_ar_process(nginx_class):
     """
     Same as `master_ar_process` fixture except for the fact that it starts 'agent'
+    nginx instead of `master`.
+    """
+    nginx = nginx_class(role="agent")
+    nginx.start()
+
+    yield nginx
+
+    nginx.stop()
+
+
+@pytest.fixture()
+def agent_ar_process_pertest(nginx_class):
+    """
+    Same as `master_ar_process_pertest` fixture except for the fact that it starts 'agent'
     nginx instead of `master`.
     """
     nginx = nginx_class(role="agent")

--- a/packages/adminrouter/extra/src/test-harness/tests/test_common.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_common.py
@@ -1,0 +1,27 @@
+import grp
+
+import psutil
+import pytest
+
+
+# A hack to be able to parameterize a test with multiple fixtures.
+# https://github.com/pytest-dev/pytest/issues/349#issuecomment-189370273
+@pytest.fixture(
+    params=[
+        'agent_ar_process_pertest',
+        'master_ar_process_pertest'
+    ])
+def ar_process(request):
+    return request.getfuncargvalue(request.param)
+
+
+class TestNginxWorkersGroup:
+    def test_if_nginx_workers_on_master_have_correct_group(
+            self, ar_process):
+        gid = grp.getgrnam('dcos_adminrouter').gr_gid
+        for proc in psutil.process_iter():
+            if proc.pid == ar_process.pid:
+                if proc.children():
+                    for child in proc.children():
+                        effective_gid = child.gids()[1]
+                        assert gid == effective_gid, "Process not running as dcos_adminrouter"

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -516,7 +516,7 @@ class UserManagement:
                 "User {} exists with current UID {}, however he should be assigned to group {} with {} UID, please "
                 "check `buildinfo.json`".format(username, user.pw_gid, group_name, group.gr_gid))
 
-    def add_user(self, username, group):
+    def add_user(self, username, groupname):
         UserManagement.validate_username(username)
 
         if not self._manage_users:
@@ -524,7 +524,7 @@ class UserManagement:
 
         # Check if the user already exists and exit.
         try:
-            UserManagement.validate_user_group(username, group)
+            UserManagement.validate_user_group(username, groupname)
             self._users.add(username)
             return
         except KeyError as ex:
@@ -545,10 +545,13 @@ class UserManagement:
             '-c', 'DCOS System User',
         ]
 
-        if group is not None:
-            UserManagement.validate_group(group)
+        # A group matching the username will be created by the adduser command.
+        # Any other group that the user is added to needs to exist prior to executing the
+        # adduser command.
+        if groupname is not None and groupname != username:
+            UserManagement.validate_group(groupname)
             add_user_cmd += [
-                '-g', group
+                '-g', groupname
             ]
 
         add_user_cmd += [username]


### PR DESCRIPTION
## High Level Description

This PR sets the user and group that the NGINX worker processes run as to `nobody` and `dcos_adminrouter` respectively. Specifying a group allows access to files that have their access restricted to processes in that group.

This PR tweaks `pkgpanda` to allow `buildinfo.json` files to specify the same value for the `"user"` and `"group"` keys. Previously, it would check that the group exists before creating the user. This PR ignores that check if the group matches the user as the group is created when the user is.

## Related Issues

  - [DCOS-14113](https://jira.mesosphere.com/browse/DCOS-14113) adminrouter: run worker processes with groups 'dcos_adminrouter'

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___