### PR TITLE
Allow extra nodes to be reported in test harness

### DIFF
--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -208,7 +208,8 @@ class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
         if ro.status_code <= 500:
             logging.info("DC/OS History is probably getting data")
             json = ro.json()
-            assert len(json["slaves"]) == len(self.all_slaves)
+            # if an agent was removed, it may linger in the history data
+            assert len(json["slaves"]) >= len(self.all_slaves)
             return True
         else:
             msg = "Waiting for DC/OS History, resp code is: {}"


### PR DESCRIPTION
## High Level Description
Changes the test harness to not fail if more agents than expected appear in the history service agent
list. This is expected to happen if a agent is replaced as in the case of the aws resiliency test

## Related Issues
https://jira.mesosphere.com/browse/QUALITY-1424

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
