### PR TITLE
Add test verifying profile symlink

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -521,6 +521,10 @@ def calculate_cosmos_package_storage_uri_flag(cosmos_config):
         return ''
 
 
+def calculate_profile_symlink_target_dir(profile_symlink_target):
+    return os.path.dirname(profile_symlink_target)
+
+
 def calculate_set(parameter):
     if parameter == '':
         return 'false'
@@ -740,7 +744,10 @@ entry = {
         'cosmos_staged_package_storage_uri_flag':
             calculate_cosmos_staged_package_storage_uri_flag,
         'cosmos_package_storage_uri_flag':
-            calculate_cosmos_package_storage_uri_flag
+            calculate_cosmos_package_storage_uri_flag,
+        'profile_symlink_source': '/opt/mesosphere/bin/add_dcos_path.sh',
+        'profile_symlink_target': '/etc/profile.d/dcos.sh',
+        'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -12,8 +12,8 @@
     Type=oneshot
     StandardOutput=journal+console
     StandardError=journal+console
-    ExecStartPre=/usr/bin/mkdir -p /etc/profile.d
-    ExecStart=/usr/bin/ln -sf /opt/mesosphere/bin/add_dcos_path.sh /etc/profile.d/dcos.sh
+    ExecStartPre=/usr/bin/mkdir -p {{ profile_symlink_target_dir }}
+    ExecStart=/usr/bin/ln -sf {{ profile_symlink_source }} {{ profile_symlink_target }}
 - name: dcos-download.service
   content: |
     [Unit]

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,4 +1,6 @@
 # Various tests that don't fit into the other categories and don't make their own really.
+import os
+
 from test_helpers import expanded_config
 
 from pkgpanda.util import load_yaml
@@ -22,3 +24,10 @@ def test_expanded_config():
 
     # TODO(cmaloney): Test user provided parameters are present. All the
     # platforms have different sets...
+
+
+def test_profile_symlink():
+    """Assert the DC/OS profile script is symlinked from the correct source."""
+    symlink_target = expanded_config['profile_symlink_target']
+    expected_symlink_source = expanded_config['profile_symlink_source']
+    assert expected_symlink_source == os.readlink(symlink_target)


### PR DESCRIPTION
## High Level Description

This adds a test which verifies that the DC/OS profile script is symlinked from the correct source file.

## Related Issues

  - [DCOS_OSS-947](https://jira.mesosphere.com/browse/DCOS_OSS-947) On 1.8->1.9 upgrade, /etc/profile.d/dcos.sh symlink is not updated.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]