### PR TITLE
[1.9.2] Bump dcos-metrics hash

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -180,20 +180,14 @@ def test_metrics_containers(dcos_api_session):
                     assert len(app_response.json()['datapoints']) == 3, 'got {}'.format(
                         len(app_response.json()['datapoints']))
 
-                    datapoint_keys = ['name', 'value', 'unit', 'timestamp']
+                    datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
                     for k in datapoint_keys:
                         assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
+                    assert 'test_tag_key' in uptime_dp['tags'], 'got {}'.format(uptime_dp)
+                    assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+
                     assert 'dimensions' in app_response.json(), 'got {}'.format(app_response.json())
-                    assert 'labels' in app_response.json()['dimensions'], 'got {}'.format(
-                        app_response.json()['dimensions'])
-
-                    assert 'test_tag_key' in app_response.json()['dimensions']['labels'], 'got {}'.format(
-                        app_response.json()['dimensions']['labels'])
-
-                    assert app_response.json()['dimensions']['labels']['test_tag_key'] == "test_tag_value", ''
-                    'got {}'.format(
-                        app_response.json()['dimensions']['labels']['test_tag_key'])
 
                     return True
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -166,7 +166,7 @@ def test_metrics_containers(dcos_api_session):
 
                     # Ensure all /container/<id>/app data is correct
                     assert 'datapoints' in app_response.json(), 'got {}'.format(app_response.json())
-                    assert len(app_response.json()['datapoints']) == 1, 'got {}'.format(
+                    assert len(app_response.json()['datapoints']) == 3, 'got {}'.format(
                         len(app_response.json()['datapoints']))
 
                     datapoint_keys = ['name', 'value', 'unit', 'timestamp']

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -177,9 +177,6 @@ def test_metrics_containers(dcos_api_session):
                     # If this metric is missing, statsd-emitter's metrics were not received
                     assert uptime_dp is not None, 'got {}'.format(app_response.json())
 
-                    assert len(app_response.json()['datapoints']) == 3, 'got {}'.format(
-                        len(app_response.json()['datapoints']))
-
                     datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
                     for k in datapoint_keys:
                         assert k in uptime_dp, 'got {}'.format(uptime_dp)

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -166,16 +166,23 @@ def test_metrics_containers(dcos_api_session):
 
                     # Ensure all /container/<id>/app data is correct
                     assert 'datapoints' in app_response.json(), 'got {}'.format(app_response.json())
+
+                    # We expect three datapoints, could be in any order
+                    uptime_dp = None
+                    for dp in app_response.json()['datapoints']:
+                        if dp['name'] == 'statsd_tester.time.uptime':
+                            uptime_dp = dp
+                            break
+
+                    # If this metric is missing, statsd-emitter's metrics were not received
+                    assert uptime_dp is not None, 'got {}'.format(app_response.json())
+
                     assert len(app_response.json()['datapoints']) == 3, 'got {}'.format(
                         len(app_response.json()['datapoints']))
 
                     datapoint_keys = ['name', 'value', 'unit', 'timestamp']
                     for k in datapoint_keys:
-                        assert k in app_response.json()['datapoints'][0], 'got {}'.format(
-                            app_response.json()['datapoints'][0])
-
-                        assert app_response.json()['datapoints'][0]['name'] == 'statsd_tester.time.uptime', 'got '
-                        '{}'.format(app_response.json()['datapoints'][0]['name'])
+                        assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
                     assert 'dimensions' in app_response.json(), 'got {}'.format(app_response.json())
                     assert 'labels' in app_response.json()['dimensions'], 'got {}'.format(

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "cca85f336eee440c2468d4b4c9d1c3b246654188",
-    "ref_origin": "branch-1.9.1"
+    "ref": "1b4e0138bf6615583cf69ccfe7aa5230dfd30917",
+    "ref_origin": "master"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High Level Description

This PR updates dcos-metrics to the latest master. This brings in a fix to a bug where app data would be lost if it was not sent as a single batch. Additionally, a stability fix which was already in master is brought back into 1.9.2 in this PR. 

## Related Issues

  - [DCOS-16350](https://jira.mesosphere.com/browse/DCOS-16350) dcos-metrics drops nearly all app data	
  - [DCOS-15939](https://jira.mesosphere.com/browse/DCOS-16350) Long labels can cause errors in datadog plugin for dcos-metrics

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Changelog](https://github.com/dcos/dcos-metrics/compare/cca85f336eee440c2468d4b4c9d1c3b246654188...1b4e0138bf6615583cf69ccfe7aa5230dfd30917)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-metrics%2Fpublic-dcos-metrics-master/detail/public-dcos-metrics-master/114/pipeline)
  - [x] Code Coverage: [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/lastBuild/cobertura/)