### PR TITLE
Move dcos-log configs out of the middle of mesos-slave-common.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -406,24 +406,6 @@ package:
       MESOS_GC_DELAY={{ gc_delay }}
       MESOS_HOSTNAME_LOOKUP=false
       GLOG_drop_log_memory=false
-  - path: /etc/dcos-log.env
-    content: |
-      DCOS_LOG_CONFIG_PATH=/opt/mesosphere/etc/dcos-log-config.json
-  - path: /etc_master/dcos-log-config.json
-    content: |
-      {
-        "role": "master"
-      }
-  - path: /etc_slave/dcos-log-config.json
-    content: |
-      {
-        "role": "agent"
-      }
-  - path: /etc_slave_public/dcos-log-config.json
-    content: |
-      {
-        "role": "agent_public"
-      }
 {% switch use_mesos_hooks %}
 {% case "true" %}
       MESOS_HOOKS={{ mesos_hooks }}
@@ -463,6 +445,24 @@ package:
         "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
         "SASL_PATH": "/opt/mesosphere/lib/sasl2",
         "LIBPROCESS_NUM_WORKER_THREADS": "8"
+      }
+  - path: /etc/dcos-log.env
+    content: |
+      DCOS_LOG_CONFIG_PATH=/opt/mesosphere/etc/dcos-log-config.json
+  - path: /etc_master/dcos-log-config.json
+    content: |
+      {
+        "role": "master"
+      }
+  - path: /etc_slave/dcos-log-config.json
+    content: |
+      {
+        "role": "agent"
+      }
+  - path: /etc_slave_public/dcos-log-config.json
+    content: |
+      {
+        "role": "agent_public"
       }
   - path: /etc/dns_search_config
     content: |


### PR DESCRIPTION
## High Level Description

While investigating failures in https://github.com/dcos/dcos/pull/1091 we discovered that sometime early in 1.9, we injected dcos-log config files in the middle of the `/etc/mesos-slave-common` definition, which renders the (conditional) setting of MESOS_DOCKER_REGISTRY, MESOS_DOCKER_CONFIG, and MESOS_HOOKS futile, since they are now set in `/etc_slave_public/dcos-log-config.json` instead of becoming Mesos flags. This patch moves the dcos-log configs out, and reunites the conditional parts of mesos-slave-common with the rest.

## Related Issues

  - [DCOS-14473](https://jira.mesosphere.com/browse/DCOS-14473) MESOS_DOCKER_REGISTRY, MESOS_DOCKER_CONFIG, and MESOS_HOOKS ignored in OSS dcos

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: It's really hard to test conditional code that is disabled-by-default.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)