### PR TITLE
Use the new marathon packaging (testing with a snapshot build)

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -847,7 +847,7 @@ package:
       LIBPROCESS_PORT=15101
 {% switch dcos_overlay_enable %}
 {% case "true" %}
-      MARATHON_CMD_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
+      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
 {% case "false" %}
 {% endswitch %}
   - path: /etc/proxy.env

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -7,7 +7,7 @@ mkdir -p "$PKG_PATH/lib"
 
 cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/bin/marathon"
 chmod +x "$PKG_PATH/bin/marathon"
-cp -rp /pkg/src/marathon/lib/*.jar "$PKG_PATH/lib"
+cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/lib"
 
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -44,7 +44,6 @@ ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)"
 ExecStart=$PKG_PATH/marathon/bin/marathon \\
     --zk "\$MARATHON_ZK" \\
     --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
-    --hostname "\$MARATHON_HOSTNAME" \\
     --default_accepted_resource_roles "*" \\
     --mesos_role "slave_public" \\
     --max_tasks_per_offer 100 \\

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-mkdir -p "$PKG_PATH/usr/"
+source /opt/mesosphere/environment.export
 
-cp -rp /pkg/src/marathon/target/scala-2.11/marathon-assembly-*.jar "$PKG_PATH/usr/marathon.jar"
+mkdir -p "$PKG_PATH/bin"
+mkdir -p "$PKG_PATH/lib"
 
-chmod -R o+r "$PKG_PATH/usr"
+cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/bin/marathon"
+chmod +x "$PKG_PATH/bin/marathon"
+cp -rp /pkg/src/marathon/lib/*.jar "$PKG_PATH/lib"
 
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")
@@ -24,14 +27,13 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStart=/opt/mesosphere/bin/java \\
-    -Xmx2G \\
-    -jar "$PKG_PATH/usr/marathon.jar" \\
+ExecStart=/opt/mesosphere/bin/marathon \\
     --zk "\$MARATHON_ZK" \\
     --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
     --hostname "\$MARATHON_HOSTNAME" \\

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -2,12 +2,12 @@
 
 source /opt/mesosphere/environment.export
 
-mkdir -p "$PKG_PATH/bin"
-mkdir -p "$PKG_PATH/lib"
+mkdir -p "$PKG_PATH/marathon/bin"
+mkdir -p "$PKG_PATH/marathon/lib"
 
-cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/bin/marathon"
-chmod +x "$PKG_PATH/bin/marathon"
-cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/lib"
+cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/marathon/bin/marathon"
+chmod +x "$PKG_PATH/marathon/bin/marathon"
+cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/marathon/lib"
 
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")
@@ -33,7 +33,7 @@ ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStart=/opt/mesosphere/bin/marathon \\
+ExecStart=$PKG_PATH/marathon/bin/marathon \\
     --zk "\$MARATHON_ZK" \\
     --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
     --hostname "\$MARATHON_HOSTNAME" \\

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Marathon and Metronome use the same jars, and pkgpanda doens't allow two packages
+# to have files at the same path, so essentially make marathon package-private.
+# Nothing will end up in /opt/mesosphere/{bin, lib}
+# This is not ideal but its one of the few solutions.
+# the lib directory is _supposed_ to be in the parent of $(realpath bin/marathon)
+# and its unclear how to change that without creating a very custom zipfile
+# that is different.
+
 source /opt/mesosphere/environment.export
 
 mkdir -p "$PKG_PATH/marathon/bin"

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.2/marathon-1.4.2.tgz",
-    "sha1": "df92349fd3c4d2977ce62b40e68bbc1c01e05de3"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/jobs/marathon-pipelines/master/377/marathon-1.5.0-SNAPSHOT-456-gaa3972d.zip",
+    "sha1": "e4c370bc9b1246d20faef1dbda8c9b14bfbece19"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/jobs/marathon-pipelines/master/377/marathon-1.5.0-SNAPSHOT-456-gaa3972d.zip",
+    "url": "https://downloads.mesosphere.io/marathon/snapshots/jobs/marathon-pipelines/master/377/marathon-1.5.0-SNAPSHOT-456-gaa3972d.zip",
     "sha1": "e4c370bc9b1246d20faef1dbda8c9b14bfbece19"
   },
   "username": "dcos_marathon",

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 pushd "/pkg/src/metronome"
 rm -rf bin/metronome.bat README.md RUNNING_PID share/ logs/
-cp -a * "$PKG_PATH/"
+cp -an * "$PKG_PATH/"
 cp -f /pkg/extra/logback.xml "$PKG_PATH/conf/"
 
 metronome_service="$PKG_PATH/dcos.target.wants_master/dcos-metronome.service"


### PR DESCRIPTION
## High Level Description

Adapt to the new Marathon bundle which has a better way to launch and supports snapshot builds.

Don't actually merge this right now, we need an actual snapshot first.

## Related Issues

  - [DCOS_OSS-950](https://jira.mesosphere.com/browse/DCOS_OSS-950) Update DCOS packaging for marathon to use new format

## Checklist for all PR's

  - [N/A] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: If this doesn't work, DCOS won't either.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): Do not merge me. This is for when we actually have a new package ready.
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/phabricator-package-test-d696/56/
  - [x] Code Coverage (if available): N/A.
