### PR TITLE
AdminRouter: Test library improvements

### DIFF
--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
@@ -4,6 +4,7 @@
 Shared management code for DC/OS mocks used by AR instances, both EE and Open.
 """
 
+import concurrent.futures
 import logging
 
 from mocker.endpoints.reflectors import (
@@ -98,16 +99,18 @@ class MockerBase():
 
     def start(self):
         """Start all endpoints registered with this Mocker instance"""
-        for endpoint in self._endpoints.values():
-            endpoint.start()
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for endpoint in self._endpoints.values():
+                executor.submit(endpoint.start)
 
     def stop(self):
         """Stop all endpoints registered with this Mocker instance.
 
         Usually called right before object destruction
         """
-        for endpoint in self._endpoints.values():
-            endpoint.stop()
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for endpoint in self._endpoints.values():
+                executor.submit(endpoint.stop)
 
     def reset(self):
         """Reset all the endpoints to their initial state

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
@@ -352,10 +352,7 @@ class MarathonHTTPRequestHandler(RecordingHTTPRequestHandler):
 
         with ctx.lock:
             if base_path == '/v2/apps':
-                if ctx.data["endpoint-content-is-encoded"]:
-                    blob = ctx.data['endpoint-content']
-                else:
-                    blob = self._convert_data_to_blob(ctx.data['endpoint-content'])
+                blob = self._convert_data_to_blob(ctx.data['endpoint-content'])
             elif base_path == '/v2/leader':
                 if ctx.data['leader-content'] is None:
                     msg = "Marathon leader unknown"
@@ -390,14 +387,6 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
         with self._context.lock:
             self._context.data["endpoint-content"]["apps"].append(NGINX_APP_ENABLED)
 
-    def set_encoded_apps_response(self, content):
-        """Change the response content for apps endpoint to arbitrary data
-           and disable response JSON encoding.
-        """
-        with self._context.lock:
-            self._context.data["endpoint-content"] = content
-            self._context.data["endpoint-content-is-encoded"] = True
-
     def set_apps_response(self, apps):
         """Change the response content for apps endpoint"""
         with self._context.lock:
@@ -428,4 +417,3 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
         """Reset internal state to default values"""
         self._context.data["endpoint-content"] = {"apps": [NGINX_APP_ALWAYSTHERE, ]}
         self._context.data["leader-content"] = {"leader": "127.0.0.2:80"}
-        self._context.data["endpoint-content-is-encoded"] = False

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -684,7 +684,7 @@ class TestCacheMarathon:
 
         # Set wrong non-json response content
         mocker.send_command(endpoint_id='http://127.0.0.1:8080',
-                            func_name='set_encoded_apps_response',
+                            func_name='set_encoded_response',
                             aux_data=b"wrong response")
 
         url = ar.make_url_from_path('/service/nginx-alwaysthere/foo/bar/')


### PR DESCRIPTION
## High Level Description

* Adds new method to send arbitrary encoded response from Recording mock endpoint
* Improves startup and teardown times for mock servers

## Related Issues

  - [DCOS-14067](https://jira.mesosphere.com/browse/DCOS-14067) add tests for EE auth AR

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]