### PR TITLE
[1.9.1] Cherry-picks for logger modules crash + log rotation size.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -344,7 +344,7 @@ package:
       nomail
       /var/lib/dcos/mesos/log/mesos-master.log {
           olddir /var/lib/dcos/mesos/log/archive
-          maxsize 256M
+          size 256M
           rotate {{ mesos_log_retention_count }}
           copytruncate
           postrotate
@@ -360,7 +360,7 @@ package:
       nomail
       /var/log/mesos/mesos-agent.log {
           olddir /var/log/mesos/archive
-          maxsize 256M
+          size 256M
           rotate {{ mesos_log_retention_count }}
           copytruncate
           postrotate

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "7ce5ba397bbaa8fdcc985ef2e6dd8bc81709931a",
+      "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
       "ref_origin": "1.9.x"
     }
 }


### PR DESCRIPTION
## High Level Description

This includes two cherry-picks:
- https://github.com/dcos/dcos/pull/1565 - A CHECK failure in a logger module when running tasks with a `:` in the TaskID or ExecutorID.
- https://github.com/dcos/dcos/pull/1499 - A logrotation config error, which leads to rotating files when they are 1 MB instead of 256 MB.

## Related Issues

  - [CORE-1062](https://jira.mesosphere.com/browse/CORE-1062) Chronos launching Docker container causes Mesos agent to crash
  - [DCOS-15653](https://jira.mesosphere.com/browse/DCOS-15653) Log rotation happens 256 times more often than intended

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not: Test was added to modules repo.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-mesos-modules/compare/7ce5ba397bbaa8fdcc985ef2e6dd8bc81709931a...e46209d55e6e5be2caa2e49ca3c32bdfec5bd427
  - [ ] Test Results:
  - [x] Code Coverage (if available): N/A