### PR TITLE
Remove useless known hosts warnings

### DIFF
--- a/ssh/ssher.py
+++ b/ssh/ssher.py
@@ -91,6 +91,7 @@ def open_tunnel(user: str, key: str, host: str, port: int=22) -> Tunnelled:
             '-oControlPath=' + temp_paths[0],
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
+            '-oLogLevel=ERROR',
             '-oBatchMode=yes',
             '-oPasswordAuthentication=no',
             '-p', str(port)]


### PR DESCRIPTION
## High Level Description
This gets rid of this annoying error message: ```Warning: Permanently added '52.59.62.9' (ECDSA) to the list of known hosts.```
This is worthless because we set the known hosts list to /dev/null

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
