### PR TITLE
Make AdminRouter `make test` work on Mac (docker-machine)

### DIFF
--- a/packages/adminrouter/extra/src/Makefile
+++ b/packages/adminrouter/extra/src/Makefile
@@ -7,7 +7,7 @@ DCOSAR_AR_LOCAL_PATH := $(CURDIR)
 DCOSAR_AR_CTR_MOUNT := /usr/local/adminrouter/nginx/conf/
 
 BRIDGE_DEVNAME := $(shell docker network inspect -f '{{ index .Options "com.docker.network.bridge.name" }}' bridge | awk 'NF')
-BRIDGE_IP := $(shell ip a sh dev $(BRIDGE_DEVNAME) | awk '/inet / {print $$2}' | sed 's@/.*@@')
+BRIDGE_IP := $(shell docker run --net=host --rm alpine ifconfig $(BRIDGE_DEVNAME) | grep 'inet addr:' | cut -d: -f2 | cut -d' ' -f1)
 
 # FIXME: some problems with dns queries timing out, use hosts caching dns as a
 # workaround for now

--- a/packages/adminrouter/extra/src/Makefile
+++ b/packages/adminrouter/extra/src/Makefile
@@ -6,7 +6,11 @@ DEV_PATH := /usr/local/src
 DCOSAR_AR_LOCAL_PATH := $(CURDIR)
 DCOSAR_AR_CTR_MOUNT := /usr/local/adminrouter/nginx/conf/
 
+# Detect the docker network interface bridge name.
 BRIDGE_DEVNAME := $(shell docker network inspect -f '{{ index .Options "com.docker.network.bridge.name" }}' bridge | awk 'NF')
+
+# Detect the docker network interface bridge IP.
+# Using a docker container for this allows the docker daemon to run locally or remotely in a VM, like docker-machine.
 BRIDGE_IP := $(shell docker run --net=host --rm alpine ifconfig $(BRIDGE_DEVNAME) | grep 'inet addr:' | cut -d: -f2 | cut -d' ' -f1)
 
 # FIXME: some problems with dns queries timing out, use hosts caching dns as a


### PR DESCRIPTION
## High Level Description

Make AdminRouter `make test` work on Mac (docker-machine).

The `ip` command isn't present on Mac and even if it were, when using docker-machine the bridge interface is not present on the host machine, only inside the docker-machine VM. So to get that IP, you can run the IP detection inside a docker container (using alpine). This should work on both Mac and any variety of Linux.

Since `make test` already runs the tests in a docker container, it's no bid deal to use docker to look up the IP to use for docker dns.