### PR TITLE
Fix erlang ref

### DIFF
--- a/packages/erlang/buildinfo.json
+++ b/packages/erlang/buildinfo.json
@@ -4,7 +4,7 @@
     "erlang": {
       "kind": "git",
       "git": "https://github.com/dcos/otp.git",
-      "ref": "bea4348a94b0b804818056591a4059cd8f61aa90",
+      "ref": "53c0dddd12e90cea408a503245e796ae08258c21",
       "ref_origin": "maint-19"
     }
   },


### PR DESCRIPTION
I tried building locally and failed because this ref is not in the repo.

Looks like this was pinned against a merge commit that is no longer in the branch?