### PR TITLE
Reduce dcos-integration-test logging

### DIFF
--- a/test_util/helpers.py
+++ b/test_util/helpers.py
@@ -138,7 +138,7 @@ class ApiClientSession:
             fragment=fragment,
             port=port))
 
-        log.info('Request method {}: {}'.format(method, request_url))
+        log.debug('Request method {}: {}. Arguments: {}'.format(method, request_url, repr(kwargs)))
         r = self.session.request(method, request_url, **kwargs)
         self.session.cookies.clear()
         return r


### PR DESCRIPTION
## High Level Description
Our testing logs are becoming so large that it takes considerable amount of time to download the logs into the browser, not to mention how cumbersome they become to scroll through. Most of this information is overly verbose and should be accessed on demand by changing the logging level.

This PR does the following:
- Reduce a few loggers from info to debug to reduce clutter
- Increase polling interval to cut down on repeated, uninformative information

## Related Issues

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)