### PR TITLE
gen: validate s3_prefix

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -552,6 +552,11 @@ def validate_exhibitor_storage_master_discovery(master_discovery, exhibitor_stor
             "`master_http_load_balancer` then exhibitor_storage_backend must not be static."
 
 
+def validate_s3_prefix(s3_prefix):
+    # See DCOS_OSS-1353
+    assert not s3_prefix.endswith('/'), "Must be a file path and cannot end in a /"
+
+
 def validate_dns_bind_ip_blacklist(dns_bind_ip_blacklist):
     return validate_ip_list(dns_bind_ip_blacklist)
 
@@ -832,6 +837,7 @@ __dcos_overlay_network_default_name = 'dcos'
 
 entry = {
     'validate': [
+        validate_s3_prefix,
         validate_num_masters,
         validate_bootstrap_url,
         validate_channel_name,

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -171,13 +171,26 @@ def test_exhibitor_storage_master_discovery():
         'exhibitor_explicit_keys': 'false',
         's3_bucket': 'foo',
         'aws_region': 'bar',
-        's3_prefix': 'baz'})
+        's3_prefix': 'baz/bar'})
     validate_error_multikey(
         {'exhibitor_storage_backend': 'static',
          'master_discovery': 'master_http_loadbalancer'},
         ['exhibitor_storage_backend', 'master_discovery'],
         msg_master_discovery,
         unset={'exhibitor_address', 'num_masters'})
+
+
+def test_validate_s3_prefix():
+    validate_error({
+        'exhibitor_storage_backend': 'aws_s3',
+        'exhibitor_explicit_keys': 'false',
+        'aws_region': 'bar',
+        's3_bucket': 'baz',
+        's3_prefix': 'baz/'},
+        's3_prefix',
+        'Must be a file path and cannot end in a /')
+    validate_success({'s3_prefix': 'baz'})
+    validate_success({'s3_prefix': 'bar/baz'})
 
 
 def test_validate_default_overlay_network_name():

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
   PyYAML
   webtest
   webtest-aiohttp==1.1.0
+  schema
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 
@@ -66,6 +67,7 @@ passenv =
   SSH_AUTH_SOCK
 deps =
   pytest
+  schema
 changedir=pkgpanda/build/tests
 commands=
   py.test --basetemp={envtmpdir} {posargs} build_integration_test.py


### PR DESCRIPTION
## High Level Description

This PR ensures the user cannot pass a `s3_prefix` that ends in a '/' when installing DC/OS. This would have prevented an issue that one of our users ran into. See the jira for more details.

It also fixes the tox.ini to install the 'schema' python package when running tests.

## Related Issues

  - [DCOS_OSS-1353](https://jira.mesosphere.com/browse/DCOS_OSS-1353) gen: don't allow s3_prefix ending in '/'

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
