### PR TITLE
Admin Router: /marathon endpoint fix

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -34,8 +34,8 @@ Use `make check-api-docs` to validate that the YAML and HTML files are up to dat
 ## Repository structure
 
 There are two Admin Router "flavours" residing in DC/OS repos:
-  * [Opensource version or `Open` in short](https://github.com/dcos/dcos/tree/master/packages/adminrouter)
-  * [Enterprise version or `EE` in short](https://github.com/mesosphere/dcos-enterprise/tree/master/packages/adminrouter)
+  * Opensource version or `Open` in short
+  * Enterprise version or `EE` in short
 
 The `Open` version is the base on top of which `EE` version is built. `EE` is in
 fact an overlay on top of `Open`, it re-uses some of its components.

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -146,10 +146,6 @@ routes:
     description: Redirect to add trailing slash
     visibility: hidden
     deprecated: Use `/service/marathon/`
-    rewrites:
-      - regex: ^/marathon$
-        replacement: /service/marathon/
-        type: last
     path: /marathon
   /marathon/:
     group: Marathon

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -112,8 +112,9 @@ location /dcos-history-service/ {
 # Description: Redirect to add trailing slash
 # Deprecated: Use `/service/marathon/`
 # Visibility: hidden
+## See https://jira.mesosphere.com/browse/DCOS_OSS-1163 for more context
 location = /marathon {
-    rewrite ^/marathon$ /service/marathon/ last;
+    return 307 /marathon/$is_args$args;
 }
 
 # Group: Marathon
@@ -160,8 +161,6 @@ location ~ ^/service/(?<service_path>.+) {
     include includes/disable-request-response-buffering.conf;
 
     proxy_redirect $upstream_scheme://$host/service/$service_realpath/ /service/$service_realpath/;
-    # Due to legacy reasons:
-    proxy_redirect $upstream_scheme://$host/marathon/ /service/$service_realpath/;
     proxy_redirect $upstream_scheme://$host/ /service/$service_realpath/;
     proxy_redirect / /service/$service_realpath/;
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -47,7 +47,7 @@ def ping_mesos_agent(ar,
         assert req_data['endpoint_id'] == endpoint_id
 
 
-def generic_no_slash_redirect_test(ar, path):
+def generic_no_slash_redirect_test(ar, path, code=301):
     """Test if request for location without trailing slash is redirected
 
     Helper function meant to simplify writing multiple tests testing the
@@ -56,11 +56,12 @@ def generic_no_slash_redirect_test(ar, path):
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
         path (str): path for which request should be made
+        code (int): expected http redirect code
     """
     url = ar.make_url_from_path(path)
     r = requests.get(url, allow_redirects=False)
 
-    assert r.status_code == 301
+    assert r.status_code == code
     assert r.headers['Location'] == url + '/'
 
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -123,7 +123,9 @@ def _verify_is_endpoint_redirecting_properly(t_config):
 
     assert len(t_config['locations']) > 0
     for p in t_config['locations']:
-        assert p.startswith('/')
+        _check_all_keys_are_present_in_dict(p, ['path', 'code'])
+        assert p['path'].startswith('/')
+        assert p['code'] in [301, 302, 303, 307, 308]
 
 
 def _verify_is_unauthed_access_permitted(t_config):
@@ -340,7 +342,8 @@ def _testdata_to_redirect_testdata(tests_config, node_type):
         if h['enabled'] is not True:
             continue
 
-        res.extend(h['locations'])
+        for l in h['locations']:
+            res.append((l['path'], l['code']))
 
     return res
 
@@ -375,7 +378,7 @@ def create_tests(metafunc, path):
 
     if 'redirect_path' in metafunc.fixturenames:
         args = _testdata_to_redirect_testdata(tests_config, ar_type)
-        metafunc.parametrize("redirect_path", args)
+        metafunc.parametrize("redirect_path, code", args)
         return
 
     if 'unauthed_path' in metafunc.fixturenames:
@@ -467,8 +470,11 @@ class GenericTestMasterClass:
             )
 
     def test_redirect_req_without_slash(
-            self, master_ar_process_perclass, redirect_path):
-        generic_no_slash_redirect_test(master_ar_process_perclass, redirect_path)
+            self, master_ar_process_perclass, redirect_path, code):
+        generic_no_slash_redirect_test(
+            master_ar_process_perclass,
+            redirect_path,
+            code)
 
     def test_if_unauthn_user_is_granted_access(
             self, master_ar_process_perclass, unauthed_path):
@@ -582,8 +588,11 @@ class GenericTestAgentClass:
             )
 
     def test_redirect_req_without_slash(
-            self, agent_ar_process_perclass, redirect_path):
-        generic_no_slash_redirect_test(agent_ar_process_perclass, redirect_path)
+            self, agent_ar_process_perclass, redirect_path, code):
+        generic_no_slash_redirect_test(
+            agent_ar_process_perclass,
+            redirect_path,
+            code)
 
     def test_if_unauthn_user_is_granted_access(
             self, agent_ar_process_perclass, unauthed_path):

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -24,7 +24,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /exhibitor
+          - path: /exhibitor
+            code: 301
       is_unauthed_access_permitted:
         enabled: true
         locations:
@@ -54,7 +55,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /service/scheduler-alwaysthere
+          - path: /service/scheduler-alwaysthere
+            code: 301
       is_upstream_req_ok:
         enabled: true
         expected_http_ver: websockets
@@ -392,7 +394,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /system/v1/logs/v1
+          - path: /system/v1/logs/v1
+            code: 301
     type:
       - master
       - agent
@@ -554,7 +557,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /mesos_dns
+          - path: /mesos_dns
+            code: 301
     type:
       - master
 
@@ -579,7 +583,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /mesos
+          - path: /mesos
+            code: 301
     type:
       - master
 
@@ -680,7 +685,8 @@ endpoint_tests:
       is_endpoint_redirecting_properly:
         enabled: true
         locations:
-          - /system/v1/metrics
+          - path: /system/v1/metrics
+            code: 301
     type:
       - master
 ######### /marathon

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -695,13 +695,11 @@ endpoint_tests:
         enabled: true
         jwt_should_be_forwarded: true
         test_paths:
-          - /marathon
           - /marathon/
           - /marathon/v2/reflect/me
       is_upstream_correct:
         enabled: true
         test_paths:
-          - /marathon
           - /marathon/
           - /marathon/v2/reflect/me
         upstream: http://127.0.0.1:8080
@@ -712,19 +710,11 @@ endpoint_tests:
           - expected: /v2/reflect/me
             sent: /marathon/v2/reflect/me
           - expected: /
-            sent: /marathon
-          - expected: /
             sent: /marathon/
-      is_location_header_rewritten:
+      is_endpoint_redirecting_properly:
         enabled: true
-        basepath: /marathon/v2/reflect/me
-        endpoint_id: http://127.0.0.1:8080
-        redirect_testscases:
-          - location_expected: http://127.0.0.1/service/marathon/v2/reflect/me
-            location_set: http://127.0.0.1/marathon/v2/reflect/me
-          - location_expected: http://127.0.0.1/service/marathon/v2/reflect/me
-            location_set: http://127.0.0.1/v2/reflect/me
-          - location_expected: http://127.0.0.1/service/marathon/v2/reflect/me
-            location_set: /v2/reflect/me
+        locations:
+          - path: /marathon
+            code: 307
     type:
       - master

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -96,6 +96,13 @@ def test_if_marathon_ui_is_up(dcos_api_session):
     assert '<title>Marathon</title>' in r.text
 
 
+def test_if_marathon_ui_redir_works(dcos_api_session):
+    r = dcos_api_session.get('/marathon')
+
+    assert r.status_code == 200
+    assert '<title>Marathon</title>' in r.text
+
+
 def test_if_srouter_service_endpoint_works(dcos_api_session):
     r = dcos_api_session.get('/service/marathon/ui/')
 


### PR DESCRIPTION
## High Level Description

This PR:
* fixes `/marathon` endpoint redirect (see the discussion in the issue for more details)
* piggybacks removing some redundant information from README.md
* make `is_endpoint_redirecting_properly` test more flexible - now it is possible to verify the code of the redirect sent by the backend


## Related Issues

  - https://jira.mesosphere.com/browse/DCOS_OSS-1163 - "mycluster.com/marathon" routes to "mycluster.com/ui" => 404

## Related PRs
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1023