### PR TITLE
Update libsodium dependency.

### DIFF
--- a/packages/libsodium/buildinfo.json
+++ b/packages/libsodium/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://download.libsodium.org/libsodium/releases/libsodium-1.0.9.tar.gz",
+    "url": "https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.9.tar.gz",
     "sha1": "6e886fa6c7b0c0dc8a9039f49e1b04532401a6ae"
   }
 }


### PR DESCRIPTION
## High Level Description

* Existing version mentioned in buildinfo.json is no longer available.

The builds have been working out off our cache. 