### PR TITLE
Change KeyPair->KeyName for consistency

### DIFF
--- a/test_util/aws.py
+++ b/test_util/aws.py
@@ -446,7 +446,7 @@ class BareClusterCfStack(CfStack):
                         admin_location, key_pair_name, boto_wrapper):
         template = template_by_instance_type(instance_type)
         parameters = {
-            'KeyPair': key_pair_name,
+            'KeyName': key_pair_name,
             'AllowAccessFrom': admin_location,
             'ClusterSize': instance_count,
             'InstanceType': instance_type,

--- a/test_util/templates/vpc-cluster-template.json
+++ b/test_util/templates/vpc-cluster-template.json
@@ -31,7 +31,7 @@
       "Default": "0.0.0.0/0",
       "Type": "String"
     },
-    "KeyPair": {
+    "KeyName": {
       "Description": "The name of an EC2 Key Pair to allow SSH access to the instance.",
       "Type": "String"
     }
@@ -239,7 +239,7 @@
           "Ref": "InstanceType"
         },
         "KeyName": {
-          "Ref": "KeyPair"
+          "Ref": "KeyName"
         },
         "SecurityGroups": [
           {

--- a/test_util/templates/vpc-ebs-only-cluster-template.json
+++ b/test_util/templates/vpc-ebs-only-cluster-template.json
@@ -42,7 +42,7 @@
       "Default": "0.0.0.0/0",
       "Type": "String"
     },
-    "KeyPair": {
+    "KeyName": {
       "Description": "The name of an EC2 Key Pair to allow SSH access to the instance.",
       "Type": "String"
     }
@@ -250,7 +250,7 @@
           "Ref": "InstanceType"
         },
         "KeyName": {
-          "Ref": "KeyPair"
+          "Ref": "KeyName"
         },
         "SecurityGroups": [
           {


### PR DESCRIPTION
## High Level Description
- All of the other templates use the term KeyName
- KeyName is AWS native and more intuitive
- dcos-launch has a utility that injects KeyName into template parameters after generating a key, so this change will enable seamless integration

## Related Issues
https://jira.mesosphere.com/browse/DCOS-13299
 
## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)