### PR TITLE
Remove gen from dcos launch

### DIFF
--- a/packages/dcos-launch/build
+++ b/packages/dcos-launch/build
@@ -1,15 +1,11 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
 
-# Copy from the ro /pkg/extra to a rw folder.
 mkdir -p /build
 cp -r /pkg/extra/* /build
-# install the lib for export
+cp -r /pkg/src/cerberus/cerberus /build
 cd /build
-pip3 install --no-deps --install-option="--prefix=$PKG_PATH" /pkg/extra/
-# verify the build
-py.test
-# create the installer
+pytest
 python3 /pkg/src/pyinstaller/pyinstaller.py dcos-launch.spec
 cd dist/
 # sanity check the installer

--- a/packages/dcos-launch/buildinfo.json
+++ b/packages/dcos-launch/buildinfo.json
@@ -9,6 +9,11 @@
       "kind": "url_extract",
       "url": "https://github.com/pyinstaller/pyinstaller/archive/8b491def32d02cedc912198930225cddfab2e871.zip",
       "sha1": "d98d271f9b70021417b34a059766131a0d73fdb4"
+    },
+    "cerberus": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/e0/7e/3949c86f4e60bc2b3d24ebc94af55ffaf9d62ad221f47c194edc9bd7fa94/Cerberus-1.1.tar.gz",
+      "sha1": "da78773979913e01200c961456f069145894f3c5"
     }
   }
 }

--- a/packages/dcos-launch/extra/dcos-launch.spec
+++ b/packages/dcos-launch/extra/dcos-launch.spec
@@ -6,10 +6,8 @@
 #     with the final exe. Ensure build system has OpenSSL 1.0.2g or greater
 a = Analysis(['launch/cli.py'],
              hiddenimports=['html.parser'],
-             datas=[('/opt/mesosphere/active/dcos-image/lib/python3.5/site-packages/gen/ip-detect/*.sh',
-                    'gen/ip-detect'),
-                    ('/opt/mesosphere/active/dcos-image/lib/python3.5/site-packages/gen/*.yaml',
-                    'gen/'),
+             datas=[('launch/ip-detect/aws.sh', 'launch/ip-detect'),
+                    ('launch/ip-detect/aws_public.sh', 'launch/ip-detect'),
                     ('/opt/mesosphere/active/dcos-image/lib/python3.5/site-packages/test_util/templates/*.json',
                     'test_util/templates'),
 ])

--- a/packages/dcos-launch/extra/launch/aws.py
+++ b/packages/dcos-launch/extra/launch/aws.py
@@ -1,8 +1,6 @@
 import copy
 import logging
 
-import yaml
-
 import launch.util
 import test_util.aws
 import test_util.runner
@@ -30,7 +28,7 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
         try:
             stack = self.boto_wrapper.create_stack(
                 self.config['deployment_name'],
-                yaml.load(self.config['template_parameters']),
+                self.config['template_parameters'],
                 template_url=self.config.get('template_url'),
                 template_body=self.config.get('template_body'))
         except Exception as ex:
@@ -48,9 +46,9 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
         will be provided (must be done in correct order) and added to the info
         JSON as 'temp_resources'
         """
-        if self.config['zen_helper'] != 'true':
+        if self.config['zen_helper'] is not True:
             return {}
-        parameters = yaml.load(self.config['template_parameters'])
+        parameters = self.config['template_parameters']
         temp_resources = {}
         if 'Vpc' not in parameters:
             vpc_id = self.boto_wrapper.create_vpc_tagged('10.0.0.0/16', self.config['deployment_name'])
@@ -70,7 +68,7 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
                 vpc_id, '10.0.128.0/20', self.config['deployment_name'] + '-public')
             parameters['PublicSubnet'] = public_subnet_id
             temp_resources.update({'public_subnet': public_subnet_id})
-        self.config['template_parameters'] = yaml.dump(parameters)
+        self.config['template_parameters'] = parameters
         return temp_resources
 
     def wait(self):
@@ -107,14 +105,15 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
         as the cloudformation stack, update the config with the resulting private key,
         and amend the cloudformation template parameters to have KeyName set as this key
         """
-        if self.config['key_helper'] != 'true':
+        if self.config['key_helper'] is not True:
             return {}
+        if 'KeyName' in self.config['template_parameters']:
+            raise launch.util.LauncherError('KeyHelperError', 'KeyName cannot be set in '
+                                            'template_parameters when key_helper is true')
         key_name = self.config['deployment_name']
         private_key = self.boto_wrapper.create_key_pair(key_name)
         self.config.update({'ssh_private_key': private_key})
-        template_parameters = yaml.load(self.config['template_parameters'])
-        template_parameters.update({'KeyName': key_name})
-        self.config['template_parameters'] = yaml.dump(template_parameters)
+        self.config['template_parameters'].update({'KeyName': key_name})
         return {'key_name': key_name}
 
     @property
@@ -131,14 +130,18 @@ class BareClusterLauncher(DcosCloudformationLauncher):
     def create(self):
         """ Amend the config to add a template_body and the appropriate parameters
         """
+        template_parameters = {
+            'AllowAccessFrom': self.config['admin_location'],
+            # cluster size is +1 for the bootstrap node
+            'ClusterSize': (1 + self.config['num_masters'] + self.config['num_public_agents'] +
+                            self.config['num_private_agents']),
+            'InstanceType': self.config['instance_type'],
+            'AmiCode': self.config['instance_ami']}
+        if self.config['key_helper'] is not True:
+            template_parameters['KeyName'] = self.config['aws_key_name']
         self.config.update({
             'template_body': test_util.aws.template_by_instance_type(self.config['instance_type']),
-            'template_parameters': yaml.dump({
-                'KeyName': self.config['aws_key_name'],
-                'AllowAccessFrom': self.config['admin_location'],
-                'ClusterSize': self.config['cluster_size'],
-                'InstanceType': self.config['instance_type'],
-                'AmiCode': self.config['instance_ami']})})
+            'template_parameters': template_parameters})
         return super().create()
 
     def get_hosts(self):

--- a/packages/dcos-launch/extra/launch/aws.py
+++ b/packages/dcos-launch/extra/launch/aws.py
@@ -46,7 +46,7 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
         will be provided (must be done in correct order) and added to the info
         JSON as 'temp_resources'
         """
-        if self.config['zen_helper'] is not True:
+        if not self.config['zen_helper']:
             return {}
         parameters = self.config['template_parameters']
         temp_resources = {}
@@ -105,7 +105,7 @@ class DcosCloudformationLauncher(launch.util.AbstractLauncher):
         as the cloudformation stack, update the config with the resulting private key,
         and amend the cloudformation template parameters to have KeyName set as this key
         """
-        if self.config['key_helper'] is not True:
+        if not self.config['key_helper']:
             return {}
         if 'KeyName' in self.config['template_parameters']:
             raise launch.util.LauncherError('KeyHelperError', 'KeyName cannot be set in '
@@ -137,7 +137,7 @@ class BareClusterLauncher(DcosCloudformationLauncher):
                             self.config['num_private_agents']),
             'InstanceType': self.config['instance_type'],
             'AmiCode': self.config['instance_ami']}
-        if self.config['key_helper'] is not True:
+        if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']
         self.config.update({
             'template_body': test_util.aws.template_by_instance_type(self.config['instance_type']),

--- a/packages/dcos-launch/extra/launch/azure.py
+++ b/packages/dcos-launch/extra/launch/azure.py
@@ -44,7 +44,7 @@ class AzureResourceGroupLauncher(launch.util.AbstractLauncher):
         """ Adds private key to the config and injects the public key into
         the template parameters
         """
-        if self.config['key_helper'] is not True:
+        if not self.config['key_helper']:
             return
         if 'sshRSAPublicKey' in self.config['template_parameters']:
             raise launch.util.LauncherError('KeyHelperError', 'key_helper will automatically'

--- a/packages/dcos-launch/extra/launch/config.py
+++ b/packages/dcos-launch/extra/launch/config.py
@@ -1,44 +1,28 @@
-import atexit
-import copy
 import os
 
-import requests
+import cerberus
 import yaml
 
-import gen
 import launch.util
-import ssh.validate
 import test_util.aws
 import test_util.helpers
-from gen.internals import resolve_configuration, Scope, Source, Target, validate_one_of
-from pkgpanda.util import load_string, load_yaml, YamlParseError
 
-# DCOS_OSS-802: [gen/dcos_installer] allow using library uncoupled from installer
-# dcos_installer.config will directly import gen.build_deploy.util
-# which expects to find the image commit in the environment or in
-# a directory-local git tree **at import time**. Therefore, the
-# environment variable DCOS_IMAGE_COMMIT must be set here.
-if 'DCOS_IMAGE_COMMIT' not in os.environ:
-    os.environ['DCOS_IMAGE_COMMIT'] = ''
-    atexit.register(os.unsetenv, 'DCOS_IMAGE_COMMIT')
 
-import dcos_installer.config  # noqa
+class YamlParseError(Exception):
+    pass
 
-# gen.build_deploy.bash expects to be run from the installer or git-tree
-# environment and will expect this when resolving the onprem configuration
-if 'BOOTSTRAP_VARIANT' not in os.environ:
-    os.environ['BOOTSTRAP_VARIANT'] = ''
-    atexit.register(os.unsetenv, 'BOOTSTRAP_VARIANT')
 
-# gen.build_deploy.bash expects to be able to get a list of packages
-# from a JSON at a hard-coded path. The package list is used for the deploy
-# logic of the installer and trivializing it here will have no bearing on
-# the onprem config.yaml pre-validation performed in this module
-setattr(dcos_installer.config_util, 'installer_latest_complete_artifact', launch.util.stub({'packages': []}))
+def load_yaml(filename: str):
+    try:
+        with open(filename) as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError as ex:
+        raise YamlParseError("Invalid YAML in {}: {}".format(filename, ex)) from ex
 
 
 def expand_path(path: str, relative_dir: str) -> str:
-    """ Returns an absolute path
+    """ Returns an absolute path by performing '~' and '..' substitution target path
+
     path: the user-provided path
     relative_dir: the absolute directory to which `path` should be seen as
         relative
@@ -47,32 +31,6 @@ def expand_path(path: str, relative_dir: str) -> str:
     if os.path.isabs(path):
         return path
     return os.path.abspath(os.path.join(relative_dir, path))
-
-
-def expand_filenames(config: dict, config_dir: str) -> dict:
-    """ Recursively mutates a config dict so that all keys that end with
-    '_filename' will be ensured to be absolute paths
-    """
-    new_config = copy.deepcopy(config)
-    for k, v in new_config.items():
-        if isinstance(v, dict):
-            new_config[k] = expand_filenames(v, config_dir)
-        if not isinstance(v, str):
-            continue
-        if k.endswith('_filename'):
-            new_config[k] = expand_path(v, config_dir)
-    return new_config
-
-
-def yaml_flatten(config: dict) -> dict:
-    """ Takes a multi-layered dict and converts it to a single-layer dict by
-    converting sub-icts into yaml strings
-    """
-    new_config = copy.deepcopy(config)
-    for k, v in new_config.items():
-        if isinstance(v, dict):
-            new_config[k] = yaml.dump(v)
-    return new_config
 
 
 def load_config(config_path: str) -> dict:
@@ -85,339 +43,255 @@ def load_config(config_path: str) -> dict:
         raise launch.util.LauncherError('MissingConfig', None) from ex
 
 
-def gen_format_config(config: dict, config_dir: str) -> dict:
-    """ path-expands, yaml-flattens, and stringifies user-provided config-dict
+def validate_url(field, value, error):
+    if not value.startswith('http'):
+        error(field, 'Not a valid HTTP URL')
+
+
+def load_ssh_private_key(doc):
+    if doc.get('key_helper') == 'true':
+        return 'unset'
+    if 'ssh_private_key_filename' not in doc:
+        return launch.util.NO_TEST_FLAG
+    return launch.util.load_string(doc['ssh_private_key_filename'])
+
+
+class LaunchValidator(cerberus.Validator):
+    """ Needs to use unintuitive pattern so that child validator can be created
+    for validated the nested dcos_config
     """
-    return gen.stringify_configuration(yaml_flatten(expand_filenames(config, config_dir)))
+    def __init__(self, *args, **kwargs):
+        super(LaunchValidator, self).__init__(*args, **kwargs)
+        if 'config_dir' in kwargs:
+            self.config_dir = kwargs['config_dir']
+
+    def _normalize_coerce_expand_local_path(self, value):
+        return expand_path(value, self.config_dir)
+
+    def _normalize_coerce_local_path_to_contents(self, value):
+        """ Converts a localized filename to the contents of said file
+        """
+        return launch.util.load_string(expand_path(value, self.config_dir))
+
+
+def expand_error_dict(errors: dict) -> str:
+    message = ''
+    for key, errors in errors.items():
+        sub_message = 'Field: {}, Errors: '.format(key)
+        for e in errors:
+            if isinstance(e, dict):
+                sub_message += expand_error_dict(e)
+            else:
+                sub_message += e
+            sub_message += '\n'
+        message += sub_message
+    return message
+
+
+def raise_errors(validator: LaunchValidator):
+    message = expand_error_dict(validator.errors)
+    raise launch.util.LauncherError('ValidationError', message)
 
 
 def get_validated_config(config_path: str) -> dict:
     """ Returns validated a finalized argument dictionary for dcos-launch
+    Given the huge range of configuration space provided by this configuration
+    file, it must be processed in three steps (common, provider-specifc,
+    platform-specific)
     """
     config = load_config(config_path)
     config_dir = os.path.dirname(config_path)
-    config = gen_format_config(config, config_dir)
-    resolver = validate_config(config)
-    final_args = gen.get_final_arguments(resolver)
-    # TODO DCOS-14196: [gen.internals] disallow extra user provided arguments
-    unrecognized_args = set(config.keys()) - set(final_args.keys())
-    if len(unrecognized_args) > 0:
-        raise launch.util.LauncherError(
-            'ValidationError', 'Unrecognized/incompatible arguments: {}'.format(unrecognized_args))
-    return final_args
+    # validate against the fields common to all configs
+    basic_validator = LaunchValidator(COMMON_SCHEMA, config_dir=config_dir, allow_unknown=True)
+    if not basic_validator.validate(config):
+        raise_errors(basic_validator)
 
-
-def validate_config(user_config: dict) -> gen.internals.Resolver:
-    """ Converts the user config to to a source and evaluates it
-    versus the targets and source in this module. Also, catches
-    and reformats the validation exception before raising
-    """
-    sources = [Source(entry), gen.user_arguments_to_source(user_config)]
-    try:
-        return gen.validate_and_raise(sources, [get_target()])
-    except gen.exceptions.ValidationError as ex:
-        raise launch.util.LauncherError(
-            'ValidationError', pretty_print_validate_error(ex.errors, ex.unset))
-
-
-def pretty_print_validate_error(errors, unset):
-    out = ''
-    if errors != {}:
-        out = '\nErrors:\n'
-        for k, v in errors.items():
-            out += '  {}: {}\n'.format(k, v['message'])
-    if len(unset) > 0:
-        out += '\nUnset arguments:\n'
-        for u in unset:
-            out += '  ' + u + '\n'
-    return out
-
-
-def get_target():
-    """ Targets must never be re-used after its been evaluated by gen, so
-    do not define it as a global constant
-    """
-    aws_platform_target = Target({
-        'aws_region',
-        'aws_access_key_id',
-        'aws_secret_access_key',
-        'key_helper',
-        'zen_helper',
-        'deployment_name'},
-        {
-            'provider': Scope('provider', {
-                'aws': Target({}),
-                'azure': Target({}),
-                'onprem': Target({}, {
-                    'key_helper': Scope('key_helper', {
-                        'true': Target({}),
-                        'false': Target({'aws_key_name'})
-                    })
-                })
-            })
-    })
-    azure_platform_target = Target({
-        'azure_location',
-        'azure_client_id',
-        'azure_client_secret',
-        'azure_tenant_id',
-        'azure_subscription_id',
-        'deployment_name',
-        'key_helper'})
-    template_target = Target({
-        'template_url',
-        'template_parameters'})
-    onprem_target = Target(
-        {
-            'installer_url',
-            'installer_port',
-            'num_private_agents',
-            'num_public_agents',
-            'num_masters',
-            'prevalidate_onprem_config',
-            'onprem_dcos_config_contents'
-        },
-        {
-            'platform': Scope('platform', {
-                'aws': Target({
-                    'aws_key_name',
-                    'cluster_size',
-                    'instance_ami',
-                    'instance_type',
-                    'admin_location'}),
-                'azure': Target({})})})  # Unsupported currently
-    return Target({
-        'launch_config_version',
-        'platform',
-        'provider',
-        'ssh_port',
-        'ssh_private_key',
-        'ssh_user'},
-        {
-            'platform': Scope('platform', {
-                'aws': aws_platform_target,
-                'azure': azure_platform_target}),
-            'provider': Scope('provider', {
-                'aws': template_target,
-                'azure': template_target,
-                'onprem': onprem_target})})
-
-
-def validate_template_url(template_url):
-    assert template_url.startswith('http')
-
-
-def validate_installer_url(installer_url):
-    assert installer_url.startswith('http'), 'Not a valid URL: {}'.format(installer_url)
-    assert requests.head(installer_url).status_code == 200
-
-
-def validate_launch_config_version(launch_config_version):
-    assert int(launch_config_version) == 1
-
-
-def validate_onprem_dcos_config_contents(onprem_dcos_config_contents, num_masters, prevalidate_onprem_config):
-    # TODO DCOS-14033: [gen.internals] Source validate functions are global only
-    if prevalidate_onprem_config != 'true':
-        return
-    user_config = yaml.load(onprem_dcos_config_contents)
-    # Use the default config in the installer
-    config = yaml.load(dcos_installer.config.config_sample)
-    config.update(user_config)
-    # This field is required and auto-added by installer, so add a dummy here
-    if 'bootstrap_id' not in config:
-        config['bootstrap_id'] = 'deadbeef'
-
-    # dummy master list to pass validation
-    config['master_list'] = [('10.0.0.' + str(i)) for i in range(int(num_masters))]
-
-    # Use the default config in the installer
-    sources, targets, templates = gen.get_dcosconfig_source_target_and_templates(
-        gen.stringify_configuration(config), list(), [ssh.validate.source, gen.build_deploy.bash.onprem_source])
-
-    # Copy the gen target from dcos_installer/config.py, but instead remove
-    # 'ssh_key_path' from the target because the validate fn in ssh_source is
-    # too strict I.E. we cannot validate a key if we are going to generate
-    # Furthermore, we cannot use the target ssh_key_path as it will automatically
-    # invoked the validate fn from ssh/validate.py Luckily, we can instead use
-    # the more idiomatic 'ssh_private_key_filename'
-    targets.append(Target({
-        'ssh_user',
-        'ssh_port',
-        'master_list',
-        'agent_list',
-        'public_agent_list',
-        'ssh_parallelism',
-        'process_timeout'}))
-
-    resolver = resolve_configuration(sources, targets)
-    status = resolver.status_dict
-    if status['status'] == 'errors':
-        raise AssertionError(pretty_print_validate_error(status['errors'], status['unset']))
-
-
-def calculate_dcos_config_contents(dcos_config, num_masters, ssh_user, ssh_private_key, platform):
-    """ Fills in the ssh user, ssh private key and ip-detect script if possible
-    Takes the config's local references and converts them into transmittable content
-    """
-    user_config = yaml.load(dcos_config)
-    # Use the default config in the installer for the same experience
-    # w.r.t the auto-filled settings
-    config = yaml.load(dcos_installer.config.config_sample)
-    config.update(user_config)
-    config['ssh_user'] = ssh_user
-    config['ssh_key'] = ssh_private_key
-    for key_name in ['ip_detect_filename', 'ip_detect_public_filename']:
-        if key_name in config:
-            config[key_name.replace('_filename', '_contents')] = load_string(config[key_name])
-            del config[key_name]
-    if 'ip_detect_contents' not in config:
-        config['ip_detect_contents'] = test_util.helpers.ip_detect_script(platform)
-    return yaml.dump(config)
-
-
-def validate_onprem_provider_platform(provider, platform):
-    # TODO DCOS-14033: [gen.internals] Source validate functions are global only
+    # add provider specific information to the basic validator
+    provider = basic_validator.normalized(config)['provider']
     if provider == 'onprem':
-        assert platform != 'azure', '`provider: onprem` is not currently not support on azure'
+        basic_validator.schema.update(ONPREM_DEPLOY_COMMON_SCHEMA)
     else:
-        assert platform == provider
+        basic_validator.schema.update(TEMPLATE_DEPLOY_COMMON_SCHEMA)
 
+    # validate again before attempting to add platform information
+    if not basic_validator.validate(config):
+        raise_errors(basic_validator)
 
-def validate_key_helper_support(platform, key_helper):
-    # TODO DCOS-14033: [gen.internals] Source validate functions are global only
-    if key_helper == 'false':
-        return
-    assert platform in ('aws', 'azure')
-
-
-def calculate_ssh_user(os_name, platform):
+    # use the intermediate provider-validated config to add the platform schema
+    platform = basic_validator.normalized(config)['platform']
     if platform == 'aws':
-        return test_util.aws.OS_SSH_INFO[os_name].user
+        basic_validator.schema.update(AWS_PLATFORM_SCHEMA)
+        if provider == 'onprem':
+            basic_validator.schema.update(AWS_ONPREM_SCHEMA)
+    elif platform == 'azure':
+        basic_validator.schema.update(AZURE_PLATFORM_SCHEMA)
     else:
-        raise Exception('Cannot yet calculate user for {} platform'.format(platform))
+        raise NotImplementedError()
+
+    # onprem requires some special configuration per platform, so add those here
+
+    # pop dcos_config field from the user config as we must allow the inner
+    # fields to contain unknowns, but no
+    # create a strict validator with our final schema and process it
+    final_validator = LaunchValidator(basic_validator.schema, config_dir=config_dir, allow_unknown=False)
+    if not final_validator.validate(config):
+        raise_errors(final_validator)
+    return final_validator.normalized(config)
 
 
-def validate_key_helper_parameters(template_parameters, provider, key_helper):
-    # TODO DCOS-14033: [gen.internals] Source validate functions are global only
-    if key_helper == 'false':
-        return
-    if provider == 'aws':
-        assert 'KeyName' not in yaml.load(template_parameters), 'key_helper will '\
-            'automatically calculate and inject KeyName; do not set this parameter'
-    if provider == 'azure':
-        assert 'sshRSAPublicKey' not in yaml.load(template_parameters), 'key_helper will '\
-            'automatically calculate and inject sshRSAPublicKey; do not set this parameter'
+COMMON_SCHEMA = {
+    'deployment_name': {
+        'type': 'string',
+        'required': True},
+    'provider': {
+        'type': 'string',
+        'required': True,
+        'allowed': [
+            'aws',
+            'azure',
+            'onprem']},
+    'launch_config_version': {
+        'type': 'integer',
+        'required': True,
+        'allowed': [1]},
+    'ssh_port': {
+        'type': 'integer',
+        'required': False,
+        'default': 22},
+    'ssh_private_key_filename': {
+        'type': 'string',
+        'coerce': 'expand_local_path',
+        'required': False},
+    'ssh_private_key': {
+        'type': 'string',
+        'required': False,
+        'default_setter': load_ssh_private_key},
+    'ssh_user': {
+        'type': 'string',
+        'required': False,
+        'default': 'core'},
+    'key_helper': {
+        'type': 'boolean',
+        'default': False}}
 
 
-def calculate_instance_count(num_masters, num_private_agents, num_public_agents):
-    return str(1 + int(num_masters) + int(num_private_agents) + int(num_public_agents))
+AWS_PLATFORM_SCHEMA = {
+    'aws_region': {
+        'type': 'string',
+        'required': True},
+    'aws_access_key_id': {
+        'type': 'string',
+        'required': True},
+    'aws_secret_access_key': {
+        'type': 'string',
+        'required': True},
+    'zen_helper': {
+        'type': 'boolean',
+        'default': False}}
 
 
-def validate_os_name(os_name, platform, provider):
-    # TODO DCOS-14033: [gen.internals] Source validate functions are global only
-    if provider != 'onprem':
-        # the os_name parameter only applies to homogenous clusters that need
-        # to be created by dcos-launch for an onprem install. In other cases,
-        # the deployment template is parameterized for OS selection
-        return
-    if platform == 'aws':
-        validate_one_of(os_name, list(test_util.aws.OS_SSH_INFO.keys()))
-    else:
-        raise AssertionError('Support not yet implemented for {} bare cluster'.format(platform))
+AZURE_PLATFORM_SCHEMA = {
+    'azure_location': {
+        'type': 'string',
+        'required': True},
+    'azure_client_id': {
+        'type': 'string',
+        'required': True},
+    'azure_client_secret': {
+        'type': 'string',
+        'required': True},
+    'azure_tenant_id': {
+        'type': 'string',
+        'required': True},
+    'azure_subscription_id': {
+        'type': 'string',
+        'required': True}}
 
 
-def calculate_ssh_private_key(ssh_private_key_filename):
-    if ssh_private_key_filename == '':
-        return launch.util.NO_TEST_FLAG
-    return load_string(ssh_private_key_filename)
+TEMPLATE_DEPLOY_COMMON_SCHEMA = {
+    # platform MUST be equal to provider when using templates
+    'platform': {
+        'type': 'string',
+        'readonly': True,
+        'default_setter': lambda doc: doc['provider']},
+    'template_url': {
+        'type': 'string',
+        'required': True,
+        'validator': validate_url},
+    'template_parameters': {
+        'type': 'dict',
+        'required': True}}
 
 
-def calculate_instance_ami(os_name, aws_region):
-    return test_util.aws.OS_AMIS[os_name][aws_region]
+ONPREM_DEPLOY_COMMON_SCHEMA = {
+    'platform': {
+        'type': 'string',
+        'required': True,
+        'allowed': ['aws']},
+    'installer_url': {
+        'validator': validate_url,
+        'type': 'string',
+        'required': True},
+    'installer_port': {
+        'type': 'integer',
+        'default': 9000},
+    'num_private_agents': {
+        'type': 'integer',
+        'required': True,
+        'min': 0},
+    'num_public_agents': {
+        'type': 'integer',
+        'required': True,
+        'min': 0},
+    'num_masters': {
+        'type': 'integer',
+        'allowed': [1, 3, 5, 7, 9],
+        'required': True},
+    'os_name': {
+        'type': 'string',
+        # not required because it can be set by ami directly
+        'required': False,
+        'default': 'cent-os-7-prereqs',
+        # This is AWS specific and is kind of awkward here, move to launcher?
+        'allowed': list(test_util.aws.OS_SSH_INFO.keys())},
+    'ssh_user': {
+        'required': True,
+        'type': 'string',
+        'default_setter': lambda doc: test_util.aws.OS_SSH_INFO[doc['os_name']].user},
+    'dcos_config': {
+        'type': 'dict',
+        'required': True,
+        'allow_unknown': True,
+        'schema': {
+            'ip_detect_filename': {
+                'coerce': 'expand_local_path',
+                'excludes': 'ip_detect_content'},
+            'ip_detect_public_filename': {
+                'coerce': 'expand_local_path',
+                'excludes': 'ip_detect_public_content'},
+            'ip_detect_contents': {
+                'excludes': 'ip_detect_filename'},
+            'ip_detect_public_contents': {
+                'excludes': 'ip_detect_public_filename'},
+            # currently, these values cannot be set by a user, only by the launch process
+            'master_list': {'readonly': True},
+            'agent_list': {'readonly': True},
+            'public_agent_list': {'readonly': True}}}}
 
 
-def validate_key_name(provider, platform, key_helper):
-    if provider == 'aws' and platform == 'onprem' and key_helper == 'false':
-        raise AssertionError('Either provide `key_name`')
-
-
-def calculate_cluster_size(num_masters, num_private_agents, num_public_agents):
-    # add one for the installer bootstrap host
-    return str(1 + int(num_masters) + int(num_private_agents) + int(num_public_agents))
-
-
-entry = {
-    'validate': [
-        validate_installer_url,
-        validate_launch_config_version,
-        validate_onprem_dcos_config_contents,
-        validate_key_helper_parameters,
-        validate_key_helper_support,
-        validate_onprem_provider_platform,
-        validate_os_name,
-        lambda key_helper: gen.calc.validate_true_false(key_helper),
-        lambda zen_helper: gen.calc.validate_true_false(zen_helper),
-        lambda provider: validate_one_of(provider, ['aws', 'azure', 'onprem']),
-        lambda platform: validate_one_of(platform, ['aws', 'azure']),
-    ],
-    'default': {
-        'ssh_port': '22',
-        'ssh_private_key': calculate_ssh_private_key,
-        'instance_ami': calculate_instance_ami,
-        'os_name': 'cent-os-7-prereqs',
-        'key_helper': 'false',
-        'zen_helper': 'false'
-    },
-    'conditional': {
-        'provider': {
-            'aws': {
-                'default': {
-                    # allow untest-able deployment
-                    'ssh_user': '',
-                    'ssh_private_key_filename': ''
-                },
-                'must': {
-                    # TODO DCOS-14048: [gen.internals] allow user providing arguments
-                    # for a 'must' if the arguments agree
-                    'platform': 'aws'
-                }
-            },
-            'azure': {
-                'default': {
-                    # allow untest-able deployment
-                    'ssh_user': '',
-                    'ssh_private_key_filename': ''
-                },
-                'must': {
-                    # TODO DCOS-14048: [gen.internals] allow user providing arguments
-                    # for a 'must' if the arguments agree
-                    'platform': 'azure'
-                }
-            },
-            'onprem': {
-                'default': {
-                    'prevalidate_onprem_config': 'false',
-                    'num_public_agents': '0',
-                    'num_private_agents': '0',
-                    'installer_port': '9000',
-                    'admin_location': '0.0.0.0/0'
-                },
-                'must': {
-                    'onprem_dcos_config_contents': calculate_dcos_config_contents,
-                    'ssh_user': calculate_ssh_user,
-                    'cluster_size': calculate_cluster_size
-                },
-            },
-        },
-        'key_helper': {
-            'true': {
-                'must': {
-                    # key input not applicable if helper is used
-                    'aws_key_name': 'unset',
-                    'ssh_private_key_filename': 'unset',
-                    'ssh_private_key': 'unset'}},
-            'false': {}
-        }
-    }
-}
+AWS_ONPREM_SCHEMA = {
+    'aws_key_name': {
+        'type': 'string',
+        'dependencies': {
+            'key_helper': False}},
+    'instance_ami': {
+        'type': 'string',
+        'required': True,
+        'default_setter': lambda doc: test_util.aws.OS_AMIS[doc['os_name']][doc['aws_region']]},
+    'instance_type': {
+        'type': 'string',
+        'required': True},
+    'admin_location': {
+        'type': 'string',
+        'required': True,
+        'default': '0.0.0.0/0'}}

--- a/packages/dcos-launch/extra/launch/ip-detect/aws.sh
+++ b/packages/dcos-launch/extra/launch/ip-detect/aws.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -o nounset -o errexit
+
+# Get COREOS COREOS_PRIVATE_IPV4
+if [ -e /etc/environment ]
+then
+  set -o allexport
+  source /etc/environment
+  set +o allexport
+fi
+
+get_private_ip_from_metaserver()
+{
+    curl -fsSL http://169.254.169.254/latest/meta-data/local-ipv4
+}
+
+echo ${COREOS_PRIVATE_IPV4:-$(get_private_ip_from_metaserver)}

--- a/packages/dcos-launch/extra/launch/ip-detect/aws_public.sh
+++ b/packages/dcos-launch/extra/launch/ip-detect/aws_public.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -o nounset -o errexit
+
+curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4

--- a/packages/dcos-launch/extra/launch/ip-detect/aws_public.sh
+++ b/packages/dcos-launch/extra/launch/ip-detect/aws_public.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 set -o nounset -o errexit
 
+if [ -e /etc/environment ]
+then
+  set -o allexport
+  source /etc/environment
+  set +o allexport
+fi
+
 curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4

--- a/packages/dcos-launch/extra/launch/onprem.py
+++ b/packages/dcos-launch/extra/launch/onprem.py
@@ -77,7 +77,7 @@ class OnpremLauncher(launch.util.AbstractLauncher):
             if new_key_name in onprem_config:
                 raise launch.util.LauncherError(
                     'InvalidDcosConfig', 'Cannot set *_filename and *_contents simultaneously!')
-            onprem_config[new_key_name] = launch.util.load_string(onprem_config[key_name])
+            onprem_config[new_key_name] = launch.util.read_file(onprem_config[key_name])
             del onprem_config[key_name]
         # set the simple default IP detect script if not provided
         # currently, only AWS is supported, but when support changes, this will have to update

--- a/packages/dcos-launch/extra/launch/onprem.py
+++ b/packages/dcos-launch/extra/launch/onprem.py
@@ -36,7 +36,7 @@ class OnpremLauncher(launch.util.AbstractLauncher):
         self.get_ssher().command(self.bootstrap_host, ['printf', state, '>', STATE_FILE])
 
     def get_last_state(self):
-        return self.get_ssher(self.config).command(self.bootstrap_host, ['cat', STATE_FILE]).decode().strip()
+        return self.get_ssher().command(self.bootstrap_host, ['cat', STATE_FILE]).decode().strip()
 
     def get_bare_cluster_launcher(self):
         if self.config['platform'] == 'aws':

--- a/packages/dcos-launch/extra/launch/onprem.py
+++ b/packages/dcos-launch/extra/launch/onprem.py
@@ -2,8 +2,8 @@ import copy
 import logging
 import subprocess
 
+import pkg_resources
 import retrying
-import yaml
 
 import launch.aws
 import launch.util
@@ -53,24 +53,43 @@ class OnpremLauncher(launch.util.AbstractLauncher):
             num_private_agents=int(self.config['num_private_agents']),
             num_public_agents=int(self.config['num_public_agents']))
 
-    def get_completed_onprem_config(self, cluster):
-        onprem_config = yaml.load(self.config['onprem_dcos_config_contents'])
-        zk_backend = onprem_config.get('exhibitor_storage_backend') == 'zookeeper'
-        if zk_backend:
-            onprem_config['exhibitor_zk_hosts'] = self.bootstrap_host + ':2181'
-        if zk_backend:
-            cluster.start_bootstrap_zk()
+    def get_completed_onprem_config(self, cluster: test_util.onprem.OnpremCluster) -> dict:
+        onprem_config = self.config['dcos_config']
+        # First, try and retrieve the agent list from the cluster
         onprem_config['agent_list'] = [h.private_ip for h in cluster.private_agents]
         onprem_config['public_agent_list'] = [h.private_ip for h in cluster.public_agents]
         onprem_config['master_list'] = [h.private_ip for h in cluster.masters]
-        # SSH private key must have been provided at creation time or key helper true
-        # if provided initially then it will be set, if key_helper is true, then its unset
-        if onprem_config.get('ssh_key') == 'unset':
+        # if the user wanted to use exhibitor as the backend, then start it
+        if onprem_config.get('exhibitor_storage_backend') == 'zookeeper':
+            onprem_config['exhibitor_zk_hosts'] = cluster.start_bootstrap_zk()
+        # if key helper is true then ssh key must be injected, or the key
+        # must have been provided as a file and still needs to be injected
+        if self.config['key_helper'] or 'ssh_key' not in onprem_config:
             onprem_config['ssh_key'] = self.config['ssh_private_key']
+        # check if ssh user was not provided
+        if 'ssh_user' not in onprem_config:
+            onprem_config['ssh_user'] = self.config['ssh_user']
+        # check if the user provided any filenames and convert them into content
+        for key_name in ('ip_detect_filename', 'ip_detect_public_filename'):
+            if key_name not in onprem_config:
+                continue
+            new_key_name = key_name.replace('_filename', '_contents')
+            if new_key_name in onprem_config:
+                raise launch.util.LauncherError(
+                    'InvalidDcosConfig', 'Cannot set *_filename and *_contents simultaneously!')
+            onprem_config[new_key_name] = launch.util.load_string(onprem_config[key_name])
+            del onprem_config[key_name]
+        # set the simple default IP detect script if not provided
+        # currently, only AWS is supported, but when support changes, this will have to update
+        if 'ip_detect_contents' not in onprem_config:
+            onprem_config['ip_detect_contents'] = pkg_resources.resource_string(
+                'launch', 'ip-detect/aws.sh').decode('utf-8')
+        if 'ip_detect_contents' not in onprem_config:
+            onprem_config['ip_detect_public_contents'] = pkg_resources.resource_string(
+                'launch', 'ip-detect/aws_public.sh').decode('utf-8')
         # For no good reason the installer uses 'ip_detect_script' instead of 'ip_detect_contents'
-        if 'ip_detect_contents' in onprem_config:
-            onprem_config['ip_detect_script'] = onprem_config['ip_detect_contents']
-            del onprem_config['ip_detect_contents']
+        onprem_config['ip_detect_script'] = self.config['dcos_config']['ip_detect_contents']
+        del onprem_config['ip_detect_contents']
         log.debug('Generated cluster configuration: {}'.format(onprem_config))
         return onprem_config
 
@@ -111,7 +130,7 @@ class OnpremLauncher(launch.util.AbstractLauncher):
             last_complete = 'POSTFLIGHT'
             self.post_state(last_complete)
         if last_complete != 'POSTFLIGHT':
-            raise launch.util.LauncherError('InconsistentState', last_complete)
+            raise launch.util.LauncherError('InconsistentState', 'State on bootstrap host is: ' + last_complete)
 
     def describe(self):
         """ returns host information stored in the config as
@@ -128,8 +147,6 @@ class OnpremLauncher(launch.util.AbstractLauncher):
         # blackout unwanted fields
         del desc['template_body']
         del desc['template_parameters']
-        desc['dcos_config'] = yaml.load(desc['onprem_dcos_config_contents'])
-        del desc['onprem_dcos_config_contents']
         return desc
 
     def delete(self):

--- a/packages/dcos-launch/extra/launch/util.py
+++ b/packages/dcos-launch/extra/launch/util.py
@@ -24,6 +24,11 @@ MOCK_STACK_ID = 'this-is-a-important-test-stack::deadbeefdeadbeef'
 NO_TEST_FLAG = 'NO PRIVATE SSH KEY PROVIDED - CANNOT TEST'
 
 
+def load_string(filename: str):
+    with open(filename) as f:
+        return f.read().strip()
+
+
 def stub(output):
     def accept_any_args(*args, **kwargs):
         return output

--- a/packages/dcos-launch/extra/launch/util.py
+++ b/packages/dcos-launch/extra/launch/util.py
@@ -24,7 +24,7 @@ MOCK_STACK_ID = 'this-is-a-important-test-stack::deadbeefdeadbeef'
 NO_TEST_FLAG = 'NO PRIVATE SSH KEY PROVIDED - CANNOT TEST'
 
 
-def load_string(filename: str):
+def read_file(filename: str):
     with open(filename) as f:
         return f.read().strip()
 

--- a/packages/dcos-launch/extra/setup.py
+++ b/packages/dcos-launch/extra/setup.py
@@ -25,6 +25,7 @@ setup(
         'azure-mgmt-resource==0.30.0rc4',
         'boto3',
         'botocore',
+        'cerberus',
         'docopt',
         'pyinstaller==3.2',
         'pyyaml'],
@@ -35,6 +36,8 @@ setup(
     },
     package_data={
         'launch': [
+            'ip-detect/aws.sh',
+            'ip-detect/aws_public.sh',
             'sample_configs/*.yaml',
             'dcos-launch.spec'
         ],

--- a/packages/dcos-launch/extra/test_aws.py
+++ b/packages/dcos-launch/extra/test_aws.py
@@ -1,5 +1,4 @@
 import pytest
-import yaml
 
 import launch
 import launch.cli
@@ -60,7 +59,7 @@ def test_key_helper(aws_cf_with_helper_config_path):
     aws_launcher = launch.get_launcher(config)
     temp_resources = aws_launcher.key_helper()
     assert temp_resources['key_name'] == config['deployment_name']
-    assert yaml.load(config['template_parameters'])['KeyName'] == config['deployment_name']
+    assert config['template_parameters']['KeyName'] == config['deployment_name']
     assert config['ssh_private_key'] == launch.util.MOCK_SSH_KEY_DATA
 
 
@@ -72,8 +71,7 @@ def test_zen_helper(aws_zen_cf_config_path):
     assert temp_resources['gateway'] == launch.util.MOCK_GATEWAY_ID
     assert temp_resources['private_subnet'] == launch.util.MOCK_SUBNET_ID
     assert temp_resources['public_subnet'] == launch.util.MOCK_SUBNET_ID
-    template_parameters = yaml.load(config['template_parameters'])
-    assert template_parameters['Vpc'] == launch.util.MOCK_VPC_ID
-    assert template_parameters['InternetGateway'] == launch.util.MOCK_GATEWAY_ID
-    assert template_parameters['PrivateSubnet'] == launch.util.MOCK_SUBNET_ID
-    assert template_parameters['PublicSubnet'] == launch.util.MOCK_SUBNET_ID
+    assert config['template_parameters']['Vpc'] == launch.util.MOCK_VPC_ID
+    assert config['template_parameters']['InternetGateway'] == launch.util.MOCK_GATEWAY_ID
+    assert config['template_parameters']['PrivateSubnet'] == launch.util.MOCK_SUBNET_ID
+    assert config['template_parameters']['PublicSubnet'] == launch.util.MOCK_SUBNET_ID

--- a/packages/dcos-launch/extra/test_config.py
+++ b/packages/dcos-launch/extra/test_config.py
@@ -1,9 +1,8 @@
 import os
 
 import pytest
-import yaml
 
-from launch.config import gen_format_config, get_validated_config
+from launch.config import get_validated_config, expand_path
 from launch.util import get_temp_config_path, LauncherError
 
 
@@ -24,35 +23,9 @@ def mock_relative_path(tmpdir):
         yield str(tmpdir)
 
 
-def test_gen_formatting(mock_home, mock_relative_path):
-    config = {
-        'foobarbaz': True,
-        'fizzbuzz': 3}
-
-    abs_config = {'foo_filename': '/abc'}
-    foo_filename = '/abc'
-    config.update(abs_config)
-    config['foo'] = abs_config  # Test single nest
-
-    rel_config = {'bar_filename': 'some_other_dir'}
-    config.update(rel_config)
-    bar_filename = os.path.join(mock_relative_path, 'some_other_dir')
-    config['bar'] = {'bar': rel_config}  # Test double nested
-
-    user_config = {'baz_filename': '~/foo/bar/dir'}
-    baz_filename = os.path.join(mock_home, 'foo/bar/dir')
-    config.update(user_config)
-    config['baz'] = {'baz': {'baz': user_config}}  # Test triple-nested
-
-    assert gen_format_config(config, mock_relative_path) == {
-        'foobarbaz': 'true',
-        'fizzbuzz': '3',
-        'foo_filename': foo_filename,
-        'bar_filename': bar_filename,
-        'baz_filename': baz_filename,
-        'foo': yaml.dump({'foo_filename': foo_filename}),
-        'bar': yaml.dump({'bar': {'bar_filename': bar_filename}}),
-        'baz': yaml.dump({'baz': {'baz': {'baz_filename': baz_filename}}})}
+def test_expand_path(mock_home, mock_relative_path):
+    assert expand_path('foo/bar', mock_relative_path) == os.path.join(mock_relative_path, 'foo/bar')
+    assert expand_path('~/baz', mock_relative_path) == os.path.join(mock_home, 'baz')
 
 
 class TestAwsCloudformation:
@@ -75,7 +48,6 @@ class TestAwsCloudformation:
                     tmpdir, 'aws-cf-with-helper.yaml', update={'installer_url': 'foobar'}))
         assert exinfo.value.error == 'ValidationError'
         assert 'installer_url' in exinfo.value.msg
-        assert 'Unrecognized/incompatible' in exinfo.value.msg
 
 
 class TestAzureTemplate:
@@ -91,7 +63,7 @@ class TestAzureTemplate:
                 get_temp_config_path(
                     tmpdir, 'azure-with-helper.yaml', update={'platform': 'aws'}))
         assert exinfo.value.error == 'ValidationError'
-        assert 'platform must be calculated' in exinfo.value.msg
+        assert 'platform' in exinfo.value.msg
 
 
 class TestAwsOnprem:
@@ -106,9 +78,11 @@ class TestAwsOnprem:
             get_validated_config(
                 get_temp_config_path(
                     tmpdir, 'aws-onprem-with-helper.yaml',
-                    update={'dcos_config': {'provider': 'aws'}, 'prevalidate_onprem_config': 'true'}))
+                    update={'dcos_config': {
+                        'ip_detect_content': 'foo',
+                        'ip_detect_filename': 'bar'}}))
         assert exinfo.value.error == 'ValidationError'
-        assert 'onprem_dcos_config_contents' in exinfo.value.msg
+        assert 'ip_detect' in exinfo.value.msg
 
     def test_error_is_skipped_in_nested_config(self, tmpdir):
         get_validated_config(

--- a/packages/dcos-launch/extra/test_config.py
+++ b/packages/dcos-launch/extra/test_config.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from launch.config import get_validated_config, expand_path
+from launch.config import expand_path, get_validated_config
 from launch.util import get_temp_config_path, LauncherError
 
 

--- a/packages/dcos-launch/extra/test_onprem.py
+++ b/packages/dcos-launch/extra/test_onprem.py
@@ -5,16 +5,12 @@ def test_aws_onprem(check_cli_success, aws_onprem_config_path):
     info, desc = check_cli_success(aws_onprem_config_path)
     assert 'stack_id' in info
     assert info['ssh_private_key'] == launch.util.MOCK_SSH_KEY_DATA
-    assert 'onprem_dcos_config_contents' in info  # needs to be in info for provisioning
     assert 'template_body' not in desc  # distracting irrelevant information
-    assert 'dcos_config' in desc  # check for the re-formatted fields
 
 
 def test_aws_onprem_with_helper(check_cli_success, aws_onprem_with_helper_config_path):
     info, desc = check_cli_success(aws_onprem_with_helper_config_path)
     assert 'stack_id' in info
     assert info['ssh_private_key'] == launch.util.MOCK_SSH_KEY_DATA
-    assert 'onprem_dcos_config_contents' in info  # needs to be in info for provisioning
     assert 'template_body' not in desc  # distracting irrelevant information
-    assert 'dcos_config' in desc  # check for the re-formatted fields
     assert 'KeyName' in info['template_parameters']


### PR DESCRIPTION
## High Level Description
gen required many hacks to integrate in at all. The only reason it was used was the convenience of the shared code-base. However, given that the shared code-base has now crippled dcos-launch with its custom-SSL, dcos-launch must be split off.

gen and the rest of the "DC/OS Image" library is a long ways away from being converted into a legitimately importable library, so it must be removed to make the dcos-launch packaging feasible.

## Related Issues
https://jira.mesosphere.com/browse/DCOS_OSS-1060
https://jira.mesosphere.com/browse/DCOS_OSS-1041
https://jira.mesosphere.com/browse/DCOS_OSS-1084

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
