### PR TITLE
Bumped Apache Mesos to latest 1.2.1-rc1.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "27761cab0cfd7c787e05d20effbd3bd14f029c02",
-    "ref_origin" : "dcos-mesos-1.2.x-596661d"
+    "ref": "c0a93bec85707de09f3618dc9f5009f099186804",
+    "ref_origin" : "dcos-mesos-1.2.1-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Bumps Apache Mesos to 1.2.1-rc1 with the addition of

https://github.com/mesosphere/mesos/commit/d39453dd32a91ec21098e10c3ae445363a7bf7e8 
https://github.com/mesosphere/mesos/commit/db85099218ebc1e97bc54f730a2292c2b34a7597
https://github.com/mesosphere/mesos/commit/d562795d5fed1628e8bf56dede7ef2ea93b838c5
https://github.com/mesosphere/mesos/commit/f5ba5b06ebf80353991cf65e413cd3045ea52d22
https://github.com/mesosphere/mesos/commit/5189618e10ae8492c7d6f6f17d3e74b398fb3cba
https://github.com/mesosphere/mesos/commit/417be416d832225db67af0b96694a0ab13d95e81

## Related Issues

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Apache Mesos commits since DC/OS 1.9.0](https://github.com/apache/mesos/compare/596661dd2456fec442dad27ee759fbff85fd4173...1.2.1-rc1)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Mesos/job/mesos/job/Mesos_CI-build/942/
  - [ ] Code Coverage (if available): [link to code coverage report]