### PR TITLE
Add HTTP routing to master for Azure

### DIFF
--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -764,7 +764,7 @@
         "frontendIPConfiguration": {
           "id": "[variables('masterLbIPConfigID')]"
         },
-        "frontendPort": "22",
+        "frontendPort": 22,
         "protocol": "tcp"
       }
     },
@@ -781,7 +781,7 @@
               "description": "Allow SSH",
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "22",
+              "destinationPortRange": 22,
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
@@ -795,7 +795,7 @@
               "description": "Allow SSH",
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "2222",
+              "destinationPortRange": 2222,
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
@@ -809,7 +809,7 @@
               "description": "HTTP Port 80",
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "80",
+              "destinationPortRange": 80,
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               {% switch oauth_available %}
@@ -833,7 +833,7 @@
               "description": "HTTPS Port 443",
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "443",
+              "destinationPortRange": 443,
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               {% switch oauth_available %}
@@ -868,7 +868,7 @@
         "frontendIPConfiguration": {
           "id": "[variables('masterLbIPConfigID')]"
         },
-        "frontendPort": "80",
+        "frontendPort": 80,
         "protocol": "tcp"
       }
     },
@@ -886,7 +886,7 @@
         "frontendIPConfiguration": {
           "id": "[variables('masterLbIPConfigID')]"
         },
-        "frontendPort": "443",
+        "frontendPort": 443,
         "protocol": "tcp"
       }
     },
@@ -909,7 +909,7 @@
               "description": "Allow HTTP traffic from the Internet to Public Agents",
               "protocol": "*",
               "sourcePortRange": "*",
-              "destinationPortRange": "80",
+              "destinationPortRange": 80,
               "sourceAddressPrefix": "Internet",
               "destinationAddressPrefix": "*",
               "access": "Allow",
@@ -923,7 +923,7 @@
               "description": "Allow HTTPS traffic from the Internet to Public Agents",
               "protocol": "*",
               "sourcePortRange": "*",
-              "destinationPortRange": "443",
+              "destinationPortRange": 443,
               "sourceAddressPrefix": "Internet",
               "destinationAddressPrefix": "*",
               "access": "Allow",
@@ -937,7 +937,7 @@
               "description": "Allow 8080 traffic from the Internet to Public Agents",
               "protocol": "*",
               "sourcePortRange": "*",
-              "destinationPortRange": "8080",
+              "destinationPortRange": 8080,
               "sourceAddressPrefix": "Internet",
               "destinationAddressPrefix": "*",
               "access": "Allow",

--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -521,6 +521,8 @@
     "masterLbName": "[concat(variables('orchestratorName'), '-master-lb-', variables('nameSuffix'))]",
     "masterSshInboundNatRuleNamePrefix": "[concat(variables('masterLbName'),'/SSH-',variables('masterVMNamePrefix'))]",
     "masterSshPort22InboundNatRuleName": "[concat(variables('masterLbName'),'/SSHPort22-',variables('masterVMNamePrefix'),'0')]",
+    "masterHttpPort80InboundNatRuleName": "[concat(variables('masterLbName'),'/HTTPPort80-',variables('masterVMNamePrefix'),'0')]",
+    "masterHttpsPort443InboundNatRuleName": "[concat(variables('masterLbName'),'/HTTPSPort443-',variables('masterVMNamePrefix'),'0')]",
     "masterVMSize": "[variables('masterSizes')[variables('isValidation')]]",
     "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
     "masterLbIPConfigName": "[concat(variables('orchestratorName'), '-master-lbFrontEnd-', variables('nameSuffix'))]",
@@ -528,6 +530,8 @@
     "masterLbBackendPoolName": "[concat(variables('orchestratorName'), '-master-pool-', variables('nameSuffix'))]",
     "masterSshInboundNatRuleIdPrefix": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'))]",
     "masterSshPort22InboundNatRuleId": "[concat(variables('masterLbID'),'/inboundNatRules/SSHPort22-',variables('masterVMNamePrefix'),'0')]",
