### PR TITLE
Fix octarine, tests, and increase coverage

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -140,7 +140,8 @@ def test_octarine_http(dcos_api_session, timeout=30):
         }]
     }
 
-    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
+        pass
 
 
 def test_octarine_srv(dcos_api_session, timeout=30):
@@ -187,7 +188,8 @@ def test_octarine_srv(dcos_api_session, timeout=30):
         }]
     }
 
-    dcos_api_session.marathon.deploy_and_cleanup(app_definition)
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
+        pass
 
 
 def test_pkgpanda_api(dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -1,8 +1,11 @@
+import logging
 import uuid
 
 import pytest
 
 from test_util.marathon import get_test_app, get_test_app_in_docker, get_test_app_in_ucr
+
+log = logging.getLogger(__name__)
 
 
 def test_if_marathon_app_can_be_deployed(dcos_api_session):
@@ -109,86 +112,82 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
         pass
 
 
-def test_octarine_http(dcos_api_session, timeout=30):
-    """
-    Test if we are able to send traffic through octarine.
-    """
+def test_octarine(dcos_api_session, timeout=30):
+    # This app binds to port 80. This is only required by the http (not srv)
+    # transparent mode test. In transparent mode, we use ".mydcos.directory"
+    # to go to localhost, the port attached there is only used to
+    # determine which port to send traffic to on localhost. When it
+    # reaches the proxy, the port is not used, and a request is made
+    # to port 80.
 
-    test_uuid = uuid.uuid4().hex
-    octarine_id = uuid.uuid4().hex
-    proxy = ('"http://127.0.0.1:$(/opt/mesosphere/bin/octarine ' +
-             '--client --port {})"'.format(octarine_id))
-    check_command = 'curl --fail --proxy {} marathon.mesos.mydcos.directory'.format(proxy)
+    app, uuid = get_test_app()
+    app['acceptedResourceRoles'] = ["slave_public"]
+    app['portDefinitions'][0]["port"] = 80
+    app['requirePorts'] = True
 
-    app_definition = {
-        'id': '/integration-test-app-octarine-http-{}'.format(test_uuid),
-        'cpus': 0.1,
-        'mem': 128,
-        'ports': [0],
-        'cmd': '/opt/mesosphere/bin/octarine {}'.format(octarine_id),
-        'disk': 0,
-        'instances': 1,
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {
-                'value': check_command
-            },
-            'gracePeriodSeconds': 5,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 3
-        }]
-    }
+    with dcos_api_session.marathon.deploy_and_cleanup(app) as service_points:
+        port_number = service_points[0].port
+        # It didn't actually grab port 80 when requirePorts was unset
+        assert port_number == app['portDefinitions'][0]["port"]
 
-    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
-        pass
+        app_name = app["id"].strip("/")
+        port_name = app['portDefinitions'][0]["name"]
+        port_protocol = app['portDefinitions'][0]["protocol"]
+
+        srv = "_{}._{}._{}.marathon.mesos".format(port_name, app_name, port_protocol)
+        addr = "{}.marathon.mesos".format(app_name)
+        transparent_suffix = ".mydcos.directory"
+
+        standard_mode = "standard"
+        transparent_mode = "transparent"
+
+        t_addr_bind = 2508
+        t_srv_bind = 2509
+
+        standard_addr = "{}:{}/ping".format(addr, port_number)
+        standard_srv = "{}/ping".format(srv)
+        transparent_addr = "{}{}:{}/ping".format(addr, transparent_suffix, t_addr_bind)
+        transparent_srv = "{}{}:{}/ping".format(srv, transparent_suffix, t_srv_bind)
+
+        # The uuids are different between runs so that they don't have a
+        # chance of colliding. They shouldn't anyways, but just to be safe.
+        octarine_runner(dcos_api_session, standard_mode, uuid + "1", standard_addr)
+        octarine_runner(dcos_api_session, standard_mode, uuid + "2", standard_srv)
+        octarine_runner(dcos_api_session, transparent_mode, uuid + "3", transparent_addr, bind_port=t_addr_bind)
+        octarine_runner(dcos_api_session, transparent_mode, uuid + "4", transparent_srv, bind_port=t_srv_bind)
 
 
-def test_octarine_srv(dcos_api_session, timeout=30):
-    """
-    Test resolving SRV records through octarine.
-    """
+def octarine_runner(dcos_api_session, mode, uuid, uri, bind_port=None):
+    log.info("Running octarine(mode={}, uuid={}, uri={}".format(mode, uuid, uri))
 
