### PR TITLE
Add AWS bare cluster template

### DIFF
--- a/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
+++ b/packages/dcos-integration-test/extra/resiliency/test_aws_cf.py
@@ -36,7 +36,7 @@ def dcos_stack(boto_wrapper):
     """ Works with either Zen or Simple cloud formations
     """
     stack = test_util.aws.fetch_stack(os.environ['AWS_STACK_NAME'], boto_wrapper)
-    if isinstance(stack, test_util.aws.VpcCfStack):
+    if isinstance(stack, test_util.aws.BareClusterCfStack):
         pytest.skip('Onprem Vpc not currently supported')
     return stack
 

--- a/packages/dcos-launch/extra/launch/aws.py
+++ b/packages/dcos-launch/extra/launch/aws.py
@@ -32,7 +32,9 @@ class AwsCloudformationLauncher(launch.util.AbstractLauncher):
             temp_resources.update(self.zen_helper(config))
         try:
             stack = self.boto_wrapper.create_stack(
-                config['deployment_name'], config['template_url'], yaml.load(config['template_parameters']))
+                config['deployment_name'],
+                yaml.load(config['template_parameters']),
+                template_url=config['template_url'])
         except Exception as ex:
             self.delete_temp_resources(temp_resources)
             raise launch.util.LauncherError('ProviderError', None) from ex

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,10 @@ setup(
         ] + get_advanced_templates(),
         'pkgpanda': [
             'docker/dcos-builder/Dockerfile'
+        ],
+        'test_util': [
+            'templates/vpc-cluster-template.json',
+            'templates/vpc-ebs-only-cluster-template.json'
         ]
     },
     zip_safe=False

--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -143,7 +143,7 @@ class Cluster:
         )
 
     @classmethod
