### PR TITLE
upgrade navstar

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "7c5ad38ce3d1d95a240ba6e6384cc8a7a9660e3f",
+      "ref": "f4ba3ec9784b9e5c26e4ed2e4dc9782861aefd9c",
       "ref_origin": "master"
     }
   },

--- a/packages/navstar/extra/dcos-navstar.service
+++ b/packages/navstar/extra/dcos-navstar.service
@@ -22,7 +22,6 @@ ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-navstar
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-minuteman
 ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/mnesia
 ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/lashup
-ExecStartPre=/usr/bin/mkdir -p /var/lib/dcos/navstar/minuteman/dets
 ExecStartPre=/usr/bin/env modprobe dummy
 ExecStartPre=-/usr/bin/env ip link add minuteman type dummy
 ExecStartPre=/usr/bin/env ip link set minuteman up


### PR DESCRIPTION
## High Level Description

Fixes the issue of high memory usage by navstar due to file fd leak in ip_vs_conn module.

## Related Issues

  - [DCOS-14438](https://jira.mesosphere.com/browse/DCOS-14438) Investigate high memory usage of Navstar

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated 
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/dcos/minuteman/pull/91
https://github.com/mesosphere/ip_vs_conn/pull/15
https://github.com/dcos/navstar/pull/54


___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
