### PR TITLE
marathon: "fix" checksum of build artifact (DCOS_OSS-1289)

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-582-g1793076.tgz",
-    "sha1": "8bc00666df1825daf984ee945ec4fef1d72e3c5b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-582-g1793076.tgz",
+    "sha1": "bfb029f0b384d5bfec16a010fda0df4845b16e95"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
This attempts to address [DCOS_OSS-1289](https://jira.mesosphere.com/browse/DCOS_OSS-1289), assuming that the current state of `https://downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-582-g1793076.tgz` is sane. The root cause of the current mismatch in the `master` branch is still to be identified and will hopefully be reported to https://jira.mesosphere.com/browse/DCOS_OSS-1289.

