### PR TITLE
AMI: XFS - store inode type in directory structure by default

### DIFF
--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -44,7 +44,7 @@ function main {
   until test -b "$device"; do sleep 1; echo -n .; done
   echo
   local formated
-  mkfs.xfs $device > /dev/null 2>&1 && formated=true || formated=false
+  mkfs.xfs -n ftype=1 $device > /dev/null 2>&1 && formated=true || formated=false
   if [ "$formated" = true ]
   then
     echo "Setting up device mount"


### PR DESCRIPTION
## High Level Description

This turns on an XFS filesystem function where the inode type is stored in the directory structure. This is vital to the use of Overlay and a bug it wasn't there before.
Without it the Filesystem in containers can corrupt.

This setting is default beginning with EL 7.3.

## Related Issues

  - [DCOS-14872](https://jira.mesosphere.com/browse/DCOS-14872) Filesystem corruption in dcos-ui container.
