### PR TITLE
Create state directory for packages activated via the Pkgpanda API

### DIFF
--- a/pkgpanda/cli.py
+++ b/pkgpanda/cli.py
@@ -18,6 +18,8 @@ Options:
     --no-systemd                Don't try starting/stopping systemd services
     --no-block-systemd          Don't block waiting for systemd services to come up.
     --root=<root>               Testing only: Use an alternate root [default: {default_root}]
+    --state-dir-root=<root>     Testing only: Use an alternate package state directory root
+                                [default: {default_state_dir_root}]
     --repository=<repository>   Testing only: Use an alternate local package
                                 repository directory [default: {default_repository}]
     --rooted-systemd            Use $ROOT/dcos.target.wants for systemd management
@@ -128,6 +130,7 @@ def main():
             default_config_dir=constants.config_dir,
             default_root=constants.install_root,
             default_repository=constants.repository_base,
+            default_state_dir_root=constants.STATE_DIR_ROOT,
         ),
     )
     umask(0o022)
@@ -141,7 +144,8 @@ def main():
         not arguments['--no-block-systemd'],
         manage_users=True,
         add_users=not os.path.exists('/etc/mesosphere/manual_host_users'),
-        manage_state_dir=True)
+        manage_state_dir=True,
+        state_dir_root=os.path.abspath(arguments['--state-dir-root']))
 
     repository = Repository(os.path.abspath(arguments['--repository']))
 

--- a/pkgpanda/constants.py
+++ b/pkgpanda/constants.py
@@ -8,6 +8,8 @@ DCOS_SERVICE_CONFIGURATION_FILE = "dcos-service-configuration.json"
 DCOS_SERVICE_CONFIGURATION_PATH = "/opt/mesosphere/etc/" + DCOS_SERVICE_CONFIGURATION_FILE
 SYSCTL_SETTING_KEY = "sysctl"
 
+STATE_DIR_ROOT = '/var/lib/dcos'
+
 config_dir = '/etc/mesosphere'
 install_root = '/opt/mesosphere'
 repository_base = '/opt/mesosphere/packages'

--- a/pkgpanda/http/__init__.py
+++ b/pkgpanda/http/__init__.py
@@ -93,7 +93,9 @@ def set_app_attrs_from_config():
         current_app.config['DCOS_CONFIG_DIR'],
         current_app.config['DCOS_ROOTED_SYSTEMD'],
         manage_systemd=True,
-        block_systemd=False)
+        block_systemd=False,
+        manage_state_dir=True,
+        state_dir_root=current_app.config['DCOS_STATE_DIR_ROOT'])
     current_app.repository = Repository(
         current_app.config['DCOS_REPO_DIR'])
 

--- a/pkgpanda/http/config.py
+++ b/pkgpanda/http/config.py
@@ -8,5 +8,6 @@ DCOS_ROOT = constants.install_root
 DCOS_CONFIG_DIR = constants.config_dir
 DCOS_REPO_DIR = constants.repository_base
 DCOS_ROOTED_SYSTEMD = False
+DCOS_STATE_DIR_ROOT = constants.STATE_DIR_ROOT
 
 WORK_DIR = os.path.join(tempfile.gettempdir(), 'pkgpanda_api')

--- a/pkgpanda/test_http.py
+++ b/pkgpanda/test_http.py
@@ -80,6 +80,7 @@ def assert_error(response, status_code, headers=None, **kwargs):
 def _set_test_config(app):
     app.config['TESTING'] = True
     app.config['DCOS_ROOT'] = resources_test_dir('install')
+    app.config['DCOS_STATE_DIR_ROOT'] = resources_test_dir('install/package_state')
     app.config['DCOS_REPO_DIR'] = resources_test_dir('packages')
 
 
@@ -165,6 +166,9 @@ def test_activate_packages(tmpdir):
         b'',
     )
     assert_json_response(client.get('/active/'), 200, new_packages)
+
+    # mesos--0.23.0 expects to have a state directory.
+    assert os.path.isdir(app.config['DCOS_STATE_DIR_ROOT'] + '/mesos')
 
     # Attempt to activate nonexistent packages.
     nonexistent_packages = [

--- a/pkgpanda/test_resources/packages/mesos--0.23.0/pkginfo.json
+++ b/pkgpanda/test_resources/packages/mesos--0.23.0/pkginfo.json
@@ -1,2 +1,3 @@
 {
+  "state_directory": true
 }

--- a/pkgpanda/test_setup.py
+++ b/pkgpanda/test_setup.py
@@ -1,3 +1,4 @@
+import os
 from shutil import copytree
 from subprocess import check_call, check_output
 
@@ -165,6 +166,7 @@ def test_setup(tmpdir):
 
 def test_activate(tmpdir):
     repo_path = tmp_repository(tmpdir)
+    state_dir_root = tmpdir.join("package_state")
     tmpdir.join("root", "bootstrap").write("", ensure=True)
 
     # TODO(cmaloney): Depending on setup here is less than ideal, but meh.
@@ -238,6 +240,19 @@ def test_activate(tmpdir):
         "--config-dir=../resources/etc-active"]).decode().split())
 
     assert active == {"mesos--0.22.0"}
+
+    # Check that mesos--0.23.0 gets its state directory created.
+    assert not os.path.isdir(str(state_dir_root) + '/mesos')
+    assert run(["pkgpanda",
+                "activate",
+                "mesos--0.23.0",
+                "--root={0}/root".format(tmpdir),
+                "--rooted-systemd",
+                "--repository={}".format(repo_path),
+                "--config-dir=../resources/etc-active",
+                "--no-systemd",
+                "--state-dir-root={}".format(state_dir_root)]) == ""
+    assert os.path.isdir(str(state_dir_root) + '/mesos')
 
     # TODO(cmaloney): expect_fs
     # TODO(cmaloney): Test a full OS setup using http://0pointer.de/blog/projects/changing-roots.html


### PR DESCRIPTION
## High Level Description

This causes the Pkgpanda API to create state directories as appropriate for the packages it activates, making it consistent with the CLI's current behavior.

## Related Issues

  - [DCOS_OSS-1212](https://jira.mesosphere.com/browse/DCOS_OSS-1212) Pkgpanda API does not create package state dirs in /var/lib/dcos/

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]