### PR TITLE
Set PATH and LD_LIBRARY_PATH for check commands

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -615,7 +615,7 @@ def validate_mesos_max_completed_tasks_per_framework(
                                  "parameter as an integer: {}".format(ex)) from ex
 
 
-def calculate_check_config_contents(check_config, custom_checks):
+def calculate_check_config_contents(check_config, custom_checks, check_search_path, check_ld_library_path):
 
     def merged_check_config(config_a, config_b):
         # config_b overwrites config_a. Validation should assert that names won't conflict.
@@ -657,6 +657,10 @@ def calculate_check_config_contents(check_config, custom_checks):
     dcos_checks = json.loads(check_config)
     user_checks = json.loads(custom_checks)
     merged_checks = merged_check_config(user_checks, dcos_checks)
+    merged_checks['check_env'] = {
+        'PATH': check_search_path,
+        'LD_LIBRARY_PATH': check_ld_library_path,
+    }
     return yaml.dump(json.dumps(merged_checks, indent=2))
 
 
@@ -1008,7 +1012,9 @@ entry = {
         'profile_symlink_target': '/etc/profile.d/dcos.sh',
         'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
         'fair_sharing_excluded_resource_names': calculate_fair_sharing_excluded_resource_names,
-        'check_config_contents': calculate_check_config_contents
+        'check_config_contents': calculate_check_config_contents,
+        'check_search_path': '/opt/mesosphere/bin:/usr/bin:/bin:/sbin',
+        'check_ld_library_path': '/opt/mesosphere/lib'
     },
     'conditional': {
         'master_discovery': {

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "422d00ed1a3a47ecb605f4d3adcafe5945d4e3bc",
+    "ref": "f0e7cc0eddce6672f45fbb930c0f967023a99fb1",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -676,6 +676,10 @@ def test_dcos_diagnostics_runner_poststart(dcos_api_session):
 
 def test_dcos_diagnostics_runner_cluster(dcos_api_session):
     cmd = [
+        # Set PATH and LD_LIBRARY_PATH to bad values to assert we're using their values from check config.
+        "env",
+        "PATH=badvalue",
+        "LD_LIBRARY_PATH=badvalue",
         "/opt/mesosphere/bin/dcos-diagnostics",
         "check",
         "--check-config",


### PR DESCRIPTION
## High Level Description

This PR sets the `PATH` and `LD_LIBRARY_PATH` for check commands in the check runner's config file, rather than inheriting them from the runner's environment.

## Related Issues

  - [DCOS_OSS-1321](https://jira.mesosphere.com/browse/DCOS_OSS-1321) Configurable search path for checks

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-diagnostics/compare/422d00ed1a3a47ecb605f4d3adcafe5945d4e3bc...f0e7cc0eddce6672f45fbb930c0f967023a99fb1
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-diagnostics-pulls/17/
  - [x] Code Coverage (if available): https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-diagnostics-pulls/17/