### PR TITLE
Admin Router: Test harness improvements

### DIFF
--- a/packages/adminrouter/docker/adminrouter-upstreams.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams.conf
@@ -12,6 +12,6 @@ set $upstream_secrets http://127.0.0.1:1337;
 set $upstream_cosmos http://127.0.0.1:7070;
 
 # Required by EE Agent:
-set $upstream_bouncer http://127.0.0.1:8101;
+set $upstream_iam http://127.0.0.1:8101;
 
 set $adminrouter_agent_port 61001;

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
@@ -375,13 +375,13 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
     """An endpoint that mimics DC/OS root Marathon"""
     def __init__(self, port, ip=''):
         super().__init__(port, ip, MarathonHTTPRequestHandler)
-        self._reset()
+        self.__context_init()
 
     def reset(self, *_):
         """Reset the endpoint to the default/initial state."""
         with self._context.lock:
             super().reset()
-            self._reset()
+            self.__context_init()
 
     def enable_nginx_app(self, *_):
         """Change the endpoint output so that it simulates extra Nginx app
@@ -416,7 +416,8 @@ class MarathonEndpoint(RecordingTcpIpEndpoint):
         with self._context.lock:
             self._context.data["leader-content"] = 'blah blah buh buh'
 
-    def _reset(self):
-        """Reset internal state to default values"""
+    def __context_init(self):
+        """Helper function meant to initialize all the data relevant to this
+           particular type of endpoint"""
         self._context.data["endpoint-content"] = {"apps": [NGINX_APP_ALWAYSTHERE, ]}
         self._context.data["leader-content"] = {"leader": "127.0.0.2:80"}

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
@@ -325,13 +325,18 @@ class MesosEndpoint(RecordingTcpIpEndpoint):
     """An endpoint that mimics DC/OS leader.mesos Mesos"""
     def __init__(self, port, ip=''):
         super().__init__(port, ip, MesosHTTPRequestHandler)
-        self._context.data["endpoint-content"] = copy.deepcopy(INITIAL_STATEJSON)
+        self.__context_init()
 
     def reset(self, *_):
         """Reset the endpoint to the default/initial state."""
         with self._context.lock:
             super().reset()
-            self._context.data["endpoint-content"] = copy.deepcopy(INITIAL_STATEJSON)
+            self.__context_init()
+
+    def __context_init(self):
+        """Helper function meant to initialize all the data relevant to this
+           particular type of endpoint"""
+        self._context.data["endpoint-content"] = copy.deepcopy(INITIAL_STATEJSON)
 
     def enable_extra_slave(self, *_):
         """Change returned JSON to include extra slave - as if cluster had three

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
@@ -60,10 +60,16 @@ class IamEndpoint(RecordingTcpIpEndpoint):
     def __init__(self, port, ip=''):
         """Initialize a new IamEndpoint"""
         super().__init__(port, ip, IamHTTPRequestHandler)
-        self._context.data["allowed"] = True
+        self.__context_init()
 
     def reset(self):
-        super().reset()
+        with self._context.lock:
+            super().reset()
+            self.__context_init()
+
+    def __context_init(self):
+        """Helper function meant to initialize all the data relevant to this
+           particular type of endpoint"""
         self._context.data["allowed"] = True
 
     def permit_all_queries(self, *_):

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/open/iam.py
@@ -25,10 +25,9 @@ class IamHTTPRequestHandler(RecordingHTTPRequestHandler):
         if match:
             return self.__users_permissions_request_handler(match.group(1))
 
-        stub_paths = [
-            '/acs/api/v1/foo/bar',
-        ]
-        if base_path in stub_paths:
+        if base_path == '/acs/api/v1/foo/bar':
+            # A test URI that is used by tests. In some cases it is impossible
+            # to reuse /acs/api/v1/users/ path.
             blob = self._convert_data_to_blob({})
             return 200, 'application/json', blob
 

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
@@ -106,9 +106,7 @@ class RecordingTcpIpEndpoint(TcpIpHttpEndpoint):
     def __init__(self, port, ip='', request_handler=RecordingHTTPRequestHandler):
         """Initialize new RecordingTcpIpEndpoint endpoint"""
         super().__init__(request_handler, port, ip)
-        self._context.data["record_requests"] = False
-        self._context.data["requests"] = list()
-        self._context.data["encoded_response"] = None
+        self.__context_init()
 
     def record_requests(self, *_):
         """Enable recording the requests data by the handler."""
@@ -140,6 +138,11 @@ class RecordingTcpIpEndpoint(TcpIpHttpEndpoint):
         """Reset the endpoint to the default/initial state."""
         with self._context.lock:
             super().reset()
-            self._context.data["record_requests"] = False
-            self._context.data["requests"] = list()
-            self._context.data["encoded_response"] = None
+            self.__context_init()
+
+    def __context_init(self):
+        """Helper function meant to initialize all the data relevant to this
+           particular type of endpoint"""
+        self._context.data["record_requests"] = False
+        self._context.data["requests"] = list()
+        self._context.data["encoded_response"] = None


### PR DESCRIPTION
## High Level Description

This PR:
* refactors the way endpoints are reset in order to keep things DRY
* makes IAM `/foo/bar` test-path more concise 
* renames Bouncer to IAM in AR configuration

## Related Issues

  - [DCOS-14238](https://jira.mesosphere.com/browse/DCOS-14238) Admin Router: Create a single way to reset endpoint configuration without code duplication
  - [DCOS-14585](https://jira.mesosphere.com/browse/DCOS-14585) Admin Router: Add reflecting path to Recording endpoints
  - [DCOS-14836](https://jira.mesosphere.com/browse/DCOS-DCOS-14836) Admin Router: Standardize on IAM/get rid of `bouncer` term in AR configuration files

## Dependencies

EE counterpart: https://github.com/mesosphere/dcos-enterprise/pull/743