### PR TITLE
Remove zk check 

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -713,12 +713,6 @@ def calculate_check_config(check_time):
                     'timeout': '1s',
                     'roles': ['agent']
                 },
-                'zookeeper_serving': {
-                    'description': 'The ZooKeeper instance is serving',
-                    'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'master', 'zk-quorum'],
-                    'timeout': '3s',
-                    'roles': ['master']
-                },
             },
             'prestart': [],
             'poststart': [
@@ -731,7 +725,6 @@ def calculate_check_config(check_time):
                 'ip_detect_script',
                 'mesos_master_replog_synchronized',
                 'mesos_agent_registered_with_masters',
-                'zookeeper_serving',
             ],
         },
     }

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-checks.git",
-    "ref": "41da92d4f18d9582e692a96b537dd2c1193bf2e1",
+    "ref": "422e531a6f180495c2569cf7a9ea407e67de4e3a",
     "ref_origin": "master"
   },
   "state_directory": true,


### PR DESCRIPTION
## High Level Description

The current zk check uses port 8181, removing the check and moving it to use adminrouter. Unfortunately not supported in open. 

## Related Issues
https://jira.mesosphere.com/browse/DCOS-16650
https://github.com/mesosphere/dcos-enterprise/pull/1143

Changelog:
https://github.com/dcos/dcos-checks/commit/422e531a6f180495c2569cf7a9ea407e67de4e3a

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
