### PR TITLE
Update link to JIRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To learn more, see the [DC/OS Overview](https://dcos.io/docs/latest/overview/).
 - Get Started - <https://dcos.io/get-started/>
 - Get Help - <http://chat.dcos.io/>
 - Join the Discussion - <https://groups.google.com/a/dcos.io/d/forum/users>
-- Report an Issue - <https://dcosjira.atlassian.net>
+- Report an Issue - <https://jira.mesosphere.com/>
 - Contribute - <https://dcos.io/contribute/>
 
 


### PR DESCRIPTION
## High Level Description

The current link to JIRA is incorrect. This fixes it.