### PR TITLE
Added a default bridge for UCR.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -260,6 +260,15 @@ def validate_network_default_name(dcos_overlay_network_default_name, dcos_overla
             dcos_overlay_network_default_name))
 
 
+def validate_dcos_ucr_default_bridge_subnet(dcos_ucr_default_bridge_subnet):
+    try:
+        ipaddress.ip_network(dcos_ucr_default_bridge_subnet)
+    except ValueError as ex:
+        raise AssertionError(
+            "Incorrect value for dcos_ucr_default_bridge_subnet: {}."
+            " Only IPv4 subnets are allowed".format(dcos_ucr_default_bridge_subnet)) from ex
+
+
 def validate_dcos_overlay_network(dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
@@ -603,6 +612,7 @@ entry = {
         lambda master_dns_bindall: validate_true_false(master_dns_bindall),
         validate_os_type,
         validate_dcos_overlay_network,
+        validate_dcos_ucr_default_bridge_subnet,
         lambda dcos_overlay_network_default_name, dcos_overlay_network:
             validate_network_default_name(dcos_overlay_network_default_name, dcos_overlay_network),
         lambda dcos_overlay_enable: validate_true_false(dcos_overlay_enable),
@@ -680,6 +690,7 @@ entry = {
             }]
         }),
         'dcos_overlay_network_default_name': __dcos_overlay_network_default_name,
+        'dcos_ucr_default_bridge_subnet': '172.31.254.0/24',
         'dcos_remove_dockercfg_enable': "false",
         'minuteman_min_named_ip': '11.0.0.0',
         'minuteman_max_named_ip': '11.255.255.255',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -132,6 +132,30 @@ package:
         "name": "dummy",
         "type": "bridge"
       }
+  - path: /etc/dcos/network/cni/ucr-default-bridge.cni
+    content: |
+      {
+        "name": "mesos-bridge",
+        "type" : "mesos-cni-port-mapper",
+        "excludeDevices" : ["ucr-br0"],
+        "chain": "UCR-DEFAULT-BRIDGE",
+        "delegate": {
+          "type": "bridge",
+          "bridge": "ucr-br0",
+          "isDefaultGateway": true,
+          "forceAddress": false,
+          "ipMasq": true,
+          "hairpinMode": true,
+          "ipam": {
+            "type": "host-local",
+            "subnet": "{{ dcos_ucr_default_bridge_subnet }}",
+            "routes": [
+            { "dst":
+              "0.0.0.0/0" }
+            ]
+          }
+        }
+      }
   - path: /etc/overlay/config/agent.json
     content: |
       {
@@ -391,7 +415,7 @@ package:
       MESOS_DOCKER_VOLUME_CHECKPOINT_DIR=/var/lib/mesos/isolators/docker/volume
       MESOS_IMAGE_PROVIDERS=docker
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
-      MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/
+      MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_WORK_DIR=/var/lib/mesos/slave
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos


### PR DESCRIPTION
## High Level Description

This adds a default BRIDGE mode networking for UCR.

Supersedes #1481 

## Related Issues

  - [DCOS_OSS-954](https://jira.dcos.io/browse/DCOS_OSS-954) Add default bridge network for UCR.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
