### PR TITLE
Simplify parameter input in dcos-launch

### DIFF
--- a/packages/dcos-launch/extra/conftest.py
+++ b/packages/dcos-launch/extra/conftest.py
@@ -185,11 +185,12 @@ def check_success(capsys, tmpdir, config_path):
     # Test launcher directly first
     config = launch.config.get_validated_config(config_path)
     launcher = launch.get_launcher(config)
-    info = launcher.create(config)
-    launcher.wait(info)
-    launcher.describe(info)
-    launcher.test(info, 'py.test')
-    launcher.delete(info)
+    info = launcher.create()
+    launcher = launch.get_launcher(info)
+    launcher.wait()
+    launcher.describe()
+    launcher.test('py.test')
+    launcher.delete()
 
     info_path = str(tmpdir.join('my_specific_info.json'))  # test non-default name
 

--- a/packages/dcos-launch/extra/launch/__init__.py
+++ b/packages/dcos-launch/extra/launch/__init__.py
@@ -1,7 +1,5 @@
 import launch.aws
 import launch.azure
-import test_util.aws
-import test_util.azure
 
 
 def get_launcher(config):
@@ -9,10 +7,7 @@ def get_launcher(config):
     """
     platform = config['platform']
     if platform == 'aws':
-        return launch.aws.AwsCloudformationLauncher(test_util.aws.BotoWrapper(
-            config['aws_region'], config['aws_access_key_id'], config['aws_secret_access_key']))
+        return launch.aws.AwsCloudformationLauncher(config)
     if platform == 'azure':
-        return launch.azure.AzureResourceGroupLauncher(test_util.azure.AzureWrapper(
-            config['azure_location'], config['azure_subscription_id'], config['azure_client_id'],
-            config['azure_client_secret'], config['azure_tenant_id']))
+        return launch.azure.AzureResourceGroupLauncher(config)
     raise launch.util.LauncherError('UnsupportedAction', 'Launch platform not supported: {}'.format(platform))

--- a/packages/dcos-launch/extra/launch/aws.py
+++ b/packages/dcos-launch/extra/launch/aws.py
@@ -12,11 +12,13 @@ log = logging.getLogger(__name__)
 
 
 class AwsCloudformationLauncher(launch.util.AbstractLauncher):
-    def __init__(self, boto_wrapper: test_util.aws.BotoWrapper):
-        self.boto_wrapper = boto_wrapper
+    def __init__(self, config: dict):
+        self.boto_wrapper = test_util.aws.BotoWrapper(
+            config['aws_region'], config['aws_access_key_id'], config['aws_secret_access_key'])
+        self.config = config
         log.debug('Using AWS Cloudformation Launcher')
 
-    def create(self, config):
+    def create(self):
         """ Checks if the key helper or zen helper are enabled,
         provides resources according to those helpers, tracking which resources
         were created, and then attempts to deploy the template.
