### PR TITLE
bump dcos-signal sha

### DIFF
--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -2,8 +2,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "5f64585fe945480aa1b3c363fa7e5d6c0f9878d7",
-    "ref_origin": "1.4.0"
+    "ref": "a1771632a3bc1298fdd422a5544a405bdf733784",
+    "ref_origin": "master"
   },
   "username": "dcos_signal"
 }


### PR DESCRIPTION
## High Level Description

When dcos-signal is invoked it will report a list of installed packages. The list comes from cosmos. Current implementation provides unreadable output
```level=warning msg="REPORT:\n&{Packages:[{AppID:/jenkins} {AppID:/kafka}]}"```

This change makes the output easier to read and includes the version of the package.
```Installed cosmos packages: flink 3.0, hello-world 3.0, jenkins 3.0```

## Related Issues

  - [DCOS-15379](https://jira.mesosphere.com/browse/DCOS-15379)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
The unittest has been added to dcos-signal.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-signal](https://github.com/dcos/dcos-signal/compare/5f64585fe945480aa1b3c363fa7e5d6c0f9878d7...a1771632a3bc1298fdd422a5544a405bdf733784)
  - [X] Test Results: [jenkins#124](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-signal-service-pulls/124/)
  - [X] Code Coverage (if available): [jenkins#124](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-signal-service-pulls/124/)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
