### PR TITLE
Admin Router: Make AR route to history-service backend, conditionally

### DIFF
--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -31,6 +31,11 @@ cp -r /pkg/src/adminrouter/* .
 rm -f win-utf uwsgi* scgi* nginx.conf* mime.types.default* koi-* fastcgi* README* *.png
 popd
 
+# AR start script:
+ar_wrapper="$PKG_PATH/nginx/sbin/adminrouter.sh"
+envsubst '$PKG_PATH' < /pkg/extra/adminrouter.sh > "$ar_wrapper"
+chmod a+x $ar_wrapper
+
 # Copy in needed libraries.
 mkdir -p "$PKG_PATH/lib"
 cp /lib/x86_64-linux-gnu/libpcre.so.3 "$PKG_PATH/lib/libpcre.so.3"

--- a/packages/adminrouter/buildinfo.json
+++ b/packages/adminrouter/buildinfo.json
@@ -9,8 +9,8 @@
       "adminrouter": {
           "kind": "git",
           "git": "https://github.com/dcos/adminrouter.git",
-          "ref": "0f1e4d44701d5b9960da980f8136c03c98c96594",
-          "ref_origin": "master"
+          "ref": "dd4c18e4e83f13d3dd1056282978bd9ee1d8aa3d",
+          "ref_origin": "dcos/1.8"
       }
   }
 }

--- a/packages/adminrouter/extra/adminrouter.sh
+++ b/packages/adminrouter/extra/adminrouter.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+# Based on:
+# https://lists.freedesktop.org/archives/systemd-devel/2012-October/007289.html
+export HOST_IP=$($MESOS_IP_DISCOVERY_COMMAND)
+
+exec $PKG_PATH/nginx/sbin/nginx "$@"

--- a/packages/adminrouter/extra/dcos-adminrouter-agent-reload.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent-reload.service
@@ -4,4 +4,4 @@ Description=Admin Router Reloader: Reload admin router to get new DNS
 [Service]
 Type=oneshot
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=-$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.agent.conf -s reload
+ExecStart=-$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.agent.conf -s reload

--- a/packages/adminrouter/extra/dcos-adminrouter-agent.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-agent.service
@@ -16,7 +16,7 @@ Environment=AUTH_ERROR_PAGE_DIR_PATH=${PKG_PATH}/nginx/conf/errorpages
 EnvironmentFile=/opt/mesosphere/etc/adminrouter.env
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/ping -c1 leader.mesos
-ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.agent.conf
+ExecStart=$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.agent.conf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT
 KillMode=mixed

--- a/packages/adminrouter/extra/dcos-adminrouter-reload.service
+++ b/packages/adminrouter/extra/dcos-adminrouter-reload.service
@@ -4,4 +4,4 @@ Description=Admin Router Reloader: Reload admin router to get new DNS
 [Service]
 Type=oneshot
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=-$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf -s reload
+ExecStart=-$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.master.conf -s reload

--- a/packages/adminrouter/extra/dcos-adminrouter.service
+++ b/packages/adminrouter/extra/dcos-adminrouter.service
@@ -23,7 +23,7 @@ ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/usr/bin/test -f /var/lib/dcos/cluster-id
 # Wait for auth backend to seed the secret key
 ExecStartPre=/usr/bin/curl --fail -sS -o /dev/null 127.0.0.1:8101/acs/api/v1/groups
-ExecStart=$PKG_PATH/nginx/sbin/nginx -c $PKG_PATH/nginx/conf/nginx.master.conf
+ExecStart=$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.master.conf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 KillSignal=SIGQUIT
 KillMode=mixed

--- a/packages/dcos-history/extra/history/server.py
+++ b/packages/dcos-history/extra/history/server.py
@@ -91,4 +91,4 @@ def start():
 
     state_buffer = BufferCollection(os.environ['HISTORY_BUFFER_DIR'])
     BufferUpdater(state_buffer, headers_cb).run()
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', '15055')))
+    app.run(host='127.0.0.1', port=int(os.environ.get('PORT', '15055')))


### PR DESCRIPTION
This is just a backport of https://github.com/dcos/dcos/pull/1521 into 1.8 Please check https://github.com/dcos/dcos/pull/1521 description for details.

As 1.8 did not have ANY AR testing infra, it's omitted here.

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/891