### PR TITLE
Fix broken reference to public_master

### DIFF
--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -366,7 +366,7 @@ class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClient
         else:
             # Exhibitor is protected with HTTP basic auth, which conflicts with adminrouter's auth. We must bypass
             # the adminrouter and access Exhibitor directly.
-            default_url = Url.from_string('http://{}:8181'.format(self.public_masters[0]))
+            default_url = Url.from_string('http://{}:8181'.format(self.masters[0]))
 
         return Exhibitor(
             default_url=default_url,


### PR DESCRIPTION
## High Level Description
#1508 and #1528 conflicted but this case silently slipped by because it was a new usage of the variable being removed. This was not caught during testing as the code was not exercised until a specific setting was enabled in CI

## Related Issues
- https://jira.mesosphere.com/browse/DCOS_OSS-1125

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A Test Fix
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
