### PR TITLE
Increase wait time for SSH capability

### DIFF
--- a/test_util/cluster.py
+++ b/test_util/cluster.py
@@ -194,11 +194,11 @@ class Cluster:
             list(itertools.islice(hosts_iter, num_public_agents)),
         )
 
-    @retry(stop_max_delay=120000)
+    @retry(stop_max_delay=300 * 1000)
     def check_ssh(self, hosts):
         """SSH to each host's public IP and run a command.
 
-        Retries on failure for up to 2 minutes.
+        Retries on failure for up to 5 minutes.
 
         """
         self.ssher.remote_cmd(hosts, ['echo'])


### PR DESCRIPTION
## High Level Description
Many CI-driven integration tests time-out due to this overly conservative timeout, so increase the period to 300 seconds (5 minutes) from 120 seconds

## Related Issues
https://jira.mesosphere.com/browse/DCOS-15839

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Timeout increase-- N/A
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
