### PR TITLE
Bump ZooKeeper to release 3.4.10

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,8 +9,8 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.com/zookeeper/zookeeper-3.4.8.tar.gz",
-      "sha1": "51b61611a329294f75aed82f3a4517a4b6ff116f"
+      "url": "http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
+      "sha1": "eb2145498c5f7a0d23650d3e0102318363206fba"
     },
     "log4j": {
         "kind": "url",


### PR DESCRIPTION
This addresses https://jira.mesosphere.com/browse/DCOS_OSS-739 and bumps ZooKeeper in DC/OS from version 3.4.8 to version 3.4.10.

Official changelog:
* http://zookeeper.apache.org/doc/r3.4.9/releasenotes.html
* http://zookeeper.apache.org/doc/r3.4.10/releasenotes.html

Particularly relevant changelog items:
* "Zookeeper service becomes unavailable when leader fails to write transaction log"
* "Back-port ZOOKEEPER-1460 to 3.4 for IPv6 literal address support."
* "CancelledKeyException in zookeeper"
* "Potential memory leak in recordio.c"
* "Large databases take a long time to regain a quorum"
* "Correct DataNode.getChildren() inconsistent behaviour."

