### PR TITLE
Use the new marathon packaging (testing with a snapshot build)

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -853,7 +853,7 @@ package:
       LIBPROCESS_PORT=15101
 {% switch dcos_overlay_enable %}
 {% case "true" %}
-      MARATHON_CMD_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
+      MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
 {% case "false" %}
 {% endswitch %}
   - path: /etc/proxy.env

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-mkdir -p "$PKG_PATH/usr/"
+# Marathon and Metronome use the same jars, and pkgpanda doens't allow two packages
+# to have files at the same path, so essentially make marathon package-private.
+# Nothing will end up in /opt/mesosphere/{bin, lib}
+# This is not ideal but its one of the few solutions.
+# the lib directory is _supposed_ to be in the parent of $(realpath bin/marathon)
+# and its unclear how to change that without creating a very custom zipfile
+# that is different.
 
-cp -rp /pkg/src/marathon/target/scala-2.11/marathon-assembly-*.jar "$PKG_PATH/usr/marathon.jar"
+source /opt/mesosphere/environment.export
 
-chmod -R o+r "$PKG_PATH/usr"
+mkdir -p "$PKG_PATH/marathon/bin"
+mkdir -p "$PKG_PATH/marathon/lib"
+
+cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/marathon/bin/marathon"
+chmod +x "$PKG_PATH/marathon/bin/marathon"
+cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/marathon/lib"
 
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")
@@ -24,20 +35,21 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStart=/opt/mesosphere/bin/java \\
-    -Xmx2G \\
-    -jar "$PKG_PATH/usr/marathon.jar" \\
-    --zk "\$MARATHON_ZK" \\
+ExecStart=$PKG_PATH/marathon/bin/marathon \\
+    -Duser.dir=/var/lib/dcos/marathon \\
+    -J-server \\
+    -J-verbose:gc \\
+    -J-XX:+PrintGCDetails \\
+    -J-XX:+PrintGCTimeStamps \\
     --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
-    --hostname "\$MARATHON_HOSTNAME" \\
     --default_accepted_resource_roles "*" \\
     --mesos_role "slave_public" \\
-    --max_tasks_per_offer 100 \\
     --task_launch_timeout 86400000 \\
     --decline_offer_duration 300000 \\
     --revive_offers_for_new_apps \\

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -50,6 +50,7 @@ ExecStart=$PKG_PATH/marathon/bin/marathon \\
     --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
     --default_accepted_resource_roles "*" \\
     --mesos_role "slave_public" \\
+    --max_instances_per_offer 100 \\
     --task_launch_timeout 86400000 \\
     --decline_offer_duration 300000 \\
     --revive_offers_for_new_apps \\

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.3/marathon-1.4.3.tgz",
-    "sha1": "e85ce11f9b054911b90ad27ac57a6b92bf2a0ba4"
+    "url": "https://downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-557-gab275cc.tgz",
+    "sha1": "552b376def6bf7f27e3328ba6e70395c15d0dd13"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 pushd "/pkg/src/metronome"
 rm -rf bin/metronome.bat README.md RUNNING_PID share/ logs/
-cp -a * "$PKG_PATH/"
+cp -an * "$PKG_PATH/"
 cp -f /pkg/extra/logback.xml "$PKG_PATH/conf/"
 
 metronome_service="$PKG_PATH/dcos.target.wants_master/dcos-metronome.service"


### PR DESCRIPTION
- Pkgpanda doesn't let marathon and metronome share files, so make marathon package-private
- Add some docs and fix MARATHON_CMD => MARATHON_
- Set Hostname is set via the environment

## High Level Description

## Changes from 1.4.x to 1.5.0 (unreleased)

### Breaking Changes

#### Packaging standardized

We now publish more normalized packages that attempt to follow Linux Standard Base Guidelines and use sbt-native-packager to achieve this.
As a result of this and the many historic ways of passing options into marathon, we will only read `/etc/default/marathon` when starting up.
This file, like `/etc/sysconfig/marathon`, has all marathon command line options as "MARATHON_XXX=YYY" which will translate to `--xx=yyy`.
We no longer support /etc/marathon/conf which was a set of files that would get translated into command line arguments. In addition,
we no longer assume that if there is no zk/master argument passed in, then both are running on localhost.

If support for any of the above is important to you, please file a JIRA and/or create a PR/Patch.


#### App JSON Fields Changed or Moved.

Marathon will continue to *accept* the app JSON as it did in 1.4;
however, applications that use deprecated fields will be normalized into a canonical representation.
The app JSON *generated* by the /v2 REST API has changed: only canonical fields are generated.
The [App RAML specification](docs/docs/rest-api/public/api/v2/types/app.raml) is the source of truth with respect to deprecated fields.
The following deprecated fields will no longer be generated for app JSON:

- `ipAddress`
- `container.docker.portMappings`
- `container.docker.network`
- `ports`
- `uris`

Marathon clients that consume these deprecated fields will require changes.
In addition, new networking API fields have been introduced:

