### PR TITLE
[1.9.3] Train 200

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "1b4e0138bf6615583cf69ccfe7aa5230dfd30917",
-    "ref_origin": "master"
+    "ref": "171bd04127ea5d67dd3b7804af79d40073939117",
+    "ref_origin": "1.9.x"
   },
   "username": "dcos_metrics"
 }

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -25,6 +25,6 @@ RestartSec=5
 LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=${PKG_PATH}/bin/epmd -port 61420
+ExecStart=${PKG_PATH}/bin/epmd -port 61420 -relaxed_command_check
 Environment=HOME=/opt/mesosphere
 EOF

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "94cffea2c16e8082743de04bd72311e60bedc324",
+      "ref": "bfc09c9eca064cacc275be04bd65c98361f2504a",
       "ref_origin": "dcos/1.9"
     }
   },

--- a/packages/spartan/buildinfo.json
+++ b/packages/spartan/buildinfo.json
@@ -4,7 +4,7 @@
     "spartan": {
       "kind": "git",
       "git": "https://github.com/dcos/spartan.git",
-      "ref": "e94d5661cd271387379fd41001b80a31a1b4eab8",
+      "ref": "7ae3d167f2839dd6d0f583feb3f6c17a1c7fe28c",
       "ref_origin": "dcos/1.9"
     }
   }


### PR DESCRIPTION
This is train 200 targeted for the 1.9.3 release, against the `1.9` branch. It contains the following pull requests:
- #1766 ([1.9.3] Bump dcos-metrics version)
- #1743 ([1.9.3] bump spartan and navstar)