### PR TITLE
[DCOS_OSS-1470] Exhibitor: use PatternLayoutEscaped logger layout for structured journal logger

### DIFF
--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -112,8 +112,8 @@ log4j.appender.journal=de.bwaldvogel.log4j.SystemdJournalAppenderWithLayout
 log4j.appender.journal.logStacktrace=true
 log4j.appender.journal.logThreadName=true
 log4j.appender.journal.logLoggerName=true
-log4j.appender.journal.layout=org.apache.log4j.PatternLayout
-log4j.appender.journal.layout.ConversionPattern=[myid:%X{myid}] %-5p [%t:%C{1}@%L] - %m%n
+log4j.appender.journal.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.journal.layout.ConversionPattern=[myid:%X{myid}] %-5p [%t:%C{1}@%L] - %m%n%throwable
 """)
 
 # Add backend specific arguments


### PR DESCRIPTION
## High Level Description

Changes the `journald` logger that Exhibitor uses from the default `PatternLayout` to `PatternLayoutExcaped` which escapes several charactes like (`\n`,` \r`, ...).

## Related Issues

  - [DCOS_OSS-1470](https://jira.dcos.io/browse/DCOS_OSS-1470) Exhibitor: use PatternLayoutEscaped logger layout for structured journal logger

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Non critical feature.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
