### PR TITLE
Set open file limits minuteman systemd unit file

### DIFF
--- a/packages/minuteman/build
+++ b/packages/minuteman/build
@@ -19,6 +19,7 @@ Description=Layer 4 Load Balancer: DC/OS Layer 4 Load Balancing Service
 Restart=always
 StartLimitInterval=0
 RestartSec=5
+LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}/minuteman
 EnvironmentFile=/opt/mesosphere/etc/minuteman-erl.env
 EnvironmentFile=/opt/mesosphere/etc/check_time.env


### PR DESCRIPTION
## High Level Description

It looks like this file was missed in https://github.com/dcos/dcos/commit/6f6bd97e9be1edef675da1907ca990b8b65746f0 . A customer running 1.8 ran into issues with minuteman and the networking team suggested making this change in minuteman unit file ref: DCOS-15097. This has already been taken care of in 1.9 since minuteman has folded into navstar.

Hoping to get this in 1.8.9 so that customers upgrading to 1.8.9 do not have to manually edit systemd unit again.
 
## Related Issues
  - [DCOS-15097](https://jira.mesosphere.com/browse/DCOS-15097) Minuteman oscillates between healthy and unhealthy every 2-3 seconds

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___

Please review @GoelDeepak 
