### PR TITLE
golang components shouldn't specify custom docker

### DIFF
--- a/packages/cni/buildinfo.json
+++ b/packages/cni/buildinfo.json
@@ -1,5 +1,4 @@
 {
-    "docker": "golang:1.6",
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/containernetworking/cni.git",

--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/dvdcli.git",

--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos-dns.git",

--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",

--- a/packages/octarine/buildinfo.json
+++ b/packages/octarine/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/octarine.git",
-    "ref": "5b7b18d7500079327a259b15371d253beaa585e3",
+    "ref": "315aa7c3e7a1eeedda005fcfeb1d31bbd9381515",
     "ref_origin": "master"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,5 +1,4 @@
 {
-  "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/rexray.git",


### PR DESCRIPTION
## High Level Description

This PR modifies the `buildinfo.json` config of various Go components that currently specify their own Go build versions. This makes ensuring that our components are built against the latest patched releases simpler by centralizing the Go build version to the `dcos-builder` docker image.

We also update the octarine version to support building with Go v1.8.

This PR needs approval by the maintainers of the individual components.

## Related Issues

  - [DCOS_OSS-1322](https://jira.mesosphere.com/browse/DCOS_OSS-1322) Go packages should use default version

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): 
[octarine](https://github.com/dcos/octarine/compare/5b7b18d7500079327a259b15371d253beaa585e3...315aa7c3e7a1eeedda005fcfeb1d31bbd9381515)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
