### PR TITLE
Backport "Removing username from operating environment"

### DIFF
--- a/packages/dcos-integration-test/extra/python_test_server.py
+++ b/packages/dcos-integration-test/extra/python_test_server.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import getpass
 import json
 import logging
 import os
@@ -244,7 +243,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
     def _handle_operating_environment(self):
         """Gets basic operating environment info (such as running user)"""
         self._send_reply({
-            'username': getpass.getuser()
+            'uid': os.getuid()
         })
 
     def do_GET(self):  # noqa: ignore=N802

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.0',
         'msrestazure==0.4.1',
+        'azure-common==1.1.4',
         'azure-storage==0.32.0',
         'azure-mgmt-network==0.30.0rc4',
         'azure-mgmt-resource==0.30.0rc4',


### PR DESCRIPTION
## High Level Description

This backports the test fix from https://github.com/dcos/dcos/pull/1162 to 1.8.9.

## Related Issues

- Original issue: [DCOS-10327](https://jira.mesosphere.com/browse/DCOS-10327)
- PR that hit the error in 1.8.9: https://github.com/mesosphere/dcos-enterprise/pull/807

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is a test fix
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
