### PR TITLE
Admin Router: store AR build logs

### DIFF
--- a/Jenkinsfile-insecure.groovy
+++ b/Jenkinsfile-insecure.groovy
@@ -13,6 +13,10 @@ dir("packages/adminrouter/extra/src") {
         }
 
     } finally {
+        stage('archive build logs') {
+             archiveArtifacts artifacts: 'test-harness/logs/*.log', allowEmptyArchive: true, excludes: 'test_harness/', fingerprint: true
+        }
+
         stage('Cleanup docker container'){
             sh 'make clean-containers'
             sh "docker rmi -f adminrouter-devkit || true"


### PR DESCRIPTION
## High Level Description

This PR:
*  enables storing Admin Router test logs in Jenkins

## Related Issues

  - [DCOS_OSS-998](https://jira.mesosphere.com/browse/DCOS_OSS-998) SecCI: make AR build logs available as build artifacts


## Dependencies:

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/819