@@ -24,73 +26,71 @@ class AwsCloudformationLauncher(launch.util.AbstractLauncher):
         Note: both key helper and zen helper will mutate the config to inject
         the appropriate template parameters for the generated resources
         """
-        launch.util.check_keys(config, ['deployment_name', 'template_url'])
+        launch.util.check_keys(self.config, ['deployment_name', 'template_url'])
         temp_resources = {}
-        if config['key_helper'] == 'true':
-            temp_resources.update(self.key_helper(config))
-        if config['zen_helper'] == 'true':
-            temp_resources.update(self.zen_helper(config))
+        if self.config['key_helper'] == 'true':
+            temp_resources.update(self.key_helper())
+        if self.config['zen_helper'] == 'true':
+            temp_resources.update(self.zen_helper())
         try:
             stack = self.boto_wrapper.create_stack(
-                config['deployment_name'],
-                yaml.load(config['template_parameters']),
-                template_url=config['template_url'])
+                self.config['deployment_name'],
+                yaml.load(self.config['template_parameters']),
+                template_url=self.config['template_url'])
         except Exception as ex:
             self.delete_temp_resources(temp_resources)
             raise launch.util.LauncherError('ProviderError', None) from ex
-        info = copy.deepcopy(config)
+        info = copy.deepcopy(self.config)
         info.update({
             'stack_id': stack.stack_id,
             'temp_resources': temp_resources})
         return info
 
-    def zen_helper(self, config):
+    def zen_helper(self):
         """
         Checks parameters for Zen template prerequisites are met. If not met, they
         will be provided (must be done in correct order) and added to the info
         JSON as 'temp_resources'
         """
-        parameters = yaml.load(config['template_parameters'])
+        parameters = yaml.load(self.config['template_parameters'])
         temp_resources = {}
         if 'Vpc' not in parameters:
-            vpc_id = self.boto_wrapper.create_vpc_tagged('10.0.0.0/16', config['deployment_name'])
+            vpc_id = self.boto_wrapper.create_vpc_tagged('10.0.0.0/16', self.config['deployment_name'])
             parameters['Vpc'] = vpc_id
             temp_resources['vpc'] = vpc_id
         if 'InternetGateway' not in parameters:
-            gateway_id = self.boto_wrapper.create_internet_gateway_tagged(vpc_id, config['deployment_name'])
+            gateway_id = self.boto_wrapper.create_internet_gateway_tagged(vpc_id, self.config['deployment_name'])
             parameters['InternetGateway'] = gateway_id
             temp_resources.update({'gateway': gateway_id})
         if 'PrivateSubnet' not in parameters:
             private_subnet_id = self.boto_wrapper.create_subnet_tagged(
-                vpc_id, '10.0.0.0/17', config['deployment_name'] + 'private')
+                vpc_id, '10.0.0.0/17', self.config['deployment_name'] + 'private')
             parameters['PrivateSubnet'] = private_subnet_id
             temp_resources.update({'private_subnet': private_subnet_id})
         if 'PublicSubnet' not in parameters:
             public_subnet_id = self.boto_wrapper.create_subnet_tagged(
-                vpc_id, '10.0.128.0/20', config['deployment_name'] + '-public')
+                vpc_id, '10.0.128.0/20', self.config['deployment_name'] + '-public')
             parameters['PublicSubnet'] = public_subnet_id
             temp_resources.update({'public_subnet': public_subnet_id})
-        config['template_parameters'] = yaml.dump(parameters)
+        self.config['template_parameters'] = yaml.dump(parameters)
         return temp_resources
 
-    def wait(self, info):
-        self.get_stack(info).wait_for_complete()
+    def wait(self):
+        self.stack.wait_for_complete()
 
-    def describe(self, info):
-        cf = self.get_stack(info)
+    def describe(self):
         return {
-            'masters': launch.util.convert_host_list(cf.get_master_ips()),
-            'private_agents': launch.util.convert_host_list(cf.get_private_agent_ips()),
-            'public_agents': launch.util.convert_host_list(cf.get_public_agent_ips())}
+            'masters': launch.util.convert_host_list(self.stack.get_master_ips()),
+            'private_agents': launch.util.convert_host_list(self.stack.get_private_agent_ips()),
+            'public_agents': launch.util.convert_host_list(self.stack.get_public_agent_ips())}
 
-    def delete(self, info):
-        stack = self.get_stack(info)
-        stack.delete()
-        if len(info['temp_resources']) > 0:
+    def delete(self):
+        self.stack.delete()
+        if len(self.config['temp_resources']) > 0:
             # must wait for stack to be deleted before removing
             # network resources on which it depends
-            stack.wait_for_complete()
-            self.delete_temp_resources(info['temp_resources'])
+            self.stack.wait_for_complete()
+            self.delete_temp_resources(self.config['temp_resources'])
 
     def delete_temp_resources(self, temp_resources):
         if 'key_name' in temp_resources:
@@ -104,33 +104,34 @@ class AwsCloudformationLauncher(launch.util.AbstractLauncher):
         if 'vpc' in temp_resources:
             self.boto_wrapper.delete_vpc(temp_resources['vpc'])
 
-    def key_helper(self, config):
-        key_name = config['deployment_name']
+    def key_helper(self):
+        key_name = self.config['deployment_name']
         private_key = self.boto_wrapper.create_key_pair(key_name)
-        config.update({'ssh_private_key': private_key})
-        template_parameters = yaml.load(config['template_parameters'])
+        self.config.update({'ssh_private_key': private_key})
+        template_parameters = yaml.load(self.config['template_parameters'])
         template_parameters.update({'KeyName': key_name})
-        config['template_parameters'] = yaml.dump(template_parameters)
+        self.config['template_parameters'] = yaml.dump(template_parameters)
         return {'key_name': key_name}
 
-    def get_stack(self, info):
+    @property
+    def stack(self):
         try:
-            return test_util.aws.fetch_stack(info['stack_id'], self.boto_wrapper)
+            return test_util.aws.fetch_stack(self.config['stack_id'], self.boto_wrapper)
         except Exception as ex:
             raise launch.util.LauncherError('StackNotFound', None) from ex
 
-    def test(self, info, test_cmd):
-        launch.util.check_testable(info)
-        details = self.describe(info)
+    def test(self, test_cmd):
+        launch.util.check_testable(self.config)
+        details = self.describe()
         test_host = details['masters'][0]['public_ip']
-        with ssh.tunnel.tunnel(info['ssh_user'], info['ssh_private_key'], test_host) as test_tunnel:
+        with ssh.tunnel.tunnel(self.config['ssh_user'], self.config['ssh_private_key'], test_host) as test_tunnel:
             return test_util.runner.integration_test(
                 tunnel=test_tunnel,
                 dcos_dns=test_host,
                 master_list=[m['private_ip'] for m in details['masters']],
                 agent_list=[a['private_ip'] for a in details['private_agents']],
                 public_agent_list=[a['private_ip'] for a in details['public_agents']],
-                aws_access_key_id=info['aws_access_key_id'],
-                aws_secret_access_key=info['aws_secret_access_key'],
-                region=info['aws_region'],
+                aws_access_key_id=self.config['aws_access_key_id'],
+                aws_secret_access_key=self.config['aws_secret_access_key'],
+                region=self.config['aws_region'],
                 test_cmd=test_cmd)

--- a/packages/dcos-launch/extra/launch/azure.py
+++ b/packages/dcos-launch/extra/launch/azure.py
@@ -13,56 +13,62 @@ log = logging.getLogger(__name__)
 
 
 class AzureResourceGroupLauncher(launch.util.AbstractLauncher):
-    def __init__(self, azure_wrapper: test_util.azure.AzureWrapper):
-        self.azure_wrapper = azure_wrapper
+    def __init__(self, config: dict):
+        self.azure_wrapper = test_util.azure.AzureWrapper(
+            config['azure_location'], config['azure_subscription_id'], config['azure_client_id'],
+            config['azure_client_secret'], config['azure_tenant_id'])
+        self.config = config
         log.debug('Using Azure Resource Group Launcher')
 
-    def create(self, config):
-        launch.util.check_keys(config, ['deployment_name', 'template_url'])
-        if config['key_helper'] == 'true':
-            self.key_helper(config)
+    def create(self):
+        launch.util.check_keys(self.config, ['deployment_name', 'template_url'])
+        if self.config['key_helper'] == 'true':
+            self.key_helper()
         self.azure_wrapper.deploy_template_to_new_resource_group(
-            config['template_url'], config['deployment_name'], yaml.load(config['template_parameters']))
-        info = copy.deepcopy(config)
+            self.config['template_url'],
+            self.config['deployment_name'],
+            yaml.load(self.config['template_parameters']))
+        info = copy.deepcopy(self.config)
         return info
 
-    def wait(self, info):
-        self.get_resource_group(info).wait_for_deployment()
+    def wait(self):
+        self.resource_group.wait_for_deployment()
 
-    def describe(self, info):
-        rg = self.get_resource_group(info)
+    def describe(self):
         return {
-            'masters': launch.util.convert_host_list(rg.get_master_ips()),
-            'private_agents': launch.util.convert_host_list(rg.get_private_agent_ips()),
-            'public_agents': launch.util.convert_host_list(rg.get_public_agent_ips()),
-            'master_fqdn': rg.public_master_lb_fqdn,
-            'public_agent_fqdn': rg.public_agent_lb_fqdn}
+            'masters': launch.util.convert_host_list(self.resource_group.get_master_ips()),
+            'private_agents': launch.util.convert_host_list(self.resource_group.get_private_agent_ips()),
+            'public_agents': launch.util.convert_host_list(self.resource_group.get_public_agent_ips()),
+            'master_fqdn': self.resource_group.public_master_lb_fqdn,
+            'public_agent_fqdn': self.resource_group.public_agent_lb_fqdn}
 
-    def delete(self, info):
-        self.get_resource_group(info).delete()
+    def delete(self):
+        self.resource_group.delete()
 
-    def key_helper(self, config):
+    def key_helper(self):
         """ Adds private key to the config and injects the public key into
         the template parameters
         """
         private_key, public_key = launch.util.generate_rsa_keypair()
-        config.update({'ssh_private_key': private_key.decode()})
-        template_parameters = yaml.load(config['template_parameters'])
+        self.config.update({'ssh_private_key': private_key.decode()})
+        template_parameters = yaml.load(self.config['template_parameters'])
         template_parameters.update({'sshRSAPublicKey': public_key.decode()})
-        config['template_parameters'] = yaml.dump(template_parameters)
+        self.config['template_parameters'] = yaml.dump(template_parameters)
 
-    def get_resource_group(self, info):
+    @property
+    def resource_group(self):
         try:
-            return test_util.azure.DcosAzureResourceGroup(info['deployment_name'], self.azure_wrapper)
+            return test_util.azure.DcosAzureResourceGroup(self.config['deployment_name'], self.azure_wrapper)
         except Exception as ex:
             raise launch.util.LauncherError('GroupNotFound', None) from ex
 
-    def test(self, info, test_cmd):
-        launch.util.check_testable(info)
-        details = self.describe(info)
+    def test(self, test_cmd):
+        launch.util.check_testable(self.config)
+        details = self.describe()
         test_host = details['master_fqdn']
         master_private_ips = [m['private_ip'] for m in details['masters']]
-        with ssh.tunnel.tunnel(info['ssh_user'], info['ssh_private_key'], test_host, port=2200) as test_tunnel:
+        with ssh.tunnel.tunnel(
+                self.config['ssh_user'], self.config['ssh_private_key'], test_host, port=2200) as test_tunnel:
             return test_util.runner.integration_test(
                 tunnel=test_tunnel,
                 # DCOS-14627 [azure] route port 80 and 443 to master via master public LB if oauth enbaled

--- a/packages/dcos-launch/extra/launch/cli.py
+++ b/packages/dcos-launch/extra/launch/cli.py
@@ -75,7 +75,7 @@ def do_main(args):
         info_path = args['--info-path']
         if os.path.exists(info_path):
             raise launch.util.LauncherError('InputConflict', 'Target info path already exists!')
-        write_json(info_path, launch.get_launcher(config).create(config))
+        write_json(info_path, launch.get_launcher(config).create())
         return 0
 
     try:
@@ -86,12 +86,12 @@ def do_main(args):
     launcher = launch.get_launcher(info)
 
     if args['wait']:
-        launcher.wait(info)
+        launcher.wait()
         print('Cluster is ready!')
         return 0
 
     if args['describe']:
-        print(json_prettyprint(launcher.describe(info)))
+        print(json_prettyprint(launcher.describe()))
         return 0
 
     if args['pytest']:
@@ -107,11 +107,11 @@ def do_main(args):
             test_cmd = ' '.join(['{}={}'.format(e, os.environ[e]) for e in var_list]) + ' ' + test_cmd
         if len(args['<pytest_extras>']) > 0:
             test_cmd += ' ' + ' '.join(args['<pytest_extras>'])
-        launcher.test(info, test_cmd)
+        launcher.test(test_cmd)
         return 0
 
     if args['delete']:
-        launcher.delete(info)
+        launcher.delete()
         return 0
 
 

--- a/packages/dcos-launch/extra/test_aws.py
+++ b/packages/dcos-launch/extra/test_aws.py
@@ -40,7 +40,6 @@ def test_missing_aws_stack(aws_cf_config_path, monkeypatch):
     """
     monkeypatch.setattr(test_util.aws, 'fetch_stack', mock_stack_not_found)
     config = launch.config.get_validated_config(aws_cf_config_path)
