### PR TITLE
Upgrade to marathon 1.3.10

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.3.9/marathon-1.3.9.tgz",
-    "sha1": "a384bb485d7dea4ec17e4f94907ce806c970e024"
+    "url": "https://downloads.mesosphere.io/marathon/v1.3.10/marathon-1.3.10.tgz",
+    "sha1": "d5299a392560d45c56d001032bf1148d05bc0088"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

Upgrade to Marathon 1.3.10

## Related Issues

21d4d70 Fixes #4948 | Lazy event parsing in HTTP callbacks. (#5114) (janisz)
8b0ee47 undo def -> lazy val toProto change (Tim Harper)
a09ea81 Improve performance of zookeeper layer and groups (Tim Harper)
17a082e Fixes #4978 | AppDefinition.Conteiner validation (#4989) (janisz)
1613ae1 Fixes #4948 | Lazy event parsing (#4986) (janisz)
553b27f Initial stab at making deployment plans cheaper. Back port of https://phabricator.mesosphere.com/D476 (Johannes Unterstein)
1027968 A group is accessible, if the group is selected, a subgroup is selected or a pod/app in that group is selected. (Matthias Veit)

## Checklist for all PR's

  - [N/A] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [1.3.10](https://github.com/mesosphere/marathon/releases/tag/v1.3.10)
  - [X] Test Results: [TeamCity](https://teamcity.mesosphere.io/viewLog.html?buildId=553279&buildTypeId=Oss_Marathon_PublishTar&tab=buildResultsDiv)
  - [N/A] Code Coverage (if available): Not available anymore
