### PR TITLE
Ignore task failures for viplisten in upgrade test

### DIFF
--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -192,10 +192,12 @@ class Marathon(ApiClientSession):
 
             data = r.json()
 
-            if not ignore_failed_tasks:
-                assert 'lastTaskFailure' not in data['app'], (
-                    'Application deployment failed, reason: {}'.format(data['app']['lastTaskFailure']['message'])
-                )
+            if 'lastTaskFailure' in data['app']:
+                message = data['app']['lastTaskFailure']['message']
+                if not ignore_failed_tasks:
+                    raise AssertionError('Application deployment failed, reason: {}'.format(message))
+                else:
+                    log.warn('Task failure detected: {}'.format(message))
 
             check_tasks_running = (data['app']['tasksRunning'] == app_definition['instances'])
             check_tasks_healthy = (not check_health or data['app']['tasksHealthy'] == app_definition['instances'])

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -307,7 +307,9 @@ class VpcClusterUpgradeTest:
 
             dcos_api.marathon.deploy_app(viplisten_app)
             dcos_api.marathon.ensure_deployments_complete()
-            dcos_api.marathon.deploy_app(viptalk_app)
+            # viptalk app depends on VIP from viplisten app, which may still fail
+            # the first try immediately after ensure_deployments_complete
+            dcos_api.marathon.deploy_app(viptalk_app, ignore_failed_tasks=True)
             dcos_api.marathon.ensure_deployments_complete()
 
             dcos_api.marathon.deploy_app(healthcheck_app)


### PR DESCRIPTION
## High Level Description

Although the necessary VIP should have been ensured to exist
by polling marathon deployments for the app to be healthy (which
requires the VIP to be established), the viptalk app still fails
due to inability to connect to the VIP. This is a relatively minor
error if the VIP eventually works within the app deployment timeout.
Networking latency relating to app deployment should not cause
upgrade tests to fail out.

## Related Issues
https://jira.mesosphere.com/browse/DCOS-14660


## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)