### PR TITLE
Authenticate requests to Exhibitor during upgrade

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -386,6 +386,12 @@ def calculate_exhibitor_static_ensemble(master_list):
     return ','.join(['%d:%s' % (i + 1, m) for i, m in enumerate(masters)])
 
 
+def calculate_exhibitor_admin_password_enabled(exhibitor_admin_password):
+    if exhibitor_admin_password:
+        return 'true'
+    return 'false'
+
+
 def calculate_adminrouter_auth_enabled(oauth_enabled):
     return oauth_enabled
 
@@ -610,6 +616,7 @@ entry = {
         lambda cluster_docker_credentials: validate_json_dictionary(cluster_docker_credentials),
         lambda aws_masters_have_public_ip: validate_true_false(aws_masters_have_public_ip),
         validate_exhibitor_storage_master_discovery,
+        lambda exhibitor_admin_password_enabled: validate_true_false(exhibitor_admin_password_enabled),
         validate_cosmos_config,
         lambda enable_lb: validate_true_false(enable_lb),
         lambda adminrouter_tls_1_0_enabled: validate_true_false(adminrouter_tls_1_0_enabled),
@@ -646,6 +653,7 @@ entry = {
         'oauth_client_id': '3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m',
         'oauth_auth_redirector': 'https://auth.dcos.io',
         'oauth_auth_host': 'https://dcos.auth0.com',
+        'exhibitor_admin_password': '',
         'ui_tracking': 'true',
         'ui_banner': 'false',
         'ui_banner_background_color': '#1E232F',
@@ -710,6 +718,7 @@ entry = {
         'cluster_packages': calculate_cluster_packages,
         'config_id': calculate_config_id,
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,
+        'exhibitor_admin_password_enabled': calculate_exhibitor_admin_password_enabled,
         'ui_branding': 'false',
         'ui_external_links': 'false',
         'ui_networking': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -924,3 +924,42 @@ package:
   - path: /etc_slave_public/adminrouter-listen-open.conf
     content: |
         listen 61001 default_server;
+{% switch exhibitor_admin_password_enabled %}
+{% case "true" %}
+  - path: /etc_master/exhibitor_web.xml
+    permissions: "0644"
+    content: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <web-app xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+        version="2.5">
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>Protected</web-resource-name>
+            <url-pattern>/*</url-pattern>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>admin</role-name>
+          </auth-constraint>
+        </security-constraint>
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>Public</web-resource-name>
+            <url-pattern>/exhibitor/v1/cluster/status</url-pattern>
+          </web-resource-collection>
+        </security-constraint>
+        <security-role>
+          <role-name>admin</role-name>
+        </security-role>
+        <login-config>
+          <auth-method>BASIC</auth-method>
+          <realm-name>DCOS</realm-name>
+        </login-config>
+      </web-app>
+  - path: /etc_master/exhibitor_realm
+    permissions: "0644"
+    content: |
+      admin: {{ exhibitor_admin_password }},admin
+{% case "false" %}
+{% endswitch %}

--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -2,13 +2,22 @@
 DcosApiSession object that will be injected into the pytest 'dcos_api_session' fixture
 via the make_session_fixture() method
 """
+from test_helpers import expanded_config
+
 from test_util.dcos_api_session import DcosApiSession, DcosUser, get_args_from_env
 from test_util.helpers import CI_CREDENTIALS
 
 
 def make_session_fixture():
     args = get_args_from_env()
-    args['auth_user'] = DcosUser(CI_CREDENTIALS)
-    dcos_api_session = DcosApiSession(**args)
+
+    exhibitor_admin_password = None
+    if expanded_config['exhibitor_admin_password_enabled'] == 'true':
+        exhibitor_admin_password = expanded_config['exhibitor_admin_password']
+
+    dcos_api_session = DcosApiSession(
+        auth_user=DcosUser(CI_CREDENTIALS),
+        exhibitor_admin_password=exhibitor_admin_password,
+        **args)
     dcos_api_session.wait_for_dcos()
     return dcos_api_session

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -47,7 +47,7 @@ def test_if_all_mesos_slaves_have_registered(dcos_api_session):
 
 
 def test_if_exhibitor_api_is_up(dcos_api_session):
-    r = dcos_api_session.get('/exhibitor/exhibitor/v1/cluster/list')
+    r = dcos_api_session.exhibitor.get('/exhibitor/v1/cluster/list')
     assert r.status_code == 200
 
     data = r.json()
@@ -55,7 +55,7 @@ def test_if_exhibitor_api_is_up(dcos_api_session):
 
 
 def test_if_exhibitor_ui_is_up(dcos_api_session):
-    r = dcos_api_session.get('/exhibitor')
+    r = dcos_api_session.exhibitor.get('/')
     assert r.status_code == 200
     assert 'Exhibitor for ZooKeeper' in r.text
 

--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -58,6 +58,17 @@ class DcosAuth(requests.auth.AuthBase):
         return request
 
 
+class Exhibitor(RetryCommonHttpErrorsMixin, ApiClientSession):
+    def __init__(self, default_url: Url, session: Optional[requests.Session]=None,
+                 exhibitor_admin_password: Optional[str]=None):
+        super().__init__(default_url)
+        if session is not None:
+            self.session = session
+        if exhibitor_admin_password is not None:
+            # Override auth to use HTTP basic auth with the provided admin password.
+            self.session.auth = requests.auth.HTTPBasicAuth('admin', exhibitor_admin_password)
+
+
 class ARNodeApiClientMixin:
     def api_request(self, method, path_extension, *, scheme=None, host=None, query=None,
                     fragment=None, port=None, node=None, **kwargs):
@@ -91,7 +102,7 @@ class ARNodeApiClientMixin:
 class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSession):
     def __init__(self, dcos_url: str, masters: list, public_masters: list,
                  slaves: list, public_slaves: list, default_os_user: str,
-                 auth_user: Optional[DcosUser]):
+                 auth_user: Optional[DcosUser], exhibitor_admin_password: Optional[str]=None):
         """Proxy class for DC/OS clusters.
 
         Args:
@@ -112,6 +123,7 @@ class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClient
         self.all_slaves = sorted(slaves + public_slaves)
         self.default_os_user = default_os_user
         self.auth_user = auth_user
+        self.exhibitor_admin_password = exhibitor_admin_password
 
         assert len(self.masters) == len(self.public_masters)
 
@@ -303,6 +315,21 @@ class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClient
             new.auth_user = user
             new._authenticate_default_user()
         return new
+
+    @property
+    def exhibitor(self):
+        if self.exhibitor_admin_password is None:
+            # No basic HTTP auth. Access Exhibitor via the adminrouter.
+            default_url = self.default_url.copy(path='exhibitor')
+        else:
+            # Exhibitor is protected with HTTP basic auth, which conflicts with adminrouter's auth. We must bypass
+            # the adminrouter and access Exhibitor directly.
+            default_url = Url.from_string('http://{}:8181'.format(self.public_masters[0]))
+
+        return Exhibitor(
+            default_url=default_url,
+            session=self.copy().session,
+            exhibitor_admin_password=self.exhibitor_admin_password)
 
     @property
     def marathon(self):


### PR DESCRIPTION
## High Level Description

This teaches the upgrade script to authenticate Exhibitor requests if Exhibitor requires it.

Depends on #1528.

## Related Issues

  - [DCOS-15495](https://jira.mesosphere.com/browse/DCOS-15495) DC/OS upgrade script does not support exhibitor HTTP auth

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I ran the upgrade test against this PR with `exhibitor_admin_password: "deleteme"`: https://teamcity.mesosphere.io/viewLog.html?buildId=650893&buildTypeId=ClosedSource_Dcos_IntegrationTests_CloudIntegrationTests_DcosOssUpgradeTestOnPre&tab=buildResultsDiv
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]