### PR TITLE
Added a new cherry-pick to the dcos-mesos-master-d02195157 branch.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -7,3 +7,4 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[44eec8e7935d6de83afe80f22bdd4fd979b63fc7] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[dbd3bc2947efe0a1f66bb645f6bc48c154a9f130] Revert "Fixed the broken metrics information of master in WebUI."
 <li>[9cc627d9f32d56f14f277e823a759183ef4b234d] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[08f0b6b3aee032998c66bbc3abe8b5863a900c43] Fixed the broken 'Roles' tab of the webui.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "13b7c1143b2ced464d4fca0bb381b158ffaed8ad",
+    "ref": "08f0b6b3aee032998c66bbc3abe8b5863a900c43",
     "ref_origin" : "dcos-mesos-master-abe9d1b"
   },
   "environment": {


### PR DESCRIPTION
## High Level Description
This bumps to the tip of mesos master, with the following fixes included in the cherry-picks:

* Fixed a regression in the mesos webui sandbox redirection.
* Fixed the broken 'Roles' tab in the mesos webui.

## Related Issues

* [CORE-1159](https://jira.mesosphere.com/browse/CORE-1159): Mesos UI sandbox redirection is broken in DC/OS.
* [CORE-1160](https://jira.mesosphere.com/browse/CORE-1160): The roles tab in the Mesos webui is broken in DC/OS.

## Checklist for all PR's

  - [ x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: No existing tests for the mesos ui cherry picks.
  - [ x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/mesos/compare/dcos-mesos-master-abe9d1b...mesosphere:dcos-mesos-master-d02195157
  - [x ] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Mesos/job/mesos/job/Mesos_CI-build/1313/
  - [x ] Code Coverage (if available): N/A