### PR TITLE
Fixed bug in 'test_mesos.test_if_ucr_app_runs_in_new_pid_namespace'.

### DIFF
--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -2,6 +2,7 @@ import json
 import logging
 import uuid
 
+import retrying
 
 from test_util.marathon import Container, get_test_app
 from test_util.recordio import Decoder, Encoder
@@ -157,7 +158,12 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
         marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']
         app_task = dcos_api_session.marathon.get('/v2/apps/{}/tasks'.format(app['id'])).json()['tasks'][0]
 
-        content = dcos_api_session.mesos_sandbox_file(
-            app_task['slaveId'], marathon_framework_id, app_task['id'], ps_output_file)
+        # There is a short delay between the `app_task` starting and it writing
+        # its output to the `pd_output_file`. Because of this, we wait up to 10
+        # seconds for this file to appear before throwing an exception.
+        @retrying.retry(wait_fixed=1000, stop_max_delay=10000)
+        def get_ps_output():
+            return dcos_api_session.mesos_sandbox_file(
+                app_task['slaveId'], marathon_framework_id, app_task['id'], ps_output_file)
 
-        assert len(content.split()) <= 4, 'UCR app has more than 4 processes running in its pid namespace'
+        assert len(get_ps_output().split()) <= 4, 'UCR app has more than 4 processes running in its pid namespace'


### PR DESCRIPTION
Previously, there was a race between the `app_task` starting and it
writing its output to the `ps_output_file`. We now wait up to 10 seconds
for this file to appear before giving up and throwing an exception.

## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

## Related Issues

  - [DCOS_OSS-862](https://jira.mesosphere.com/browse/DCOS_OSS-862) Vagrant integration test test_mesos.test_if_ucr_app_runs_in_new_pid_namespace is flaky.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a fix to a test itself
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___