### PR TITLE
Fixed: Partial download of dcos_generate_config.sh results in unrecoverable error that requires manual intervention.

### DIFF
--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -12,6 +12,17 @@ backout(){{
     exit 1
 }}
 trap 'backout' INT
+
+# if the tarball was previously extracted
+if [ -f "{genconf_tar}" ]; then
+    # but not successfully loaded into Docker
+    if [ -z "$(docker images -q {docker_image_name} 2>/dev/null)" ]; then
+        # remove the potentially corrupted tarball and
+        # cause it to be re-extracted in the next step
+        rm -f {genconf_tar}
+    fi
+fi
+
 # extract payload and load into docker if not extracted
 if [ ! -f "{genconf_tar}" ]; then
     echo Extracting image from this script and loading into docker daemon, this step can take a few minutes

--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -1,5 +1,10 @@
 #!/bin/bash
 # variant: {variant}
+#
+# All logging and tool output should be redirected to stderr
+# as the Docker container might output json that would
+# otherwise be tainted.
+#
 set -o errexit -o nounset -o pipefail
 
 # preflight checks
@@ -25,9 +30,9 @@ fi
 
 # extract payload and load into docker if not extracted
 if [ ! -f "{genconf_tar}" ]; then
-    echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
+    >&2 echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
     sed '1,/^#EOF#$/d' $0 | tar xv
-    docker load -i {genconf_tar}
+    >&2 docker load -i {genconf_tar}
 fi
 trap - INT
 

--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -7,14 +7,13 @@ docker version >/dev/null 2>&1 || {{ echo >&2 "docker should be installed and ru
 
 backout(){{
     if [ -f "{genconf_tar}" ]; then
-        rm {genconf_tar}
+        rm -f {genconf_tar}
     fi
     exit 1
 }}
 trap 'backout' INT
 # extract payload and load into docker if not extracted
-if [ ! -f "{genconf_tar}" ]
-then
+if [ ! -f "{genconf_tar}" ]; then
     echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
     sed '1,/^#EOF#$/d' $0 | tar xv
     docker load -i {genconf_tar}


### PR DESCRIPTION
## High Level Description

Currently if `dcos_generate_config.sh` is truncated or otherwise corrupted and run it'll extract a corrupted tarball that can't be loaded into Docker.
Then when `dcos_generate_config.sh` is redownloaded it'll fail to run as it'll find a tarball with matching name which causes it to not extract the image tarball and load it into Docker.

Resulting in:
```
Unable to find image 'mesosphere/dcos-genconf:0ce03387884523f026-58fd0833ce81b6244f' locally
Trying to pull repository docker.io/mesosphere/dcos-genconf ...
/usr/bin/docker-current: unauthorized: authentication required.
See '/usr/bin/docker-current run --help'.
```

This PR adds an additional check that, if a tarball of the same name already exists it confirms that the image was actually loaded into Docker. If not it removes the tarball causing it to be extracted and loaded from the current `dcos_generate_config.sh` installer.

PR also contains some minor syntax and style fixes. I also added two stdout to stderr redirects when loading the image. Otherwise the `--version` json output will be corrupted when `dcos_generate_config.sh` is run for the first time.

## Related Issues

  - [DCOS_OSS-1047](https://jira.mesosphere.com/browse/DCOS_OSS-1047) Partial download of dcos_generate_config.sh results in unrecoverable error that requires manual intervention.
