### PR TITLE
Add ConnectionError retrying Mixin

### DIFF
--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -22,6 +22,8 @@ from botocore.exceptions import ClientError, WaiterError
 Host = namedtuple('Host', ['private_ip', 'public_ip'])
 SshInfo = namedtuple('SshInfo', ['user', 'home_dir'])
 
+log = logging.getLogger(__name__)
+
 
 # Token valid until 2036 for user albert@bekstil.net
 #    {
@@ -106,7 +108,7 @@ class ApiClientSession:
         self.session = requests.Session()
 
     def api_request(self, method, path_extension, *, scheme=None, host=None, query=None,
-                    fragment=None, port=None, **kwargs):
+                    fragment=None, port=None, **kwargs) -> requests.Response:
         """ Direct wrapper for requests.session.request. This method is kept deliberatly
         simple so that child classes can alter this behavior without much copying
 
@@ -136,7 +138,7 @@ class ApiClientSession:
             fragment=fragment,
             port=port))
 
-        logging.info('Request method {}: {}'.format(method, request_url))
+        log.info('Request method {}: {}'.format(method, request_url))
         r = self.session.request(method, request_url, **kwargs)
         self.session.cookies.clear()
         return r
@@ -170,7 +172,11 @@ class ApiClientSession:
         return self.api_request('OPTIONS', *args, **kwargs)
 
 
-def is_retryable_exception(exception):
+def is_retryable_exception(exception: Exception) -> bool:
+    """ Helper method to catch HTTP errors that are likely safe to retry.
+    Args:
+        exception: exception raised from ApiClientSession.api_request instance
+    """
     for ex in [requests.exceptions.ConnectionError, requests.exceptions.Timeout]:
         if isinstance(exception, ex):
             return True
@@ -178,15 +184,27 @@ def is_retryable_exception(exception):
 
 
 class RetryCommonHttpErrorsMixin:
-    """ Mixin for ApiClientSession so that random disconnects from
-    network instability do not derail entire scripts
+    """ Mixin for ApiClientSession so that random disconnects from network
+    instability do not derail entire scripts. This functionality is configured
+    through the retry_timeout keyword
     """
-    def api_request(self, *args, retry_timeout=60, **kwargs):
+    def api_request(self, *args, retry_timeout: int=60, **kwargs) -> requests.Response:
+        """ Adds 'retry_timeout' keyword to API requests.
+        Args:
+            *args: args to be passed to super()'s api_request method
+            **kwargs: keyword args to be passed to super()'s api_request method
+            retry_timeout: total number of seconds to keep retrying after
+                the initial exception was raised
+        """
         @retrying.retry(
             stop_max_delay=retry_timeout * 1000,
             retry_on_exception=is_retryable_exception)
         def retry_errors():
-            return super(RetryCommonHttpErrorsMixin, self).api_request(*args, **kwargs)
+            try:
+                return super(RetryCommonHttpErrorsMixin, self).api_request(*args, **kwargs)
+            except:
+                log.exception('Retrying common HTTP error...')
+                raise
 
         return retry_errors()
 
@@ -212,8 +230,8 @@ def retry_boto_rate_limits(boto_fn, wait=2, timeout=60 * 60):
                 else:
                     raise
                 if error_code in ['Throttling', 'RequestLimitExceeded']:
-                    logging.warn('AWS API Limiting error: {}'.format(error_code))
-                    logging.warn('Sleeping for {} seconds before retrying'.format(local_wait))
+                    log.warn('AWS API Limiting error: {}'.format(error_code))
+                    log.warn('Sleeping for {} seconds before retrying'.format(local_wait))
                     time_to_next = next_time - time.time()
                     if time_to_next > 0:
                         time.sleep(time_to_next)
@@ -233,7 +251,7 @@ def wait_for_pong(url, timeout):
     """
     @retrying.retry(wait_fixed=3000, stop_max_delay=timeout * 1000)
     def ping_app():
-        logging.info('Attempting to ping test application')
+        log.info('Attempting to ping test application')
         r = requests.get('http://{}/ping'.format(url), timeout=10)
         r.raise_for_status()
         assert r.json() == {"pong": True}, 'Unexpected response from server: ' + repr(r.json())
@@ -280,7 +298,7 @@ def skip_test_if_dcos_journald_log_disabled(dcos_api_session):
     try:
         strategy = response['uiConfiguration']['plugins']['mesos']['logging-strategy']
     except Exception:
-        logging.error('Unable to find logging strategy')
+        log.error('Unable to find logging strategy')
         raise
     if not strategy.startswith('journald'):
         pytest.skip('Skipping a test since journald logging is disabled')

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import requests
 import retrying
 
-from test_util.helpers import ApiClientSession, path_join
+from test_util.helpers import ApiClientSession, path_join, RetryCommonHttpErrorsMixin
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
 REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}
@@ -102,7 +102,7 @@ def get_test_app_in_ucr(healthcheck='HTTP'):
     return app, test_uuid
 
 
-class Marathon(ApiClientSession):
+class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
     def __init__(self, default_url, default_os_user='root', session=None):
         super().__init__(default_url)
         if session is not None:


### PR DESCRIPTION
## High Level Description
Modifies the Marathon API client in test_util to ignore Connection and Timeout errors

## Related Issues
https://jira.mesosphere.com/browse/DCOS-14969

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: DEFLAKE WORK
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
