### PR TITLE
[DCOS_OSS-1203] Make it possible to set custom container names for DC/OS installer co…

### DIFF
--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -42,11 +42,12 @@ fi
 
 PORT=${{PORT:-9000}}
 DCOS_INSTALLER_DAEMONIZE=${{DCOS_INSTALLER_DAEMONIZE:-false}}
+DCOS_INSTALLER_CONTAINER_NAME=${{DCOS_INSTALLER_CONTAINER_NAME:-{genconf_tar}}}
 
 if [ "$DCOS_INSTALLER_DAEMONIZE" == "true" ]; then
-    docker run --name={genconf_tar} -d -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
+    docker run --name=$DCOS_INSTALLER_CONTAINER_NAME -d -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
 else
     trap 'docker kill {genconf_tar}' HUP QUIT INT TERM
-    docker run --rm --name={genconf_tar} -i -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
+    docker run --rm --name=$DCOS_INSTALLER_CONTAINER_NAME -i -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
 fi
 exit $?


### PR DESCRIPTION
…ntainers

## High Level Description

This allows custom names to be used for installer containers.
This means that multiple installer containers will not conflict on names.
With the changes here, WIP code I have spins up multiple clusters in parallel with random installer container names and these do not conflict.

## Related Issues

  - [DCOS_OSS-1203](https://jira.mesosphere.com/browse/DCOS_OSS-1203) Make it possible to run multiple installer containers in parallel

## Checklist for all PR's

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I am currently building tests which will use this but in order to run installer containers in parallel, other changes are required. Once the last of those changes is merged, there will be a test on CI which would catch errors in this.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)