### PR TITLE
[1.9.3] bump spartan and navstar

### DIFF
--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -25,6 +25,6 @@ RestartSec=5
 LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=${PKG_PATH}/bin/epmd -port 61420
+ExecStart=${PKG_PATH}/bin/epmd -port 61420 -relaxed_command_check
 Environment=HOME=/opt/mesosphere
 EOF

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "727c7457ddfe81b8fc6dc2893d48582f947aa247",
+      "ref": "bfc09c9eca064cacc275be04bd65c98361f2504a",
       "ref_origin": "dcos/1.9"
     }
   },

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "94cffea2c16e8082743de04bd72311e60bedc324",
+      "ref": "727c7457ddfe81b8fc6dc2893d48582f947aa247",
       "ref_origin": "dcos/1.9"
     }
   },

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "e94d5661cd271387379fd41001b80a31a1b4eab8",
+      "ref": "7ae3d167f2839dd6d0f583feb3f6c17a1c7fe28c",
       "ref_origin": "dcos/1.9"
     }
   }


### PR DESCRIPTION
## High Level Description

* Spartan exits repeatedly after a network partition test

* Currently it is possible for spartan to start it's own epmd if dcos-epmd is not yet started or has died for some reason. The systemd services for each of the Erlang based components should be reviewed and modified so that each ensures dcos-epmd is already running before starting.

* Fix inconsistent state error in minuteman

## Related Issues

  - [DCOS-17271](https://jira.mesosphere.com/browse/DCOS-17271) dcos-epmd failing after host reboot
  - [DCOS-17217](https://jira.mesosphere.com/browse/DCOS-17217) Spartan exits repeatedly after a network partition test
  - [DCOS_OSS-1128](https://jira.mesosphere.com/browse/DCOS_OSS-1128) Ensure DC/OS Erlang based apps use dcos-epmd.service
  - [DCOS_OSS-1472](https://jira.mesosphere.com/browse/DCOS_OSS-1472) Inconsistent state of minuteman

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/dcos/dcos/pull/1589
https://github.com/dcos/dcos/pull/1730
https://github.com/dcos/spartan/pull/45
https://github.com/dcos/navstar/pull/83
https://github.com/dcos/navstar/pull/86

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).