### PR TITLE
Bump metrics git hash to incorporate default executor change

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "62702c3396deb5b47f4492a5a39d9dfb6f95ab0b",
+    "ref": "ca9e6396f4dbe643c65bb8e853f9eccfc955496d",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "b0330aa8742e08cee795c249c27b5bb1198c020b",
-    "ref_origin": "master"
+    "ref": "25415a022e5d86b2001acb3e46da7197b1636811",
+    "ref_origin": "ignore-debug-containers"
   },
   "username": "dcos_metrics"
 }

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "ca9e6396f4dbe643c65bb8e853f9eccfc955496d",
+    "ref": "cdd30f703685b017ea1ce3964b8144a95ee9af5d",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "cdd30f703685b017ea1ce3964b8144a95ee9af5d",
-    "ref_origin": "mrb/fix-supports-nesting"
+    "ref": "b0330aa8742e08cee795c249c27b5bb1198c020b",
+    "ref_origin": "master"
   },
   "username": "dcos_metrics"
 }

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -4,7 +4,7 @@
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
     "ref": "cdd30f703685b017ea1ce3964b8144a95ee9af5d",
-    "ref_origin": "master"
+    "ref_origin": "mrb/fix-supports-nesting"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High Level Description

 - This change bumps the commit hash of the `dcos-metrics` module so that the `STATSD_UDP_HOST` and `STATSD_UDP_PORT` envvars are exposed to tasks running on the Mesos default executor (https://github.com/dcos/dcos-metrics/pull/106).

## Related Issues

  - None

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This merely changes a reference to a commit in another repo that has not seen any interface changes.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [commit](https://github.com/dcos/dcos-metrics/pull/109/commits/cdd30f703685b017ea1ce3964b8144a95ee9af5d)
  - [x] Test Results: [results](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/387/)
  - [x] Code Coverage (if available): [coverage](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-pulls/387/cobertura/)
___