### PR TITLE
Add uppercase version of proxy environment variables in dcos-config

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -896,6 +896,9 @@ package:
       http_proxy={{ http_proxy }}
       https_proxy={{ https_proxy }}
       no_proxy="{{ no_proxy_final }}"
+      HTTP_PROXY={{ http_proxy }}
+      HTTPS_PROXY={{ https_proxy }}
+      NO_PROXY="{{ no_proxy_final }}"
 {% case "false" %}
     content: ""
 {% endswitch %}


### PR DESCRIPTION
## High Level Description

This PR adds the export of uppercase variants of proxy environment variables (e.g `HTTP_PROXY`) for reluctant services that ignore lowercase variants.

## Related Issues

  - [DCOS_OSS-1499](https://jira.dcos.io/browse/DCOS_OSS-1499) Proxy settings only export lowercase environment variables

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

