### PR TITLE
dcos-signal: bugfix update

### DIFF
--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "a1771632a3bc1298fdd422a5544a405bdf733784",
+    "ref": "7026c19aca3c85c8454f36fcb5e4c5ca8a37f063",
     "ref_origin": "master"
   },
   "username": "dcos_signal"


### PR DESCRIPTION
## High Level Description

send package version of installed package instead of packaging version to segment. We updated signal to parse /package/list to get out packaging version in https://github.com/dcos/dcos-signal/commit/67ce8b98c0d7cbc58cf921951f3d52ef0286ef5b, but turns out we actually wanted package version. this updates to package version. 

## Related Issues

  - [DCOS_OSS-1102](https://jira.dcos.io/browse/DCOS_OSS-1102) Foo the Bar so it stops Bazzing.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**