### PR TITLE
Master train 174

### DIFF
--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -27,7 +27,7 @@ ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
 ExecStart=/opt/mesosphere/bin/java \\
     -Xmx2G \\
-    -Djdk.http.auth.tunneling.disabledSchemes="" \\
+    -Djdk.http.auth.tunneling.disabledSchemes="NTLM" \\
     -classpath ${PKG_PATH}/usr/cosmos.jar \\
     com.simontuffs.onejar.Boot \\
     -admin.port=127.0.0.1:9990 \\

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.4.0-SNAPSHOT-239-master-6e67fd9a18/cosmos-server-0.4.0-SNAPSHOT-239-master-6e67fd9a18-one-jar.jar",
-    "sha1": "c1ff5073631b7feae2d447146c1df4578aeca32e"
+    "url": "https://downloads.dcos.io/cosmos/0.4.0-SNAPSHOT-250-master-df6306ebf1/cosmos-server-0.4.0-SNAPSHOT-250-master-df6306ebf1-one-jar.jar",
+    "sha1": "df272078933c46c589dfe2f360eb7894bffdb0bc"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -2,6 +2,7 @@ import json
 import logging
 import uuid
 
+import retrying
 
 from test_util.marathon import Container, get_test_app
 from test_util.recordio import Decoder, Encoder
@@ -157,7 +158,12 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
         marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']
         app_task = dcos_api_session.marathon.get('/v2/apps/{}/tasks'.format(app['id'])).json()['tasks'][0]
 
-        content = dcos_api_session.mesos_sandbox_file(
-            app_task['slaveId'], marathon_framework_id, app_task['id'], ps_output_file)
+        # There is a short delay between the `app_task` starting and it writing
+        # its output to the `pd_output_file`. Because of this, we wait up to 10
+        # seconds for this file to appear before throwing an exception.
+        @retrying.retry(wait_fixed=1000, stop_max_delay=10000)
+        def get_ps_output():
+            return dcos_api_session.mesos_sandbox_file(
+                app_task['slaveId'], marathon_framework_id, app_task['id'], ps_output_file)
 
-        assert len(content.split()) <= 4, 'UCR app has more than 4 processes running in its pid namespace'
+        assert len(get_ps_output().split()) <= 4, 'UCR app has more than 4 processes running in its pid namespace'

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -109,11 +109,10 @@ def test_vip(dcos_api_session, container: Container, vip_net: Network, proxy_net
     failure_stack = []
     for test in setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
         cmd, origin_app, proxy_app, proxy_net = test
-        log.info('ORIGIN APP INFO')
-        log.info(wait_for_tasks_healthy(dcos_api_session, origin_app))
-        log.info('PROXY APP INFO')
+        log.info('Deploying origin app')
+        wait_for_tasks_healthy(dcos_api_session, origin_app)
+        log.info('Origin app successful, deploying proxy app..')
         proxy_info = wait_for_tasks_healthy(dcos_api_session, proxy_app)
-        log.info(proxy_info)
         proxy_task_info = proxy_info['app']['tasks'][0]
         if proxy_net == Network.USER:
             proxy_host = proxy_task_info['ipAddresses'][0]['ipAddress']
@@ -173,7 +172,7 @@ def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
 
 @retrying.retry(
     wait_fixed=5000,
-    stop_max_delay=240 * 1000,
+    stop_max_delay=360 * 1000,
     # the app monitored by this function typically takes 2 minutes when starting from
     # a fresh state, but in this case the previous app load may still be winding down,
     # so allow a larger buffer time

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "7ce5ba397bbaa8fdcc985ef2e6dd8bc81709931a",
-      "ref_origin": "1.9.x"
+      "ref": "2a5a02f1de47dcbe44844f7358adf85ea630cf4a",
+      "ref_origin": "master"
     }
 }


### PR DESCRIPTION
Fixed CHECK failure in logger module due to Docker workaround.
https://github.com/dcos/dcos/pull/1565

Fixed bug in 'test_mesos.test_if_ucr_app_runs_in_new_pid_namespace'.
https://github.com/dcos/dcos/pull/1617

Disable NTLM proxy auth for cosmos
https://github.com/dcos/dcos/pull/1632

Increase timeout in test_vip
https://github.com/dcos/dcos/pull/1641

Update cosmos to latest version
https://github.com/dcos/dcos/pull/1646
