### PR TITLE
OpenSSL build: globally disable 3DES ("Triple-DES" / "DES-CBC3"), bump to 1.0.2l

### DIFF
--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -14,7 +14,6 @@ pushd "/pkg/src/openssl"
   no-rc4 \
   no-ssl2 \
   no-ssl3 \
-  no-des \
   no-descbcm \
   enable-ec_nistp_64_gcc_128 \
   -Wa,--noexecstack \

--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -14,6 +14,8 @@ pushd "/pkg/src/openssl"
   no-rc4 \
   no-ssl2 \
   no-ssl3 \
+  no-des \
+  no-descbcm \
   enable-ec_nistp_64_gcc_128 \
   -Wa,--noexecstack \
   -O2 -DFORTIFY_SOURCE=2

--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2k.tar.gz",
-    "sha1": "5f26a624479c51847ebd2f22bb9f84b3b44dcb44"
+    "url": "https://www.openssl.org/source/openssl-1.0.2l.tar.gz",
+    "sha1": "b58d5d0e9cea20e571d903aafa853e2ccd914138"
   }
 }


### PR DESCRIPTION
## High Level Description

This pull request attempts to globally disable the bulk encryption method 3DES ("Triple-DES" / "DES-CBC3") in all applications that link against OpenSSL for TLS support.

## Related Issues

  - [DCOS_OSS-1310](https://jira.mesosphere.com/browse/DCOS_OSS-1310)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Going to test this manually.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]