### PR TITLE
Backporting the fix for DCOS_OSS-683 to 1.8

### DIFF
--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -22,7 +22,7 @@ ExecStartPre=/bin/ping -c1 marathon.mesos
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 # Wait for auth backend to seed the secret key
-ExecStartPre=/usr/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
+ExecStartPre=/opt/mesosphere/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
 ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT


### PR DESCRIPTION
## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.
In newer versions of CoreOS, libcurl shipped with DC/OS is incompatible(old) with system curl, leading to `curl: (48) An unknown option was passed in to libcurl` error. This has laready been fixed in 1.9 but 1.8.8 had already been released before the fix so backporting the fix to 1.8.9

## Related Issues

  - [DCOS_OSS-683](https://jira.dcos.io/browse/DCOS_OSS-683) Latest Stable version of CoreOS break dcos-adminrouter

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**
