### PR TITLE
Revert "Bump navstar"

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "193dea241d408d1f820bff8ecd2ba67800d6ec88",
+      "ref": "c4e9ea6f18f8fa256139a0b66771f1349302ab52",
       "ref_origin": "master"
     }
   },


### PR DESCRIPTION
This reverts commit b14e5d04368236720f941ee25799d1dc96f9f4c3 (PR #1778). This
change is causing the overlay network to break for existing Data Agility
services.