### PR TITLE
Bumped Mesos and Mesos modules to include ContainerLogger changes.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "36ce01e6cf869b4bb2bfe9e91766f984f333f742",
+      "ref": "5e9d41bc618476686cd9aef318562d5980905517",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "3f504ec18ba5925efbc7245c871cc0583b2f7890",
-    "ref_origin" : "dcos-mesos-1.2.0"
+    "ref": "35ed299f463877d78df66858dee34bbcf5db25ff",
+    "ref_origin" : "dcos-mesos-master-6d7b25ad"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -330,7 +330,9 @@ class VpcClusterUpgradeTest:
             def test_mesos_task_state_remains_consistent():
                 # Verify that the "state" of the task does not change.
                 task_state_end = self.get_master_task_state(dcos_api, self.tasks_start[self.test_app_ids[0]][0])
-                if not self.task_state_start == task_state_end:
+                # To avoid errors when new items are added to the task state, we
+                # check that the old state is a subset of the new state.
+                if not all(item in task_state_end.items() for item in self.task_state_start.items()):
                     self.teamcity_msg.testFailed(
                         "test_upgrade_vpc.test_mesos_task_state_remains_consistent",
                         details="expected: {}\nactual:   {}".format(self.task_state_start, task_state_end))


### PR DESCRIPTION
## High Level Description

Recent [breaking changes](https://reviews.apache.org/r/57121/) to the `ContainerLogger` interface landed in Mesos. This PR incorporates updates to the DC/OS journald logging module (https://github.com/dcos/dcos-mesos-modules/pull/11) to accommodate these changes. The PR also bumps Mesos to the latest master. Note that these Mesos changes will not be brought into DC/OS 1.9, so this PR is relevant for DC/OS 1.10, when Mesos will be bumped past version 1.2.0.

## Related Issues

  - [MESOS-7050](https://issues.apache.org/jira/browse/MESOS-7050) IOSwitchboard FDs leaked when containerizer launch fails -- leads to deadlock.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Relies on the Mesos test suite, specifically the `ContainerLoggerTest`s. Note that the `test_mesos_task_state_remains_consistent` test in the DC/OS upgrade suite is updated in this PR; without the changes here it would fail due to a new field in the Mesos master state.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-mesos-modules/compare/36ce01e6cf869b4bb2bfe9e91766f984f333f742...55ac711639f101a81756b7477fa916f9b17d0058
  - [x] Test Results: [ASF CI results](https://builds.apache.org/job/Mesos-Buildbot/BUILDTOOL=autotools,COMPILER=gcc,CONFIGURATION=--verbose,ENVIRONMENT=GLOG_v=1%20MESOS_VERBOSE=1,OS=ubuntu:14.04,label_exp=(docker%7C%7CHadoop)&&(!ubuntu-us1)&&(!ubuntu-eu2)/3351/)
  - [ ] Code Coverage (if available): N/A