### PR TITLE
add a new config.yaml option gpus_are_scarce

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -579,6 +579,12 @@ def validate_dns_forward_zones(dns_forward_zones):
             validate_int_in_range(port, 1, 65535)
 
 
+def calculate_fair_sharing_excluded_resource_names(gpus_are_scarce):
+    if gpus_are_scarce == 'true':
+        return 'gpus'
+    return ''
+
+
 __dcos_overlay_network_default_name = 'dcos'
 
 
@@ -624,6 +630,7 @@ entry = {
         validate_cosmos_config,
         lambda enable_lb: validate_true_false(enable_lb),
         lambda adminrouter_tls_1_0_enabled: validate_true_false(adminrouter_tls_1_0_enabled),
+        lambda gpus_are_scarce: validate_true_false(gpus_are_scarce)
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -703,7 +710,8 @@ entry = {
         'cluster_docker_credentials_write_to_etc': 'false',
         'cluster_docker_credentials_enabled': 'false',
         'cluster_docker_credentials': "{}",
-        'cosmos_config': '{}'
+        'cosmos_config': '{}',
+        'gpus_are_scarce': 'true'
     },
     'must': {
         'custom_auth': 'false',
@@ -746,6 +754,7 @@ entry = {
         'profile_symlink_source': '/opt/mesosphere/bin/add_dcos_path.sh',
         'profile_symlink_target': '/etc/profile.d/dcos.sh',
         'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
+        'fair_sharing_excluded_resource_names': calculate_fair_sharing_excluded_resource_names
     },
     'conditional': {
         'master_discovery': {

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -375,6 +375,8 @@ package:
       MESOS_QUORUM={{ master_quorum }}
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_MAX_SLAVE_PING_TIMEOUTS=20
+      MESOS_FAIR_SHARING_EXCLUDED_RESOURCE_NAMES={{ fair_sharing_excluded_resource_names }}
+      MESOS_FILTER_GPU_RESOURCES={{ gpus_are_scarce }}
       GLOG_drop_log_memory=false
       SASL_PATH=/opt/mesosphere/lib/sasl2
   - path: /etc/mesos-master-provider

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,7 +1,8 @@
 <H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
-<li>[98411cfa4684acfec72134efd9f39e03b06a390e] Set LIBPROCESS_IP into docker container.
-<li>[f0cf3500192a13134dc9dc4664b4ac002d88d049] Changed agent_host to expect a relative path.
-<li>[96e43839155098bb8fc56b31a541d19d585dd18c] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
-<li>[b1d6545bdbf7b05764441946a2f97b355e021f34] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[d37e306f1e541cf6df5f6c89bf8468e5ae8acfb0] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[3d64f669c5e34162844345a6a923e7b3cdb79a4td] Set LIBPROCESS_IP into docker container.
+<li>[03e8c27aa5ad6bf6e4f15b781f126d274ec41d7f] Changed agent_host to expect a relative path.
+<li>[44eec8e7935d6de83afe80f22bdd4fd979b63fc7] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[dbd3bc2947efe0a1f66bb645f6bc48c154a9f130] Revert "Fixed the broken metrics information of master in WebUI."
+<li>[9cc627d9f32d56f14f277e823a759183ef4b234d] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[f2b490010136c4eb8e2e3055a2549d6cbf3429ac] Added '--filter_gpu_resources' flag to the mesos master.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "9cc627d9f32d56f14f277e823a759183ef4b234d",
+    "ref": "f2b490010136c4eb8e2e3055a2549d6cbf3429ac",
     "ref_origin" : "dcos-mesos-master-4faca73"
   },
   "environment": {


### PR DESCRIPTION
## High Level Description

- introduce a new config.yaml option `gpus_are_scarce` with default values `true`
- bump mesos to include `--filter-gpu-resources` master flag.

## Related Issues

  - [DCOS_OSS-876](https://jira.mesosphere.com/browse/DCOS_OSS-876)
  - [CORE-1107](https://jira.mesosphere.com/browse/CORE-1107)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
The PR does not include any integration test, since we do not have an infrastructure for integration tests with GPUs. @klueska has performed manual tests to make sure this change works as expected.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [mesos](https://github.com/mesosphere/mesos/compare/27761cab0cfd7c787e05d20effbd3bd14f029c02...bd7a0065bf61121ed2d38d6f028bd1456f40c198)
  - [X] Test Results: [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1132/)
  - [X] Code Coverage (if available): [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1132/)