### PR TITLE
Serialize test_vip

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -34,13 +34,11 @@ def pytest_collection_modifyitems(session, config, items):
 @pytest.fixture
 def vip_apps(dcos_api_session):
     vip1 = '6.6.6.1:6661'
-    test_app1, _ = get_test_app()
-    test_app1['portDefinitions'][0]['labels'] = {
-        'VIP_0': vip1}
-    test_app2, _ = get_test_app()
-    test_app2['portDefinitions'][0]['labels'] = {
-        'VIP_0': 'foobarbaz:5432'}
-    vip2 = 'foobarbaz.marathon.l4lb.thisdcos.directory:5432'
+    test_app1, _ = get_test_app(vip=vip1)
+    name = 'foobarbaz'
+    port = 5432
+    test_app2, _ = get_test_app(vip='{}:{}'.format(name, port))
+    vip2 = '{}.marathon.l4lb.thisdcos.directory:{}'.format(name, port)
     with dcos_api_session.marathon.deploy_and_cleanup(test_app1):
         with dcos_api_session.marathon.deploy_and_cleanup(test_app2):
             yield ((test_app1, vip1), (test_app2, vip2))

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -35,7 +35,7 @@ def pytest_collection_modifyitems(session, config, items):
 def vip_apps(dcos_api_session):
     vip1 = '6.6.6.1:6661'
     test_app1, _ = get_test_app(vip=vip1)
-    name = 'foobarbaz'
+    name = 'myvipapp'
     port = 5432
     test_app2, _ = get_test_app(vip='{}:{}'.format(name, port))
     vip2 = '{}.marathon.l4lb.thisdcos.directory:{}'.format(name, port)

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -3,7 +3,7 @@ import uuid
 
 import pytest
 
-from test_util.marathon import get_test_app
+from test_util.marathon import Container, get_test_app, Healthcheck, Network
 
 log = logging.getLogger(__name__)
 
@@ -32,12 +32,12 @@ def test_if_docker_app_can_be_deployed(dcos_api_session):
     deployed and accessed as expected.
     """
     dcos_api_session.marathon.deploy_test_app_and_check(
-        *get_test_app(network='BRIDGE', container_type='DOCKER', container_port=9080))
+        *get_test_app(network=Network.BRIDGE, container_type=Container.DOCKER, container_port=9080))
 
 
-@pytest.mark.parametrize("healthcheck", [
-    "HTTP",
-    "MESOS_HTTP",
+@pytest.mark.parametrize('healthcheck', [
+    Healthcheck.HTTP,
+    Healthcheck.MESOS_HTTP,
 ])
 def test_if_ucr_app_can_be_deployed(dcos_api_session, healthcheck):
     """Marathon app inside ucr deployment integration test.
@@ -46,7 +46,7 @@ def test_if_ucr_app_can_be_deployed(dcos_api_session, healthcheck):
     deployed and accessed as expected.
     """
     dcos_api_session.marathon.deploy_test_app_and_check(
-        *get_test_app(container_type='MESOS', healthcheck_protocol=healthcheck))
+        *get_test_app(container_type=Container.MESOS, healthcheck_protocol=healthcheck))
 
 
 def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(dcos_api_session):
@@ -63,7 +63,7 @@ def test_if_marathon_app_can_be_deployed_with_mesos_containerizer(dcos_api_sessi
     When port mapping is available (MESOS-4777), this test should be updated to
     reflect that.
     """
-    app, test_uuid = get_test_app(container_type='MESOS')
+    app, test_uuid = get_test_app(container_type=Container.MESOS)
     dcos_api_session.marathon.deploy_test_app_and_check(app, test_uuid)
 
 

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 
 
-from test_util.marathon import get_test_app, get_test_app_in_ucr
+from test_util.marathon import get_test_app
 from test_util.recordio import Decoder, Encoder
 
 
@@ -148,7 +148,7 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
     # doesn't support running docker images with the UCR. We need this
     # functionality in order to test that the pid namespace isolator
     # is functioning correctly.
-    app, test_uuid = get_test_app_in_ucr()
+    app, test_uuid = get_test_app(container_type='MESOS')
 
     ps_output_file = 'ps_output'
     app['cmd'] = 'ps ax -o pid= > {}; sleep 1000'.format(ps_output_file)

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 
 
-from test_util.marathon import get_test_app
+from test_util.marathon import Container, get_test_app
 from test_util.recordio import Decoder, Encoder
 
 
