### PR TITLE
Bump dcos-ui to latest

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "89b9fbd36582d107e67bea114151c4c5504b93a3",
-    "ref_origin": "release/1.9"
+    "ref": "45aca9660add3eaab34e855ddde4d6a8028aaea2",
+    "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description

 - Can't delete CMD in UI or JSON editor
 - Correct pod definition gives error
 - Environment vars for Pods are broken
 - Volumes size should say GiB not MiB
 - Declined offers showing NaN for resource offer received
 - Environment variable set to "null" if populating only the value
 - Rename Remove/Destroy anywhere in the UI to “Delete”
 - Zeppelin package is gone from Universe in UI
 - Incorrect Resource Reporting
 - Support host volume for Pods in DC/OS UI.
 - Labels (certified, community) to the Universe View
 - Declined offers debug information doesn't show until 5minutes
 - Write integration tests for the Sidebar
 - Provide names for service paths
 - Automate "Create an app with HTTP health check (via UI)" Test
 - Automate "Create a pod with multiple containers (via UI)" Test
 - Automate "Create an app with persistent volume (via UI)" Test
 - Automate "Create an app with labels (via UI)" Test
 - Automate "Create a simple job (via UI)" Test
 - Automate "Create an app with command health check (via UI)" Test
 - Automate "Create an app with external volume (via UI)" Test
 - Automate "Create a job with docker config (via UI)" Test
 - Automate "Create an app with docker config (via UI)" Test
 - Automate "Create a job with schedule (via UI)" Test
 - Automate "Create a job with labels (via UI)" Test
 - Automate "Create a simple app (via UI)" Test
 - Service create form content not mobile friendly
 - Clean up if-else statements in Service- and PodDebugContainer
 - Automate "Create an pod with service address (via UI)" Test
 - Automate "Create an app with artifacts (via UI)" Test
 - Write integration tests for the Run a Service modal: General Behavior
 - Sorting by health in Service task table throws error
 - Rename JSONAppReducers to JSONSingelContainerReducers
 - Write integration tests for the Run a Service modal: Single Container form
 - Automate "Create a pod with environment variables (via UI)" Test
 - Write integration tests for the Page Header components
 - Automate "Create a simple pod (via UI)" Test
 - Extract foundation-ui
 - Deploying a new service in the UI routes to /services/overview/undefined
 - Use prettier formatter
 - Make all page tabs routed: ServiceDetail
 - Write integration tests for Networking pages that are not EE
 - Delete button in first placement constraints row is misaligned
 - Add scrollContainerParentSelector prop to Table
 - Automate "Create an pod with artifacts (via UI)" Test
 - Read-only value is misaligned in service configuration review
 - Explore and implement i18n poc
 - Sort components by Unhealthy first
 - "EDIT" button in services UI doesn't do anything when clicked
 - Update help text and tooltips in create flow
 - [SDK-DPLY] Remove old code from SDK Deployments v1