-    assert 'platform' in config, str(config.items())
     aws_launcher = launch.get_launcher(config)
 
     def check_stack_error(cmd, args):
@@ -48,17 +47,18 @@ def test_missing_aws_stack(aws_cf_config_path, monkeypatch):
             getattr(aws_launcher, cmd)(*args)
         assert exinfo.value.error == 'StackNotFound'
 
-    info = aws_launcher.create(config)
-    check_stack_error('wait', (info,))
-    check_stack_error('describe', (info,))
-    check_stack_error('delete', (info,))
-    check_stack_error('test', (info, 'py.test'))
+    info = aws_launcher.create()
+    aws_launcher = launch.get_launcher(info)
+    check_stack_error('wait', ())
+    check_stack_error('describe', ())
+    check_stack_error('delete', ())
+    check_stack_error('test', ('py.test',))
 
 
 def test_key_helper(aws_cf_config_path):
     config = launch.config.get_validated_config(aws_cf_config_path)
     aws_launcher = launch.get_launcher(config)
-    temp_resources = aws_launcher.key_helper(config)
+    temp_resources = aws_launcher.key_helper()
     assert temp_resources['key_name'] == config['deployment_name']
     assert yaml.load(config['template_parameters'])['KeyName'] == config['deployment_name']
     assert config['ssh_private_key'] == launch.util.MOCK_SSH_KEY_DATA
@@ -67,7 +67,7 @@ def test_key_helper(aws_cf_config_path):
 def test_zen_helper(aws_zen_cf_config_path):
     config = launch.config.get_validated_config(aws_zen_cf_config_path)
     aws_launcher = launch.get_launcher(config)
-    temp_resources = aws_launcher.zen_helper(config)
+    temp_resources = aws_launcher.zen_helper()
     assert temp_resources['vpc'] == launch.util.MOCK_VPC_ID
     assert temp_resources['gateway'] == launch.util.MOCK_GATEWAY_ID
     assert temp_resources['private_subnet'] == launch.util.MOCK_SUBNET_ID


### PR DESCRIPTION
## High Level Description
When dcos-launch was first implemented there was some difference in the internal data structures 'config' and 'info' and as such, only the create function took the config, which created the info, and all other functions took the info. However, the info has simply become a superset of the config, so these remain identical. Additionally, all of these values can just be set at instantiation for simplification and to avoid needless argument passing, e.g. `get_launcher(info).wait(info)`

## Related Issues

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
marginal refactor
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)