### PR TITLE
Pin azure common 1.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.0',
         'msrestazure==0.4.1',
+        'azure-common==1.1.4',
         'azure-storage==0.32.0',
         'azure-mgmt-network==0.30.0rc4',
         'azure-mgmt-resource==0.30.0rc4',


### PR DESCRIPTION
## High Level Description
Builds have been broken for a while because pip's default azure-common lib moved to 1.1.5. E.G.:
https://teamcity.mesosphere.io/viewLog.html?buildId=616254&tab=buildResultsDiv&buildTypeId=DcosIo_Dcos_Master

## Related Issues
All builds broken

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: the tests will run at all. That is an improvement
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)