### PR TITLE
Bump Mesos to 396cda9cef532b9be980002d97e4aadf12ccec85.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "9cc627d9f32d56f14f277e823a759183ef4b234d",
-    "ref_origin" : "dcos-mesos-master-4faca73"
+    "ref": "3a86b3ba693efd9e5c24c59d8325ee146e6292a2",
+    "ref_origin" : "dcos-mesos-master-396cda9"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

This change contains file-based secrets and image pull secrets along with several bug fixes.

## Related Issues
https://jira.mesosphere.com/browse/DCOS-10236 File-Based Secrets
https://jira.mesosphere.com/browse/CORE-810 Image pull secrets

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
    This PR relies upon Mesos test suite.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/5724bfbf390502c79d7f53d6c9bb0ce92e6d9454...3a86b3ba693efd9e5c24c59d8325ee146e6292a2)
  - [x] Test Results: [ASF CI Results](https://builds.apache.org/job/Mesos-Buildbot/3759/)
  - [ ] Code Coverage (if available): [link to code coverage report]