### PR TITLE
Bumped Mesos to include fixes for leakage of sensitive data - Mesos 1.0.4

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "3d4a8d7caec7cd0239dbc40e39c8ec4d965a9a67",
-    "ref_origin" : "dcos-mesos-1.0.3-rc1"
+    "ref": "40c19bd8d8beb02d212ee7e488611b77c71f856c",
+    "ref_origin" : "dcos-mesos-1.0.x-17ac024"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "40c19bd8d8beb02d212ee7e488611b77c71f856c",
+    "ref": "c7b7ca12e9a5d5a2bed92994f534868bda5c1bc9",
     "ref_origin" : "dcos-mesos-1.0.x-17ac024"
   },
   "environment": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c7b7ca12e9a5d5a2bed92994f534868bda5c1bc9",
+    "ref": "0fd32e4e537507f900a5c3ea0bf3051bea76b0d3",
     "ref_origin" : "dcos-mesos-1.0.x-17ac024"
   },
   "environment": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "0fd32e4e537507f900a5c3ea0bf3051bea76b0d3",
-    "ref_origin" : "dcos-mesos-1.0.x-17ac024"
+    "ref": "7f136d6a940f218234375771a3e5df2f8a237864",
+    "ref_origin" : "dcos-mesos-1.0.x-4154f66"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Generally fixes sensitive data leakage to task sandbox. 

Updates Mesos package to be based on Apache/Mesos 1.0.4 (WIP). 

## Related Issues

  - [DCOS-11709](https://jira.mesosphere.com/browse/DCOS-11709) Secrets printed directly to the logs.
   -  [MESOS-2537] - AC_ARG_ENABLED checks are broken
   -  [MESOS-6606] - Reject optimized builds with libcxx before 3.9
   -  [MESOS-7008] - Quota not recovered from registry in empty cluster.
   -  [MESOS-7265] - Containerizer startup may cause sensitive data to leak into sandbox logs.
   -  [MESOS-7366] - Agent sandbox gc could accidentally delete the entire persistent volume content.
   -  [MESOS-7383] - Docker executor logs possibly sensitive parameters.
   -  [MESOS-7422] - Docker containerizer should not leak possibly sensitive data to agent log.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-mesos-1.0.3-rc1...dcos-mesos-1.0.x-4154f66](https://github.com/mesosphere/mesos/compare/dcos-mesos-1.0.3-rc1...dcos-mesos-1.0.x-4154f66)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Mesos/job/mesos/job/Mesos_CI-build/722/
  - [ ] Code Coverage (if available): [link to code coverage report]