### PR TITLE
Bumped Mesos to current (1.4.x WIP) master.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -7,5 +7,3 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[44eec8e7935d6de83afe80f22bdd4fd979b63fc7] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[dbd3bc2947efe0a1f66bb645f6bc48c154a9f130] Revert "Fixed the broken metrics information of master in WebUI."
 <li>[9cc627d9f32d56f14f277e823a759183ef4b234d] Updated mesos containerizer to ignore GPU isolator creation failure.
-<li>[f2b490010136c4eb8e2e3055a2549d6cbf3429ac] Added '--filter_gpu_resources' flag to the mesos master.
-<li>[1a99252362a73134dd3e028c69016f98a3735a8d] Fixed a bug in 'ComposingContainerizerProcess::wait()'.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "1a99252362a73134dd3e028c69016f98a3735a8d",
-    "ref_origin" : "dcos-mesos-master-4faca73"
+    "ref": "883087751e5589a015d07c9b64887db8a93eaeb0",
+    "ref_origin" : "dcos-mesos-master-77d5075"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Updates to Apache Mesos master (1.4.0 WIP) beyond the recently introduced and then fixed Docker containerizer issue in strict mode. Backports are not needed.

## Related Issues

  - [CORE-1134](https://jira.mesosphere.com/browse/CORE-1134) Docker containerized tasks fail with broken pipe in strict mode.
  - [DCOS-16115](https://jira.mesosphere.com/browse/DCOS-16115) Bump mesos for 1.10.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [4faca73e9608664a5fcf46cc95951c318a64861f...77d5075784f2e804274adc243eb8e3fb458edfd9](https://github.com/apache/mesos/compare/4faca73e9608664a5fcf46cc95951c318a64861f...77d5075784f2e804274adc243eb8e3fb458edfd9)
  - [x] Test Results: [1231](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI/1231/)
  - [ ] Code Coverage (if available): [link to code coverage report]