-    def from_vpc(
+    def from_bare_cluster(
         cls,
         vpc,
         ssh_info,

--- a/test_util/templates/vpc-cluster-template.json
+++ b/test_util/templates/vpc-cluster-template.json
@@ -1,0 +1,269 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "VPC with custom OS",
+  "Mappings": {
+    "SubnetConfig" : {
+      "VPC"     : { "CIDR" : "10.10.0.0/16" },
+      "Public"  : { "CIDR" : "10.10.0.0/24" }
+    }
+  },
+  "Parameters": {
+
+    "InstanceType": {
+      "Description": "EC2 PV instance type (m3.medium, etc).",
+      "Type": "String",
+      "Default": "m4.xlarge",
+      "ConstraintDescription": "Must be a valid EC2 PV instance type."
+    },
+    "AmiCode": {
+        "Description": "Image id of desired OS",
+        "Type": "String"
+    },
+    "ClusterSize": {
+      "Default": "3",
+      "MinValue": "1",
+      "MaxValue": "100",
+      "Description": "Number of nodes in cluster (1-100).",
+      "Type": "Number"
+    },
+    "AllowAccessFrom": {
+      "Description": "The (CIDR) from which cluster is available",
+      "Default": "0.0.0.0/0",
+      "Type": "String"
+    },
+    "KeyPair": {
+      "Description": "The name of an EC2 Key Pair to allow SSH access to the instance.",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+
+    "VPC" : {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "VPC", "CIDR" ]},
+        "EnableDnsSupport" : "true",
+        "EnableDnsHostnames" : "true",
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "PublicSubnet" : {
+      "Type" : "AWS::EC2::Subnet",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "InternetGateway" : {
+      "Type" : "AWS::EC2::InternetGateway",
+      "Properties" : {
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "GatewayToInternet" : {
+       "Type" : "AWS::EC2::VPCGatewayAttachment",
+       "Properties" : {
+         "VpcId" : { "Ref" : "VPC" },
+         "InternetGatewayId" : { "Ref" : "InternetGateway" }
+       }
+    },
+
+    "PublicRouteTable" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "PublicRoute" : {
+      "Type" : "AWS::EC2::Route",
+      "DependsOn" : "GatewayToInternet",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "PublicRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "InternetGateway" }
+      }
+    },
+
+    "PublicSubnetRouteTableAssociation" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "PublicSubnet" },
+        "RouteTableId" : { "Ref" : "PublicRouteTable" }
+      }
+    },
+
+    "BareSecurityGroup": {
+
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Bare SecurityGroup",
+        "VpcId" : { "Ref" : "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          }
+        ]
+      }
+    },
+    "BareRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [ {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ec2.amazonaws.com" ]
+            },
+            "Action": [ "sts:AssumeRole" ]
+          } ]
+        },
+        "Policies": [ {
+          "PolicyName": "BareServers",
+          "PolicyDocument": {
+            "Version" : "2012-10-17",
+            "Statement": [ {
+              "Resource": [
+                  { "Ref" : "AWS::StackId" },
+                  { "Fn::Join" : ["", [{ "Ref" : "AWS::StackId" }, "/*" ]]}
+              ],
+              "Action": [
+                  "cloudformation:*"
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Resource": "*",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DescribeInstances",
+                "ec2:CreateVolume",
+                "ec2:DeleteVolume",
+                "ec2:AttachVolume",
+                "ec2:DetachVolume",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DescribeVolumeAttribute",
+                "ec2:CreateSnapshot",
+                "ec2:CopySnapshot",
+                "ec2:DeleteSnapshot",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeSnapshotAttribute"
+              ],
+              "Effect": "Allow"
+            }
+            ]
+          }
+        } ]
+      }
+    },
+    "BareInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [ {
+          "Ref": "BareRole"
+        } ]
+      }
+    },
+    "BareServerAutoScale": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn" : "PublicRoute",
+      "Properties": {
+        "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
+        "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
+        "LaunchConfigurationName": {
+          "Ref": "BareServerLaunchConfig"
+        },
+        "MinSize": "1",
+        "MaxSize": "100",
+        "DesiredCapacity": {
+          "Ref": "ClusterSize"
+        },
+        "Tags" : [
+          {
+            "Key" : "Network",
+            "Value" : "Public",
+            "PropagateAtLaunch" : "true"
+            }
+          ]
+      }
+    },
+    "BareServerLaunchConfig": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress" : "true",
+        "ImageId": {
+          "Ref": "AmiCode"
+        },
+        "InstanceType": {
+          "Ref": "InstanceType"
+        },
+        "KeyName": {
+          "Ref": "KeyPair"
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "BareSecurityGroup"
+          }
+        ],
+        "IamInstanceProfile": {
+            "Ref": "BareInstanceProfile"
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": "30",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/sdb",
+            "VirtualName": "ephemeral0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test_util/templates/vpc-ebs-only-cluster-template.json
+++ b/test_util/templates/vpc-ebs-only-cluster-template.json
@@ -1,0 +1,285 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "VPC with custom OS",
+  "Mappings": {
+    "SubnetConfig" : {
+      "VPC"     : { "CIDR" : "10.10.0.0/16" },
+      "Public"  : { "CIDR" : "10.10.0.0/24" }
+    },
+    "SDBSnapshot": {
+      "us-west-2": {"snap": "snap-00ae1a58"},
+      "us-west-1": {"snap": "snap-2f2c1516"},
+      "sa-east-1": {"snap": "snap-356b2302"},
+      "us-east-1": {"snap": "snap-5f580f42"},
+      "ap-southeast-1": {"snap": "snap-a7be23b6"},
+      "ap-southeast-2": {"snap": "snap-e1f4bfed"},
+      "ap-northeast-1": {"snap": "snap-b970ec81"},
+      "eu-west-1": {"snap": "snap-056ada2d"},
+      "eu-central-1": {"snap": "snap-2c830027"}
+    }
+  },
+  "Parameters": {
+
+    "InstanceType": {
+      "Description": "EC2 PV instance type (m3.medium, etc).",
+      "Type": "String",
+      "Default": "m4.xlarge",
+      "ConstraintDescription": "Must be a valid EC2 PV instance type."
+    },
+    "AmiCode": {
+        "Description": "Image id of desired OS",
+        "Type": "String"
+    },
+    "ClusterSize": {
+      "Default": "3",
+      "MinValue": "1",
+      "MaxValue": "100",
+      "Description": "Number of nodes in cluster (1-100).",
+      "Type": "Number"
+    },
+    "AllowAccessFrom": {
+      "Description": "The (CIDR) from which cluster is available",
+      "Default": "0.0.0.0/0",
+      "Type": "String"
+    },
+    "KeyPair": {
+      "Description": "The name of an EC2 Key Pair to allow SSH access to the instance.",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+
+    "VPC" : {
+      "Type" : "AWS::EC2::VPC",
+      "Properties" : {
+        "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "VPC", "CIDR" ]},
+        "EnableDnsSupport" : "true",
+        "EnableDnsHostnames" : "true",
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "PublicSubnet" : {
+      "Type" : "AWS::EC2::Subnet",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "InternetGateway" : {
+      "Type" : "AWS::EC2::InternetGateway",
+      "Properties" : {
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "GatewayToInternet" : {
+       "Type" : "AWS::EC2::VPCGatewayAttachment",
+       "Properties" : {
+         "VpcId" : { "Ref" : "VPC" },
+         "InternetGatewayId" : { "Ref" : "InternetGateway" }
+       }
+    },
+
+    "PublicRouteTable" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+
+    "PublicRoute" : {
+      "Type" : "AWS::EC2::Route",
+      "DependsOn" : "GatewayToInternet",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "PublicRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "InternetGateway" }
+      }
+    },
+
+    "PublicSubnetRouteTableAssociation" : {
+      "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "PublicSubnet" },
+        "RouteTableId" : { "Ref" : "PublicRouteTable" }
+      }
+    },
+
+    "BareSecurityGroup": {
+
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Bare SecurityGroup",
+        "VpcId" : { "Ref" : "VPC" },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "udp",
+            "FromPort": "0",
+            "ToPort": "65535",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "icmp",
+            "FromPort": "-1",
+            "ToPort": "-1",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          }
+        ]
+      }
+    },
+    "BareRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [ {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ec2.amazonaws.com" ]
+            },
+            "Action": [ "sts:AssumeRole" ]
+          } ]
+        },
+        "Policies": [ {
+          "PolicyName": "BareServers",
+          "PolicyDocument": {
+            "Version" : "2012-10-17",
+            "Statement": [ {
+              "Resource": [
+                  { "Ref" : "AWS::StackId" },
+                  { "Fn::Join" : ["", [{ "Ref" : "AWS::StackId" }, "/*" ]]}
+              ],
+              "Action": [
+                  "cloudformation:*"
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Resource": "*",
+              "Action": [
+                "ec2:CreateTags",
+                "ec2:DescribeInstances",
+                "ec2:CreateVolume",
+                "ec2:DeleteVolume",
+                "ec2:AttachVolume",
+                "ec2:DetachVolume",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DescribeVolumeAttribute",
+                "ec2:CreateSnapshot",
+                "ec2:CopySnapshot",
+                "ec2:DeleteSnapshot",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeSnapshotAttribute"
+              ],
+              "Effect": "Allow"
+            }
+            ]
+          }
+        } ]
+      }
+    },
+    "BareInstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [ {
+          "Ref": "BareRole"
+        } ]
+      }
+    },
+    "BareServerAutoScale": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn" : "PublicRoute",
+      "Properties": {
+        "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
+        "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
+        "LaunchConfigurationName": {
+          "Ref": "BareServerLaunchConfig"
+        },
+        "MinSize": "1",
+        "MaxSize": "100",
+        "DesiredCapacity": {
+          "Ref": "ClusterSize"
+        },
+        "Tags" : [
+          {
+            "Key" : "Network",
+            "Value" : "Public",
+            "PropagateAtLaunch" : "true"
+            }
+          ]
+      }
+    },
+    "BareServerLaunchConfig": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress" : "true",
+        "ImageId": {
+          "Ref": "AmiCode"
+        },
+        "InstanceType": {
+          "Ref": "InstanceType"
+        },
+        "KeyName": {
+          "Ref": "KeyPair"
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "BareSecurityGroup"
+          }
+        ],
+        "IamInstanceProfile": {
+            "Ref": "BareInstanceProfile"
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": "150",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/sdb",
+            "Ebs": {
+              "VolumeSize": "150",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2",
+              "SnapshotId": { "Fn::FindInMap" : [ "SDBSnapshot", { "Ref" : "AWS::Region" }, "snap"]}
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -164,7 +164,7 @@ def main():
     write_string('ssh_key', ssh_key)
 
     if options.cluster_ami:
-        vpc = test_util.aws.VpcCfStack.create_from_ami(
+        vpc = test_util.aws.BareClusterCfStack.create_from_ami(
             stack_name=unique_cluster_id,
             instance_type=options.instance_type,
             instance_ami=options.cluster_ami,
@@ -175,7 +175,7 @@ def main():
             boto_wrapper=bw)
         ssh_info = SshInfo(user=options.cluster_ami_ssh_user, home_dir=options.cluster_ami_ssh_home_dir)
     else:
-        vpc, ssh_info = test_util.aws.VpcCfStack.create(
+        vpc, ssh_info = test_util.aws.BareClusterCfStack.create(
             stack_name=unique_cluster_id,
             instance_type=options.instance_type,
             instance_os=os_name,
@@ -186,7 +186,7 @@ def main():
             boto_wrapper=bw)
     vpc.wait_for_complete()
 
-    cluster = test_util.cluster.Cluster.from_vpc(
+    cluster = test_util.cluster.Cluster.from_bare_cluster(
         vpc,
         ssh_info,
         ssh_key=ssh_key,

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -504,7 +504,7 @@ class VpcClusterUpgradeTest:
                 aws_secret_access_key=self.aws_secret_access_key)
             ssh_key = bw.create_key_pair(stack_name)
             write_string('ssh_key', ssh_key)
-            vpc, ssh_info = test_util.aws.VpcCfStack.create(
+            bare_cluster, ssh_info = test_util.aws.BareClusterCfStack.create(
                 stack_name=stack_name,
                 instance_type='m4.xlarge',
                 instance_os='cent-os-7-dcos-prereqs',
@@ -514,10 +514,10 @@ class VpcClusterUpgradeTest:
                 key_pair_name=stack_name,
                 boto_wrapper=bw
             )
-            vpc.wait_for_complete()
+            bare_cluster.wait_for_complete()
 
-        cluster = test_util.cluster.Cluster.from_vpc(
-            vpc,
+        cluster = test_util.cluster.Cluster.from_bare_cluster(
+            bare_cluster,
             ssh_info,
             ssh_key=ssh_key,
             num_masters=self.num_masters,
@@ -587,7 +587,7 @@ class VpcClusterUpgradeTest:
 
         if result == 0:
             self.log.info("Test successful! Deleting VPC if provided in this run.")
-            vpc.delete()
+            bare_cluster.delete()
             bw.delete_key_pair(stack_name)
         else:
             self.log.info("Test failed! VPC cluster will remain available for "


### PR DESCRIPTION
## High Level Description
These templates are currently pulled from a magic bucket on S3. There is no reason why these should not just live in the repo where they can be updated in sync with DC/OS.

Additionally, the arbitrary names in the template are switched from CentOS to Bare as the intention of this template is to provide homogenous AMIs without DC/OS for use with the onprem installer.

## Related Issues
https://jira.mesosphere.com/browse/DCOS-11534

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)