### PR TITLE
Fill out dependencies in Azure deployment

### DIFF
--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -520,21 +520,21 @@
     "masterAvailabilitySet": "[concat(variables('orchestratorName'), '-master-availabilitySet-', variables('nameSuffix'))]",
     "masterLbName": "[concat(variables('orchestratorName'), '-master-lb-', variables('nameSuffix'))]",
     "masterSshInboundNatRuleNamePrefix": "[concat(variables('masterLbName'),'/SSH-',variables('masterVMNamePrefix'))]",
-    "masterSshPort22InboundNatRuleNamePrefix": "[concat(variables('masterLbName'),'/SSHPort22-',variables('masterVMNamePrefix'))]",
+    "masterSshPort22InboundNatRuleName": "[concat(variables('masterLbName'),'/SSHPort22-',variables('masterVMNamePrefix'),'0')]",
     "masterVMSize": "[variables('masterSizes')[variables('isValidation')]]",
     "masterLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('masterLbName'))]",
     "masterLbIPConfigName": "[concat(variables('orchestratorName'), '-master-lbFrontEnd-', variables('nameSuffix'))]",
     "masterLbIPConfigID": "[concat(variables('masterLbID'),'/frontendIPConfigurations/', variables('masterLbIPConfigName'))]",
     "masterLbBackendPoolName": "[concat(variables('orchestratorName'), '-master-pool-', variables('nameSuffix'))]",
     "masterSshInboundNatRuleIdPrefix": "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'))]",
-    "masterSshPort22InboundNatRuleIdPrefix": "[concat(variables('masterLbID'),'/inboundNatRules/SSHPort22-',variables('masterVMNamePrefix'))]",
+    "masterSshPort22InboundNatRuleId": "[concat(variables('masterLbID'),'/inboundNatRules/SSHPort22-',variables('masterVMNamePrefix'),'0')]",
     "masterLbInboundNatRules":[
       [
         {
           "id": "[concat(variables('masterSshInboundNatRuleIdPrefix'),'0')]"
         },
         {
-          "id": "[concat(variables('masterSshPort22InboundNatRuleIdPrefix'),'0')]"
+          "id": "[variables('masterSshPort22InboundNatRuleId')]"
         }
       ],
       [
@@ -739,11 +739,12 @@
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
+      "type": "Microsoft.Network/loadBalancers/inboundNatRules",
+      "name": "[variables('masterSshPort22InboundNatRuleName')]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[variables('masterLbID')]"
       ],
-      "location": "[resourceGroup().location]",
-      "name": "[concat(variables('masterSshPort22InboundNatRuleNamePrefix'), '0')]",
       "properties": {
         "backendPort": 2222,
         "enableFloatingIP": false,
@@ -752,8 +753,7 @@
         },
         "frontendPort": "22",
         "protocol": "tcp"
-      },
-      "type": "Microsoft.Network/loadBalancers/inboundNatRules"
+      }
     },
     {
       "apiVersion": "[variables('apiVersionDefault')]",
@@ -864,6 +864,7 @@
         "[variables('masterLbID')]",
         "[variables('vnetID')]",
         "[concat(variables('masterLbID'),'/inboundNatRules/SSH-',variables('masterVMNamePrefix'),copyIndex())]",
+        "[variables('masterSshPort22InboundNatRuleId')]",
         "[variables('masterNSGID')]"
       ],
       "properties": {


### PR DESCRIPTION
## High Level Description
- Quite often templates will fail to deploy because a resource that is required by zero-th master NIC is not available. That is because the current master NIC resource template only waits for the 2200+ indexed SSH port rules to be established. Rather, all of them should wait for the rules that are consistently named regardless of master count
- Also hard codes the rule names that are not indexed across the masters given that there can only be one anyway.

## Related Issues
- Azure PR checks fail with errors like this: https://teamcity.mesosphere.io/viewLog.html?buildId=602849&buildTypeId=ClosedSource_Dcos_IntegrationTests_CloudIntegrationTests_DcosOssAzureIntegrati_2&tab=buildLog#_focus=435

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This will be exercised by existing Azure integration tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]