### PR TITLE
Add ConnectionError Retrying Mixin to test harness

### DIFF
--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -15,7 +15,7 @@ import requests
 import retrying
 
 import test_util.marathon
-from test_util.helpers import ApiClientSession, Url
+from test_util.helpers import ApiClientSession, RetryCommonHttpErrorsMixin, Url
 
 
 def get_args_from_env():
@@ -88,7 +88,7 @@ class ARNodeApiClientMixin:
                                    query=query, fragment=fragment, port=port, **kwargs)
 
 
-class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
+class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSession):
     def __init__(self, dcos_url: str, masters: list, public_masters: list,
                  slaves: list, public_slaves: list, default_os_user: str,
                  auth_user: Optional[DcosUser]):


### PR DESCRIPTION
## High Level Description
Sporadic RemoteDisconnected / ConnectionError test failures do not illuminate any wider issues not happen at a high enough frequency to warrant dedicated investigation. This change will add a retrying mixin for this specific failure case to the DcosApiSession object used in the integration tests. This is the same treatment applied to marathon polling to reduce test flakiness

## Related Issues
https://jira.mesosphere.com/browse/QUALITY-1426

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
