### PR TITLE
Switch EC2 instance type default from m3 to m4

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -44,8 +44,8 @@
     },
     "MasterInstanceType": {
       "Type": "String",
-      "Default": "m3.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+      "Default": "m4.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -187,8 +187,8 @@
     },
     "PrivateAgentInstanceType": {
       "Type": "String",
-      "Default": "m3.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+      "Default": "m4.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -179,8 +179,8 @@
     },
     "PublicAgentInstanceType": {
       "Type": "String",
-      "Default": "m3.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+      "Default": "m4.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -40,18 +40,18 @@
         },
         "MasterInstanceType": {
           "Type": "String",
-          "Default": "m3.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+          "Default": "m4.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
         },
         "PublicAgentInstanceType": {
           "Type": "String",
-          "Default": "m3.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+          "Default": "m4.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
         },
         "PrivateAgentInstanceType": {
           "Type": "String",
-          "Default": "m3.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m3.xlarge"
+          "Default": "m4.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
         },
         "CustomAMI": {
           "Default": "default",

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -50,10 +50,10 @@
     "NATAmi" : {{ nat_ami_mapping }},
     "Parameters": {
       "MasterInstanceType": {
-        "default": "m3.xlarge"
+        "default": "m4.xlarge"
       },
       "SlaveInstanceType": {
-        "default": "m3.xlarge"
+        "default": "m4.xlarge"
       },
       "PublicSubnetRange": {
         "default": "10.0.4.0/22"
@@ -65,7 +65,7 @@
         "default": "10.0.0.0/16"
       },
       "PublicSlaveInstanceType": {
-        "default": "m3.xlarge"
+        "default": "m4.xlarge"
       },
       "StackCreationTimeout": {
           "default": "PT45M"

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -125,62 +125,62 @@ aws_region_names = [
 
 region_to_ami_map = {
     'ap-northeast-1': {
-        'coreos': 'ami-86f1b9e1',
-        'stable': 'ami-86f1b9e1',
+        'coreos': 'ami-93f2baf4',
+        'stable': 'ami-93f2baf4',
         'el7': 'ami-5942133e',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
-        'coreos': 'ami-27cc7d44',
-        'stable': 'ami-27cc7d44',
+        'coreos': 'ami-aacc7dc9',
+        'stable': 'ami-aacc7dc9',
         'el7': 'ami-83ea59e0',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
-        'coreos': 'ami-5baeae38',
-        'stable': 'ami-5baeae38',
+        'coreos': 'ami-9db0b0fe',
+        'stable': 'ami-9db0b0fe',
         'el7': 'ami-7f393b1c',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
-        'coreos': 'ami-4733f928',
-        'stable': 'ami-4733f928',
+        'coreos': 'ami-903df7ff',
+        'stable': 'ami-903df7ff',
         'el7': 'ami-9e13c7f1',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
-        'coreos': 'ami-89f6dbef',
-        'stable': 'ami-89f6dbef',
+        'coreos': 'ami-abcde0cd',
+        'stable': 'ami-abcde0cd',
         'el7': 'ami-41b89327',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
-        'coreos': 'ami-c51573a9',
-        'stable': 'ami-c51573a9',
+        'coreos': 'ami-c11573ad',
+        'stable': 'ami-c11573ad',
         'el7': 'ami-6d600101',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
-        'coreos': 'ami-42ad7d54',
-        'stable': 'ami-42ad7d54',
+        'coreos': 'ami-1ad0000c',
+        'stable': 'ami-1ad0000c',
         'el7': 'ami-84862092',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
-        'coreos': 'ami-a846fcc9',
-        'stable': 'ami-a846fcc9',
+        'coreos': 'ami-e441fb85',
+        'stable': 'ami-e441fb85',
         'el7': 'ami-8dce4bec',
         'natami': ''
     },
     'us-west-1': {
-        'coreos': 'ami-1a1b457a',
-        'stable': 'ami-1a1b457a',
+        'coreos': 'ami-b31d43d3',
+        'stable': 'ami-b31d43d3',
         'el7': 'ami-794f1619',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
-        'coreos': 'ami-2551d145',
-        'stable': 'ami-2551d145',
+        'coreos': 'ami-444dcd24',
+        'stable': 'ami-444dcd24',
         'el7': 'ami-4953df29',
         'natami': 'ami-bb69128b'
     }


### PR DESCRIPTION
## High Level Description

This changes the default AWS EC2 instance type from m3 to m4 in the generated Cloudformation Templates.
m4 are about 20% cheaper than m3 and also a bit faster. However they are EBS only.
m3 will eventually be phased out.