### PR TITLE
Add custom_checks config parameter

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -26,11 +26,13 @@ import ipaddress
 import json
 import os
 import socket
+import string
 import textwrap
 from math import floor
 from subprocess import check_output
 from urllib.parse import urlparse
 
+import schema
 import yaml
 
 import gen.internals
@@ -614,7 +616,6 @@ def calculate_check_config_contents(check_config):
 
 def calculate_check_config(check_time):
     check_config = {
-        'cluster_checks': {},
         'node_checks': {
             'checks': {
                 'components_master': {
@@ -702,6 +703,64 @@ def calculate_check_config(check_time):
     return json.dumps(check_config)
 
 
+def validate_check_config(check_config):
+
+    class PrettyReprAnd(schema.And):
+
+        def __repr__(self):
+            return self._error
+
+    check_name = PrettyReprAnd(
+        str,
+        lambda val: len(val) > 0,
+        lambda val: not any(w in val for w in string.whitespace),
+        error='Check name must be a nonzero length string with no whitespace')
+
+    timeout_units = ['ns', 'us', 'µs', 'ms', 's', 'm', 'h']
+    timeout = schema.Regex(
+        '^\d+(\.\d+)?({})$'.format('|'.join(timeout_units)),
+        error='Timeout must be a string containing an integer or float followed by a unit: {}'.format(
+            ', '.join(timeout_units)))
+
+    check_config_schema = schema.Schema({
+        schema.Optional('cluster_checks'): {
+            check_name: {
+                'description': str,
+                'cmd': [str],
+                'timeout': timeout,
+            },
+        },
+        schema.Optional('node_checks'): {
+            'checks': {
+                check_name: {
+                    'description': str,
+                    'cmd': [str],
+                    'timeout': timeout,
+                    schema.Optional('roles'): schema.Schema(
+                        ['master', 'agent'],
+                        error='roles must be a list containing master or agent or both',
+                    ),
+                },
+            },
+            schema.Optional('prestart'): [check_name],
+            schema.Optional('poststart'): [check_name],
+        },
+    })
+
+    check_config_obj = validate_json_dictionary(check_config)
+    try:
+        check_config_schema.validate(check_config_obj)
+    except schema.SchemaError as exc:
+        raise AssertionError(str(exc).replace('\n', ' ')) from exc
+
+    if 'node_checks' in check_config_obj.keys():
+        node_checks = check_config_obj['node_checks']
+        assert any(k in node_checks.keys() for k in ['prestart', 'poststart']), (
+            'At least one of prestart or poststart must be defined in node_checks')
+        assert node_checks['checks'].keys() == set(
+            node_checks.get('prestart', []) + node_checks.get('poststart', [])), (
+            'All node checks must be referenced in either prestart or poststart, or both')
+
 __dcos_overlay_network_default_name = 'dcos'
 
 
@@ -749,7 +808,8 @@ entry = {
         lambda enable_lb: validate_true_false(enable_lb),
         lambda adminrouter_tls_1_0_enabled: validate_true_false(adminrouter_tls_1_0_enabled),
         lambda gpus_are_scarce: validate_true_false(gpus_are_scarce),
-        validate_mesos_max_completed_tasks_per_framework
+        validate_mesos_max_completed_tasks_per_framework,
+        lambda check_config: validate_check_config(check_config)
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -652,7 +652,7 @@ def calculate_check_config_contents(check_config, custom_checks):
     dcos_checks = json.loads(check_config)
     user_checks = json.loads(custom_checks)
     merged_checks = merged_check_config(user_checks, dcos_checks)
-    return yaml.dump(json.dumps(merged_checks))
+    return yaml.dump(json.dumps(merged_checks, indent=2))
 
 
 def calculate_check_config(check_time):

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -27,12 +27,6 @@ def validate_error_multikey(new_arguments, keys, message, unset=None):
     }
 
 
-def validate_ok(new_arguments):
-    assert gen.validate(arguments=make_arguments(new_arguments)) == {
-        'status': 'ok',
-    }
-
-
 def test_invalid_telemetry_enabled():
     err_msg = "Must be one of 'true', 'false'. Got 'foo'."
     validate_error(
@@ -61,9 +55,7 @@ def test_invalid_ports():
 def test_dns_bind_ip_blacklist():
     test_ips = '["52.37.192.49", "52.37.181.230", "52.37.163.105"]'
 
-    validate_success(
-        {'dns_bind_ip_blacklist': test_ips},
-        'dns_bind_ip_blacklist')
+    validate_success({'dns_bind_ip_blacklist': test_ips})
 
 
 def test_dns_forward_zones():
@@ -71,9 +63,7 @@ def test_dns_forward_zones():
     bad_zones = bad_dns_forward_zones_str
     err_msg = 'Invalid "dns_forward_zones": 1 not a valid IP address'
 
-    validate_success(
-        {'dns_forward_zones': zones},
-        'dns_forward_zones')
+    validate_success({'dns_forward_zones': zones})
 
     validate_error(
         {'dns_forward_zones': bad_zones},
@@ -163,10 +153,10 @@ def test_exhibitor_storage_master_discovery():
         "master ips doesn't `master_http_load_balancer` then exhibitor_storage_backend must not " \
         "be static."
 
-    validate_ok({
+    validate_success({
         'exhibitor_storage_backend': 'static',
         'master_discovery': 'static'})
-    validate_ok({
+    validate_success({
         'exhibitor_storage_backend': 'aws_s3',
         'master_discovery': 'master_http_loadbalancer',
         'aws_region': 'foo',
@@ -175,7 +165,7 @@ def test_exhibitor_storage_master_discovery():
         'num_masters': '5',
         's3_bucket': 'baz',
         's3_prefix': 'mofo'})
-    validate_ok({
+    validate_success({
         'exhibitor_storage_backend': 'aws_s3',
         'master_discovery': 'static',
         'exhibitor_explicit_keys': 'false',

--- a/gen/tests/utils.py
+++ b/gen/tests/utils.py
@@ -47,7 +47,7 @@ def validate_error(new_arguments, key, message, unset=None):
     }
 
 
-def validate_success(new_arguments, key):
+def validate_success(new_arguments):
     assert gen.validate(arguments=make_arguments(new_arguments)) == {
         'status': 'ok',
     }

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -6,7 +6,7 @@ mkdir -p "$LIB_INSTALL_DIR"
 # Install wheels.
 for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
     azure-mgmt-network azure-storage beautifulsoup4 certifi docutils enum34 keyring msrest \
-    msrestazure py requests-oauthlib webob; do
+    msrestazure py requests-oauthlib schema webob; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -128,6 +128,11 @@
       "url": "https://pypi.python.org/packages/3d/b9/895abf47ce871c80460727ba385d10d246a2d9ded1bc82ba3748d02e5196/requests_oauthlib-0.6.1-py2.py3-none-any.whl",
       "sha1": "f364a323b1a96dea6d0f1ef7286144613504c9d7"
     },
+    "schema": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/7b/46/657c4b2a4dbfd353df49cf39edf5955cd10a63a5111751e7e80d2676398d/schema-0.6.6-py2.py3-none-any.whl",
+      "sha1": "adb60d9b58d98b7d54cdf9f0498ab752185eebd2"
+    },
     "waitress": {
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/source/w/waitress/waitress-0.8.10.tar.gz",

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'pyyaml',
         'requests==2.10.0',
         'retrying',
+        'schema',
         'keyring==9.1',  # FIXME: pin keyring to prevent dbus dep
         'teamcity-messages'],
     entry_points={


### PR DESCRIPTION
## High Level Description

This PR adds `custom_checks` as a supported parameter in `config.yaml`. This parameter contains custom check definitions which are added to the check config that is read by `dcos-diagnostics`. These custom checks are then executed alongside the builtin checks when `dcos-diagnostics check` is used.

Example custom check config:
```
custom_checks:
  cluster_checks:
    custom-check-1:
      description: Foobar cluster service is healthy
      cmd:
        - echo
        - hello
      timeout: 1s
  node_checks:
    checks:
      custom-check-2:
        description: Foobar node service is healthy
        cmd:
          - echo
          - hello
        timeout: 1s
        roles:
          - agent
    poststart:
      - custom-check-2
```

## Related Issues

- [DCOS_OSS-1024](https://jira.mesosphere.com/browse/DCOS_OSS-1024) Support adding custom check config during onprem installation

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]