### PR TITLE
pkgpanda-api: don't use systemd socket

### DIFF
--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -156,7 +156,6 @@ def test_signal_service(dcos_api_session):
         'gen-resolvconf-timer',
         'navstar-service',
         'pkgpanda-api-service',
-        'pkgpanda-api-socket',
         'signal-timer',
         'spartan-service',
         'spartan-watchdog-service',

--- a/packages/pkgpanda-api/build
+++ b/packages/pkgpanda-api/build
@@ -6,10 +6,6 @@ cat <<EOF > $PKG_PATH/etc/pkgpanda-api.conf.py
 WORK_DIR = '/run/dcos/pkgpanda-api/'
 EOF
 
-systemd_socket=$PKG_PATH/dcos.target.wants/dcos-pkgpanda-api.socket
-mkdir -p $(dirname $systemd_socket)
-cp /pkg/extra/dcos-pkgpanda-api.socket $systemd_socket
-
 systemd_service=$PKG_PATH/dcos.target.wants/dcos-pkgpanda-api.service
 mkdir -p $(dirname $systemd_service)
 envsubst '${PKG_PATH}' < /pkg/extra/dcos-pkgpanda-api.service > "$systemd_service"

--- a/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
+++ b/packages/pkgpanda-api/extra/dcos-pkgpanda-api.service
@@ -23,4 +23,3 @@ ExecStart=${PKG_PATH}/pkgpanda-api/bin/pkgpanda-api.sh
 KillMode=mixed
 KillSignal=SIGTERM
 TimeoutStopSec=30
-Sockets=dcos-pkgpanda-api.socket

--- a/packages/pkgpanda-api/extra/dcos-pkgpanda-api.socket
+++ b/packages/pkgpanda-api/extra/dcos-pkgpanda-api.socket
@@ -1,8 +1,0 @@
-[Unit]
-Description=DC/OS Component Package Manager (Pkgpanda) Socket: socket for DC/OS Component Package Manager
-
-[Socket]
-ListenStream=/run/dcos/pkgpanda-api.sock
-SocketUser=root
-SocketGroup=dcos_adminrouter
-SocketMode=0660

--- a/packages/pkgpanda-api/extra/pkgpanda-api.sh
+++ b/packages/pkgpanda-api/extra/pkgpanda-api.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -xe
 
-# Wait for dcos-pkgpanda-api.socket to create the socket file so we don't
-# create one with the wrong ownership and permissions below.
-test -S /run/dcos/pkgpanda-api.sock
-
 exec /opt/mesosphere/bin/gunicorn --worker-class=sync \
     --workers=1 \
     --threads=10 \
@@ -16,4 +12,6 @@ exec /opt/mesosphere/bin/gunicorn --worker-class=sync \
     --access-logformat '%({X-Forwarded-For}i)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" (%(L)s s)' \
     --error-logfile - \
     --log-level=info \
+    --umask 79 \
+    --group dcos_adminrouter \
     pkgpanda.http:app


### PR DESCRIPTION
## High Level Description

This applies https://github.com/dcos/dcos/pull/1463 to the 1.9.1 branch. That PR apparently didn't get merged by the time 1.9.1 was branched.

The `dcos-pkgpanda-api` service runs as a gunicorn web server. This service listens on a unix socket `/run/dcos/pkgpanda-api.sock`. This socket used to be managed by systemd as the `dcos-pkgpanda-api.socket` unit. However, gunicorn removes the socket file when it exits and creates it on start if it doesn't already exist. In short, it is not intended for use with systemd managed sockets.

This PR removes the systemd socket unit and relies on gunicorn's command-line flags to correctly set the permissions and ownership of its socket file.

This fixes an issue where upgrading a master from 1.8.8 to 1.9.0 would sometimes require a manual `systemctl restart dcos-pkgpanda-api.socket` as a final step so the `dcos-pkgpanda-api` service could start.

## Related Issues

  - [DCOS-14644](https://jira.mesosphere.com/browse/DCOS-14644) DC/OS 1.8.8 -> 1.9.0-rc3 DC/OS Component Package Manager (Pkgpanda) (Unhealthy)
  - [CORE-985](https://jira.mesosphere.com/browse/CORE-985) Unhealthy Pkgpanda component on some masters/agents after upgrade

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is seen during upgrade. Three nodes were upgraded to this PR and it worked every time.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___