### PR TITLE
Override storage region

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -226,7 +226,7 @@ aws_advanced_source = gen.internals.Source({
     'conditional': {
         'aws_template_upload': {
             'true': {
-                'must': {
+                'default': {
                     'aws_template_storage_region_name': calculate_aws_template_storage_region_name
                 }
             },

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -307,25 +307,38 @@ aws_template_upload: true
 
 
 def test_do_aws_cf_configure_valid_storage_config(config_aws, tmpdir, monkeypatch):
+    bucket = str(uuid.uuid4())
+    config_str = valid_storage_config.format(
+        key_id=config_aws["access_key_id"],
+        bucket=bucket,
+        access_key=config_aws["secret_access_key"])
+    assert aws_cf_configure(bucket, config_str, config_aws, tmpdir, monkeypatch) == 0
+    # TODO: add an assertion that the config that was resolved inside do_aws_cf_configure
+    # ended up with the correct region where the above testing bucket was created.
+
+
+def test_override_aws_template_storage_region_name(config_aws, tmpdir, monkeypatch):
+    bucket = str(uuid.uuid4())
+    config_str = valid_storage_config.format(
+        key_id=config_aws["access_key_id"],
+        bucket=bucket,
+        access_key=config_aws["secret_access_key"])
+    config_str += '\naws_template_storage_region_name: {}'.format(config_aws['region_name'])
+    assert aws_cf_configure(bucket, config_str, config_aws, tmpdir, monkeypatch) == 0
+
+
+def aws_cf_configure(s3_bucket_name, config, config_aws, tmpdir, monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'test_variant')
     session = gen.build_deploy.aws.get_test_session(config_aws)
     s3 = session.resource('s3')
-    bucket = str(uuid.uuid4())
-    s3_bucket = s3.Bucket(bucket)
+    s3_bucket = s3.Bucket(s3_bucket_name)
     s3_bucket.create(CreateBucketConfiguration={'LocationConstraint': config_aws['region_name']})
 
+    create_config(config, tmpdir)
+    create_fake_build_artifacts(tmpdir)
     try:
-        config_str = valid_storage_config.format(
-            key_id=config_aws["access_key_id"],
-            bucket=bucket,
-            access_key=config_aws["secret_access_key"])
-        create_config(config_str, tmpdir)
-        create_fake_build_artifacts(tmpdir)
-
         with tmpdir.as_cwd():
-            assert backend.do_aws_cf_configure() == 0
-            # TODO: add an assertion that the config that was resolved inside do_aws_cf_configure
-            # ended up with the correct region where the above testing bucket was created.
+            return backend.do_aws_cf_configure()
     finally:
         objects = [{'Key': o.key} for o in s3_bucket.objects.all()]
         s3_bucket.delete_objects(Delete={'Objects': objects})


### PR DESCRIPTION
## High Level Description

This allows a user to override `aws_template_storage_region_name` in their `config.yaml` when generating cloud templates.

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-16737

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
