### PR TITLE
Upload packages along with AWS advanced templates

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -332,6 +332,13 @@ def do_aws_cf_configure():
         'artifacts',
     ))
 
+    for package_id in json.loads(full_config['package_ids']):
+        package_filename = release.make_package_filename(package_id)
+        artifacts.append({
+            'reproducible_path': package_filename,
+            'local_path': 'artifacts/' + package_filename,
+        })
+
     # Upload all the artifacts to the config-id path and then print out what
     # the path that should be used is, as well as saving a local json file for
     # easy machine access / processing.

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -302,7 +302,7 @@ def requests_fetcher(base_url, id_str, target, work_dir):
     # TODO(cmaloney): Use a private tmp directory so there is no chance of a user
     # intercepting the tarball + other validation data locally.
     with tempfile.NamedTemporaryFile(suffix=".tar.xz") as file:
-        download(file.name, url, work_dir)
+        download(file.name, url, work_dir, rm_on_error=False)
         extract_tarball(file.name, target)
 
 

--- a/pkgpanda/actions.py
+++ b/pkgpanda/actions.py
@@ -229,6 +229,7 @@ def _do_bootstrap(install, repository):
                 f.name,
                 repository_url + '/packages/{0}/{1}.dcos_config'.format(pkg_id.name, pkg_id_str),
                 os.getcwd(),
+                rm_on_error=False,
             )
             late_package = load_yaml(f.name)
 

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -57,7 +57,7 @@ def variant_prefix(variant):
     return variant + '.'
 
 
-def download(out_filename, url, work_dir):
+def download(out_filename, url, work_dir, rm_on_error=True):
     assert os.path.isabs(out_filename)
     assert os.path.isabs(work_dir)
     work_dir = work_dir.rstrip('/')
@@ -83,16 +83,19 @@ def download(out_filename, url, work_dir):
                 for chunk in r.iter_content(chunk_size=4096):
                     f.write(chunk)
     except Exception as fetch_exception:
-        rm_passed = False
+        if rm_on_error:
+            rm_passed = False
 
-        # try / except so if remove fails we don't get an exception during an exception.
-        # Sets rm_passed to true so if this fails we can include a special error message in the
-        # FetchError
-        try:
-            os.remove(out_filename)
+            # try / except so if remove fails we don't get an exception during an exception.
+            # Sets rm_passed to true so if this fails we can include a special error message in the
+            # FetchError
+            try:
+                os.remove(out_filename)
+                rm_passed = True
+            except Exception:
+                pass
+        else:
             rm_passed = True
-        except Exception:
-            pass
 
         raise FetchError(url, out_filename, fetch_exception, rm_passed) from fetch_exception
 


### PR DESCRIPTION
## High Level Description

This includes packages in the artifacts that get uploaded along with generated AWS templates.

This also fixes an issue where failed downloads to tempfile locations during node setup cause an incidental error that hides the original download error.

## Related Issues

  - [DCOS-14381](https://jira.mesosphere.com/browse/DCOS-14381) Various reports of failure when using templates generated by --aws-cloudformation

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: We need an integration test covering advanced template gen + deploy, which is outside the scope of this PR.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
