### PR TITLE
Restore NATAmi mapping for govcloud regions

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -170,7 +170,7 @@ region_to_ami_map = {
         'coreos': 'ami-a846fcc9',
         'stable': 'ami-a846fcc9',
         'el7': 'ami-35b43354',
-        'natami': ''
+        'natami': 'ami-e8ab1489'
     },
     'us-west-1': {
         'coreos': 'ami-1a1b457a',


### PR DESCRIPTION
## High Level Description

AWS templates launched in the govcloud region were failing with the error:

```
CREATE_FAILED AWS::EC2::Instance NATInstance The request must contain the parameter ImageId 
```

The NAT mapping in the template appears to have been accidentally removed with commit
95b7dbccd.

Backporting to 1.9.x with #1659 

FIXES: https://jira.mesosphere.com/browse/DCOS-15295

## Related Issues

  - [DCOS-15295](https://jira.mesosphere.com/browse/DCOS-15295>) DC/OS 1.9 not working in govcloud

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: We do have a lot of AWS template integration tests, but none run against govcloud regions and it is likely too expensive to run regularly. Would be worth running these periodically however.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)