### PR TITLE
bumping Marathon to 1.4.4

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.3/marathon-1.4.3.tgz",
-    "sha1": "e85ce11f9b054911b90ad27ac57a6b92bf2a0ba4"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.4/marathon-1.4.4.tgz",
+    "sha1": "50dcec7e3be9f44852afef3021d1f37913b0017a"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

## Changes from 1.4.3 to 1.4.4

### Changes

- [MARATHON-7411](https://jira.mesosphere.com/browse/MARATHON-7411) Include USER networked docker containers in /v2/tasks text/plain output. If no host port is specified, specify address as `{containerIp}:{containerPort}`. If host port is specified, `{agentIp}:{hostPort}`.

### Fixed issues

- [MARATHON-7396](https://jira.mesosphere.com/browse/MARATHON-7396) Marathon leader would become a zombie process in certain Zookeper failure scenarios.
- Marathon would not load authentication plugins in certain situations. This has been addressed.
- [MARATHON-7322](https://jira.mesosphere.com/browse/MARATHON-7322) /ping endpoint returns the correct content type
- [MARATHON-7320](https://jira.mesosphere.com/browse/MARATHON-7320) Fix MAX_PER constraint for attributes.
- Fix issue related to Marathon plugins and authorization for the endpoint `v2/tasks`

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
    - text/plain endpoint has vastly improved unit test coverage. 
    - zk issue is difficult to test
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [v1.4.3..v1.4.4](https://github.com/mesosphere/marathon/compare/v1.4.3..v1.4.4)
  - [x] Test Results: [results](https://jenkins.mesosphere.com/service/jenkins/job/marathon-sandbox/job/marathon-loop-1.4/3168/console)
  - [x] Code Coverage (not available)