### PR TITLE
Increase timeout for apps to be healthy

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -3,6 +3,8 @@ import uuid
 
 import pytest
 
+from test_helpers import expanded_config
+
 from test_util.marathon import Container, get_test_app, Healthcheck, Network
 
 log = logging.getLogger(__name__)
@@ -103,6 +105,9 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
         pass
 
 
+@pytest.mark.skipif(
+    expanded_config.get('security') == 'strict',
+    reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
 def test_octarine(dcos_api_session, timeout=30):
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -161,7 +161,7 @@ def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
 
 @retrying.retry(
     wait_fixed=5000,
-    stop_max_delay=120 * 1000,
+    stop_max_delay=180 * 1000,
     retry_on_result=lambda res: res is None)
 def wait_for_tasks_healthy(dcos_api_session, app_definition):
     proxy_info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()


### PR DESCRIPTION
## High Level Overveiew
apps usually take less than 120 seconds to deploy
and achieve a healthy status, but in test_vip there
is no blocking on the previous test cleaning up state.
This speeds up execution to allow marathon to optimize
the deployments, but also adds a small increase to the
time any given app spends deploying

## Related Issues
Timeouts occurring on random test cases such as https://teamcity.mesosphere.io/viewLog.html?buildId=653598&

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A This PR is stabilizing a test
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)