### PR TITLE
Explicitly require six

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ passenv =
   AWS_DEFAULT_REGION
 deps =
   dnspython
+  six
   pytest
   PyYAML
   webtest


### PR DESCRIPTION
## High Level Description
Something changed with one of: setuptools wheel or virtualenv and the result was that six needs to be explicitly required for the library tools to work

## Related Issues


## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)