### PR TITLE
Admin Router: Re-enable request buffering for /service endpoint

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -158,7 +158,10 @@ location ~ ^/service/(?<service_path>.+) {
 
     include includes/proxy-headers.conf;
     include includes/websockets.conf;
-    include includes/disable-request-response-buffering.conf;
+
+    # Disable response buffering for SSE support.
+    # Also see https://serverfault.com/a/801629/121951
+    proxy_buffering off;
 
     proxy_redirect $upstream_scheme://$host/service/$service_realpath/ /service/$service_realpath/;
     proxy_redirect $upstream_scheme://$host/ /service/$service_realpath/;


### PR DESCRIPTION
## High Level Description

Re-enables request buffering for `/service` endpoint.

## Related Issues

https://jira.mesosphere.com/browse/DCOS_OSS-1491 - Admin Router: /service endpoint request buffering was disabled w/o strong technical reason