### PR TITLE
Add script that fixes /etc/hosts in CentOS 7 on EC2 upon boot

### DIFF
--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -99,6 +99,41 @@ echo ">>> Remove history"
 unset HISTFILE
 rm -rf /home/*/.*history /root/.*history
 
+echo ">>> Update /etc/hosts on boot"
+update_hosts_script=/usr/local/sbin/dcos-update-etc-hosts
+update_hosts_unit=/etc/systemd/system/dcos-update-etc-hosts.service
+
+mkdir -p "$(dirname $update_hosts_script)"
+
+cat << 'EOF' > "$update_hosts_script"
+#!/bin/bash
+export PATH=/opt/mesosphere/bin:/sbin:/bin:/usr/sbin:/usr/bin
+curl="curl -s -f -m 30 --retry 3"
+fqdn=$($curl http://169.254.169.254/latest/meta-data/local-hostname)
+ip=$($curl http://169.254.169.254/latest/meta-data/local-ipv4)
+echo "Adding $fqdn if $ip is not in /etc/hosts"
+grep ^$ip /etc/hosts > /dev/null || echo -e "$ip\t$fqdn ${fqdn%%.*}" >> /etc/hosts
+EOF
+
+chmod +x "$update_hosts_script"
+
+cat << EOF > "$update_hosts_unit"
+[Unit]
+Description=Update /etc/hosts with local FQDN if necessary
+After=network.target
+
+[Service]
+Restart=no
+Type=oneshot
+ExecStart=$update_hosts_script
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable $(basename "$update_hosts_unit")
+
+
 # Make sure we wait until all the data is written to disk, otherwise
 # Packer might quite too early before the large files are deleted
 sync


### PR DESCRIPTION
## High Level Description

Several Frameworks rely on the local FQDN being present in /etc/hosts. This is currently not the case in CentOS 7 on EC2. This PR adds a script that, if necessary, updates /etc/hosts with metadata retrieved from the AWS API upon boot.

We generally recommend for frameworks not to rely on working DNS resolution. However according to Julien Eid Zeppelin, Elasticsearch, Kafka and Chronos do.

## Related Issues

  - [DCOS-14302](https://jira.mesosphere.com/browse/DCOS-14302) Chronos requires the hostname inside /etc/hosts.
  - [OPS-578](https://jira.mesosphere.com/browse/OPS-578) DC/OS CentOS 7 AMI has broken hostname config.
