### PR TITLE
Admin Router: Remove periodic AR reloading in favour of DNS queries

### DIFF
--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -25,16 +25,12 @@ mkdir -p "$PKG_PATH/lib"
 cp /lib/x86_64-linux-gnu/libpcre.so.3 "$PKG_PATH/lib/libpcre.so.3"
 
 # Copy systemd unit files:
-for st in ".service" "-reload.service" "-reload.timer"; do
-    tmp="$PKG_PATH/dcos.target.wants_master/dcos-adminrouter${st}"
-    mkdir -vp "$(dirname "$tmp")"
-    envsubst '$PKG_PATH' < "/pkg/extra/systemd/dcos-adminrouter${st}" > "$tmp"
-done
+tmp="$PKG_PATH/dcos.target.wants_master/dcos-adminrouter.service"
+mkdir -vp "$(dirname "$tmp")"
+envsubst '$PKG_PATH' < "/pkg/extra/systemd/dcos-adminrouter.service" > "$tmp"
 
 for at in slave slave_public; do
-    for st in ".service" "-reload.service" "-reload.timer"; do
-        tmp="$PKG_PATH/dcos.target.wants_${at}/dcos-adminrouter-agent${st}"
-        mkdir -vp "$(dirname "$tmp")"
-        envsubst '$PKG_PATH' < "/pkg/extra/systemd/dcos-adminrouter-agent${st}" > "$tmp"
-    done
+    tmp="$PKG_PATH/dcos.target.wants_${at}/dcos-adminrouter-agent.service"
+    mkdir -vp "$(dirname "$tmp")"
+    envsubst '$PKG_PATH' < "/pkg/extra/systemd/dcos-adminrouter-agent.service" > "$tmp"
 done

--- a/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
@@ -1,6 +1,6 @@
 set $upstream_networking_api http://127.0.0.1:61430;
 
-proxy_ssl_trusted_certificate /run/dcos/pki/CA/certs/ca.crt;
+proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 

--- a/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
@@ -4,11 +4,11 @@ proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 
-set $upstream_mesos http://127.0.0.2:5050;
+set $upstream_mesos http://leader.mesos:5050;
 set $upstream_secrets http://127.0.0.1:1337;
 set $upstream_cosmos http://127.0.0.1:7070;
 
 # Required by EE Agent:
-set $upstream_iam http://127.0.0.1:8101;
+set $upstream_iam http://master.mesos:8101;
 
 set $adminrouter_agent_port 61001;

--- a/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-ee.conf
@@ -4,10 +4,7 @@ proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 
-# For the sake of tests simplicity, we will not be using/testing leader.mesos
-# alias here. This should be done by integration tests.
 set $upstream_mesos http://127.0.0.2:5050;
-set $upstream_marathon http://127.0.0.1:8080;
 set $upstream_secrets http://127.0.0.1:1337;
 set $upstream_cosmos http://127.0.0.1:7070;
 

--- a/packages/adminrouter/docker/adminrouter-upstreams-open.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-open.conf
@@ -1,6 +1,6 @@
 set $upstream_networking_api http://127.0.0.1:61430;
 
-proxy_ssl_trusted_certificate /run/dcos/pki/CA/certs/ca.crt;
+proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 

--- a/packages/adminrouter/docker/adminrouter-upstreams-open.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-open.conf
@@ -4,11 +4,11 @@ proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 
-set $upstream_mesos http://127.0.0.2:5050;
+set $upstream_mesos http://leader.mesos:5050;
 set $upstream_secrets http://127.0.0.1:1337;
 set $upstream_cosmos http://127.0.0.1:7070;
 
 # Required by EE Agent:
-set $upstream_iam http://127.0.0.1:8101;
+set $upstream_iam http://master.mesos:8101;
 
 set $adminrouter_agent_port 61001;

