### PR TITLE
openssl: add no-rc4 no-ssl2(3) enable-ec_nistp_64_gcc_128 build opts

### DIFF
--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -9,8 +9,12 @@ pushd "/pkg/src/openssl"
   --openssldir="$PKG_PATH/etc/ssl" \
   shared \
   zlib \
-  no-krb5 \
   linux-x86_64 \
+  no-krb5 \
+  no-rc4 \
+  no-ssl2 \
+  no-ssl3 \
+  enable-ec_nistp_64_gcc_128 \
   -Wa,--noexecstack \
   -O2 -DFORTIFY_SOURCE=2
 


### PR DESCRIPTION
## High Level Description

Disable support for the insecure RC4 stream cipher (cf. RFC [7465](https://tools.ietf.org/html/rfc7465)). Assume AMD64 architecture and enable the usage of machine code optimized for certain curves.

For more background information see https://jira.mesosphere.com/browse/DCOS_OSS-1010 and https://jira.mesosphere.com/browse/DCOS_OSS-1009.

## Related Issues

  - [DCOS_OSS-1010](https://jira.mesosphere.com/browse/DCOS_OSS-1010) OpenSSL: build with no-rc4 option (also set no-ssl2 and no-ssl3)
  - [DCOS_OSS-1009](https://jira.mesosphere.com/browse/DCOS_OSS-1009) OpenSSL: build with enable-ec_nistp_64_gcc_128 option

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: the patch is not expected to affect DC/OS. Downstream integration tests will be added.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]