### PR TITLE
skip intermediate tarball to avoid `tar: Unrecognized archive format`

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -657,12 +657,8 @@ def make_installer_docker(variant, variant_info, installer_info):
                 variant=variant) + '\n#EOF#\n')
         subprocess.check_call(
             ['docker', 'save', docker_image_name],
-            stdout=open(genconf_tar, 'w'))
-        subprocess.check_call(['tar', 'cvf', '-', genconf_tar], stdout=open(installer_filename, 'a'))
+            stdout=open(installer_filename, 'a'))
         subprocess.check_call(['chmod', '+x', installer_filename])
-
-        # Cleanup
-        subprocess.check_call(['rm', genconf_tar])
 
     return installer_filename
 

--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -10,31 +10,11 @@ set -o errexit -o nounset -o pipefail
 # preflight checks
 docker version >/dev/null 2>&1 || {{ echo >&2 "docker should be installed and running. Aborting."; exit 1; }}
 
-backout(){{
-    if [ -f "{genconf_tar}" ]; then
-        rm -f {genconf_tar}
-    fi
-    exit 1
-}}
-trap 'backout' INT
-
-# if the tarball was previously extracted
-if [ -f "{genconf_tar}" ]; then
-    # but not successfully loaded into Docker
-    if [ -z "$(docker images -q {docker_image_name} 2>/dev/null)" ]; then
-        # remove the potentially corrupted tarball and
-        # cause it to be re-extracted in the next step
-        rm -f {genconf_tar}
-    fi
-fi
-
 # extract payload and load into docker if not extracted
-if [ ! -f "{genconf_tar}" ]; then
+if [ -z "$(docker images -q {docker_image_name})" ]; then
     >&2 echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
-    sed '1,/^#EOF#$/d' $0 | tar xv
-    >&2 docker load -i {genconf_tar}
+    sed '1,/^#EOF#$/d' $0 | docker load
 fi
-trap - INT
 
 if [ ! -d genconf/state ]; then
     mkdir -p genconf/state


### PR DESCRIPTION
## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

allows MacOS to run dcos_generate_config.sh without requiring GNU tar by dropping the intermediate tarball.

## Related Issues

  - [DCOS_OSS-168](https://jira.dcos.io/browse/DCOS_OSS-168) dcos_generate_config.sh should support OS X.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:

build requires Linux, install requires MacOS.

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
