### PR TITLE
dcos-signal: bugfix update

### DIFF
--- a/packages/dcos-signal/buildinfo.json
+++ b/packages/dcos-signal/buildinfo.json
@@ -2,8 +2,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-signal.git",
-    "ref": "5f64585fe945480aa1b3c363fa7e5d6c0f9878d7",
-    "ref_origin": "1.4.0"
+    "ref": "7026c19aca3c85c8454f36fcb5e4c5ca8a37f063",
+    "ref_origin": "1.5.0"
   },
   "username": "dcos_signal"
 }


### PR DESCRIPTION
## High Level Description

send package version of installed package instead of packaging version to segment. Per Tal, backporting to 1.9

## Related Issues

  - [DCOS_OSS-1102](https://jira.dcos.io/browse/DCOS_OSS-1102)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [here](https://github.com/dcos/dcos-signal/commit/493e3f576501960119662c6d272a4b297f21f704)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**