--- a/packages/adminrouter/docker/adminrouter-upstreams-open.conf
+++ b/packages/adminrouter/docker/adminrouter-upstreams-open.conf
@@ -4,10 +4,7 @@ proxy_ssl_trusted_certificate /run/dcos/pki/CA/ca-bundle.crt;
 proxy_ssl_verify on;
 proxy_ssl_verify_depth 5;
 
-# For the sake of tests simplicity, we will not be using/testing leader.mesos
-# alias here. This should be done by integration tests.
 set $upstream_mesos http://127.0.0.2:5050;
-set $upstream_marathon http://127.0.0.1:8080;
 set $upstream_secrets http://127.0.0.1:1337;
 set $upstream_cosmos http://127.0.0.1:7070;
 

--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -19,11 +19,20 @@ BRIDGE_DEVNAME := $(shell docker network inspect -f '{{ index .Options "com.dock
 # Using a docker container for this allows the docker daemon to run locally or remotely in a VM, like docker-machine.
 BRIDGE_IP := $(shell docker run --net=host --rm alpine ifconfig $(BRIDGE_DEVNAME) | grep 'inet addr:' | cut -d: -f2 | cut -d' ' -f1)
 
+# Vary the name of the container on the per-flavour basis.
+# The way we detect the repository flavour is consistent with how test harness
+# does it.
+ifeq ($(wildcard test-harness/tests/ee/), test-harness/tests/ee/)
+    DEVKIT_NAME=adminrouter-devkit-ee
+else
+    DEVKIT_NAME=adminrouter-devkit-open
+endif
+
 # FIXME: some problems with dns queries timing out, use hosts caching dns as a
 # workaround for now
 # DNS_DOCKER_OPTS := --dns=8.8.8.8 --dns=8.8.4.4
 DNS_DOCKER_OPTS := --dns=$(BRIDGE_IP) --dns=8.8.8.8 --dns=8.8.4.4
-DEVKIT_BASE_DOCKER_OPTS := --name adminrouter-devkit \
+DEVKIT_BASE_DOCKER_OPTS := --name $(DEVKIT_NAME) \
 	$(DNS_DOCKER_OPTS) \
 	-e NUM_CORES=2 \
 	-e PYTHONDONTWRITEBYTECODE=true
@@ -32,7 +41,7 @@ DEVKIT_DOCKER_OPTS := $(DEVKIT_BASE_DOCKER_OPTS) \
 
 .PHONY: clean-devkit-container
 clean-devkit-container:
-	-docker rm -vf adminrouter-devkit > /dev/null 2>&1
+	-docker rm -vf $(DEVKIT_NAME) > /dev/null 2>&1
 
 .PHONY: clean-containers
 clean-containers: clean-devkit-container
@@ -44,55 +53,55 @@ clean:
 
 .PHONY: devkit
 devkit:
-	if $$(docker images | grep mesosphere/adminrouter-devkit | grep -q full); then \
+	if $$(docker images | grep mesosphere/$(DEVKIT_NAME) | grep -q full); then \
 		echo "+ Devkit image already build"; \
 	else \
 		echo "+ Building devkit image"; \
 		docker build \
 			--rm --force-rm \
-			-t mesosphere/adminrouter-devkit:noresty \
+			-t mesosphere/$(DEVKIT_NAME):noresty \
 			-f ../../docker/Dockerfile \
 				../../docker/ && \
 		docker run \
 			$(DEVKIT_BASE_DOCKER_OPTS) \
-			mesosphere/adminrouter-devkit:noresty \
+			mesosphere/$(DEVKIT_NAME):noresty \
 				/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT" && \
-		docker commit $$(docker ps -a -q -f name=adminrouter-devkit) \
-			mesosphere/adminrouter-devkit:full && \
-		docker rm adminrouter-devkit && \
-		docker rmi -f mesosphere/adminrouter-devkit:noresty; \
+		docker commit $$(docker ps -a -q -f name=$(DEVKIT_NAME)) \
+			mesosphere/$(DEVKIT_NAME):full && \
+		docker rm $(DEVKIT_NAME) && \
+		docker rmi -f mesosphere/$(DEVKIT_NAME):noresty; \
 	fi
 
 .PHONY: update-devkit
 update-devkit: clean-devkit-container
-	-docker rm adminrouter-devkit
+	-docker rm $(DEVKIT_NAME)
 	docker build \
 		--rm --force-rm \
-		-t mesosphere/adminrouter-devkit:noresty \
+		-t mesosphere/$(DEVKIT_NAME):noresty \
 		-f ../../docker/Dockerfile \
 			../../docker/
 	docker run \
 		$(DEVKIT_BASE_DOCKER_OPTS) \
-		mesosphere/adminrouter-devkit:noresty \
+		mesosphere/$(DEVKIT_NAME):noresty \
 			/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT" && \
-	docker commit $$(docker ps -a -q -f name=adminrouter-devkit) \
-		mesosphere/adminrouter-devkit:full
-	docker rm adminrouter-devkit
-	docker rmi -f mesosphere/adminrouter-devkit:noresty
+	docker commit $$(docker ps -a -q -f name=$(DEVKIT_NAME)) \
+		mesosphere/$(DEVKIT_NAME):full
+	docker rm $(DEVKIT_NAME)
+	docker rmi -f mesosphere/$(DEVKIT_NAME):noresty
 
 .PHONY: shell
 shell: clean-devkit-container devkit
 	docker run --rm -it \
 		$(DEVKIT_DOCKER_OPTS) \
 		--privileged \
-		mesosphere/adminrouter-devkit:full /bin/bash
+		mesosphere/$(DEVKIT_NAME):full /bin/bash
 
 .PHONY: test
 test: clean-devkit-container devkit
 	docker run \
 		$(DEVKIT_DOCKER_OPTS) \
 		--privileged \
-		mesosphere/adminrouter-devkit:full /bin/bash -x -c " \
+		mesosphere/$(DEVKIT_NAME):full /bin/bash -x -c " \
  			py.test \
  		"
 
@@ -101,10 +110,10 @@ api-docs: clean-devkit-container devkit
 	@mkdir -p $(SRC_DIR)/$(API_DOCS_DIR)
 	@for prefix in nginx.master nginx.agent ; do \
 		echo "Generating $(API_DOCS_DIR)/$${prefix}.yaml" >&2 && \
-		docker run --rm $(DEVKIT_DOCKER_OPTS) mesosphere/adminrouter-devkit:full \
+		docker run --rm $(DEVKIT_DOCKER_OPTS) mesosphere/$(DEVKIT_NAME):full \
 			ngindox parse -f $${prefix}.conf > $(SRC_DIR)/$(API_DOCS_DIR)/$${prefix}.yaml && \
 		echo "Generating $(API_DOCS_DIR)/$${prefix}.html" >&2 && \
-		docker run --rm $(DEVKIT_DOCKER_OPTS) mesosphere/adminrouter-devkit:full \
+		docker run --rm $(DEVKIT_DOCKER_OPTS) mesosphere/$(DEVKIT_NAME):full \
 			ngindox ui -f $(API_DOCS_DIR)/$${prefix}.yaml > $(SRC_DIR)/$(API_DOCS_DIR)/$${prefix}.html ; \
 	done
 
@@ -120,7 +129,7 @@ flake8: clean-devkit-container devkit
 	#FIXME - split it into two targets
 	docker run \
 		$(DEVKIT_DOCKER_OPTS) \
-		mesosphere/adminrouter-devkit:full /bin/bash -x -c " \
+		mesosphere/$(DEVKIT_NAME):full /bin/bash -x -c " \
 			flake8 -v \
  		"
 

--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -605,6 +605,35 @@ update.
 Worth noting is that NGINX reload resets all the timers. Cache is left intact
 though.
 
+## DNS resolution
+
+Some of the AR configuration depends on a correct DNS resolution of the current
+Mesos leader instance. NGINX comes with its own DNS resolver component that can
+be configured to resolve names from a particular DNS server. The configuration
+refers to DC/OS DNS names (e.g. `leader.mesos`, `master.mesos`) and expects
+that a DNS server used as a resolver backend resolves the name to the IP address
+of the coresponding server/servers.
+
+The open source version of NGINX does not support periodic re-resolution of
+hostnames used in the upstream definitions. In Admin Router, we use
+[a workaround](https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/)
+to overcome this limitation, so that hostnames used in
+[`proxy_pass`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
+configuration directives are guaranteed to be re-resolved periodically, either according to
+the TTL emitted by the DNS server or, if given, according to the `valid=`
+argument of the
+[resolver](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver)
+configuration.
+
+AR currently uses a `mesos-dns` as a DNS server backend, direclty or through
+Spartan. It expects the server to run on a port `61053` and respond at least
+to following type `A` queries:
+* `leader.mesos`
+* `master.mesos`
+
+Related links:
+* http://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p
+
 ## Testing
 
 Admin Router repository includes a test harness that is meant to make

--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -751,7 +751,7 @@ queries:
 
 Mocking library comes with a simple DNS in-memory programmable server that
 can be used to mock various DNS query responses and also to simulate leader
-instance changes.
+instance changes. Please check test-harness/modules/mocker/dns.py for details.
 
 #### Subprocess management
 Pytest fixture starts an `Admin Router` subprocess.

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -1801,7 +1801,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>http://leader.mesos/system/v1$url$is_args$query_string</code>
+                  <code>$system_v1_leader_mesos</code>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -319,7 +319,7 @@ routes:
     matcher: regex
     description: System proxy to the master node with the Mesos leader
     proxy:
-      path: 'http://leader.mesos/system/v1$url$is_args$query_string'
+      path: $system_v1_leader_mesos
     path: /system/v1/leader/mesos(?<url>.*)
   /system/v1/logs/:
     group: System

--- a/packages/adminrouter/extra/src/includes/http/agent.conf
+++ b/packages/adminrouter/extra/src/includes/http/agent.conf
@@ -1,4 +1,6 @@
-resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=60s ipv6=off;
+# See the comment for Master's resovler configuration in
+# includes/http/master.conf.
+resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 
 ## Please check https://github.com/openresty/lua-nginx-module/issues/467#issuecomment-305529857
 ## for some context.

--- a/packages/adminrouter/extra/src/includes/http/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/master.conf
@@ -1,6 +1,24 @@
-# Without this, cosocket-based code in worker
-# initialization cannot resolve leader.mesos.
-resolver 127.0.0.1:61053 valid=60s ipv6=off;
+# Without this, cosocket-based code in worker initialization cannot
+# resolve ``leader.mesos``.
+#
+# The value for this is a bit of a compromise:
+# * In the case of upstreams defined using DNS (like e.g. /mesos), we can't
+#   override DNS validity period with a value higher than the TTL set originally
+#   by mesos_dns. This gives us 60s upper limit.
+#
+# * As for the tests, the lower the better, with TTL=1 being the reasonable
+#   minimum.
+#
+# * As for the Lua code - this is a place where stuff starts to be interesting.
+#   Currently CACHE_POLL_PERIOD = 25 seconds, we also want to be sure that
+#   leader.mesos will be re-resolved on every cache refresh, so max TTL of any
+#   DNS entry should be lower than 25s.
+#
+# Soon one hand, we should not be using default TTL provided by the MesosDNS
+# as it is too high, on the other hand, we should not query MesosDNS too often.
+# Five seconds seems like a reasonable value and this shouldn't slow down our
+# tests too much.
+resolver 127.0.0.1:61053 valid=5s ipv6=off;
 
 lua_shared_dict cache 100m;
 lua_shared_dict shmlocks 100k;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -26,7 +26,10 @@ location ~ ^/system/v1/leader/mesos(?<url>.*)$ {
 
     include includes/http-11.conf;
     include includes/proxy-headers.conf;
-    proxy_pass http://leader.mesos/system/v1$url$is_args$query_string;
+
+    # Please check README.md, DNS section for reasoning behind it.
+    set $system_v1_leader_mesos "http://leader.mesos/system/v1$url$is_args$query_string";
+    proxy_pass $system_v1_leader_mesos;
 }
 
 # Group: System

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -13,6 +13,9 @@ local util = require "util"
 --
 -- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
 --
+-- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
+-- statement configuration in includes/http/master.conf
+--
 -- All are in units of seconds. Below are the defaults:
 local _CONFIG = {}
 local env_vars = {CACHE_FIRST_POLL_DELAY = 2,

--- a/packages/adminrouter/extra/src/test-harness/conftest.py
+++ b/packages/adminrouter/extra/src/test-harness/conftest.py
@@ -23,7 +23,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     util.setup_thread_debugger()
-    util.configure_logger(config)
+    util.configure_logger(config.getoption('tests_log_level'))
 
 
 pytest.register_assert_rewrite('generic_test_code.common')

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/dns.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/dns.py
@@ -59,10 +59,10 @@ class DcosDnsResolver(BaseResolver):
 
         log.info(
             "DNS query for `{}`, type `{}`, reply `{}`, ttl `{}`".format(
-            query,
-            request.q.qtype,
-            self._records[query]['ip'],
-            self._records[query]['ttl'])
+                query,
+                request.q.qtype,
+                self._records[query]['ip'],
+                self._records[query]['ttl'])
         )
 
         reply.add_answer(

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/dns.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/dns.py
@@ -58,7 +58,12 @@ class DcosDnsResolver(BaseResolver):
             return reply
 
         log.info(
-            "DNS query for `{}`, type `{}`".format(query, request.q.qtype))
+            "DNS query for `{}`, type `{}`, reply `{}`, ttl `{}`".format(
+            query,
+            request.q.qtype,
+            self._records[query]['ip'],
+            self._records[query]['ttl'])
+        )
 
         reply.add_answer(
             *RR.fromZone("{} {} A {}".format(

--- a/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/runner/common.py
@@ -298,8 +298,11 @@ class LogCatcher:
         the tests, and appending to old log files could confuse tests developers.
         """
         for f_name in os.listdir(self._LOG_DIR):
-            if f_name == self._GIT_KEEP_FILE:
-                log.debug("Skipping git keep-file: `%s`", f_name)
+            # Test harness logs are created before this code has a chance to run,
+            # so we make an exception so that cleanup does not remove test's
+            # harnes log.
+            if f_name == self._GIT_KEEP_FILE or f_name == 'test-harness.log':
+                log.debug("Skipping file: `%s`", f_name)
                 continue
 
             f_path = os.path.join(self._LOG_DIR, f_name)

--- a/packages/adminrouter/extra/src/test-harness/tests/test_dns.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_dns.py
@@ -1,0 +1,111 @@
+# Copyright (C) Mesosphere, Inc. See LICENSE file for details.
+
+import time
+
+import pytest
+
+from generic_test_code.common import (
+    generic_correct_upstream_dest_test,
+    ping_mesos_agent,
+)
+from mocker.endpoints.mesos import AGENT_EXTRA_ID
+from util import GuardedSubprocess
+
+
+class TestNginxResolver:
+
+    # In order to test that TTL of the DNS entry is indeed ignored/overriden,
+    # we set this to a very high value. If `valid` argument has been properly
+    # set for the resolver config option, then tests will pass
+    LONG_TTL = 120
+
+    @pytest.mark.parametrize("path,dest_port",
+                             [("/system/v1/leader/mesos/foo/bar", 80),
+                              ("/mesos/reflect/me", 5050),
+                              ])
+    def test_mesos_leader_reresolve_in_proxy_pass(
+            self,
+            nginx_class,
+            valid_user_header,
+            dns_server_mock,
+            path,
+            dest_port,
+            ):
+        # Change the TTL of `leader.mesos.` entry
+        dns_server_mock.set_dns_entry(
+            'leader.mesos.', ip='127.0.0.2', ttl=self.LONG_TTL)
+
+        ar = nginx_class(upstream_mesos="http://leader.mesos:5050")
+        with GuardedSubprocess(ar):
+            generic_correct_upstream_dest_test(
+                ar,
+                valid_user_header,
+                path,
+                "http://127.0.0.2:{}".format(dest_port),
+                )
+
+            # Update the `leader.mesos.` entry with new value
+            dns_server_mock.set_dns_entry(
+                'leader.mesos.', ip='127.0.0.3', ttl=self.LONG_TTL)
+            # This should be equal to 1.5 times the value of `valid=` DNS TTL
+            # override in `resolver` config option -> 5s * 1.5 = 7.5s
+            time.sleep(5 * 1.5)
+
+            generic_correct_upstream_dest_test(
+                ar,
+                valid_user_header,
+                path,
+                "http://127.0.0.3:{}".format(dest_port),
+                )
+
+    def test_if_mesos_leader_is_reresolved_by_lua(
+            self, nginx_class, mocker, dns_server_mock, valid_user_header):
+        # Change the TTL of `leader.mesos.` entry
+        dns_server_mock.set_dns_entry(
+            'leader.mesos.', ip='127.0.0.2', ttl=self.LONG_TTL)
+
+        # This should be equal or greater than 1.5 times the value of `valid=`
+        # DNS TTL override in `resolver` config option -> 5s * 1.5 = 7.5s
+        cache_poll_period = 8
+        cache_expiration = cache_poll_period - 1
+        cache_first_poll = 1
+
+        # We can just ask Mesos endpoints to perform request recording here,
+        # but varying the responses of the Mesos endpoints will make tests less
+        # prone to timing issues (i.e. `first poll` cache request will result
+        # both mocks recording requests).
+        mocker.send_command(
+            endpoint_id='http://127.0.0.3:5050',
+            func_name='enable_extra_agent',
+            )
+
+        ar = nginx_class(
+            cache_first_poll_delay=cache_first_poll,
+            cache_poll_period=cache_poll_period,
+            cache_expiration=cache_expiration,
+            upstream_mesos="http://leader.mesos:5050",
+            )
+
+        with GuardedSubprocess(ar):
+            # Force cache update by issuing a request
+            ping_mesos_agent(
+                ar,
+                valid_user_header,
+                expect_status=404,
+                agent_id=AGENT_EXTRA_ID)
+
+            # Now, let's change DNS entry to point to other Mesos master
+            dns_server_mock.set_dns_entry(
+                'leader.mesos.', ip='127.0.0.3', ttl=self.LONG_TTL)
+
+            # Wait for cache to expire and let DNS entry be re-resolved
+            # during the refresh
+            time.sleep(cache_poll_period + cache_first_poll + 1)
+
+            # Make sure that cache now used the right upstream
+            ping_mesos_agent(
+                ar,
+                valid_user_header,
+                expect_status=200,
+                endpoint_id='http://127.0.0.4:15003',
+                agent_id=AGENT_EXTRA_ID)

--- a/packages/adminrouter/extra/systemd/dcos-adminrouter-agent-reload.service
+++ b/packages/adminrouter/extra/systemd/dcos-adminrouter-agent-reload.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Admin Router Reloader: reloads Admin Router to pick up domain resolution changes
-
-[Service]
-Type=oneshot
-EnvironmentFile=/opt/mesosphere/environment
-ExecStart=-$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.agent.conf -s reload

--- a/packages/adminrouter/extra/systemd/dcos-adminrouter-agent-reload.timer
+++ b/packages/adminrouter/extra/systemd/dcos-adminrouter-agent-reload.timer
@@ -1,5 +1,0 @@
-[Unit]
-Description=Admin Router Reloader Timer: periodically reloads Admin Router to pick up domain resolution changes
-[Timer]
-OnBootSec=5sec
-OnUnitActiveSec=30s

--- a/packages/adminrouter/extra/systemd/dcos-adminrouter-reload.service
+++ b/packages/adminrouter/extra/systemd/dcos-adminrouter-reload.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Admin Router Reloader: reloads Admin Router to pick up domain resolution changes
-
-[Service]
-Type=oneshot
-EnvironmentFile=/opt/mesosphere/environment
-ExecStart=-$PKG_PATH/nginx/sbin/adminrouter.sh -c $PKG_PATH/nginx/conf/nginx.master.conf -s reload

--- a/packages/adminrouter/extra/systemd/dcos-adminrouter-reload.timer
+++ b/packages/adminrouter/extra/systemd/dcos-adminrouter-reload.timer
@@ -1,5 +1,0 @@
-[Unit]
-Description=Admin Router Reloader Timer: periodically reloads Admin Router to pick up domain resolution changes
-[Timer]
-OnBootSec=5sec
-OnUnitActiveSec=30s

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -132,8 +132,6 @@ def test_signal_service(dcos_api_session):
     # Insert all the diagnostics data programmatically
     master_units = [
         'adminrouter-service',
-        'adminrouter-reload-service',
-        'adminrouter-reload-timer',
         'cosmos-service',
         'metrics-master-service',
         'metrics-master-socket',
@@ -170,8 +168,6 @@ def test_signal_service(dcos_api_session):
         'metrics-agent-service',
         'metrics-agent-socket',
         'adminrouter-agent-service',
-        'adminrouter-agent-reload-service',
-        'adminrouter-agent-reload-timer',
         'log-agent-service',
         'log-agent-socket',
         'logrotate-agent-service',


### PR DESCRIPTION
## High Level Description

This PR:
* performs some minor cleanup of docker files - CA bundle location sync
* removes $upstream_marathon variable definition as it is no longer needed - all requests go through /service endpoint and the upstream is determined basing on Mesos' `/state-summary` endpoint
* makes devkit as per-flavour. This enables running both EE and Open devkits side-by-side and permits differences between EE and Open devkits
* exposes test harness logs in a log file, Jenkins should automatically pick it up and treat it as yet another artefact
* removes period reloading of AR in favour of DNS queries, see DCOS_OSS-1446 for details
* removes TTL override for AR DNS resolver. See the comments in the configuration for more details.

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS_OSS-1446 - Admin Router: Dynamic DNS resolution of upstreams

## Failing tests
This PR has already been once removed from a Train due to tests constantly failing. Please have a look at https://jira.mesosphere.com/browse/DCOS_OSS-1467 where I tried to prove that the failures are unrelated to the PR itself. The PR just exposes bugs and race conditions that were already present in DC/OS.

The tests that are failing and will need to be muted after merging this PR:
* `test_octarine`
* `test_service_discovery_docker_bridge`
* `test_service_discovery_docker_overlay`
* `test_service_discovery_docker_overlay_port_mapping`
* `test_ip_per_container`

DC/OS Vagrant issues that need to be addressed to unmute them:
* https://jira.mesosphere.com/browse/DCOS_OSS-1523 `DC/OS Vagrant: Improve how memory resources are defined for agents`
* https://jira.mesosphere.com/browse/DCOS_OSS-1524 `dcos-diagnostics --diag` returns false positives during DC/OS install.

## Related PRs:
Base PR from old AR repo: https://github.com/dcos/adminrouter/pull/50
Enterprise PR: https://github.com/mesosphere/dcos-enterprise/pull/1205