### PR TITLE
Only run rexray tests when config shows aws env

### DIFF
--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -9,7 +9,7 @@ import kazoo.client
 import pytest
 import requests
 
-from test_helpers import dcos_config
+from test_helpers import expanded_config
 
 from pkgpanda.util import load_json, load_string
 
@@ -115,8 +115,8 @@ def test_signal_service(dcos_api_session):
 
     # Generic properties which are the same between all tracks
     generic_properties = {
-        'platform': dcos_config['platform'],
-        'provider': dcos_config['provider'],
+        'platform': expanded_config['platform'],
+        'provider': expanded_config['provider'],
         'source': 'cluster',
         'clusterId': cluster_id,
         'customerKey': customer_key,

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -6,7 +6,7 @@ import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 
-from pkgpanda.util import load_json
+from test_helpers import expanded_config
 
 
 def test_if_dcos_ui_is_up(dcos_api_session):
@@ -167,9 +167,8 @@ def test_cosmos_package_add(dcos_api_session):
         }
     )
 
-    user_config = load_json("/opt/mesosphere/etc/expanded.config.json")
-    if (user_config['cosmos_staged_package_storage_uri_flag'] and
-            user_config['cosmos_package_storage_uri_flag']):
+    if (expanded_config['cosmos_staged_package_storage_uri_flag'] and
+            expanded_config['cosmos_package_storage_uri_flag']):
         # if the config is enabled then Cosmos should accept the request and
         # return 202
         assert r.status_code == 202, 'status = {}, content = {}'.format(

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -1,3 +1,3 @@
 from pkgpanda.util import load_json
 
-dcos_config = load_json('/opt/mesosphere/etc/expanded.config.json')
+expanded_config = load_json('/opt/mesosphere/etc/expanded.config.json')

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,5 +1,5 @@
 # Various tests that don't fit into the other categories and don't make their own really.
-import json
+from test_helpers import expanded_config
 
 from pkgpanda.util import load_yaml
 
@@ -16,10 +16,7 @@ def test_load_user_config():
     # platforms have different sets...
 
 
-def test_load_expanded_config():
-    with open("/opt/mesosphere/etc/expanded.config.json", "r") as f:
-        expanded_config = json.load(f)
-
+def test_expanded_config():
     # Caluclated parameters should be present
     assert 'master_quorum' in expanded_config
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -12,7 +12,8 @@ import pytest
 import requests
 import retrying
 
-from pkgpanda.build import load_json
+from test_helpers import expanded_config
+
 from test_util.marathon import get_test_app, get_test_app_in_docker, get_test_app_in_ucr
 
 
@@ -23,8 +24,7 @@ backend_port_st = 8000
 
 
 def lb_enabled():
-    config = load_json('/opt/mesosphere/etc/expanded.config.json')
-    return config['enable_lb'] == 'true'
+    return expanded_config['enable_lb'] == 'true'
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -4,8 +4,12 @@ import uuid
 
 import pytest
 
+from test_helpers import expanded_config
 
-@pytest.mark.ccm
+
+@pytest.mark.skipif(
+    not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),
+    reason='Must be run in an AWS environment!')
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 import retrying
 
-from test_helpers import dcos_config
+from test_helpers import expanded_config
 
 from test_util.marathon import get_test_app, get_test_app_in_docker, get_test_app_in_ucr
 
@@ -334,7 +334,7 @@ def test_if_search_is_working(dcos_api_session):
         expected_error = {'error': '[Errno -2] Name or service not known'}
 
         # Check that result matches expectations for this dcos_api_session
-        if dcos_config['dns_search']:
+        if expanded_config['dns_search']:
             assert r_data['search_hit_leader'] in dcos_api_session.masters
             assert r_data['always_hit_leader'] in dcos_api_session.masters
             assert r_data['always_miss'] == expected_error

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -96,7 +96,7 @@ export PUBLIC_SLAVE_HOSTS=192.168.65.60
 export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
 export DCOS_DEFAULT_OS_USER=root
 cd /opt/mesosphere/active/dcos-integration-test
-/opt/mesosphere/bin/dcos-shell py.test -vv -rs -m "not ccm" ${CI_FLAGS:-}
+/opt/mesosphere/bin/dcos-shell py.test -vv -rs ${CI_FLAGS:-}
 EOF
 chmod +x test_wrapper.sh
 echo "Running integration test"

--- a/test_util/test_azure.py
+++ b/test_util/test_azure.py
@@ -120,7 +120,7 @@ def check_environment():
         if k.startswith(prefix):
             add_env.append(k.replace(prefix, '') + '=' + v)
     options.test_cmd = os.getenv(
-        'DCOS_PYTEST_CMD', ' '.join(add_env) + " py.test -vv -s -rs -m 'not ccm' " + options.ci_flags)
+        'DCOS_PYTEST_CMD', ' '.join(add_env) + " py.test -vv -s -rs " + options.ci_flags)
     return options
 
 


### PR DESCRIPTION
## High Level Description
Right now, people need to declare `-m 'not ccm'` when running tests that are outside of AWS. This is wrong for two reasons:
- we shouldnt assume that we are in an AWS environment
- we shouldnt have anything with the label "ccm" as it does not really add any description other than it might be involved with CI

This PR also cleans up the expanded config helper by consolidating it across the codebase

## Related Issues

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)