### PR TITLE
Refactor dcos_test_utils.marathon

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -4,8 +4,6 @@ import pytest
 
 from api_session_fixture import make_session_fixture
 
-from dcos_test_utils.marathon import get_test_app
-
 logging.basicConfig(format='[%(asctime)s] %(levelname)s: %(message)s', level=logging.INFO)
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
@@ -36,19 +34,6 @@ def clean_marathon_state(dcos_api_session):
     dcos_api_session.marathon.purge()
     yield
     dcos_api_session.marathon.purge()
-
-
-@pytest.fixture
-def vip_apps(dcos_api_session):
-    vip1 = '6.6.6.1:6661'
-    test_app1, _ = get_test_app(vip=vip1)
-    name = 'myvipapp'
-    port = 5432
-    test_app2, _ = get_test_app(vip='{}:{}'.format(name, port))
-    vip2 = '{}.marathon.l4lb.thisdcos.directory:{}'.format(name, port)
-    with dcos_api_session.marathon.deploy_and_cleanup(test_app1):
-        with dcos_api_session.marathon.deploy_and_cleanup(test_app2):
-            yield ((test_app1, vip1), (test_app2, vip2))
 
 
 @pytest.fixture(scope='session')

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -1,5 +1,133 @@
+import copy
 import json
+import uuid
 
+from dcos_test_utils import marathon
 
+TEST_APP_NAME_FMT = 'integration-test-{}'
+
+# make the expanded config available at import time to allow determining
+# which tests should run before the test suite kicks off
 with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
     expanded_config = json.load(f)
+
+
+def marathon_test_app(
+        host_port: int=0,
+        container_port: int=None,
+        container_type: marathon.Container=marathon.Container.NONE,
+        network: marathon.Network=marathon.Network.HOST,
+        healthcheck_protocol: marathon.Healthcheck=marathon.Healthcheck.HTTP,
+        vip: str=None,
+        host_constraint: str=None):
+    """ Creates an app definition for the python test server which will be
+    consistent (i.e. deployable with green health checks and desired network
+    routability). To learn more about the test server, see in this repo:
+    ../packages/dcos-integration-test/extra/util/python_test_server.py
+
+    Args:
+        host_port: port that marathon will use to route traffic into the
+            test server container. If set to zero, then marathon will assign
+            a port (which is referenced by index).
+        container_port: if network is BRIDGE, then the container can have a
+            port remapped inside the container. In HOST or USER network, the
+            container port must be the same as the host port
+        container_type: can be NONE (default Mesos runtime), MESOS (the UCR),
+            or DOCKER
+        health_check_protocol: can be MESOS_HTTP or HTTP
+        vip: either named or unnamed VIP to be applied to the host port
+        host_constraint: string representing a hostname for an agent that this
+            app should run on
+
+    Return:
+        (dict, str): 2-Tuple of app definition (dict) and app ID (string)
+    """
+    if network == marathon.Network.BRIDGE:
+        assert container_type == marathon.Container.DOCKER, \
+            'BRIDGE network mode only supported for DOCKER container type'
+        if container_port is None:
+            # provide a dummy value for the bridged container port if user is indifferent
+            container_port = 8080
+    else:
+        assert container_port is None or container_port == host_port, 'Cannot declare a different host and '\
+            'container port outside of BRIDGE network'
+        container_port = host_port
+    if network == marathon.Network.USER:
+        assert host_port != 0, 'Cannot auto-assign a port on USER network!'
+
+    test_uuid = uuid.uuid4().hex
+    app = copy.deepcopy({
+        'id': TEST_APP_NAME_FMT.format(test_uuid),
+        'cpus': 0.1,
+        'mem': 32,
+        'instances': 1,
+        'cmd': '/opt/mesosphere/bin/dcos-shell python '
+               '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
+                   # If network is host and host port is zero, then the port is auto-assigned
+                   # and the commandline should reference the port with the marathon built-in
+                   '$PORT0' if host_port == 0 and network == marathon.Network.HOST else container_port),
+        'env': {
+            'DCOS_TEST_UUID': test_uuid,
+            # required for python_test_server.py to run as nobody
+            'HOME': '/'
+        },
+        'healthChecks': [
+            {
+                'protocol': healthcheck_protocol.value,
+                'path': '/ping',
+                'gracePeriodSeconds': 5,
+                'intervalSeconds': 10,
+                'timeoutSeconds': 10,
+                'maxConsecutiveFailures': 3
+            }
+        ],
+    })
+    if host_port == 0:
+        # port is being assigned by marathon so refer to this port by index
+        app['healthChecks'][0]['portIndex'] = 0
+    elif network == marathon.Network.BRIDGE:
+        app['healthChecks'][0]['port'] = container_port if \
+            healthcheck_protocol == marathon.Healthcheck.MESOS_HTTP else host_port
+    else:
+        # HOST or USER network with non-zero host port
+        app['healthChecks'][0]['port'] = host_port
+    if container_type != marathon.Container.NONE:
+        app['container'] = {
+            'type': container_type.value,
+            'docker': {'image': 'debian:jessie'},
+            'volumes': [{
+                'containerPath': '/opt/mesosphere',
+                'hostPath': '/opt/mesosphere',
+                'mode': 'RO'}]}
+        if container_type == marathon.Container.DOCKER:
+            app['container']['docker']['network'] = network.value
+            if network != marathon.Network.HOST:
+                app['container']['docker']['portMappings'] = [{
+                    'hostPort': host_port,
+                    'containerPort': container_port,
+                    'protocol': 'tcp',
+                    'name': 'test'}]
+                if vip is not None:
+                    app['container']['docker']['portMappings'][0]['labels'] = {'VIP_0': vip}
+    if network == marathon.Network.HOST:
+        app['portDefinitions'] = [{
+            'protocol': 'tcp',
+            'port': host_port,
+            'name': 'test'}]
+        if vip is not None:
+            app['portDefinitions'][0]['labels'] = {'VIP_0': vip}
+    elif network == marathon.Network.USER:
+        app['ipAddress'] = {'networkName': 'dcos'}
+        if container_type != marathon.Container.DOCKER:
+            app['ipAddress']['discovery'] = {
+                'ports': [{
+                    'protocol': 'tcp',
+                    'name': 'test',
+                    'number': host_port,
+                }]
+            }
+            if vip is not None:
+                app['ipAddress']['discovery']['ports'][0]['labels'] = {'VIP_0': vip}
+    if host_constraint is not None:
+        app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
+    return app, test_uuid

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -197,6 +197,7 @@ def test_metrics_containers(dcos_api_session):
         "mem": 128.0,
         "instances": 1
     }
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_config, check_health=False) as app:
-        assert len(app) == 1, 'The marathon app should have been deployed exactly once.'
-        test_containers(app)
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_config, check_health=False):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_config['id'])
+        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+        test_containers(endpoints)

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -1,15 +1,52 @@
 #!/usr/bin/env python3
 import contextlib
