### PR TITLE
Admin Router: improve logging messages related to caching

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -617,7 +617,7 @@ local function get_cache_entry(name, auth_token)
 
     -- Cache is stale, but still usable:
     if cache_age > _CONFIG.CACHE_MAX_AGE_SOFT_LIMIT then
-        ngx.log(ngx.NOTICE, "Using stale `" .. name .. "` cache entry to fulfill the request")
+        ngx.log(ngx.NOTICE, "Cache entry `" .. name .. "` is stale")
     end
 
     local entry_json = cache:get(name)

--- a/packages/adminrouter/extra/src/lib/service.lua
+++ b/packages/adminrouter/extra/src/lib/service.lua
@@ -203,7 +203,7 @@ local function resolve(service_name, mesos_cache, marathon_cache)
     --    or not.
     --  - err_code, err_text - if an error occured these will be HTTP status
     --    and error text that should be sent to the client. `nil` otherwise
-    ngx.log(ngx.DEBUG, "Resolving service `".. service_name .. "`")
+    ngx.log(ngx.DEBUG, "Trying to resolve service name `".. service_name .. "`")
     res, err_code, err_text = resolve_via_marathon_apps_state(
         service_name, marathon_cache)
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -207,7 +207,7 @@ class TestCache:
                 SearchCriteria(1, False),
             'Mesos state cache has been successfully updated':
                 SearchCriteria(2, False),
-            'Using stale `svcapps` cache entry to fulfill the request':
+            'Cache entry `svcapps` is stale':
                 SearchCriteria(1, True),
         }
 
@@ -300,7 +300,7 @@ class TestCache:
                 SearchCriteria(1, False),
             'Marathon apps cache has been successfully updated':
                 SearchCriteria(2, False),
-            'Using stale `mesosstate` cache entry to fulfill the request':
+            'Cache entry `mesosstate` is stale':
                 SearchCriteria(1, True),
         }
 


### PR DESCRIPTION
## High Level Description

Improves logging messages related to caching.

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-16614 - `Admin Router: "Using stale `svcapps` cache" and "Resolved via Mesos state-summary" for the same request`

## Related PRs

EE: https://github.com/mesosphere/dcos-enterprise/pull/1220