### PR TITLE
Increase AWS polling interval

### DIFF
--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -16,7 +16,6 @@ PublicAgentStack: thin wrapper for public agent stack in a zen template
 BareClusterCfStack: Represents a homogeneous cluster of hosts with a specific AMI
 """
 import logging
-import time
 
 import boto3
 import pkg_resources
@@ -165,7 +164,7 @@ class CfStack:
         self.boto_wrapper = boto_wrapper
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(stack_name)
 
-    def wait_for_status_change(self, state_1, state_2, wait_before_poll_min, timeout=60 * 60):
+    def wait_for_status_change(self, state_1, state_2):
         """
         Note: Do not use unwrapped boto waiter class, it has very poor error handling
 
@@ -182,11 +181,8 @@ class CfStack:
         UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
         """
         log.info('Waiting for status to change from {} to {}'.format(state_1, state_2))
-        log.info('Sleeping for {} minutes before polling'.format(wait_before_poll_min))
-        time.sleep(60 * wait_before_poll_min)
 
-        @retrying.retry(wait_fixed=10 * 1000,
-                        stop_max_delay=timeout * 1000,
+        @retrying.retry(wait_fixed=60 * 1000,
                         retry_on_result=lambda res: res is False,
                         retry_on_exception=lambda ex: False)
         def wait_loop():
@@ -203,14 +199,13 @@ class CfStack:
             return False
         wait_loop()
 
-    def wait_for_complete(self, wait_before_poll_min=0):
+    def wait_for_complete(self):
         status = self.get_stack_details()['StackStatus']
         if status.endswith('_COMPLETE'):
             return
         elif status.endswith('_IN_PROGRESS'):
             self.wait_for_status_change(
-                status, status.replace('IN_PROGRESS', 'COMPLETE'),
-                wait_before_poll_min)
+                status, status.replace('IN_PROGRESS', 'COMPLETE'))
         else:
             raise Exception('AWS Stack has entered unexpected state: {}'.format(status))
 

--- a/test_util/test_aws_cf.py
+++ b/test_util/test_aws_cf.py
@@ -27,6 +27,7 @@ TEST_ADD_ENV_*: string (default=None)
 import logging
 import os
 import sys
+import time
 
 import test_util.aws
 import test_util.cluster
@@ -114,7 +115,8 @@ def main():
             admin_location='0.0.0.0/0',
             key_pair_name=stack_name,
             boto_wrapper=bw)
-    cf.wait_for_complete(wait_before_poll_min=5)
+    time.sleep(300)  # we know the cluster is not ready yet, don't poll to avoid hitting the rate limit
+    cf.wait_for_complete()
     # Resiliency testing requires knowing the stack name
     options.test_cmd = 'AWS_STACK_NAME=' + stack_name + ' ' + options.test_cmd
 

--- a/test_util/test_aws_vpc.py
+++ b/test_util/test_aws_vpc.py
@@ -63,6 +63,7 @@ TEST_ADD_ENV_*: string (default=None)
 import logging
 import os
 import sys
+import time
 
 import test_util.aws
 import test_util.cluster
@@ -184,6 +185,7 @@ def main():
             admin_location='0.0.0.0/0',
             key_pair_name=unique_cluster_id,
             boto_wrapper=bw)
+    time.sleep(300)  # we know the cluster is not ready yet, don't poll to avoid hitting the rate limit
     vpc.wait_for_complete()
 
     cluster = test_util.cluster.Cluster.from_bare_cluster(

--- a/test_util/test_upgrade_vpc.py
+++ b/test_util/test_upgrade_vpc.py
@@ -41,6 +41,7 @@ import os
 import pprint
 import random
 import sys
+import time
 import traceback
 import uuid
 from subprocess import CalledProcessError
@@ -516,6 +517,7 @@ class VpcClusterUpgradeTest:
                 key_pair_name=stack_name,
                 boto_wrapper=bw
             )
+            time.sleep(300)  # we know the cluster is not ready yet, don't poll to avoid hitting the rate limit
             bare_cluster.wait_for_complete()
 
         cluster = test_util.cluster.Cluster.from_bare_cluster(


### PR DESCRIPTION
## High Level Description

Rate limit has been cropping up in CI so this polling
limit can be reduced to increase stability with very minimal
impact. Also decouples fixed waiting code from polling code

## Related Issues
https://jira.mesosphere.com/browse/DCOS_OSS-933
https://jira.mesosphere.com/browse/DCOS_OSS-945

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
