### PR TITLE
Testing if alpine image is applicable for our integration tests.

### DIFF
--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -57,8 +57,7 @@ def get_test_app_in_docker(ip_per_container=False):
     app['container'] = {
         'type': 'DOCKER',
         'docker': {
-            # TODO(cmaloney): Switch to alpine with glibc
-            'image': 'debian:jessie',
+            'image': 'alpine:3.5',
             'portMappings': [{
                 'hostPort': 0,
                 'containerPort': 9080,
@@ -88,7 +87,7 @@ def get_test_app_in_ucr(healthcheck='HTTP'):
     app['container'] = {
         'type': 'MESOS',
         'docker': {
-            'image': 'debian:jessie'
+            'image': 'alpine:3.5'
         },
         'volumes': [{
             'containerPath': '/opt/mesosphere',

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -57,7 +57,7 @@ def get_test_app_in_docker(ip_per_container=False):
     app['container'] = {
         'type': 'DOCKER',
         'docker': {
-            'image': 'debian:jessie',
+            'image': 'frolvlad/alpine-glibc:alpine-3.5_glibc-2.24',
             'portMappings': [{
                 'hostPort': 0,
                 'containerPort': 9080,
@@ -87,7 +87,7 @@ def get_test_app_in_ucr(healthcheck='HTTP'):
     app['container'] = {
         'type': 'MESOS',
         'docker': {
-            'image': 'debian:jessie'
+            'image': 'frolvlad/alpine-glibc:alpine-3.5_glibc-2.24'
         },
         'volumes': [{
             'containerPath': '/opt/mesosphere',

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -57,7 +57,7 @@ def get_test_app_in_docker(ip_per_container=False):
     app['container'] = {
         'type': 'DOCKER',
         'docker': {
-            'image': 'alpine:3.5',
+            'image': 'debian:jessie',
             'portMappings': [{
                 'hostPort': 0,
                 'containerPort': 9080,
@@ -87,7 +87,7 @@ def get_test_app_in_ucr(healthcheck='HTTP'):
     app['container'] = {
         'type': 'MESOS',
         'docker': {
-            'image': 'alpine:3.5'
+            'image': 'debian:jessie'
         },
         'volumes': [{
             'containerPath': '/opt/mesosphere',


### PR DESCRIPTION
## High Level Description

* Killing a `TODO` that states about using alpine image.
* alpine image is smaller and if that is sufficient, we can use this consistently (FWIW, test_upgrade_vpc uses alpine:3.5 image).

## Related Issues

  -  None: There is a TODO in the code.