@@ -148,7 +148,7 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
     # doesn't support running docker images with the UCR. We need this
     # functionality in order to test that the pid namespace isolator
     # is functioning correctly.
-    app, test_uuid = get_test_app(container_type='MESOS')
+    app, test_uuid = get_test_app(container_type=Container.MESOS)
 
     ps_output_file = 'ps_output'
     app['cmd'] = 'ps ax -o pid= > {}; sleep 1000'.format(ps_output_file)

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -75,6 +75,7 @@ def generate_vip_app_permutations():
     return permutations
 
 
+@pytest.mark.slow
 @pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
 @pytest.mark.parametrize('container,named_vip,same_host,vip_net,proxy_net', generate_vip_app_permutations())
 def test_vip(dcos_api_session, container, named_vip, same_host, vip_net, proxy_net):

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -9,7 +9,7 @@ import retrying
 
 from test_helpers import expanded_config
 
-from test_util.marathon import get_test_app
+from test_util.marathon import Container, get_test_app, Healthcheck, Network
 
 DNS_ENTRY_UPDATE_TIMEOUT = 60  # in seconds
 
@@ -62,9 +62,9 @@ def _service_discovery_test(dcos_api_session, docker_network_bridge):
     # TODO(cmaloney): For non docker network bridge we should just do a mesos container.
     if docker_network_bridge:
         app_definition, test_uuid = get_test_app(
-            container_type='DOCKER', network='BRIDGE', container_port=2020, host_port=9080)
+            container_type=Container.DOCKER, network=Network.BRIDGE, container_port=2020, host_port=9080)
     else:
-        app_definition, test_uuid = get_test_app(container_type='DOCKER')
+        app_definition, test_uuid = get_test_app(container_type=Container.DOCKER)
 
     app_definition['instances'] = 2
 
@@ -219,40 +219,41 @@ def assert_service_discovery(dcos_api_session, app_definition, net_types):
 
 
 def test_service_discovery_mesos_host(dcos_api_session):
-    app_definition, test_uuid = get_test_app(container_type='MESOS', healthcheck_protocol='HTTP')
+    app_definition, test_uuid = get_test_app(
+        container_type=Container.MESOS, healthcheck_protocol=Healthcheck.HTTP)
 
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
 def test_service_discovery_mesos_overlay(dcos_api_session):
     app_definition, test_uuid = get_test_app(
-        container_type='MESOS',
+        container_type=Container.MESOS,
         host_port=9080,
-        healthcheck_protocol='MESOS_HTTP',
-        network='USER')
+        healthcheck_protocol=Healthcheck.MESOS_HTTP,
+        network=Network.USER)
 
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_host(dcos_api_session):
-    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='HOST')
+    app_definition, test_uuid = get_test_app(container_type=Container.DOCKER, network=Network.HOST)
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
 def test_service_discovery_docker_bridge(dcos_api_session):
     app_definition, test_uuid = get_test_app(
-        container_type='DOCKER', network='BRIDGE', container_port=2020, host_port=9080)
+        container_type=Container.DOCKER, network=Network.BRIDGE, container_port=2020, host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
 
 
 def test_service_discovery_docker_overlay(dcos_api_session):
-    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='USER', host_port=9080)
+    app_definition, test_uuid = get_test_app(container_type=Container.DOCKER, network=Network.USER, host_port=9080)
     del app_definition['container']['docker']['portMappings'][0]['hostPort']
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
-    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='USER', host_port=9080)
+    app_definition, test_uuid = get_test_app(container_type=Container.DOCKER, network=Network.USER, host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay, DNSPortMap])
 
 

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -9,7 +9,7 @@ import retrying
 
 from test_helpers import expanded_config
 
-from test_util.marathon import get_test_app, get_test_app_in_docker, get_test_app_in_ucr
+from test_util.marathon import get_test_app
 
 DNS_ENTRY_UPDATE_TIMEOUT = 60  # in seconds
 
