### PR TITLE
Target Marathon 1.4.5

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.4/marathon-1.4.4.tgz",
-    "sha1": "50dcec7e3be9f44852afef3021d1f37913b0017a"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.5/marathon-1.4.5.tgz",
+    "sha1": "b73f862c678db1e744df5261fb7f91e100b9a0d5"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## Changes from 1.4.4 to 1.4.5

### Fixed issues

- [MARATHON-7479](https://jira.mesosphere.com/browse/MARATHON-7479) Fixes major deployment plan computation performance regression for Marathon instances containing a large number of apps (500+).

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: [This test shows a 2000x improvement for the deployment plan computation](https://github.com/mesosphere/marathon/blob/releases/1.4/benchmark/src/main/scala/mesosphere/marathon/upgrade/FlatDependencyBenchmark.scala)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [v1.4.4 .. v1.4.5](https://github.com/mesosphere/marathon/compare/v1.4.4...v1.4.5)
  - [x] Test Results: [v1.4.5 build](https://jenkins.mesosphere.com/service/jenkins/job/marathon-pipelines/job/releases%252F1.4/6/)
  - [x] Code Coverage (if available): not avail