### PR TITLE
Train 159 (targeting 1.8.9)

### DIFF
--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -22,7 +22,7 @@ ExecStartPre=/bin/ping -c1 marathon.mesos
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 # Wait for auth backend to seed the secret key
-ExecStartPre=/usr/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
+ExecStartPre=/opt/mesosphere/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
 ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.2.0-4/cosmos-server-0.2.0-4-one-jar.jar",
-    "sha1": "7d659d8133a37a57c03218e3fcb7105551be3068"
+    "url": "https://downloads.dcos.io/cosmos/0.2.1-7/cosmos-server-0.2.1-7-one-jar.jar",
+    "sha1": "78ef9048d68dd3b458ff9bde042f82c87c4a025d"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/dcos-integration-test/extra/python_test_server.py
+++ b/packages/dcos-integration-test/extra/python_test_server.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import getpass
 import json
 import logging
 import os
@@ -244,7 +243,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
     def _handle_operating_environment(self):
         """Gets basic operating environment info (such as running user)"""
         self._send_reply({
-            'username': getpass.getuser()
+            'uid': os.getuid()
         })
 
     def do_GET(self):  # noqa: ignore=N802

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "3d4a8d7caec7cd0239dbc40e39c8ec4d965a9a67",
-    "ref_origin" : "dcos-mesos-1.0.3-rc1"
+    "ref": "7f136d6a940f218234375771a3e5df2f8a237864",
+    "ref_origin" : "dcos-mesos-1.0.x-4154f66"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/test_util/cluster_api.py
+++ b/test_util/cluster_api.py
@@ -383,7 +383,11 @@ class ClusterApi:
                 msg += "Detailed explanation of the problem: {2}"
                 raise Exception(msg.format(r.status_code, r.reason, r.text))
 
-            assert r.json() == {'username': marathon_user}
+            json_uid = r.json()['uid']
+            if marathon_user == 'root':
+                assert json_uid == 0, "App running as root should have uid 0."
+            else:
+                assert json_uid != 0, ("App running as {} should not have uid 0.".format(marathon_user))
 
     def deploy_marathon_app(self, app_definition, timeout=120, check_health=True, ignore_failed_tasks=False):
         """Deploy an app to marathon


### PR DESCRIPTION
## High Level Description

Train 159 targeting 1.8.9 branch

#1494 Backporting https://jira.mesosphere.com/browse/DCOS-10327 to 1.8.9
#1458 Update cosmos to version 0.2.1
#1456 Backporting the fix for DCOS_OSS-683 to 1.8
#1445 Bumped Mesos to include fixes for leakage of sensitive data - Mesos 1.0.4
