### PR TITLE
adminrouter: check for nil in addition to cjson_safe.null

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -93,7 +93,7 @@ local function request(url, accept_404_reply, auth_token)
 end
 
 local function is_ip_per_task(app)
-    return app["ipAddress"] ~= cjson_safe.null
+    return app["ipAddress"] ~= nil and app["ipAddress"] ~= cjson_safe.null
 end
 
 local function is_user_network(app)
@@ -178,10 +178,10 @@ local function fetch_and_store_marathon_apps(auth_token)
        local host_or_ip = task["host"] --take host  by default
        if is_ip_per_task(app) then
           ngx.log(ngx.NOTICE, "app '" .. appId .. "' is using ip-per-task")
-          -- override with the ip of the task 
+          -- override with the ip of the task
           local task_ip_addresses = task["ipAddresses"]
           if task_ip_addresses then
-             host_or_ip = task_ip_addresses[1]["ipAddress"] 
+             host_or_ip = task_ip_addresses[1]["ipAddress"]
           else
              ngx.log(ngx.NOTICE, "no ip address allocated yet for app '" .. appId .. "'")
              goto continue
@@ -202,7 +202,7 @@ local function fetch_and_store_marathon_apps(auth_token)
             local port_attr = app["container"]["docker"]["portMappings"] and "containerPort" or "port"
             for _, port_mapping in ipairs(port_mappings) do
                table.insert(ports, port_mapping[port_attr])
-            end               
+            end
          else
             --override with the discovery ports
             local discovery_ports = app["ipAddress"]["discovery"]["ports"]
@@ -210,7 +210,7 @@ local function fetch_and_store_marathon_apps(auth_token)
                 table.insert(ports, discovery_port["number"])
             end
          end
-       end      
+       end
 
        if not ports then
           ngx.log(ngx.NOTICE, "Cannot find ports for app '" .. appId .. "'")

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -871,7 +871,7 @@ class TestCacheMarathon:
             req_data = resp.json()
             assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
 
-    def test_ip_per_task_app_with_unspecified_ip_address_DCOS_16592(
+    def test_ip_per_task_app_with_unspecified_ip_address_DCOS_OSS_1366(
             self, nginx_class, mocker, valid_user_header):
         """
         Test that an app that, instead of specifying 'ipAddress: null' does not
@@ -879,7 +879,7 @@ class TestCacheMarathon:
         """
         app = self._scheduler_alwaysthere_app()
 
-        # Remove the 'ipAddress' key completely, thereby triggering DCOS-16592.
+        # Remove the 'ipAddress' key completely, thereby triggering DCOS_OSS-1366.
         del(app["ipAddress"])
 
         ar = nginx_class()


### PR DESCRIPTION
## High Level Description

This PR fixes a bug introduced in https://github.com/dcos/dcos/pull/1628 where we tested a value in a table against the json app definition encoding a 'null' value, but we never tested for the key not being specified at all.

## Related Issues

  - [DCOS_OSS-1366](https://jira.mesosphere.com/browse/DCOS_OSS-1366) Admin Router: service isn't resolved properly after some time

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___