### PR TITLE
fixes duplicate iptable rule

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "002c325bfcc9e0d806ac41af53ba4d6cae6b1d72",
+      "ref": "d99eac511c39eb3070d5064fc098de374b21b834",
       "ref_origin": "master"
     }
   },

--- a/packages/navstar/extra/setup_iptables.sh
+++ b/packages/navstar/extra/setup_iptables.sh
@@ -13,7 +13,10 @@ iptables --wait -t raw -D PREROUTING -p tcp -m set --match-set minuteman dst,dst
 iptables --wait -t raw -D OUTPUT -p tcp -m set --match-set minuteman dst,dst -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -j NFQUEUE --queue-balance 50:58 || true
 
 # to fix DCOS_OSS-980
-iptables -A FORWARD -j ACCEPT 
+RULE="FORWARD -j ACCEPT"
+if ! iptables --wait -C ${RULE}; then
+  iptables --wait -A ${RULE}
+fi
 
 RULE="POSTROUTING -m ipvs --ipvs --vdir ORIGINAL --vmethod MASQ -m comment --comment Minuteman-IPVS-IPTables-masquerade-rule -j MASQUERADE"
 


### PR DESCRIPTION
## High Level Description

This patch avoids adding same iptable rule multiple times

## Related Issues

  - [DCOS_OSS-1045](https://jira.mesosphere.com/browse/DCOS_OSS-1045) Same ip table rule is added multiple times
  - [DCOS_OSS-1040](https://jira.mesosphere.com/browse/DCOS_OSS-1040) Same ip rule is added multiple times

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/dcos/navstar/pull/70
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
