### PR TITLE
DCOS_OSS-710: Default MESOS_CGROUPS_LIMIT_SWAP to true

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -429,7 +429,7 @@ package:
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
       MESOS_CGROUPS_ENABLE_CFS=true
-      MESOS_CGROUPS_LIMIT_SWAP=false
+      MESOS_CGROUPS_LIMIT_SWAP=true
       MESOS_DOCKER_REMOVE_DELAY={{ docker_remove_delay }}
       MESOS_DOCKER_STOP_TIMEOUT={{ docker_stop_timeout }}
       MESOS_DOCKER_STORE_DIR=/var/lib/mesos/slave/store/docker


### PR DESCRIPTION
## High Level Description

Currently `MESOS_CGROUPS_LIMIT_SWAP` defaults to `false` at https://github.com/dcos/dcos/blob/master/gen/dcos-config.yaml#L402 which doesn't enforce a limit on the amount of swap that's used by a container.

I'd like to default Apache Mesos (and by extension, DC/OS) to set `memory.memsw.limit_in_bytes` to be equal to `memory.limit_in_bytes` to avoid swapping.

I'd much rather see a container be OOM-killed immediately, to help determine that we've not sized the memory allocation of the container properly, than triggering performance-impacting swapping _even if there is plenty of physical memory on the agent._

## Related Issues

  - [DCOS_OSS-710](https://jira.dcos.io/browse/DCOS_OSS-710) Set `MESOS_CGROUPS_LIMIT_SWAP=true` to set `memory.memsw.limit_in_bytes` to be equal to `memory.limit_in_bytes`
  - [INFINITY-1079](https://jira.mesosphere.com/browse/INFINITY-1079) Profile Memory and CPU usage of dcos-commons schedulers to determine optimal (default) allocations	

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
No test included.
This behaviror was verified manually by placing `MESOS_CGROUPS_LIMIT_SWAP=true` into `/var/lib/dcos/mesos-slave-common` and restarting the agent with `systemctl restart dcos-mesos-slave`
I then deployed the default HDFS scheduler configuration on DC/OS 1.9.0-RC2 and it was OOM-killed instead of triggering swapping as was witnessed prior to this change.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)