### PR TITLE
feat(DCOS-13976): Disable opening the UI in iframe

### DIFF
--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -87,8 +87,10 @@ http {
         # Description: DC/OS GUI
         root /opt/mesosphere/active/dcos-ui/usr;
 
-        # prevent opening in iframe
-        add_header X-Frame-Options DENY;
+        location / {
+            # prevent opening in iframe
+            add_header X-Frame-Options DENY;
+        }
 
         # Group: Authentication
         # Description: Redirect to OpenID Connect server for user login

--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -87,6 +87,9 @@ http {
         # Description: DC/OS GUI
         root /opt/mesosphere/active/dcos-ui/usr;
 
+        # prevent opening in iframe
+        add_header X-Frame-Options DENY;
+
         # Group: Authentication
         # Description: Redirect to OpenID Connect server for user login
         location = /login {


### PR DESCRIPTION
(**DCOS-13976**) Adds X-Frame-Options to prevent Clickjacking attack through iframe.

To test this create a index.html page and use iframe markup pointing to a cluster that contain this changes. You should see this in the console `Refused to display 'https://52.41.194.202/' in a frame because it set 'X-Frame-Options' to 'deny'.`

## Related Issues
https://jira.mesosphere.com/browse/DCOS-13976 - Application is vulnerable to Clickjacking attack

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)