### PR TITLE
Bump Mesos version to include fix for MESOS-7546.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,7 +1,11 @@
-<H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
+<h2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
+
 These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
-<li>[98411cfa4684acfec72134efd9f39e03b06a390e] Set LIBPROCESS_IP into docker container.
-<li>[f0cf3500192a13134dc9dc4664b4ac002d88d049] Changed agent_host to expect a relative path.
-<li>[96e43839155098bb8fc56b31a541d19d585dd18c] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
-<li>[b1d6545bdbf7b05764441946a2f97b355e021f34] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[d37e306f1e541cf6df5f6c89bf8468e5ae8acfb0] Updated mesos containerizer to ignore GPU isolator creation failure.
+
+<li>[3d64f669c5e34162844345a6a923e7b3cdb79a4td] Set LIBPROCESS_IP into docker container.
+<li>[03e8c27aa5ad6bf6e4f15b781f126d274ec41d7f] Changed agent_host to expect a relative path.
+<li>[44eec8e7935d6de83afe80f22bdd4fd979b63fc7] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[dbd3bc2947efe0a1f66bb645f6bc48c154a9f130] Revert "Fixed the broken metrics information of master in WebUI."
+<li>[9cc627d9f32d56f14f277e823a759183ef4b234d] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[f2b490010136c4eb8e2e3055a2549d6cbf3429ac] Added '--filter_gpu_resources' flag to the mesos master.
+<li>[1a99252362a73134dd3e028c69016f98a3735a8d] Fixed a bug in 'ComposingContainerizerProcess::wait()'.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "9cc627d9f32d56f14f277e823a759183ef4b234d",
+    "ref": "1a99252362a73134dd3e028c69016f98a3735a8d",
     "ref_origin" : "dcos-mesos-master-4faca73"
   },
   "environment": {


### PR DESCRIPTION
## High Level Description

Updates Mesos to a branch based on 4faca73e9608664a5fcf46cc95951c318a64861f with 55e7ea5ed788acb0e4f810dd4575a5a4479520d1 cherry-picked. This version of Mesos contains support for the Mesos Master `--filter_gpu_resources` flag and a fix for MESOS-7546.

## Related Issues

  - [MESOS-7546](https://issues.apache.org/jira/browse/MESOS-7546) WAIT_NESTED_CONTAINER sometimes returns 404.

## Checklist for all PR's

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR relies upon Mesos test suite.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/9cc627d9f32d56f14f277e823a759183ef4b234d...1a99252362a73134dd3e028c69016f98a3735a8d)
  - [X] Test Results: [Mesosphere CI Jenkins build result](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1171/)
  - [ ] Code Coverage (if available):