-import logging
+import copy
+import functools
 import os
 import sys
+import time
 
 import boto3
 import botocore
 import requests
 import retrying
+from botocore.exceptions import ClientError, WaiterError
 
-from dcos_test_utils.helpers import retry_boto_rate_limits
+
+def retry_boto_rate_limits(boto_fn, wait=2, timeout=60 * 60):
+    """Decorator to make boto functions resilient to AWS rate limiting and throttling.
+    If one of these errors is encounterd, the function will sleep for a geometrically
+    increasing amount of time
+    """
+    @functools.wraps(boto_fn)
+    def ignore_rate_errors(*args, **kwargs):
+        local_wait = copy.copy(wait)
+        local_timeout = copy.copy(timeout)
+        while local_timeout > 0:
+            next_time = time.time() + local_wait
+            try:
+                return boto_fn(*args, **kwargs)
+            except (ClientError, WaiterError) as e:
+                if isinstance(e, ClientError):
+                    error_code = e.response['Error']['Code']
+                elif isinstance(e, WaiterError):
+                    error_code = e.last_response['Error']['Code']
+                else:
+                    raise
+                if error_code in ['Throttling', 'RequestLimitExceeded']:
+                    print('AWS API Limiting error: {}'.format(error_code))
+                    print('Sleeping for {} seconds before retrying'.format(local_wait))
+                    time_to_next = next_time - time.time()
+                    if time_to_next > 0:
+                        time.sleep(time_to_next)
+                    else:
+                        local_timeout += time_to_next
+                    local_timeout -= local_wait
+                    local_wait *= 2
+                    continue
+                raise
+        raise Exception('Rate-limit timeout encountered waiting for {}'.format(boto_fn.__name__))
+    return ignore_rate_errors
 
 
 @contextlib.contextmanager
@@ -55,7 +92,7 @@ def delete_ec2_volume(name, timeout=300):
         try:
             return requests.get('http://169.254.169.254/latest/meta-data/placement/availability-zone').text.strip()[:-1]
         except requests.RequestException as ex:
-            logging.warning("Can't get AWS region from instance metadata: {}".format(ex))
+            print("Can't get AWS region from instance metadata: {}".format(ex))
             return None
 
     # Remove AWS environment variables to force boto to use IAM credentials.

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["dcos-image-deps"],
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/mesosphere/dcos-test-utils.git",
-    "ref": "b5163fbde449ca598a823b3a603f3e8ea29c7652",
+    "git": "https://github.com/dcos/dcos-test-utils.git",
+    "ref": "b297d1ca110411340fe4adb338588270a19eeb10",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description
Updates test suite so that the test server marathon app lives with the test server code (in dcos-integration-test). Meanwhile, the methods in dcos-test-utils were untangled

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1235
## Related Issues

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-test-utils/compare/b4859cf710d4ec1d2b49354dba98a4a7b9d40b5a...b297d1ca110411340fe4adb338588270a19eeb10
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=721328&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils
