### PR TITLE
[1.9.1] Bump dcos-metrics for 1.9.1

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "a01acda5647c3108cff62851bc694d26d1a503d5",
-    "ref_origin": "1.9.1"
+    "ref": "cca85f336eee440c2468d4b4c9d1c3b246654188",
+    "ref_origin": "branch-1.9.1"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High Level Description

This change brings dcos-metrics up to date, resolving the last known issues affecting the ability of the package to work with external metrics storage providers. 

Specifically, it improves error handling and avoids transmitting very long labels. 

### Changelog:
- [Handle errors gracefully](https://github.com/dcos/dcos-metrics/pull/96/commits/7b84b5e01d3d1cdcb3a11c0c31390a27a40b3b70)
- [Drop long labels in mesos agent](https://github.com/dcos/dcos-metrics/pull/96/commits/cca85f336eee440c2468d4b4c9d1c3b246654188)

### Test results
https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/374/

### Code coverage report
https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/374/cobertura/

## Related Issues

  - [DCOS-15224](https://jira.mesosphere.com/browse/DCOS-15224) Improve error handling to dcos-metrics DataDog plugin
  - [DCOS-15939](https://jira.mesosphere.com/browse/DCOS-15939) Long labels can cause errors in datadog plugin for dcos-metrics

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/a01acda5647c3108cff62851bc694d26d1a503d5...cca85f336eee440c2468d4b4c9d1c3b246654188)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/374/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/374/cobertura/)