### PR TITLE
Add dcos checks

### DIFF
--- a/packages/dcos-checks/build
+++ b/packages/dcos-checks/build
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e  # Fail the script if anything fails
+set -x  # Verbose output
+set -u  # Undefined variables
+
+mkdir -p /pkg/src/github.com/dcos
+mv /pkg/src/dcos-checks /pkg/src/github.com/dcos/
+cd /pkg/src/github.com/dcos/dcos-checks
+
+go install -v
+cp -r /pkg/bin/ "$PKG_PATH"

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -1,0 +1,11 @@
+{
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-checks.git",
+    "ref": "42dc43b013fe79c3dbca188e3cb7fcd3ff11d86e",
+    "ref_origin": "master"
+  },
+  "state_directory": true,
+  "username": "dcos_3dt",
+  "group": "systemd-journal"
+}

--- a/packages/dcos-integration-test/extra/test_dcos_checks.py
+++ b/packages/dcos-integration-test/extra/test_dcos_checks.py
@@ -1,0 +1,21 @@
+import uuid
+
+
+def test_dcos_checks_components_open(dcos_api_session):
+    # target contains a dcos-checks subcommand as a key and tuple of optional parameters as a value.
+    target = {
+        "components": ()
+    }
+
+    cmd_tpl = "/opt/mesosphere/bin/dcos-checks --role agent {} {}"
+    cmds = [cmd_tpl.format(subcommand, " ".join(arg for arg in args)) for subcommand, args in target.items()]
+    test_uuid = uuid.uuid4().hex
+    check_job = {
+        'id': 'test-dcos-checks-' + test_uuid,
+        'run': {
+            'cpus': .1,
+            'mem': 128,
+            'disk': 0,
+            'cmd': " && ".join(cmds)}}
+
+    dcos_api_session.metronome_one_off(check_job)


### PR DESCRIPTION
## High Level Description

[dcos-enterprise PR ](https://github.com/mesosphere/dcos-enterprise/pull/944)

Add a new pkgpanda package `dcos-checks`. The `dcos-checks` provides node and cluster checks implementation.

- [x] Add dcos-checks skeleton.
- [x] Add basic systemd units check.
- [x] Add integration test

## Related Issues

  - [DCOS-14989](https://jira.mesosphere.com/browse/DCOS-14989) Create `dcos-checks` package
## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:

  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A
  - [ ] Test Results: N/A
  - [ ] Code Coverage (if available): N/A
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
