### PR TITLE
Increase 3dt test latency to two minutes

### DIFF
--- a/packages/dcos-integration-test/extra/test_3dt.py
+++ b/packages/dcos-integration-test/extra/test_3dt.py
@@ -10,8 +10,9 @@ import pytest
 
 import retrying
 
-# Expected latency for all 3dt units to refresh after postflight
-LATENCY = 60
+# Expected latency for all 3dt units to refresh after postflight plus
+# another minute to allow for check-time to settle. See: DCOS_OSS-988
+LATENCY = 120
 
 
 def check_json(response):


### PR DESCRIPTION
## High Level Description
Azure tests have failed because check-time seems to reach consistency a little slower on the default azure OS image (ubuntu). Specifically, I have seen this test fail and then checked logs to see that check-time started working only seconds later

## Related Issues

https://jira.mesosphere.com/browse/DCOS-15228
https://jira.mesosphere.com/browse/DCOS_OSS-987
https://jira.mesosphere.com/browse/DCOS_OSS-988

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is deflaking a test
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)