### PR TITLE
Allow Azure clusters to persist

### DIFF
--- a/test_util/azure.py
+++ b/test_util/azure.py
@@ -278,7 +278,7 @@ class DcosAzureResourceGroup:
 
     def delete(self):
         log.info('Triggering delete')
-        self.azure_wrapper.rmc.resource_groups.delete(self.group_name)
+        self.azure_wrapper.rmc.resource_groups.delete(self.group_name).wait()
 
     def __enter__(self):
         return self

--- a/test_util/test_azure.py
+++ b/test_util/test_azure.py
@@ -51,9 +51,6 @@ AZURE_OAUTH_ENABLED: boolean (default=false)
 
 AZURE_VM_DIAGNOSTICS_ENABLED: boolean (default=true)
 
-AZURE_CLEANUP: boolean (default=true)
-    if enabled, the test will delete the deployed cluster when finished, pass or fail
-
 CI_FLAGS: string (default=None)
     If provided, this string will be passed directly to py.test as in:
     py.test -vv CI_FLAGS integration_test.py
@@ -65,8 +62,6 @@ TEST_ADD_ENV_*: string (default=None)
 import logging
 import os
 import sys
-
-from contextlib import ExitStack
 
 from gen.calc import calculate_environment_variable
 from pkgpanda.util import load_string
@@ -117,7 +112,6 @@ def check_environment():
     options.name_suffix = os.getenv('AZURE_DCOS_SUFFIX', '12345')
     options.oauth_enabled = os.getenv('AZURE_OAUTH_ENABLED', 'false')
     options.vm_diagnostics_enabled = os.getenv('AZURE_VM_DIAGNOSTICS_ENABLED', 'true')
-    options.azure_cleanup = os.getenv('AZURE_CLEANUP', 'true') == 'true'
     options.ci_flags = os.getenv('CI_FLAGS', '')
 
     add_env = []
@@ -152,13 +146,9 @@ def main():
         name_suffix=options.name_suffix,
         vm_diagnostics_enabled=options.vm_diagnostics_enabled)
     result = 1
-    with ExitStack() as stack:
-        if options.azure_cleanup:
-            stack.push(dcos_resource_group)
-        dcos_resource_group.wait_for_deployment()
-        t = stack.enter_context(
-            tunnel(options.linux_user, load_string(options.ssh_key_path),
-                   dcos_resource_group.outputs['masterFQDN'], port=2200))
+    dcos_resource_group.wait_for_deployment()
+    with tunnel(options.linux_user, load_string(options.ssh_key_path),
+                dcos_resource_group.outputs['masterFQDN'], port=2200) as t:
         result = integration_test(
             tunnel=t,
             dcos_dns=dcos_resource_group.get_master_ips()[0],
@@ -167,9 +157,11 @@ def main():
             public_agent_list=dcos_resource_group.get_public_ips(),
             test_cmd=options.test_cmd)
     if result == 0:
-        log.info('Test successsful!')
+        log.info('Test successsful! Deleting Azure resource group')
+        dcos_resource_group.delete()
     else:
-        logging.warning('Test exited with an error')
+        logging.warning('Test exited with an error; Resource group preserved for troubleshooting.'
+                        'See https://github.com/mesosphere/cloudcleaner project for cleanup policies')
     if options.ci_flags:
         result = 0  # Wipe the return code so that tests can be muted in CI
     sys.exit(result)


### PR DESCRIPTION
CI supporting builds now has the ability to
garbage collect Azure, like our AWS CF deploys