@@ -60,18 +60,11 @@ def _service_discovery_test(dcos_api_session, docker_network_bridge):
     """
 
     # TODO(cmaloney): For non docker network bridge we should just do a mesos container.
-    app_definition, test_uuid = get_test_app_in_docker(ip_per_container=False)
-
-    if not docker_network_bridge:
-        # TODO(cmaloney): This is very hacky to make PORT0 on the end instead of 9080...
-        app_definition['cmd'] = app_definition['cmd'][:-4] + '$PORT0'
-        app_definition['container']['docker']['network'] = 'HOST'
-        del app_definition['container']['docker']['portMappings']
-        app_definition['portDefinitions'] = [{
-            "protocol": "tcp",
-            "port": 0,
-            "name": "test"
-        }]
+    if docker_network_bridge:
+        app_definition, test_uuid = get_test_app(
+            container_type='DOCKER', network='BRIDGE', container_port=2020, host_port=9080)
+    else:
+        app_definition, test_uuid = get_test_app(container_type='DOCKER')
 
     app_definition['instances'] = 2
 
@@ -176,16 +169,6 @@ def get_marathon_addresses_by_service_points(service_points):
     return MarathonAddresses(marathon_host_addrs, marathon_ip_addrs)
 
 
-def replace_marathon_cmd_port(app_definition, port_str):
-    new_app = app_definition.copy()
-
-    cmd_list = new_app['cmd'].split()[:-1]
-    cmd_list.append(port_str)
-    mesos_cmd = ' '.join(cmd_list)
-    new_app['cmd'] = mesos_cmd
-    return new_app
-
-
 def assert_service_discovery(dcos_api_session, app_definition, net_types):
     """
     net_types: List of network types: DNSHost, DNSPortMap, or DNSOverlay
@@ -236,71 +219,48 @@ def assert_service_discovery(dcos_api_session, app_definition, net_types):
 
 
 def test_service_discovery_mesos_host(dcos_api_session):
-    app_definition, test_uuid = get_test_app_in_ucr()
+    app_definition, test_uuid = get_test_app(container_type='MESOS', healthcheck_protocol='HTTP')
 
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
 def test_service_discovery_mesos_overlay(dcos_api_session):
-    port = 9080
-    app_definition, test_uuid = get_test_app_in_ucr(healthcheck='MESOS_HTTP')
-
-    app_definition['ipAddress'] = {
-        'networkName': 'dcos',
-        'discovery': {
-            'ports': [{
-                'protocol': 'tcp',
-                'name': 'test',
-                'number': port,
-            }]
-        }
-    }
-    if 'portIndex' in app_definition['healthChecks'][0]:
-        del app_definition['healthChecks'][0]['portIndex']
-    app_definition['healthChecks'][0]['port'] = port
-    app_definition = replace_marathon_cmd_port(app_definition, str(port))
+    app_definition, test_uuid = get_test_app(
+        container_type='MESOS',
+        host_port=9080,
+        healthcheck_protocol='MESOS_HTTP',
+        network='USER')
 
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_host(dcos_api_session):
-    app_definition, test_uuid = get_test_app_in_docker()
-    app_definition['container']['docker']['network'] = 'HOST'
-    del app_definition['container']['docker']['portMappings']
-    app_definition = replace_marathon_cmd_port(app_definition, "$PORT0")
-
+    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='HOST')
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
 def test_service_discovery_docker_bridge(dcos_api_session):
-    app_definition, test_uuid = get_test_app_in_docker()
-    app_definition['container']['docker']['network'] = 'BRIDGE'
-
+    app_definition, test_uuid = get_test_app(
+        container_type='DOCKER', network='BRIDGE', container_port=2020, host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
 
 
 def test_service_discovery_docker_overlay(dcos_api_session):
-    app_definition, test_uuid = get_test_app_in_docker()
-    app_definition['container']['docker']['network'] = 'USER'
-    app_definition['ipAddress'] = {'networkName': 'dcos'}
+    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='USER', host_port=9080)
     del app_definition['container']['docker']['portMappings'][0]['hostPort']
-
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
-    app_definition, test_uuid = get_test_app_in_docker()
-    app_definition['container']['docker']['network'] = 'USER'
-    app_definition['ipAddress'] = {'networkName': 'dcos'}
-
+    app_definition, test_uuid = get_test_app(container_type='DOCKER', network='USER', host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay, DNSPortMap])
 
 
-def test_if_service_discovery_works_docker_bridged_network(dcos_api_session):
+def test_service_discovery_docker_bridged_network(dcos_api_session):
     return _service_discovery_test(dcos_api_session, docker_network_bridge=True)
 
 
