### PR TITLE
Fix logrotate URL and sha1

### DIFF
--- a/packages/logrotate/buildinfo.json
+++ b/packages/logrotate/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source": {
     "kind": "url_extract",
-    "url": "https://fedorahosted.org/releases/l/o/logrotate/logrotate-3.9.1.tar.gz",
-    "sha1": "7ba734cd1ffa7198b66edc4bca17a28ea8999386"
+    "url": "https://github.com/logrotate/logrotate/archive/r3-9-1.zip",
+    "sha1": "f5388a267908abb82b4d3124575f5c56780c4c41"
   }
 }


### PR DESCRIPTION
fedorahosted.org was retired on March 1st, 2017.