### PR TITLE
Bump spartan and navstar

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -118,6 +118,11 @@ package:
             {min_named_ip, {{ minuteman_min_named_ip_erltuple }}},
             {max_named_ip, {{ minuteman_max_named_ip_erltuple }}}
           ]
+        },
+        {navstar_overlay,
+          [
+            {enable_overlay, {{ dcos_overlay_enable }}}
+          ]
         }
       ].
   - path: /etc/overlay/config/master.json

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -43,7 +43,7 @@ package:
       ERL_FLAGS=-kernel inet_dist_listen_min 62501 -kernel inet_dist_listen_max 62501
   - path: /etc/navstar-erl.env
     content: |
-      ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502 -navstar_l4lb enable_lb {{ enable_lb }}
+      ERL_FLAGS=-kernel inet_dist_listen_min 62502 -kernel inet_dist_listen_max 62502
   - path: /etc_slave/spartan.json
     content: |
       {
@@ -115,6 +115,7 @@ package:
       [
         {navstar_l4lb,
           [
+            {enable_lb, {{ enable_lb }}},
             {min_named_ip, {{ minuteman_min_named_ip_erltuple }}},
             {max_named_ip, {{ minuteman_max_named_ip_erltuple }}}
           ]

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "d99eac511c39eb3070d5064fc098de374b21b834",
+      "ref": "e019b66441eebded14df1cfd00b7c3b6c2885858",
       "ref_origin": "master"
     }
   },

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "e019b66441eebded14df1cfd00b7c3b6c2885858",
+      "ref": "6cb70142363c9ce2f3d59a5870560967dc46e559",
       "ref_origin": "master"
     }
   },

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "f7b2311c71fa833c182a13781af00a387632fb1b",
+      "ref": "80d86355988e7d3a54a370b73d5bc769cabeab0c",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
## High Level Description

* Overlay could be enable/disable via "dcos_overlay_enable" in config.yaml. Currently, this flag is read by mesos overlay module but not by navstar overlay module. It will be good if navstar overlay module could also read this flag and enable/disable accordingly.

* Several performance improvements for spartan dns server.

* Spartan HTTP API (in there release only for debugging purposes)

* Add VIPs Debug HTTP API

* Currently it is possible for spartan to start it's own epmd if dcos-epmd is not yet started or has died for some reason. The systemd services for each of the Erlang based components should be reviewed and modified so that each ensures dcos-epmd is already running before starting.

## Related Issues

  - [DCOS_OSS-1134](https://jira.dcos.io/browse/DCOS_OSS-1134) Read dcos_overlay_enable to start/stop navstar overlay module
  - [DCOS_OSS-697](https://jira.dcos.io/browse/DCOS_OSS-697) Spartan CPU demands are Too High at High Scale
  - [DCOS-15247](https://jira.mesosphere.com/browse/DCOS-15247) Spartan repeatedly crashing on some nodes
  - [DCOS-15840](https://jira.mesosphere.com/browse/DCOS-15840) common test to assert unique rules in ip rules table
  - [DCOS_OSS-1128](https://jira.mesosphere.com/browse/DCOS_OSS-1128) Ensure DC/OS Erlang based apps use dcos-epmd.service
  - [DCOS-15240](https://jira.mesosphere.com/browse/DCOS-15240) Spartan HTTP API
  - [DCOS-15357](https://jira.dcos.io/browse/DCOS-15357) API to display state of the lashup


## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/dcos/erl-dns/pull/1
https://github.com/dcos/erl-dns/pull/2
https://github.com/dcos/spartan/pull/40
https://github.com/dcos/spartan/pull/41
https://github.com/dcos/spartan/pull/42
https://github.com/dcos/spartan/pull/43
https://github.com/dcos/spartan/pull/44
https://github.com/dcos/navstar/pull/77
https://github.com/dcos/navstar/pull/78
https://github.com/dcos/navstar/pull/79
https://github.com/dcos/navstar/pull/80
https://github.com/dcos/navstar/pull/81

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).