-    # Limit string length so we don't go past the max SRV record length
-    test_uuid = uuid.uuid4().hex[:16]
-    octarine_id = uuid.uuid4().hex
-    proxy = ('"http://127.0.0.1:$(/opt/mesosphere/bin/octarine ' +
-             '--client --port {})"'.format(octarine_id))
-    port_name = 'pinger'
-    cmd = ('/opt/mesosphere/bin/octarine {} & '.format(octarine_id) +
-           '/opt/mesosphere/bin/python -m http.server ${PORT0}')
-    raw_app_id = 'integration-test-app-octarine-srv-{}'.format(test_uuid)
-    check_command = 'curl --fail --proxy {} _{}._{}._tcp.marathon.mesos.mydcos.directory'.format(
-        proxy,
-        port_name,
-        raw_app_id)
+    octarine = "/opt/mesosphere/bin/octarine"
 
-    app_definition = {
-        'id': '/{}'.format(raw_app_id),
-        'cpus': 0.1,
-        'mem': 128,
-        'cmd': cmd,
-        'disk': 0,
-        'instances': 1,
-        'portDefinitions': [{
-            'port': 0,
-            'protocol': 'tcp',
-            'name': port_name,
-            'labels': {}
-        }],
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {
-                'value': check_command
-            },
-            'gracePeriodSeconds': 5,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 3
-        }]
-    }
+    bind_port_str = ""
+    if bind_port is not None:
+        bind_port_str = "-bindPort {}".format(bind_port)
 
-    with dcos_api_session.marathon.deploy_and_cleanup(app_definition):
+    server_cmd = "{} -mode {} {} {}".format(octarine, mode, bind_port_str, uuid)
+    log.info("Server: {}".format(server_cmd))
+
+    proxy = ('http://127.0.0.1:$({} --client --port {})'.format(octarine, uuid))
+    curl_cmd = '''"$(curl --fail --proxy {} {})"'''.format(proxy, uri)
+    expected_output = '''"$(printf "{\\n    \\"pong\\": true\\n}")"'''
+    check_cmd = """sh -c '[ {} = {} ]'""".format(curl_cmd, expected_output)
+    log.info("Check: {}".format(check_cmd))
+
+    app, uuid = get_test_app()
+    app['requirePorts'] = True
+    app['cmd'] = server_cmd
+    app['healthChecks'] = [{
+        "protocol": "COMMAND",
+        "command": {"value": check_cmd},
+        'gracePeriodSeconds': 5,
+        'intervalSeconds': 10,
+        'timeoutSeconds': 10,
+        'maxConsecutiveFailures': 30
+    }]
+
+    with dcos_api_session.marathon.deploy_and_cleanup(app):
         pass
 
 

--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",
-    "ref": "abd003681cf65e984f12168d6120cfd48c179fc6",
+    "ref": "5b7b18d7500079327a259b15371d253beaa585e3",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description

@mellenburg discovered that the octarine tests were muted. Upon fixing the test code itself and turning them back on, we discovered that they are now failing due to a bug in octarine. This fixes octarine, the existing octarine tests, and expands the test coverage.

## Related Issues

  - [DCOS_OSS-780](https://jira.mesosphere.com/browse/DCOS_OSS-780) octarine's history of why it was broken.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
