### PR TITLE
Fixed CHECK failure in logger module due to Docker workaround.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "7ce5ba397bbaa8fdcc985ef2e6dd8bc81709931a",
-      "ref_origin": "1.9.x"
+      "ref": "2a5a02f1de47dcbe44844f7358adf85ea630cf4a",
+      "ref_origin": "master"
     }
 }


### PR DESCRIPTION
## High Level Description

This bumps the logger module to include a fix for a CHECK failure when a Docker task is started with a colon (`:`) in the ID.

## Related Issues

  - [CORE-1062](https://jira.mesosphere.com/browse/CORE-1062) Chronos launching Docker container causes Mesos agent to crash
  - https://github.com/dcos/dcos/pull/1592

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not: `test_applications.test_if_docker_app_with_colon_can_be_deployed`
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-mesos-modules/compare/80a69b6ef0afb627f6b0c4cac7dd01cc6a444180...2a5a02f1de47dcbe44844f7358adf85ea630cf4a
  - [ ] Test Results: TODO
  - [x] Code Coverage (if available): N/A