### PR TITLE
Add valid ip-detect-public for onprem

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -520,6 +520,12 @@ def validate_exhibitor_storage_master_discovery(master_discovery, exhibitor_stor
 __dcos_overlay_network_default_name = 'dcos'
 
 
+ip_detect_public = """#!/bin/sh
+set -o nounset -o errexit
+curl -fsSL https://ipinfo.io/ip
+"""
+
+
 entry = {
     'validate': [
         validate_num_masters,
@@ -575,7 +581,7 @@ entry = {
         'docker_stop_timeout': '20secs',
         'gc_delay': '2days',
         'ip_detect_contents': calculate_ip_detect_contents,
-        'ip_detect_public_contents': calculate_ip_detect_public_contents,
+        'ip_detect_public_contents': yaml.dump(ip_detect_public),
         'dns_search': '',
         'auth_cookie_secure_flag': 'false',
         'master_dns_bindall': 'true',


### PR DESCRIPTION
The public IP shown in the configuration page of the DC/OS is often incorrect in onprem deploys because the user is not required to provide an ip-detect-public script, and if one is not provided, then the ip-detect (private) is used for both. This PR will simply add a more sensible default value that can be easily overridden.

## Known Issues

https://jira.mesosphere.com/browse/DCOS-11602

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)