### PR TITLE
(1.9) Fix profile symlink during upgrade

### DIFF
--- a/dcos_installer/upgrade.py
+++ b/dcos_installer/upgrade.py
@@ -87,6 +87,10 @@ echo "Upgrading DC/OS $role_name {{ installed_cluster_version }} -> {{ installer
 pkgpanda fetch --repository-url={{ bootstrap_url }} {{ cluster_packages }} > /dev/null
 pkgpanda activate --no-block {{ cluster_packages }} > /dev/null
 
+# Recreate the DC/OS profile script symlink, since its intended source may be different in the new version of DC/OS.
+rm -f {{ profile_symlink_target }}
+{{ profile_symlink_cmd }}
+
 # If this is a master node, migrate Exhibitor data to the correct directory.
 if [ "$role" == "master" ]; then
     until dcos-shell dcos-exhibitor-migrate-perform {{ exhibitor_migrate_args }} > /dev/null
@@ -123,6 +127,8 @@ def generate_node_upgrade_script(gen_out, installed_cluster_version, serve_dir=S
     # installed_cluster_version: Current installed version on the cluster
     # installer_version: Version we are upgrading to
     bootstrap_url = gen_out.arguments['bootstrap_url']
+    profile_symlink_target = gen_out.arguments['profile_symlink_target']
+    profile_symlink_cmd = gen_out.arguments['profile_symlink_cmd']
     installer_version = gen.calc.entry['must']['dcos_version']
     package_list = ' '.join(package['id'] for package in gen_out.cluster_packages.values())
     exhibitor_migrate_args = ''
@@ -136,7 +142,9 @@ def generate_node_upgrade_script(gen_out, installed_cluster_version, serve_dir=S
         'cluster_packages': package_list,
         'installed_cluster_version': installed_cluster_version,
         'installer_version': installer_version,
-        'exhibitor_migrate_args': exhibitor_migrate_args})
+        'exhibitor_migrate_args': exhibitor_migrate_args,
+        'profile_symlink_target': profile_symlink_target,
+        'profile_symlink_cmd': profile_symlink_cmd})
 
     upgrade_script_path = '/upgrade/' + uuid.uuid4().hex
     subprocess.check_call(['mkdir', '-p', serve_dir + upgrade_script_path])

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -521,6 +521,15 @@ def calculate_cosmos_package_storage_uri_flag(cosmos_config):
         return ''
 
 
+def calculate_profile_symlink_target_dir(profile_symlink_target):
+    return os.path.dirname(profile_symlink_target)
+
+
+def calculate_profile_symlink_cmd(profile_symlink_source, profile_symlink_target):
+    # We need to include the full path to `ln` so this can be used in a systemd unit file.
+    return '/usr/bin/ln -sf {} {}'.format(profile_symlink_source, profile_symlink_target)
+
+
 def calculate_set(parameter):
     if parameter == '':
         return 'false'
@@ -738,7 +747,11 @@ entry = {
         'cosmos_staged_package_storage_uri_flag':
             calculate_cosmos_staged_package_storage_uri_flag,
         'cosmos_package_storage_uri_flag':
-            calculate_cosmos_package_storage_uri_flag
+            calculate_cosmos_package_storage_uri_flag,
+        'profile_symlink_source': '/opt/mesosphere/bin/add_dcos_path.sh',
+        'profile_symlink_target': '/etc/profile.d/dcos.sh',
+        'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
+        'profile_symlink_cmd': calculate_profile_symlink_cmd,
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -12,8 +12,8 @@
     Type=oneshot
     StandardOutput=journal+console
     StandardError=journal+console
-    ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
-    ExecStart=/usr/bin/ln -sf /opt/mesosphere/bin/add_dcos_path.sh /etc/profile.d/dcos.sh
+    ExecStartPre=/usr/bin/mkdir -p {{ profile_symlink_target_dir }}
+    ExecStart={{ profile_symlink_cmd }}
 - name: dcos-download.service
   content: |
     [Unit]

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,5 +1,6 @@
 # Various tests that don't fit into the other categories and don't make their own really.
 import json
+import os
 
 from pkgpanda.util import load_yaml
 
@@ -25,3 +26,13 @@ def test_load_expanded_config():
 
     # TODO(cmaloney): Test user provided parameters are present. All the
     # platforms have different sets...
+
+
+def test_profile_symlink():
+    """Assert the DC/OS profile script is symlinked from the correct source."""
+    with open("/opt/mesosphere/etc/expanded.config.json", "r") as f:
+        expanded_config = json.load(f)
+    symlink_target = expanded_config['profile_symlink_target']
+    expected_symlink_source = expanded_config['profile_symlink_source']
+
+    assert expected_symlink_source == os.readlink(symlink_target)


### PR DESCRIPTION
## High Level Description

This makes the 1.9 upgrade script recreate the symlink at `/etc/profile.d/dcos.sh` and point it to the correct source for 1.9.

## Related Issues

  - [DCOS_OSS-947](https://jira.mesosphere.com/browse/DCOS_OSS-947) On 1.8->1.9 upgrade, /etc/profile.d/dcos.sh symlink is not updated.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]