### PR TITLE
Install Docker 1.13 with --install-prereqs (1.9)

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -401,10 +401,10 @@ StartLimitInterval=0
 RestartSec=15
 ExecStartPre=-/sbin/ip link del docker0
 ExecStart=
-ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://
+ExecStart=/usr/bin/dockerd --storage-driver=overlay
 EOF
 
-sudo yum install -y docker-engine-1.11.2
+sudo yum install -y docker-engine-1.13.1 docker-engine-selinux-1.13.1
 sudo systemctl start docker
 sudo systemctl enable docker
 


### PR DESCRIPTION
## High Level Description

This causes `dcos_generate_config.sh --install-prereqs` to install Docker 1.13, and not break existing Docker 1.13 installs. This also matches the documentation at https://github.com/dcos/dcos-docs/blob/master/1.9/administration/installing/custom/system-requirements/install-docker-centos.md.

See #1379.

## Related Issues

  - [DCOS_OSS-743](https://jira.mesosphere.com/browse/DCOS_OSS-743) `--install-prereqs` breaks Docker 1.13 on CentOS 7.3

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]