## Related Issues

 - [DCOS-14184](https://jira.mesosphere.com/browse/DCOS-14184])
 - [DCOS-14845](https://jira.mesosphere.com/browse/DCOS-14845])
 - [DCOS-14755](https://jira.mesosphere.com/browse/DCOS-14755])
 - [DCOS-12814](https://jira.mesosphere.com/browse/DCOS-12814])
 - [DCOS-14145](https://jira.mesosphere.com/browse/DCOS-14145])
 - [DCOS-15162](https://jira.mesosphere.com/browse/DCOS-15162])
 - [DCOS-14911](https://jira.mesosphere.com/browse/DCOS-14911])
 - [DCOS-13710](https://jira.mesosphere.com/browse/DCOS-13710])
 - [DCOS-15229](https://jira.mesosphere.com/browse/DCOS-15229])
 - [DCOS-14508](https://jira.mesosphere.com/browse/DCOS-14508])
 - [DCOS-14384](https://jira.mesosphere.com/browse/DCOS-14384])
 - [DCOS-14745](https://jira.mesosphere.com/browse/DCOS-14745])
 - [DCOS-14894](https://jira.mesosphere.com/browse/DCOS-14894])
 - [DCOS-14457](https://jira.mesosphere.com/browse/DCOS-14457])
 - [DCOS-14461](https://jira.mesosphere.com/browse/DCOS-14461])
 - [DCOS-14758](https://jira.mesosphere.com/browse/DCOS-14758])
 - [DCOS-14370](https://jira.mesosphere.com/browse/DCOS-14370])
 - [DCOS-11781](https://jira.mesosphere.com/browse/DCOS-11781])
 - [DCOS-14986](https://jira.mesosphere.com/browse/DCOS-14986])
 - [DCOS-12805](https://jira.mesosphere.com/browse/DCOS-12805])
 - [DCOS-14146](https://jira.mesosphere.com/browse/DCOS-14146])
 - [DCOS-14854](https://jira.mesosphere.com/browse/DCOS-14854])
 - [DCOS-15137](https://jira.mesosphere.com/browse/DCOS-15137])
 - [DCOS-14460](https://jira.mesosphere.com/browse/DCOS-14460])
 - [DCOS-12813](https://jira.mesosphere.com/browse/DCOS-12813])
 - [DCOS-12571](https://jira.mesosphere.com/browse/DCOS-12571])
 - [DCOS-13205](https://jira.mesosphere.com/browse/DCOS-13205])
 - [DCOS-14913](https://jira.mesosphere.com/browse/DCOS-14913])
 - [DCOS-15014](https://jira.mesosphere.com/browse/DCOS-15014])
 - [DCOS-13077](https://jira.mesosphere.com/browse/DCOS-13077])
 - [DCOS-14890](https://jira.mesosphere.com/browse/DCOS-14890])
 - [DCOS-14526](https://jira.mesosphere.com/browse/DCOS-14526])
 - [DCOS-13909](https://jira.mesosphere.com/browse/DCOS-13909])
 - [DCOS-12806](https://jira.mesosphere.com/browse/DCOS-12806])
 - [DCOS-12828](https://jira.mesosphere.com/browse/DCOS-12828])
 - [DCOS-12827](https://jira.mesosphere.com/browse/DCOS-12827])
 - [DCOS-12826](https://jira.mesosphere.com/browse/DCOS-12826])
 - [DCOS-12807](https://jira.mesosphere.com/browse/DCOS-12807])
 - [DCOS-12825](https://jira.mesosphere.com/browse/DCOS-12825])
 - [DCOS-12824](https://jira.mesosphere.com/browse/DCOS-12824])
 - [DCOS-12823](https://jira.mesosphere.com/browse/DCOS-12823])
 - [DCOS-12812](https://jira.mesosphere.com/browse/DCOS-12812])
 - [DCOS-12821](https://jira.mesosphere.com/browse/DCOS-12821])
 - [DCOS-12820](https://jira.mesosphere.com/browse/DCOS-12820])
 - [DCOS-12819](https://jira.mesosphere.com/browse/DCOS-12819])
 - [DCOS-12818](https://jira.mesosphere.com/browse/DCOS-12818])
 - [DCOS-12809](https://jira.mesosphere.com/browse/DCOS-12809])
 - [DCOS-14456](https://jira.mesosphere.com/browse/DCOS-14456])
 - [DCOS-14842](https://jira.mesosphere.com/browse/DCOS-14842])
 - [DCOS-13950](https://jira.mesosphere.com/browse/DCOS-13950])
 - [DCOS-14171](https://jira.mesosphere.com/browse/DCOS-14171])


## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-ui/compare/89b9fbd36582d107e67bea114151c4c5504b93a3...45aca9660add3eaab34e855ddde4d6a8028aaea2)
  - [x] Test Results: [unit](https://jenkins.mesosphere.com/service/jenkins/job/Frontend/job/public-dcos-ui-pulls/7747/), [integration](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-ui-pulls-integration/4645/)
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
