### PR TITLE
[1.9.x] Bump to Mesos 1.2.2-rc1.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "658bf9195ec9b129db6a2c3d11e26ba1a017ce51",
-    "ref_origin" : "dcos-mesos-1.2.x-1b8e468"
+    "ref": "e91c7bd05671e56e9ae8fbf0304aa1c74dd27fdd",
+    "ref_origin" : "dcos-mesos-1.2.2-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Bump Mesos to the latest 1.2.x (in this case, the rc1 for 1.2.2). We were previously on a SHA between 1.2.1 and 1.2.2.

## Related Issues

* [CORE-1250](https://jira.mesosphere.com/browse/CORE-1250) - [1.9.x] Bump Mesos to 1.2.2
* [MESOS-5187](https://issues.apache.org/jira/browse/MESOS-5187) - The filesystem/linux isolator does not set the permissions of the host_path.
* [MESOS-7252](https://issues.apache.org/jira/browse/MESOS-7252) - Need to fix resource check in long-lived framework.
* [MESOS-7830](https://issues.apache.org/jira/browse/MESOS-7830) - Sandbox_path volume does not have ownership set correctly.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated: https://github.com/mesosphere/mesos/compare/dcos-mesos-1.2.x-1b8e468...dcos-mesos-1.2.2-rc1
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins//job/mesos/job/Mesos_CI-build/1507 (as healthy as previous 1.2.x builds)
  - [ ] Code Coverage (if available): N/A