### PR TITLE
[DCOS-15645] Change `sed` in installer to not be GNU specific

### DIFF
--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -16,7 +16,7 @@ trap 'backout' INT
 if [ ! -f "{genconf_tar}" ]
 then
     echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
-    sed '0,/^#EOF#$/d' $0 | tar xv
+    sed '1,/^#EOF#$/d' $0 | tar xv
     docker load -i {genconf_tar}
 fi
 trap - INT


### PR DESCRIPTION
## High Level Description

My goal was to make DC/OS Docker runnable from my Mac as a development convenience.

This - `sed` syntax which does not work on macOS - was the one blocker in DC/OS.

## Related Issues

https://jira.mesosphere.com/browse/DCOS-15645 - Run DC/OS Docker on macOS without Vagrant

## Further context and CI

I originally wrote a way of overwriting `sed` with GNU sed on macOS (see https://github.com/dcos/dcos-docker/pull/36/files#diff-04c6e90faac2675aa89e2176d2eec7d8R33). This would require no changes to DC/OS but may have unintended consequences for the user.

I was asked by @karlkfi in review to create a cross-platform compatible change and to add to DC/OS a test which runs on a macOS builder. The suggested test would potentially spin up a DC/OS Docker cluster on macOS. My preference is to not do that because:
* That adds a support burden if anything breaks on macOS or the test, when for now I intended it as a development nice-to-have.
* That is work that wasn't scheduled for my team's work - I did this change in order to get my own work done more quickly.

I therefore submit this change and ask for feedback on whether we should:
* Merge this (or some variant),
* Merge the DC/OS Docker change,
* Merge this but require a test - blocking this issue until macOS support is prioritised and scheduled
* Say that we don't want this, at least for now

I would like DC/OS Docker macOS support, but also because since mentioning it on Slack, there has been a good response which shows that this is wanted.

### Other solutions

See the high level description for options which do not involve modifying this file.

Other solutions in this file include:
* Use `gawk` and require it to be installed on macOS with `brew install gawk` (handled in DC/OS Docker):

```
gawk '/^#EOF#/ { f = 1 } f' $0 | tail -n +2 | tar xv
```
* Come up with a solution which works on both macOS's awk and GNU awk, or macOS's `sed` and GNU sed. I failed to achieve this but I am not an expert in either tool.
* Check if `gsed` is available, and if so, use it instead of `sed`.

## Testing

I have tested this by running the following command on CentOS (DC/OS Docker Vagrant VM) and macOS.

```
python2 -c "\
import sys;
with open(sys.argv[1], 'rb') as f:
	content = f.read()
	before, after = content.split('\n#EOF#\n', 1)
	sys.stdout.write(after)
" dcos_generate_config.sh | tar xv
 ```
 
 On both platforms the command succeeds.
 I await tests mainly to see if my indentation is alright but I'm interested in feedback as early as possible.
 
## Checklist for all PR's

   - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: See "Further context and CI"
   - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
   - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)