### PR TITLE
Fixed log rotation for Mesos master/agent logs.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -331,7 +331,7 @@ package:
       nomail
       /var/lib/dcos/mesos/log/mesos-master.log {
           olddir /var/lib/dcos/mesos/log/archive
-          maxsize 256M
+          size 256M
           rotate {{ mesos_log_retention_count }}
           copytruncate
           postrotate
@@ -347,7 +347,7 @@ package:
       nomail
       /var/log/mesos/mesos-agent.log {
           olddir /var/log/mesos/archive
-          maxsize 256M
+          size 256M
           rotate {{ mesos_log_retention_count }}
           copytruncate
           postrotate


### PR DESCRIPTION
## High Level Description

Given a logrotate config with neither a time-based rotation criteria, nor a `size` option, logrotate will default to rotating files once they hit 1 MB.  The `maxsize` option apparently only takes effect if there is a time-based rotation option (i.e. daily or weekly).

Given the current logrotate config, log retention is 256 times smaller than intended.

## Related Issues

  - None at the moment.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

  - N/A
___