### PR TITLE
Added the DC/OS CNI plugins.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -391,7 +391,7 @@ package:
       MESOS_DOCKER_VOLUME_CHECKPOINT_DIR=/var/lib/mesos/isolators/docker/volume
       MESOS_IMAGE_PROVIDERS=docker
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
-      MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/
+      MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/
       MESOS_WORK_DIR=/var/lib/mesos/slave
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos

--- a/packages/dcos-cni/build
+++ b/packages/dcos-cni/build
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o nounset -o pipefail
+# Install glide
+apt-get update && \
+  apt-get install -y software-properties-common
+
+add-apt-repository ppa:masterminds/glide && \
+  apt-get update && \
+  apt-get install -y glide
+
+# Build and install DC/OS CNI plugins.
+pushd /pkg/src/dcos-cni/
+make
+popd
+
+cp /pkg/src/dcos-cni/bin/* $PKG_PATH

--- a/packages/dcos-cni/buildinfo.json
+++ b/packages/dcos-cni/buildinfo.json
@@ -1,0 +1,8 @@
+{
+    "single_source" : {
+      "kind": "git",
+      "git": "https://github.com/dcos/dcos-cni.git",
+      "ref" : "1c346d0f0a1206f688f7df92b24e683185a2562a",
+      "ref_origin": "master"
+    }
+}

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "952913f73bdc1a60791c3c32d4c2755c75f842d3",
+      "ref": "002c325bfcc9e0d806ac41af53ba4d6cae6b1d72",
       "ref_origin": "master"
     }
   },

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get -qq update && apt-get -y install \
   gettext-base \
   git \
   gzip \
-  libc6-dev \
   libapr1-dev \
   libc6-dev \
   libcurl4-openssl-dev \


### PR DESCRIPTION
## High Level Description

This PR adds DC/OS CNI plugins for minuteman and spartan. Currently minuteman and spartan cannot work with any CNI network that completely isolates container's traffic from the host network (except for agent/executor communication). The DC/OS CNI plugins plumb routes, interfaces and IPVS entries into the container's netns that allow the container to use spartan and minuteman for service discovery and load balancing respectively.

## Related Issues

  - [DCOS_OSS-854](https://jira.mesosphere.com/browse/DCOS_OSS-854) 


## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
We have unit tests in the `github.com/dcos/dcos-cni` repo. The unit-tests test the basic semantics of the `dcos-l4lb` CNI plugins. Writing integration tests for the plugins is a bit involved. It requires an installation of a CNI network that emulates the isolation semantics of CNI networks that segregate the host and container network namespaces. Since this is a bit involved, it requires a bit of introspection and so would like to have a separate PR dealing with the integration tests. Currently, have done manual tests to verify the end-to-end behavior apart form the unit-tests captured in the repo.
  - [*] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [*] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
Change log for navstar:
https://github.com/dcos/navstar/compare/952913f73bdc1a60791c3c32d4c2755c75f842d3...002c325bfcc9e0d806ac41af53ba4d6cae6b1d72
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos/1450)
<!-- Reviewable:end -->
