### PR TITLE
Set ConditionalPathExists in correct area so docker-gc-enabled works.

### DIFF
--- a/packages/docker-gc/extra/dcos-docker-gc.service
+++ b/packages/docker-gc/extra/dcos-docker-gc.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Docker GC: periodically garbage collects Docker containers and images
+ConditionPathExists=/opt/mesosphere/etc/docker_gc_enabled
 [Service]
 Type=simple
 Restart=on-failure
 RestartSec=20
 LimitNOFILE=16384
 User=dcos_docker_gc
-ConditionPathExists=/opt/mesosphere/etc/docker_gc_enabled
 EnvironmentFile=/opt/mesosphere/environment
 Environment=STATE_DIR=/var/lib/dcos/docker-gc
 Environment=PID_DIR=/var/lib/dcos/docker-gc


### PR DESCRIPTION
## High Level Description
When enable_docker_gc is set to false, the file docker_gc_enabled does not exist, which is supposed to stop the unit file from starting. The ConditionPathExists was in the wrong place, however, and needs to be in the Unit section instead of Service. 

Tested manually on my cluster. How does 3dt mark Condition failed systemd units as in the UI? On my cluster, docker-gc still shows as healthy even though it can't be executing. Could be very confusing if people are expecting docker-gc to be disabled, but still see it show up in the DC/OS UI.

## Related Issues

 https://jira.mesosphere.com/browse/DCOS_OSS-999

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


