### PR TITLE
add a new config.yaml option gpus_are_scarce [WIP]

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -579,6 +579,12 @@ def validate_dns_forward_zones(dns_forward_zones):
             validate_int_in_range(port, 1, 65535)
 
 
+def calculate_fair_sharing_excluded_resource_names(gpus_are_scarce):
+    if gpus_are_scarce == 'true':
+        return 'gpus'
+    return ''
+
+
 __dcos_overlay_network_default_name = 'dcos'
 
 
@@ -624,6 +630,7 @@ entry = {
         validate_cosmos_config,
         lambda enable_lb: validate_true_false(enable_lb),
         lambda adminrouter_tls_1_0_enabled: validate_true_false(adminrouter_tls_1_0_enabled),
+        lambda gpus_are_scarce: validate_true_false(gpus_are_scarce)
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -703,7 +710,8 @@ entry = {
         'cluster_docker_credentials_write_to_etc': 'false',
         'cluster_docker_credentials_enabled': 'false',
         'cluster_docker_credentials': "{}",
-        'cosmos_config': '{}'
+        'cosmos_config': '{}',
+        'gpus_are_scarce': 'true'
     },
     'must': {
         'custom_auth': 'false',
@@ -746,6 +754,7 @@ entry = {
         'profile_symlink_source': '/opt/mesosphere/bin/add_dcos_path.sh',
         'profile_symlink_target': '/etc/profile.d/dcos.sh',
         'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
+        'fair_sharing_excluded_resource_names': calculate_fair_sharing_excluded_resource_names
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -375,6 +375,8 @@ package:
       MESOS_QUORUM={{ master_quorum }}
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_MAX_SLAVE_PING_TIMEOUTS=20
+      MESOS_FAIR_SHARING_EXCLUDED_RESOURCE_NAMES={{ fair_sharing_excluded_resource_names }}
+      MESOS_FILTER_GPU_RESOURCES={{ gpus_are_scarce }}
       GLOG_drop_log_memory=false
       SASL_PATH=/opt/mesosphere/lib/sasl2
   - path: /etc/mesos-master-provider

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,7 +1,9 @@
 <H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
-<li>[98411cfa4684acfec72134efd9f39e03b06a390e] Set LIBPROCESS_IP into docker container.
-<li>[f0cf3500192a13134dc9dc4664b4ac002d88d049] Changed agent_host to expect a relative path.
-<li>[96e43839155098bb8fc56b31a541d19d585dd18c] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
-<li>[b1d6545bdbf7b05764441946a2f97b355e021f34] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[d37e306f1e541cf6df5f6c89bf8468e5ae8acfb0] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[742df849b15c328edc555a8852d633524062b117] Set LIBPROCESS_IP into docker container.
+<li>[f3d57cb43c2d56391527d61ac954154d906b1707] Changed agent_host to expect a relative path.
+<li>[601f3b2810442c09d8b509cf9f50ad7d216f1351] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[960aec18ad2689d5b64b1fd062683e4274a0ba6d] Revert "Fixed the broken metrics information of master in WebUI."
+<li>[13783195d6ea8e34f528022cd13a5dba4bd32c62] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[c0a93bec85707de09f3618dc9f5009f099186804] Updated the UI to fix maintenance in DC/OS.
+<li>[f219b2e4f6265c0b6c4d826a390b67fe9d5e1097] Added '--filter_gpu_resources' flag to the mesos master.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "5724bfbf390502c79d7f53d6c9bb0ce92e6d9454",
-    "ref_origin" : "dcos-mesos-master-72752fc6"
+    "ref": "f219b2e4f6265c0b6c4d826a390b67fe9d5e1097",
+    "ref_origin" : "dcos-mesos-1.2.1-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

- introduce a new config.yaml option `gpus_are_scarce` with default values `true`
- bump mesos to include `--filter-gpu-resources` master flag.

## Related Issues

  - [DCOS_OSS-876](https://jira.mesosphere.com/browse/DCOS_OSS-876)
  - [CORE-1107](https://jira.mesosphere.com/browse/CORE-1107)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
The PR does not include any integration test, since we do not have an infrastructure for integration tests with GPUs. @klueska has performed manual tests to make sure this change works as expected.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [mesos](https://github.com/mesosphere/mesos/compare/27761cab0cfd7c787e05d20effbd3bd14f029c02...bd7a0065bf61121ed2d38d6f028bd1456f40c198)
  - [X] Test Results: [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1132/)
  - [X] Code Coverage (if available): [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1132/)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
