### PR TITLE
Enable PID namespace isolator in mesos for the UCR.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -387,7 +387,7 @@ def calculate_config_yaml(user_arguments):
 def calculate_mesos_isolation(enable_gpu_isolation):
     isolators = ('cgroups/cpu,cgroups/mem,disk/du,network/cni,filesystem/linux,'
                  'docker/runtime,docker/volume,volume/sandbox_path,posix/rlimits,'
-                 'com_mesosphere_MetricsIsolatorModule')
+                 'namespaces/pid,com_mesosphere_MetricsIsolatorModule')
     if enable_gpu_isolation == 'true':
         isolators += ',cgroups/devices,gpu/nvidia'
     return isolators


### PR DESCRIPTION
## High Level Description

This change enables the pid isolator for all containers launched by the UCR.

## Related Issues

  - [DCOS_OSS-790](https://jira.mesosphere.com/browse/DCOS_OSS-790) Always enable the pid isolator for the UCR in Mesos.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]