### PR TITLE
Configurable log level

### DIFF
--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -2,21 +2,20 @@
 DcosApiSession object that will be injected into the pytest 'dcos_api_session' fixture
 via the make_session_fixture() method
 """
-from dcos_test_utils.dcos_api_session import DcosApiSession, DcosUser
-from dcos_test_utils.helpers import CI_CREDENTIALS
 
+from dcos_test_utils import dcos_api, helpers
 from test_helpers import expanded_config
 
 
 def make_session_fixture():
-    args = DcosApiSession.get_args_from_env()
+    args = dcos_api.DcosApiSession.get_args_from_env()
 
     exhibitor_admin_password = None
     if expanded_config['exhibitor_admin_password_enabled'] == 'true':
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 
-    dcos_api_session = DcosApiSession(
-        auth_user=DcosUser(CI_CREDENTIALS),
+    dcos_api_session = dcos_api.DcosApiSession(
+        auth_user=dcos_api.DcosUser(helpers.CI_CREDENTIALS),
         exhibitor_admin_password=exhibitor_admin_password,
         **args)
     dcos_api_session.wait_for_dcos()

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -1,12 +1,10 @@
-import logging
+import os
 
+import api_session_fixture
 import pytest
+from dcos_test_utils import logger
 
-from api_session_fixture import make_session_fixture
-
-logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=logging.INFO)
-logging.getLogger("requests").setLevel(logging.WARNING)
-logging.getLogger("botocore").setLevel(logging.WARNING)
+logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 
 
 def pytest_configure(config):
@@ -38,7 +36,7 @@ def clean_marathon_state(dcos_api_session):
 
 @pytest.fixture(scope='session')
 def dcos_api_session():
-    return make_session_fixture()
+    return api_session_fixture.make_session_fixture()
 
 
 @pytest.fixture(scope='session')

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "b297d1ca110411340fe4adb338588270a19eeb10",
+    "ref": "2588a9e79f7eb1b81f37689298b8c83c1f924946",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description

Log level should be configurable by environment. dcos-test-utils has a method configured for lowering the undersirable loggers a level lower than the current setting.

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1232

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: test update
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): module names changed: logging renamed to logger, dcos_api_session renamed to dcos_api
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=718248&tab=buildResultsDiv&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils
