### PR TITLE
Deflake pods test

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -85,6 +85,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
 
     test_uuid = uuid.uuid4().hex
 
+    # create pod with trivial apps that function as long running processes
     pod_definition = {
         'id': '/integration-test-pods-{}'.format(test_uuid),
         'scaling': {'kind': 'fixed', 'instances': 1},
@@ -94,7 +95,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
                 'name': 'ct1',
                 'resources': {'cpus': 0.1, 'mem': 32},
                 'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
-                'exec': {'command': {'shell': 'touch foo'}},
+                'exec': {'command': {'shell': 'touch foo; while true; do sleep 1; done'}},
                 'healthcheck': {'command': {'shell': 'test -f foo'}}
             },
             {

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -253,7 +253,7 @@ class Marathon(ApiClientSession):
         except retrying.RetryError:
             raise Exception("Deployments were not completed within {timeout} seconds".format(timeout=timeout))
 
-    def deploy_pod(self, pod_definition):
+    def deploy_pod(self, pod_definition, timeout=300):
         """Deploy a pod to marathon
 
         This function deploys an a pod and then waits for marathon to
@@ -264,13 +264,10 @@ class Marathon(ApiClientSession):
         Args:
             pod_definition: a dict with pod definition as specified in
                             Marathon API
-            check_health: wait until Marathon reports tasks as healthy before
-                          returning
+            timeout: seconds to wait for deployment to finish
         Returns:
-            Scaling instance count
+            Pod data JSON
         """
-        timeout = 120
-
         r = self.post('v2/pods', json=pod_definition)
         assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
         log.info('Response from marathon: {}'.format(repr(r.json())))
@@ -371,6 +368,6 @@ class Marathon(ApiClientSession):
         self.destroy_app(app_definition['id'], timeout)
 
     @contextmanager
-    def deploy_pod_and_cleanup(self, pod_definition, timeout=120):
-        yield self.deploy_pod(pod_definition)
+    def deploy_pod_and_cleanup(self, pod_definition, timeout=300):
+        yield self.deploy_pod(pod_definition, timeout=timeout)
         self.destroy_pod(pod_definition['id'], timeout)


### PR DESCRIPTION
## High Level Description

This test is failing due to simple timeouts on an extremely regular basis. The two minute deploy timeout for apps is not a hard limit, but rather an optimization used because few apps ever succeeded after 120 seconds of waiting. We currently have no such data for pods and as such should bump this timeout

## Related Issues
  https://jira.mesosphere.com/browse/DCOS_OSS-912
## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
