### PR TITLE
[DCOS_OSS-1003] Admin Router auth module: require a literal 'false' for disabling the module

### DIFF
--- a/packages/adminrouter/extra/src/common/auth/open.lua
+++ b/packages/adminrouter/extra/src/common/auth/open.lua
@@ -61,15 +61,15 @@ local _M = {}
 function _M.init(use_auth)
     local res = {}
 
-    if use_auth ~= "true" then
+    if use_auth == "false" then
         ngx.log(
             ngx.NOTICE,
-            "ADMINROUTER_ACTIVATE_AUTH_MODULE not `true`. " ..
-            "Using dummy module."
+            "ADMINROUTER_ACTIVATE_AUTH_MODULE set to `false`. " ..
+            "Deactivate authentication module."
             )
         res.do_authn_and_authz_or_exit = function() return end
     else
-        ngx.log(ngx.NOTICE, "Use auth module.");
+        ngx.log(ngx.NOTICE, "Activate authentication module.");
         res.do_authn_and_authz_or_exit = do_authn_and_authz_or_exit
     end
 


### PR DESCRIPTION
## High Level Description

The DC/OS `oauth_enabled` configuration parameter value determines whether Admin Router's authentication module is activated or not. This patch ensures that the auth module is deactivated only if a literal `'false'` (YAML string type) is provided and that it is enabled in _all_ other cases.

As of now, the auth module is enabled only if a literal `'true'` (YAML string type) is provided and it is disabled in all other cases. This implies an unnecessarily large risk for unintentionally deactivating the authentication module and therefore is a security risk.

Kudos to @lordnynex for the report via Slack and via [DCOS_OSS-1003](https://jira.mesosphere.com/browse/DCOS_OSS-1003).

## Related Issues

  - [DCOS_OSS-1003](https://jira.mesosphere.com/browse/DCOS_OSS-1003) `oauth_enabled` cfg param: only the literal 'false' should disable AR's auth module

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is quite a bit of work, tracked via [DCOS_OSS-1005](https://jira.mesosphere.com/browse/DCOS_OSS-1005)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)