### PR TITLE
bump 3dt sha

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "18ba85fc27867113e292c5a5ba6598cf8b750bf9",
+    "ref": "206ba11a3ec02d02f95bab6aa3cec39cd7395bb3",
     "ref_origin": "master"
   },
   "username": "dcos_3dt",


### PR DESCRIPTION
## High Level Description

Journald uses structured log format. When 3dt tries to read logs from journald for a specific systemd unit, it will only include logs which have `UNIT` field set to a given systemd unit name. We also want logs that have another field `_SYSTEMD_UNIT` set to a gived systemd unit name.

This change makes 3dt to read log entries that have either UNIT or _SYSTEMD_UNIT field set to the required unit name.

## Related Issues

  - [DCOS_OSS-987](https://jira.mesosphere.com/browse/DCOS_OSS-987)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
the test is added to `dcos-log` since 3dt reuses the code.
- [dcos-log](https://github.com/dcos/dcos-log/pull/39)
- [jenkins#113](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-log-pulls/113/)
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-3dt](https://github.com/dcos/3dt/compare/18ba85fc27867113e292c5a5ba6598cf8b750bf9...206ba11a3ec02d02f95bab6aa3cec39cd7395bb3)
  - [X] Test Results: [jenkins#332](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-3dt-pulls/332/console)
  - [X] Code Coverage (if available): [jenkins#332](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-3dt-pulls/332/console)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
