### PR TITLE
add support for ip-per-task apps in the adminrouter cache

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -276,7 +276,7 @@ Admin Router allows Marathon tasks to define custom service UI and HTTP endpoint
   }
 ```
 
-In this case `http://<dcos-cluster>/service/service-name` would be forwarded to the host running the task using the first port allocated to the task.
+When your container/task has its own IP (typically when running in a virtual network), `http://<dcos-cluster>/service/service-name` would be forwarded to the container/task's IP using one of the ports in the port mapping or port definition when USER networking is enabled or one of the discovery ports otherwise. When your task/container is mapped to the host, it would be forwarded to the host running the task using the one of the ports allocated to the task. The chosen port is defined by the DCOS_SERVICE_PORT_INDEX label.
 
 In order for the forwarding to work reliably across task failures, we recommend co-locating the endpoints with the task. This way, if the task is restarted on a potentially other host and with different ports, Admin Router will pick up the new labels and update the routing. NOTE: Due to caching there might be an up to 30-second delay until the new routing is working.
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -785,6 +785,92 @@ class TestCacheMesosLeader:
 
 class TestCacheMarathon:
 
+    def test_ip_per_task_app_with_user_networking_and_portmappings(
+            self, nginx_class, mocker, valid_user_header):
+        app = self._scheduler_alwaysthere_app()
+        app['ipAddress'] = {'networkName': 'samplenet'}
+        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
+        app['container']['docker']['network'] = "USER"
+        app['container']['docker']['portMappings'][0]['containerPort'] = '80'
+
+        ar = nginx_class()
+
+        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
+                            func_name='set_apps_response',
+                            aux_data={"apps": [app]})
+
+        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
+        with GuardedSubprocess(ar):
+            # Trigger cache update by issuing request:
+            resp = requests.get(url,
+                                allow_redirects=False,
+                                headers=valid_user_header)
+
+            assert resp.status_code == 200
+            req_data = resp.json()
+            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
+
+    def test_ip_per_task_app_with_user_networking_and_portdefinitions(
+            self, nginx_class, mocker, valid_user_header):
+        app = self._scheduler_alwaysthere_app()
+        app['ipAddress'] = {'networkName': 'samplenet'}
+        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
+        app['container']['docker']['network'] = "USER"
+        app['portDefinitions'] = [
+            {
+                "port": 80,
+                "protocol": "tcp",
+                "labels": {}
+            },
+        ]
+
+        ar = nginx_class()
+
+        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
+                            func_name='set_apps_response',
+                            aux_data={"apps": [app]})
+
+        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
+        with GuardedSubprocess(ar):
+            # Trigger cache update by issuing request:
+            resp = requests.get(url,
+                                allow_redirects=False,
+                                headers=valid_user_header)
+
+            assert resp.status_code == 200
+            req_data = resp.json()
+            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
+
+    def test_ip_per_task_app_without_user_networking(
+            self, nginx_class, mocker, valid_user_header):
+        app = self._scheduler_alwaysthere_app()
+        app['ipAddress'] = {
+            'networkName': 'samplenet',
+            'discovery': {
+                "ports": [
+                    {"number": 80, "name": "http", "protocol": "tcp"}
+                ]
+            }
+        }
+        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
+
+        ar = nginx_class()
+
+        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
+                            func_name='set_apps_response',
+                            aux_data={"apps": [app]})
+
+        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
+        with GuardedSubprocess(ar):
+            # Trigger cache update by issuing request:
+            resp = requests.get(url,
+                                allow_redirects=False,
+                                headers=valid_user_header)
+
+            assert resp.status_code == 200
+            req_data = resp.json()
+            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
+
     def test_upstream_wrong_json(
             self, nginx_class, mocker, valid_user_header):
         filter_regexp = {
@@ -897,7 +983,7 @@ class TestCacheMarathon:
         app["tasks"][0].pop("host", None)
 
         filter_regexp = {
-            "Cannot find host for app '{}'".format(app["id"]):
+            "Cannot find host or ip for app '{}'".format(app["id"]):
                 SearchCriteria(1, True),
         }
 


### PR DESCRIPTION
## High Level Description

The current DC/OS AdminRouter, the component which handles all the admin UI traffic of DC/OS, is not able to handle services which run in a virtual network (in our case Calico). Containers running in a virtual network get assigned their own IP, but the AdminRouter always takes the host name and port instead of the container's IP and port.
Therefore it's currently not possible to expose an ip-per-task app via the DC/OS admin interface (using the DCOS_SERVICE_NAME, DCOS_SERVICE_SCHEME and DCOS_SERVICE_PORT_INDEX app labels).

This PR tries to fix this issue in the AdminRouter's cache by taking the task's IP and port when it's an ip-per-task app (determined by the presence of the 'ipAddress' field on an app's definition) or taking the host's IP and port in case of a regular task (the default behaviour which existed until now).
I've used a similar approach as how it's implemented in Marathon-lb: https://github.com/mesosphere/marathon-lb/blob/master/utils.py#L314-L347

## Related Issues

N/A

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
