### PR TITLE
Bumped Mesos package to include executor reconnect retries.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -17,3 +17,7 @@
 <li>[1d45ba9f4f7f943d24282e0a91fb01c68815d6c3] Fixed sign comparisons in logrotate module.
 <li>[b546e7544c04a6d3e0da87cd6207ae8f4d827add] Added a way to set logrotate settings per executor.
 <li>[2adcc49bb584f84b358b6edb78a975382e9f9feb] Modified the executor driver to always relink on agent failover.
+<li>[52b4675a96858eac6b4709c5f46bd432cd6e20d9] Added new agent flag 'executor_reregistration_timeout'.
+<li>[378e209c0e34c955e23505e2fb32b879794cdf8e] Added 'executor_reregister_timeout' agent flag to the tests.
+<li>[815e9dd6620ad1f13d6a326079e9b61c2484294d] Introduced executor reconnect retries on the agent.
+<li>[beb19ab9d6d42ae92e1868094af23f69ad553443] Made the executor driver drop some messages when not connected.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "2adcc49bb584f84b358b6edb78a975382e9f9feb",
-    "ref_origin" : "dcos-mesos-1.0.x-4154f66"
+    "ref": "beb19ab9d6d42ae92e1868094af23f69ad553443",
+    "ref_origin" : "dcos-mesos-1.0.4"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

This PR updates the Mesos package to include backported fixes which enable retries of executor reconnect requests from the agent.

## Related Issues

  - [MESOS-7540](https://issues.apache.org/jira/browse/MESOS-7540) Add an agent flag for executor re-register timeout
  - [MESOS-7569](https://issues.apache.org/jira/browse/MESOS-7569) Allow "old" executors with half-open connections to be preserved during agent upgrade / restart.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR relies on the Mesos test suite.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/2adcc49bb584f84b358b6edb78a975382e9f9feb...beb19ab9d6d42ae92e1868094af23f69ad553443)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]