### PR TITLE
Train 193

### DIFF
--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -25,6 +25,6 @@ RestartSec=5
 LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=${PKG_PATH}/bin/epmd -port 61420
+ExecStart=${PKG_PATH}/bin/epmd -port 61420 -relaxed_command_check
 Environment=HOME=/opt/mesosphere
 EOF

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-582-g1793076.tgz",
-    "sha1": "bfb029f0b384d5bfec16a010fda0df4845b16e95"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-661-g596e861.tgz",
+    "sha1": "8e7052766259654b857e41f6dc8f15f69feb7aa1"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -6,3 +6,4 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[202dc73803a3e681e31dd30ca68a44fdae2ba902] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[6bbab709eb09aeecac705ff4ce5e5867bbe7df30] Revert "Fixed the broken metrics information of master in WebUI."
 <li>[a9678f06a8e222d97b1f784edf96030beb643552] Updated mesos containerizer to ignore GPU isolator creation failure.
+<li>[80928eaf1d66e2d06d4f301ac197c12d08eaa533] Changed an absolute path to relative in the Mesos UI.

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -9,7 +9,7 @@ mkdir -p build
 pushd build
 # TODO(cmaloney): --with-glog=/usr --with-protobuf=/usr --with-boost=/usr
 # TODO(cmaloney): DESTDIR builds so we don't have to build as root?
-LIBS="-lssl -lcrypto" LDFLAGS="-L/opt/mesosphere/active/openssl/lib" "/pkg/src/mesos/configure" \
+LDFLAGS="-Wl,-rpath,/opt/mesosphere/lib" "/pkg/src/mesos/configure" \
   --prefix="$PKG_PATH" --enable-optimize --disable-python \
   --enable-libevent --enable-ssl \
   --enable-install-module-dependencies \

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "6275099d4d5e0eadc5d39cf7a28d6d7930788680",
+    "ref": "80928eaf1d66e2d06d4f301ac197c12d08eaa533",
     "ref_origin" : "dcos-mesos-master-013f7e21"
   },
   "environment": {

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "6cb70142363c9ce2f3d59a5870560967dc46e559",
+      "ref": "c4e9ea6f18f8fa256139a0b66771f1349302ab52",
       "ref_origin": "master"
     }
   },

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "80d86355988e7d3a54a370b73d5bc769cabeab0c",
+      "ref": "2b409fef43db650afd4d9fd2c860208931b91879",
       "ref_origin": "master"
     }
   }


### PR DESCRIPTION
* #1724 ("Bumped the Mesos package to fix the Mesos web UI sandbox links.")
* #1729 ("Added an `--rpath` to Mesos builds")
* #1730 ("[1.10] Unregister node in epmd on start")
* #1744 ("Bump to the latest marathon 1.5")