### PR TITLE
rexray: read proxy.env (1.9.1)

### DIFF
--- a/packages/rexray/extra/dcos-rexray.service
+++ b/packages/rexray/extra/dcos-rexray.service
@@ -7,5 +7,6 @@ Restart=always
 RestartSec=15
 LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=/opt/mesosphere/etc/proxy.env
 Environment=REXRAY_HOME=/
 ExecStart=__PKG_PATH__/bin/rexray start -f


### PR DESCRIPTION
## High Level Description

REX-Ray does not currently source the proxy configuration in `/opt/mesosphere/etc/proxy.conf`. This means AWS agents behind a proxy can't contact the EBS API. This PR adds the proxy configuration to the `dcos-rexray.service` file to enable this behaviour.

## Related Issues

  - [DCOS_OSS-1283](https://jira.mesosphere.com/browse/DCOS_OSS-1283) rexray not honouring proxy config

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Needs a proxy test environment configured. Tested manually.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
