### PR TITLE
bump to Marathon 1.3.12

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.com/marathon/v1.3.11/marathon-1.3.11.tgz",
-    "sha1": "25447c54f91dbac1402260faa119de82ad4c5d34"
+    "url": "https://downloads.mesosphere.com/marathon/v1.3.12/marathon-1.3.12.tgz",
+    "sha1": "2fd955c55d0a9bc9a3774c5ba800a513dc6f935c"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

### Changes

- [MARATHON-7397](https://jira.mesosphere.com/browse/MARATHON-7397) Include USER networked docker containers in /v2/tasks text/plain output. If no host port is specified, specify address as `{containerIp}:{containerPort}`. If host port is specified, `{agentIp}:{hostPort}`

## Related Issues

  - [MARATHON-7397](https://jira.mesosphere.com/browse/MARATHON-7397) Foo the Bar so it stops Bazzing.


## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
    - Extensive unit tests were written, and extensive manual integration testing was performed.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [v1.3.12](https://github.com/mesosphere/marathon/releases/tag/v1.3.12)
  - [x] Test Results: [Latest results for 1.3.x](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/marathon-pipelines/detail/PR-5405/1/pipeline/46)
  - [x] Code Coverage (if available): ¯\_(ツ)_/¯ it's definitely higher than the last Marathon release
