### PR TITLE
make test ENTER context instead of generating it

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -140,7 +140,8 @@ def test_octarine_http(dcos_api_session, timeout=30):
         }]
     }
 
-    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
+        pass
 
 
 def test_octarine_srv(dcos_api_session, timeout=30):
@@ -187,7 +188,8 @@ def test_octarine_srv(dcos_api_session, timeout=30):
         }]
     }
 
-    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
+        pass
 
 
 def test_pkgpanda_api(dcos_api_session):


### PR DESCRIPTION
This test has been disabled for an ungodly amount of time. My bad. https://github.com/dcos/dcos/commit/0e12f32912679bf50339e86e012b129540d47c59