### PR TITLE
curl: add --with-ca-path configure option

### DIFF
--- a/packages/curl/build
+++ b/packages/curl/build
@@ -40,7 +40,8 @@ pushd /pkg/src/curl
             --without-spnego \
             --without-winidn \
             --without-winssl \
-            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.5/site-packages/requests/cacert.pem
+            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.5/site-packages/requests/cacert.pem \
+            --with-ca-path=/var/lib/dcos/pki/tls/certs
 make -j$NUM_CORES
 make install
 popd


### PR DESCRIPTION
## High Level Description

This addresses https://jira.mesosphere.com/browse/DCOS_OSS-721.

A copy of the commit msg:
```
This adds a second default trust database that affects all
standard invocations and usage of curl and libcurl within
DC/OS. DC/OS operators can now place custom trusted root CA
certificates (in the OpenSSL PEM format in single files) in
the directory /var/lib/dcos/pki/tls/certs (must be created
if not yet existing, must be re-hashed if contents change).
This for example affects the Mesos agent fetcher mechanisms
for pulling Docker images or remote resources via HTTPS.
```

## Related Issues

  - [DCOS_OSS-721](https://jira.mesosphere.com/browse/DCOS_OSS-721) Curl: add location where operators can place additional trusted root CA certificates

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: not enough time to build this test for the 1.9 release. Tested manually.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]