+    "masterHttpPort80InboundNatRuleId": "[concat(variables('masterLbID'),'/inboundNatRules/HTTPPort80-',variables('masterVMNamePrefix'),'0')]",
+    "masterHttpsPort443InboundNatRuleId": "[concat(variables('masterLbID'),'/inboundNatRules/HTTPSPort443-',variables('masterVMNamePrefix'),'0')]",
     "masterLbInboundNatRules":[
       [
         {
@@ -535,6 +539,12 @@
         },
         {
           "id": "[variables('masterSshPort22InboundNatRuleId')]"
+        },
+        {
+          "id": "[variables('masterHttpPort80InboundNatRuleId')]"
+        },
+        {
+          "id": "[variables('masterHttpsPort443InboundNatRuleId')]"
         }
       ],
       [
@@ -581,13 +591,16 @@
     "masterSizes": [
       "Standard_D2_v2",
       "Standard_A2"
-    ]
+    ],
 {% switch oauth_available %}
 {% case "true" %}
-    ,
-    "oauthEnabled": "[parameters('oauthEnabled')]"
+    "oauthEnabled": "[parameters('oauthEnabled')]",
 {% case "false" %}
 {% endswitch %}
+    "allowMasterHttp": {
+        "true": "Allow",
+        "false": "Deny"
+    }
   },
   "resources": [
     {
@@ -789,8 +802,92 @@
               "priority": 201,
               "direction": "Inbound"
             }
+          },
+          {
+            "name": "httpPort80",
+            "properties": {
+              "description": "HTTP Port 80",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              {% switch oauth_available %}
+              {% case "true" %}
+              "access": "[variables('allowMasterHttp')[variables('oauthEnabled')]]",
+              {% case "false" %}
+              {% switch custom_auth %}
+              {% case "true" %}
+              "access": "Allow",
+              {% case "false" %}
+              "access": "Deny",
+              {% endswitch %}
+              {% endswitch %}
+              "priority": 202,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "httpsPort443",
+            "properties": {
+              "description": "HTTPS Port 443",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              {% switch oauth_available %}
+              {% case "true" %}
+              "access": "[variables('allowMasterHttp')[variables('oauthEnabled')]]",
+              {% case "false" %}
+              {% switch custom_auth %}
+              {% case "true" %}
+              "access": "Allow",
+              {% case "false" %}
+              "access": "Deny",
+              {% endswitch %}
+              {% endswitch %}
+              "priority": 203,
+              "direction": "Inbound"
+            }
           }
         ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "type": "Microsoft.Network/loadBalancers/inboundNatRules",
+      "name": "[variables('masterHttpPort80InboundNatRuleName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[variables('masterLbID')]"
+      ],
+      "properties": {
+        "backendPort": 80,
+        "enableFloatingIP": false,
+        "frontendIPConfiguration": {
+          "id": "[variables('masterLbIPConfigID')]"
+        },
+        "frontendPort": "80",
+        "protocol": "tcp"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersionDefault')]",
+      "type": "Microsoft.Network/loadBalancers/inboundNatRules",
+      "name": "[variables('masterHttpsPort443InboundNatRuleName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[variables('masterLbID')]"
+      ],
+      "properties": {
+        "backendPort": 443,
+        "enableFloatingIP": false,
+        "frontendIPConfiguration": {
+          "id": "[variables('masterLbIPConfigID')]"
+        },
+        "frontendPort": "443",
+        "protocol": "tcp"
       }
     },
     {
@@ -861,10 +958,11 @@
         "count": "[variables('masterCount')]"
       },
       "dependsOn": [
-        "[variables('masterLbID')]",
         "[variables('vnetID')]",
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex())]",
         "[variables('masterSshPort22InboundNatRuleId')]",
+        "[variables('masterHttpPort80InboundNatRuleId')]",
+        "[variables('masterHttpsPort443InboundNatRuleId')]",
         "[variables('masterNSGID')]"
       ],
       "properties": {

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -58,7 +58,7 @@ azure_base_source = Source(entry={
         'exhibitor_storage_backend': 'azure',
         'master_cloud_config': '{{ master_cloud_config }}',
         'slave_cloud_config': '{{ slave_cloud_config }}',
-        'slave_public_cloud_config': '{{ slave_public_cloud_config }}',
+        'slave_public_cloud_config': '{{ slave_public_cloud_config }}'
     },
     'conditional': {
         'oauth_available': {

--- a/test_util/test_azure.py
+++ b/test_util/test_azure.py
@@ -110,7 +110,7 @@ def check_environment():
     options.vm_size = os.getenv('AZURE_VM_SIZE', 'Standard_D2')
     options.num_agents = os.getenv('AGENTS', '2')
     options.name_suffix = os.getenv('AZURE_DCOS_SUFFIX', '12345')
-    options.oauth_enabled = os.getenv('AZURE_OAUTH_ENABLED', 'false')
+    options.oauth_enabled = os.getenv('AZURE_OAUTH_ENABLED', 'true')
     options.vm_diagnostics_enabled = os.getenv('AZURE_VM_DIAGNOSTICS_ENABLED', 'true')
     options.ci_flags = os.getenv('CI_FLAGS', '')
 
@@ -153,7 +153,7 @@ def main():
                 dcos_dns, port=2200) as t:
         result = integration_test(
             tunnel=t,
-            dcos_dns=master_list[0],
+            dcos_dns=dcos_dns,
             master_list=master_list,
             agent_list=[ip.private_ip for ip in dcos_resource_group.get_private_agent_ips()],
             public_agent_list=[ip.private_ip for ip in dcos_resource_group.get_public_agent_ips()],


### PR DESCRIPTION
Currently, the acs template does not provide the user with a route to the master for DC/OS UI usage. This was due to security requirements and previous issues with oauth. Now that we can oauth in the acs templates without issue, this patch will add routes for http/https when oauth is *available* and then will only add extra network security rules when oauthEnabled=true at deploy time.

Thus, with this PR, when someone deploys a oauthEnabled=false cluster, the traffic will not be routed to the master, but it can easily be turned on by opening the Network Security Group rule. Additionally, if a downstream DC/OS variant is built and if it uses `custom_auth`  the routes will be enabled.

## Related Issues


## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)