### PR TITLE
mesos-dns: Allow application/json Accept header

### DIFF
--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos-dns.git",
-    "ref": "bf08ab7017207b7d7924462cfbaf7b952155a53e",
+    "ref": "af6ebc7a70f722b219f79f433b242e22667cfd4c",
     "ref_origin": "master"
   },
   "username": "dcos_mesos_dns"


### PR DESCRIPTION
## High Level Description

When using the mesos http rest api to query service information, if the client includes an Accept header of `application/json`, the request is rejected with a `406 Not-Acceptable` error.

## Related Issues

  - [DCOS_OSS-611](https://jira.mesosphere.com/browse/DCOS_OSS-611) Mesos DNS HTTP API returns 406 Not Acceptable for valid requests.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: the bumped includes a regression test in the component
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/mesos-dns/compare/bf08ab7017207b7d7924462cfbaf7b952155a53e...af6ebc7a70f722b219f79f433b242e22667cfd4c
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-mesos-dns-pulls/180/console
  - [ ] Code Coverage (if available): [link to code coverage report]
___
