### PR TITLE
Integrate DCOS_OSS-925 fix in dcos-metrics.

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "b68c5e128120d0bf96a13aa11000999170a33ed6",
-    "ref_origin": "1.1.0"
+    "ref": "4316a775d5aea98f3c482efe97af18d9f72485c4",
+    "ref_origin": "philipnrmn/fix-nans"
   },
   "username": "dcos_metrics"
 }

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "4316a775d5aea98f3c482efe97af18d9f72485c4",
-    "ref_origin": "philipnrmn/fix-nans"
+    "ref": "62702c3396deb5b47f4492a5a39d9dfb6f95ab0b",
+    "ref_origin": "master"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
This PR addresses https://jira.mesosphere.com/browse/DCOS_OSS-925.

Once it gets merged in I think the idea will be to tag dcos-metrics
and then change the ref/origin in buildinfo.json.

## High Level Description

This change brings in a bugfix in dcos-metrics.  The bug is described in

https://jira.mesosphere.com/browse/DCOS_OSS-925.

Effectively it avoids `NaN` and `encoding/json` incompatibilities by special
casing the `NaN` value in an avro record.

## Related Issues

  - [DCOS_OSS-925](https://jira.mesosphere.com/browse/DCOS_OSS-925) Metrics app endpoint can produce 'null' as a value for datapoints.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
