### PR TITLE
Increase hacky default timeout

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 def get_async_runner(config, hosts, async_delegate=None):
     # TODO(cmaloney): Delete these repeats. Use gen / expanded configuration to get all the values.
-    process_timeout = config.hacky_default_get('process_timeout', 120)
+    process_timeout = config.hacky_default_get('process_timeout', 600)
     extra_ssh_options = config.hacky_default_get('extra_ssh_options', '')
     ssh_key_path = config.hacky_default_get('ssh_key_path', SSH_KEY_PATH)
 


### PR DESCRIPTION
## High Level Description
This timeout is set to 10000 seconds when using the web installer
but in the CLI, this value gets used and deployments fail due to
unnecessarily strict timeouts. 10 minutes is much more reasonable
base timeout for the actions being performed here

## Related Issues


## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