- `networks`
- `container.portMappings`

The `networks` field replaces the `ipAddress.networkName` and `container.docker.network` fields, and supports joining an app to multiple `container` networks.
The legacy IP/CT API did not require a resolvable network name in order to use a `container` network;
it allowed both an app definition to leave `ipAddress.networkName` unspecified **and** the operator to leave `--default_network_name` unspecified.
Starting with Marathon v1.5 such apps will be rejected: apps may leave `networks[x].name` unspecified for `container` networks only if `--default_network_name` has been specified by the operator.
Marathon injects the value of `--default_network_name` into unnamed `container` networks upon app create/update.

Upgrading from Marathon 1.4.x to Marathon 1.5.x will automatically migrate existing applications to the new networking API.
Migration of legacy Mesos IP/CT apps **may fail** if those apps did not specify `ipAddress.networkName` and there is no default network name specified.
See the (networking documentation)[docs/docs/networking.md] for details concerning app migration and network API changes.

The [old app networking docs](docs/docs/ports.md) have been relocated.
See the [networking documentation](docs/docs/networking.md) for details concerning the new API.

#### Metric Names Changed or Moved.
We moved to a different Metrics library and the metrics are not _always_ compatible or the same as existing metrics;
however, the metrics are also now more accurate, use less memory, and are expected to get better throughout the release.
Where it was possible, we maintained the original metric names/groupings/etc, but some are in new locations or have
slightly different semantics. Any monitoring dashboards should be updated.

Before 1.5.0 releases, we will publish a migration guide for the new metric formats and where the replacement
metrics can be found and the formats they are now in.

#### Artifact store has been removed
The artifact store was deprecated with Marathon 1.4 and is removed in version.
The command line flag `--artifact_store` will throw an error if specified.
The REST API endpoint `/v2/artifacts` has been removed completely.

#### Logging endpoint
Marathon has the ability to view and change log level configuration during runtime via the `/logging` endpoint.
This version switches from a form based API to a JSON based API, while maintaining the functionality.
We also secured this endpoint, so you can restrict who is allowed to view or update this configuration.
Please find our [API documentation](https://mesosphere.github.io/marathon/api-console/index.html) for all details.

#### Event Subscribers has been removed.
The events subscribers endpoint (`/v2/eventSubscribers`) was deprecated in Marathon 1.4 and is removed in this version.
Please move to the `/v2/events` endpoint instead.

#### Removed command line parameters
- The command line flag `max_tasks_per_offer` has been deprecated since 1.4 and is removed now. Please use `max_instances_per_offer`.

#### Deprecated command line parameters
- The command line flag `save_tasks_to_launch_timeout` is deprecated and has no effect any longer.

### New Features

#### Networking Improvements Involving Multiple Container Networks

The field `networkNames` has been added to [app container's ContainerPortMapping](docs/docs/rest-api/public/api/v2/types/appContainer.raml) and [pod's Endpoint](docs/docs/rest-api/public/api/v2/types/network.raml). Using the field, an app or pod participating in multiple container networks can now forward ports by specifying a single item `networkNames`. For more information, see the [networking documentation](./docs/docs/networking.md).

Additionally container port discovery has been improved, with a pod or app being able specify with which container network(s) a port name/protocol/etc is associated. Discovery labels are now generated for container networks associated with ports.

#### Mesos Bridge Network Name Configurable

The CNI network used for Mesos containers when bridge networking is now configurable via the command-line argument `--mesos_bridge_name`. As with other command-line-args, this can also be specified via `MARATHON_MESOS_BRIDGE_NAME`, as well.

#### Backup and Restore Operations

You can now backup and restore Marathon's internal state via the [DELETE /v2/leader](./docs/docs/rest-api/public/api/v2/leader.raml) API endpoint.

See [MARATHON-7041](https://jira.mesosphere.com/browse/MARATHON-7041)

#### TTY support

You can now specify that a TTY should be allocated for app or pod containers. See the [TTY definition](./docs/docs/rest-api/public/api/v2/types/containerCommons.raml). An example can be found in [v2/examples/app.json](./docs/docs/rest-api/public/api/v2/examples/app.json).

See [MARATHON-7062](https://jira.mesosphere.com/browse/MARATHON-7062)

#### Improved Validation Error Messages

All validation specified in the RAML is now programatically enforced, leading to more consistent, descriptive, and legible error messages.

#### Security improvements

Marathon is in better compliance with various security best-practices. An example of this is that Marathon no longer responds to the directory listing request.

### Fixed issues
- [MARATHON-7320](https://jira.mesosphere.com/browse/MARATHON-7320) Fix MAX_PER constraint for attributes.

------------------------------------------------------------

## Related Issues

- See high level description

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [commits](https://github.com/mesosphere/marathon/compare/releases/1.4...master)
  - [ ] Test Results: [Master Marathon CI](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/25/)
  - [ ] Code Coverage (if available): ¯\_(ツ)_/¯ we track this but I don't know where it is to link. It's good. Trust me.
