### PR TITLE
upgrade rex-ray to v0.9.0

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -6,7 +6,6 @@ The following is a list of ports used by internal DC/OS services, and their corr
 
 ### TCP
 
- - 61003: dcos-rexray (default)
  - 61053: dcos-mesos-dns
  - 61420: dcos-epmd
  - 61421: dcos-minuteman

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -686,13 +686,11 @@ entry = {
             'rexray': {
                 'loglevel': 'info',
                 'modules': {
-                    'default-admin': {
-                        'host': 'tcp://127.0.0.1:61003'
-                    },
                     'default-docker': {
                         'disabled': True
                     }
-                }
+                },
+                'service': 'vfs'
             }
         }),
         'enable_gpu_isolation': 'true',
@@ -757,15 +755,16 @@ entry = {
                         # Use IAM Instance Profile for auth.
                         'rexray': {
                             'loglevel': 'info',
-                            'modules': {
-                                'default-admin': {
-                                    'host': 'tcp://127.0.0.1:61003'
-                                }
-                            },
-                            'storageDrivers': ['ec2'],
-                            'volume': {
-                                'unmount': {
-                                    'ignoreusedcount': True
+                            'service': 'ebs'
+                        },
+                        'libstorage': {
+                            'integration': {
+                                'volume': {
+                                    'operations': {
+                                        'unmount': {
+                                            'ignoreusedcount': True
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -758,6 +758,11 @@ entry = {
                             'service': 'ebs'
                         },
                         'libstorage': {
+                            'server': {
+                                'tasks': {
+                                    'logTimeout': '5m'
+                                }
+                            },
                             'integration': {
                                 'volume': {
                                     'operations': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -963,3 +963,5 @@ package:
       admin: {{ exhibitor_admin_password }},admin
 {% case "false" %}
 {% endswitch %}
+  - path: /etc/rexray.conf
+    content: {{ rexray_config_contents }}

--- a/packages/dvdcli/build
+++ b/packages/dvdcli/build
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -o errexit -o nounset -o pipefail
 
-mkdir -p $PKG_PATH/bin/
-tar -xf /pkg/src/dvdcli/dvdcli-Linux-x86_64-0.1.0.tar.gz -C $PKG_PATH/bin/
+srcdir=$GOPATH/src/github.com/codedellemc/dvdcli
+mkdir -p $(dirname $srcdir)
+ln -s /pkg/src/dvdcli $srcdir
+cd $srcdir
+
+make
+
+mkdir -p $PKG_PATH/bin
+mv $GOPATH/bin/dvdcli $PKG_PATH/bin

--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -1,7 +1,9 @@
 {
-  "single_source": {
-    "kind": "url",
-    "url": "https://downloads.dcos.io/pkgpanda-artifact-cache/dvdcli-Linux-x86_64-0.1.0.tar.gz",
-    "sha1": "a0d7757939eefdf1ad28bc44919cdba5b6310528"
+  "docker": "golang:1.7",
+  "single_source" : {
+    "kind": "git",
+    "git": "https://github.com/codedellemc/dvdcli.git",
+    "ref": "64827035b941029d01173822ca1fd1e80551cba4",
+    "ref_origin": "master"
   }
 }

--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,13 +9,12 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/emccode/rexray
+srcdir=$GOPATH/src/github.com/codedellemc/rexray
 mkdir -p $(dirname $srcdir)
 ln -s /pkg/src/rexray $srcdir
-
 cd $srcdir
 
-echo "...building rexray..."
-mkdir -p $PKG_PATH/bin/
-make build-linux-amd64 OFFLINE=1
-mv .build/bin/Linux-x86_64/rexray $PKG_PATH/bin/
+DGOOS=linux make
+
+mkdir -p $PKG_PATH/bin
+mv $GOPATH/bin/rexray $PKG_PATH/bin

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,9 +1,9 @@
 {
-  "docker": "golang:1.6",
+  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/dcos/rexray.git",
-    "ref": "7a5c745d117156a57429bb48514576b684588235",
-    "ref_origin": "v0.3.3-dcos"
+    "git": "https://github.com/codedellemc/rexray.git",
+    "ref": "2a7458dd90a79c673463e14094377baf9fc8695e",
+    "ref_origin": "v0.9.0"
   }
 }

--- a/packages/rexray/extra/dcos-rexray.service
+++ b/packages/rexray/extra/dcos-rexray.service
@@ -8,4 +8,8 @@ RestartSec=15
 LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 Environment=REXRAY_HOME=/
+# REX-Ray fails to clean up stale lock files by itself.
+ExecStartPre=/bin/rm -f /var/run/libstorage/lsx.lock
+# Allow REX-Ray configuration to be changed during upgrade.
+ExecStartPre=/bin/cp /opt/mesosphere/etc/rexray.conf /etc/rexray/config.yml
 ExecStart=__PKG_PATH__/bin/rexray start -f


### PR DESCRIPTION
## High Level Description

Upgrades rex-ray to v0.9.0. Also upgrades `dvdcli` to `v0.2.0`.

This rebases https://github.com/dcos/dcos/pull/1196 against master.

## Related Issues

  - [DCOS-13137](https://jira.mesosphere.com/browse/DCOS-13137) RexRay (libstorage) on DC/OS to be upgraded to latest in order to support Ceph/NBD driver

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Various upgrade tests were performed by hand, including creating and moving a volume between agents running the old and new versions of REX-Ray. We also ran tasks in a loop for a day and found no unexpected behaviour.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): (https://github.com/codedellemc/rexray/compare/v0.3.3...codedellemc:v0.9.0?expand=1)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___




