### PR TITLE
[WIP] anatoly/dcos 13698 navstar systemd scripts

### DIFF
--- a/packages/navstar/extra/dcos-navstar.service
+++ b/packages/navstar/extra/dcos-navstar.service
@@ -15,15 +15,5 @@ EnvironmentFile=-/opt/mesosphere/etc/minuteman.env
 EnvironmentFile=-/run/dcos/etc/navstar_auth.env
 Environment=HOME=/opt/mesosphere
 ExecStartPre=/opt/mesosphere/bin/check-time
-ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=-/usr/bin/env modprobe ip_vs_wlc
-ExecStartPre=/opt/mesosphere/bin/setup_iptables.sh
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-navstar
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-minuteman
-ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/mnesia
-ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/lashup
-ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/minuteman/dets
-ExecStartPre=/usr/bin/env modprobe dummy
-ExecStartPre=-/usr/bin/env ip link add minuteman type dummy
-ExecStartPre=/usr/bin/env ip link set minuteman up
+ExecStartPre=/usr/bin/env python dcos-navstar.start.py
 ExecStart=/opt/mesosphere/active/navstar/navstar/bin/navstar-env foreground

--- a/packages/navstar/extra/dcos-navstar.start.py
+++ b/packages/navstar/extra/dcos-navstar.start.py
@@ -1,0 +1,38 @@
+import errno
+import subprocess
+import os
+# Startup script will try to execute all the commands. It will continue on error
+# but will exit with an error if any failed.
+
+retval = 0
+
+
+# check that cmd executed and returned one of the values in `error_codes`
+# prints error_msg if fails and sets retval to an error if a failure occurred
+def check(cmd, error_msg='', error_codes=[0]):
+    ...
+
+
+# check that one of the cmds executed successfully
+# prints error_msg if fails and sets retval to an error if a failure occurred
+def oneof(cmds, error_msg='' ):
+    ...
+
+
+check('/bin/ping -c1 ready.spartan')
+oneof(["/usr/bin/env modprobe ip_vs_wlc",
+       "/usr/bin/env sh -c 'cat /lib/modules/$(uname -r)/modules.builtin | grep ip_vs_wlc'"],
+       "Failed to load ip_vs_wlc kernel module or ip_vs_wlc is not builtin.")
+check('/opt/mesosphere/bin/setup_iptables.sh')
+check('/opt/mesosphere/bin/bootstrap dcos-navstar')
+check('/opt/mesosphere/bin/bootstrap dcos-minuteman')
+check('/usr/bin/mkdir -p /var/lib/dcos/navstar/mnesia')
+check('/usr/bin/mkdir -p /var/lib/dcos/navstar/lashup')
+check('/usr/bin/mkdir -p /var/lib/dcos/navstar/minuteman/dets')
+oneof(["/usr/bin/env modprobe dummy",
+       "/usr/bin/env sh -c 'cat /lib/modules/$(uname -r)/modules.builtin | grep dummy'"],
+      "Failed to load dummy network interface kernel mdoule, or kernel module is not builtin." )
+check('/usr/bin/env ip link add minuteman type dummy', error_codes=[0,errno.EEXIST])
+check('/usr/bin/env ip link set minuteman up')
+
+os.exit(retval)


### PR DESCRIPTION
## High Level Description

Cleanup the navstar systemd init scripts

## Related Issues

  - [DCOS-13698](https://jira.mesosphere.com/browse/DCOS-13698) cleanup the systemd startup scripts.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
