### PR TITLE
Admin Router: Improve /service endpoint tests

### DIFF
--- a/packages/adminrouter/extra/src/lib/service.lua
+++ b/packages/adminrouter/extra/src/lib/service.lua
@@ -94,7 +94,7 @@ local function resolve_via_marathon_apps_state(service_name, marathon_cache)
     --  - err_code, err_text - if an error occured these will be HTTP status
     --    and error text that should be sent to the client. `nil` otherwise
     if marathon_cache == nil then
-        return nil, ngx.HTTP_SERVICE_UNAVAILABLE, "503 Service Unavailable: cache state is invalid"
+        return nil, ngx.HTTP_SERVICE_UNAVAILABLE, "503 Service Unavailable: invalid Marathon svcapps cache"
     end
 
     if marathon_cache[service_name] == nil then

--- a/packages/adminrouter/extra/src/test-harness/modules/util.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/util.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 class GuardedSubprocess:
-    """Context manager for Subproces instances
+    """Context manager for Subprocess instances
 
        The purpose of this class is to provide reliable cleanup for all Subprocess
        class instances (AR & friends), no matter the tests results or errors.

--- a/packages/adminrouter/extra/src/test-harness/tests/conftest.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/conftest.py
@@ -32,6 +32,8 @@ def repo_is_ee():
     return generic_test_code.common.repo_is_ee()
 
 
+# We explicitly need dns_server_mock_s fixture here as Mock HTTP servers
+# require DNS to resolve their server_names.
 @pytest.fixture(scope='session')
 def mocker_s(repo_is_ee, syslog_mock, extra_lo_ips, dns_server_mock_s):
     """Provide a gc-ed mocker instance suitable for the repository flavour"""

--- a/packages/adminrouter/extra/src/test-harness/tests/conftest.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/conftest.py
@@ -33,7 +33,7 @@ def repo_is_ee():
 
 
 @pytest.fixture(scope='session')
-def mocker_s(repo_is_ee, syslog_mock, extra_lo_ips):
+def mocker_s(repo_is_ee, syslog_mock, extra_lo_ips, dns_server_mock_s):
     """Provide a gc-ed mocker instance suitable for the repository flavour"""
     if repo_is_ee:
         from mocker.ee import Mocker

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -809,7 +809,8 @@ class TestCacheMarathon:
             resp = requests.get(url,
                                 allow_redirects=False,
                                 headers=valid_user_header)
-            assert "cache state is invalid" in resp.content.decode('utf-8')
+            expected = "503 Service Unavailable: invalid Marathon svcapps cache"
+            assert expected == resp.content.decode('utf-8').strip()
             assert resp.status_code == 503
 
             lbf.scan_log_buffer()

--- a/packages/adminrouter/extra/src/test-harness/tests/test_service.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_service.py
@@ -1,3 +1,4 @@
+
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
 import time
@@ -651,7 +652,7 @@ class TestServiceStateful:
             t_spent = time.time() - t_start
             assert resp.status_code == 200
             data = resp.json()
-            assert data['endpoint_id'] == 'http://127.0.0.1:16000'
+            data['endpoint_id'] == 'http://127.0.0.15:16001'
 
         assert t_spent > backend_request_timeout * 0.5
 


### PR DESCRIPTION
## High Level Description

This PR:
* makes dns mock a dependency for mocker. Without it the tests can
stall for >60s, depending on the order of fixtures in the function signature.
* adds missing tests for `/service` endpoint:
  * verify that resolving a service waits for Marathon if the cache is empty
  * verify that resolving a service waits for Mesos if the cache is empty
  * verify that resolving a service returns 503 in case when Marathon was borked AND make sure that Mesos data is ignored in this case
  * verify that resolving a service returns 503 in case when Mesos was borked AND resolving via Marathon did not succed
  * verify that resolving a service returns 200 in case when Mesos was borked AND Marathon is OK

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-16108 `Inspect integration test failures as of Admin Router's service endpoint emitting a 404 response`