-def test_if_service_discovery_works_docker_host_network(dcos_api_session):
+def test_service_discovery_docker_host_network(dcos_api_session):
     return _service_discovery_test(dcos_api_session, docker_network_bridge=False)
 
 

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -1,4 +1,4 @@
-""" Utilities for integration testing marathon in a deployed DC/OS clsuter
+""" Utilities for integration testing marathon in a deployed DC/OS cluster
 """
 import collections
 import copy
@@ -115,7 +115,6 @@ def get_test_app(
     if container_type != Container.NONE:
         app['container'] = {
             'type': container_type.value,
-            # TODO(cmaloney): Switch to alpine with glibc
             'docker': {'image': 'debian:jessie'},
             'volumes': [{
                 'containerPath': '/opt/mesosphere',

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -1,3 +1,5 @@
+""" Utilities for integration testing marathon in a deployed DC/OS clsuter
+"""
 import collections
 import copy
 import logging
@@ -14,7 +16,51 @@ REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}
 log = logging.getLogger(__name__)
 
 
-def get_test_app(custom_port=False):
+def get_test_app(
+        host_port=0,
+        container_port=None,
+        container_type=None,
+        network='HOST',
+        healthcheck_protocol='HTTP',
+        vip=None,
+        host_constraint=None):
+    """ Creates an app definition for the python test server which will be
+    consistent (i.e. deployable with green health checks and desired network
+    routability). To learn more about the test server, see in this repo:
+    ../packages/dcos-integration-test/extra/util/python_test_server.py
+
+    Args:
+        host_port: port that marathon will use to route traffic into the
+            test server container. If set to zero, then marathon will assign
+            a port (which is referenced by index). If
+        container_port: if network is BRIDGE, then the container can have a
+            port remapped inside the container. In HOST or USER network, the
+            container port must be the same as the host port
+        container_type: can be None (default Mesos runtime), MESOS (the UCR),
+            or DOCKER
+        health_check_protocol: can be MESOS_HTTP or HTTP
+        vip: either named or unnamed VIP to be applied to the host port
+        host_constraint: string representing a hostname for an agent that this
+            app should run on
+
+    Return:
+        (dict, str): 2-Tuple of app definition (dict) and app ID (string)
+    """
+    assert network in ['HOST', 'USER', 'BRIDGE']
+    assert container_type in ['DOCKER', 'MESOS', None]
+    assert healthcheck_protocol in ['HTTP', 'MESOS_HTTP']
+    if network == 'BRIDGE':
+        assert container_type == 'DOCKER', 'BRIDGE network mode only supported for DOCKER container type'
+        if container_port is None:
+            # provide a dummy value for the bridged container port if user is indifferent
+            container_port = 8080
+    else:
+        assert container_port is None or container_port == host_port, 'Cannot declare a different host and '\
+            'container port outside of BRIDGE network'
+        container_port = host_port
+    if network == 'USER':
+        assert host_port != 0, 'Cannot auto-assign a port on USER network?'
+
     test_uuid = uuid.uuid4().hex
     app = copy.deepcopy({
         'id': TEST_APP_NAME_FMT.format(test_uuid),
@@ -22,7 +68,10 @@ def get_test_app(custom_port=False):
         'mem': 32,
         'instances': 1,
         'cmd': '/opt/mesosphere/bin/dcos-shell python '
-               '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py ',
+               '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
+                   # If network is host and host port is zero, then the port is auto-assigned
+                   # and the commandline should reference the port with the marathon built-in
+                   '$PORT0' if host_port == 0 and network == 'HOST' else container_port),
         'env': {
             'DCOS_TEST_UUID': test_uuid,
             # required for python_test_server.py to run as nobody
@@ -30,9 +79,8 @@ def get_test_app(custom_port=False):
         },
         'healthChecks': [
             {
-                'protocol': 'MESOS_HTTP',
+                'protocol': healthcheck_protocol,
                 'path': '/ping',
-                'portIndex': 0,
                 'gracePeriodSeconds': 5,
                 'intervalSeconds': 10,
                 'timeoutSeconds': 10,
@@ -40,65 +88,54 @@ def get_test_app(custom_port=False):
             }
         ],
     })
-    if not custom_port:
-        app['cmd'] += '$PORT0'
-        app['portDefinitions'] = [{
-            "protocol": "tcp",
-            "port": 0,
-            "name": "test"
-        }]
-    return app, test_uuid
-
-
-def get_test_app_in_docker(ip_per_container=False):
-    app, test_uuid = get_test_app(custom_port=True)
-    assert 'portDefinitions' not in app
-    app['cmd'] += '9080'  # Fixed port for inside bridge networking or IP per container
-    app['container'] = {
-        'type': 'DOCKER',
-        'docker': {
-            # TODO(cmaloney): Switch to alpine with glibc
-            'image': 'debian:jessie',
-            'portMappings': [{
-                'hostPort': 0,
-                'containerPort': 9080,
-                'protocol': 'tcp',
-                'name': 'test',
-                'labels': {}
-            }]},
-        'volumes': [{
-            'containerPath': '/opt/mesosphere',
-            'hostPath': '/opt/mesosphere',
-            'mode': 'RO'
-        }]
-    }
-    if ip_per_container:
-        app['container']['docker']['network'] = 'USER'
-        app['ipAddress'] = {'networkName': 'dcos'}
+    if host_port == 0:
+        # port is being assigned by marathon so refer to this port by index
+        app['healthChecks'][0]['portIndex'] = 0
+    elif network == 'BRIDGE':
+        app['healthChecks'][0]['port'] = container_port if healthcheck_protocol == 'MESOS_HTTP' else host_port
     else:
-        app['container']['docker']['network'] = 'BRIDGE'
-    return app, test_uuid
-
-
-def get_test_app_in_ucr(healthcheck='HTTP'):
-    app, test_uuid = get_test_app(custom_port=True)
-    assert 'portDefinitions' not in app
-    # UCR does NOT support portmappings host only.  must use $PORT0
-    app['cmd'] += '$PORT0'
-    app['container'] = {
-        'type': 'MESOS',
-        'docker': {
-            'image': 'debian:jessie'
-        },
-        'volumes': [{
-            'containerPath': '/opt/mesosphere',
-            'hostPath': '/opt/mesosphere',
-            'mode': 'RO'
-        }]
-    }
-    # currently UCR does NOT support bridge mode or port mappings
-    # UCR supports host mode
-    app['healthChecks'][0]['protocol'] = healthcheck
+        # HOST or USER network with non-zero host port
+        app['healthChecks'][0]['port'] = host_port
+    if container_type is not None:
+        app['container'] = {
+            'type': container_type,
+            # TODO(cmaloney): Switch to alpine with glibc
+            'docker': {'image': 'debian:jessie'},
+            'volumes': [{
+                'containerPath': '/opt/mesosphere',
+                'hostPath': '/opt/mesosphere',
+                'mode': 'RO'}]}
+        if container_type == 'DOCKER':
+            app['container']['docker']['network'] = network
+            if network != 'HOST':
+                app['container']['docker']['portMappings'] = [{
+                    'hostPort': host_port,
+                    'containerPort': container_port,
+                    'protocol': 'tcp',
+                    'name': 'test'}]
+                if vip is not None:
+                    app['container']['docker']['portMappings'][0]['labels'] = {'VIP_0': vip}
+    if network == 'HOST':
+        app['portDefinitions'] = [{
+            'protocol': 'tcp',
+            'port': host_port,
+            'name': 'test'}]
+        if vip is not None:
+            app['portDefinitions'][0]['labels'] = {'VIP_0': vip}
+    elif network == 'USER':
+        app['ipAddress'] = {'networkName': 'dcos'}
+        if container_type != 'DOCKER':
+            app['ipAddress']['discovery'] = {
+                'ports': [{
+                    'protocol': 'tcp',
+                    'name': 'test',
+                    'number': host_port,
+                }]
+            }
+            if vip is not None:
+                app['ipAddress']['discovery']['ports'][0]['labels'] = {'VIP_0': vip}
+    if host_constraint is not None:
+        app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
     return app, test_uuid
 
 

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -590,7 +590,8 @@ class VpcClusterUpgradeTest:
             for k, v in os.environ.items():
                 if k.startswith(prefix):
                     add_env.append(k.replace(prefix, '') + '=' + v)
-            test_cmd = ' '.join(add_env) + ' py.test -vv -s -rs ' + os.getenv('CI_FLAGS', '')
+            # this test is slow enough, so disable the slow tests
+            test_cmd = ' '.join(add_env) + ' py.test -vv -s -rs -m "not slow" ' + os.getenv('CI_FLAGS', '')
             result = test_util.cluster.run_integration_tests(cluster, test_cmd=test_cmd)
 
         if result == 0:


### PR DESCRIPTION
## High Level Description

Testing all network VIP configuration permutations at once is not a viable test. When it fails, it is near impossible to de-tangle what is broken and the logs are returned in a totally unorganized manner. This PR will:
- consolidate the code for generating consistent test server applications to make the tests calling it far more readable
 - serialize the test so that pytest can report results in an organized manner, thereby allowing others to debug from CI or to simply just focus on problem areas (rather than python threading issues). Unfortunately, this serialization will add ~30 minutes to tests

## Related Issue
https://jira.mesosphere.com/browse/DCOS-14950
https://jira.mesosphere.com/browse/DCOS_OSS-909
https://jira.mesosphere.com/browse/DCOS_OSS-910

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)



