### PR TITLE
Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "62702c3396deb5b47f4492a5a39d9dfb6f95ab0b",
+    "ref": "73e5c8136facfd6990dcf992a9dab5700ea0146e",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This change brings dcos-metrics up to date, resolving the last known issues affecting the ability of the package to work with external metrics storage providers. 

Specifically, it improves error handling and avoids transmitting very long labels. 

NB these are the same changes as in the already-approved #1598 , which was made against the 1.9.1 branch.

## Related Issues

  - [DCOS-15224](https://jira.mesosphere.com/browse/DCOS-15224) Improve error handling to dcos-metrics DataDog plugin
  - [DCOS-15939](https://jira.mesosphere.com/browse/DCOS-15939) Long labels can cause errors in datadog plugin for dcos-metrics

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-metrics/compare/62702c3396deb5b47f4492a5a39d9dfb6f95ab0b...73e5c8136facfd6990dcf992a9dab5700ea0146e)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/105/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/105/cobertura/)