### PR TITLE
Backport PR #1219 to 1.8.9

### DIFF
--- a/packages/3dt/buildinfo.json
+++ b/packages/3dt/buildinfo.json
@@ -4,8 +4,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/3dt.git",
-    "ref": "cc7a19f9c9c062745f313fe0e221cddba3feb5e7",
-    "ref_origin": "master"
+    "ref": "2624cbacf8959ccf584cfe87a2e535aca59c4755",
+    "ref_origin": "1.8.9"
   },
   "username": "dcos_3dt",
   "group": "systemd-journal",

--- a/packages/dcos-integration-test/extra/test_3dt.py
+++ b/packages/dcos-integration-test/extra/test_3dt.py
@@ -534,10 +534,13 @@ def test_3dt_bundle_download_and_extract(cluster):
     bundles = _get_bundle_list(cluster)
     assert bundles
 
-    expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz', '3dt-health.json']
+    expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz', '3dt-health.json',
+                             'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
+                             'opt/mesosphere/etc/user.config.yaml.gz']
 
     # these files are expected to be in archive for a master host
-    expected_master_files = ['dcos-mesos-master.service.gz'] + expected_common_files
+    expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',
+                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz'] + expected_common_files
 
     # for agent host
     expected_agent_files = ['dcos-mesos-slave.service.gz'] + expected_common_files


### PR DESCRIPTION
## High Level Description
Backporting #1219 in attempt to get some more debugging information into diagnostic bundles.

Corresponding enterprise PR https://github.com/mesosphere/dcos-enterprise/pull/874

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

## Related Issues

 The following JIRA is associated with #1219 not really relevant to this PR
  - [DCOS-13706](https://jira.mesosphere.com/browse/DCOS-13706) Add Zookeeper.out to DC/OS Diagnostic Bundle

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated: [Added more files to the log bundle](https://github.com/dcos/3dt/compare/cc7a19f9c9c062745f313fe0e221cddba3feb5e7...2624cbacf8959ccf584cfe87a2e535aca59c4755)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

@darkonie and @adam-mesos  please review
