### PR TITLE
dcos-config.yaml: set MESOS_EXECUTOR_REGISTRATION_TIMEOUT to 30mins (…

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -427,7 +427,7 @@ package:
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
-      MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
+      MESOS_EXECUTOR_REGISTRATION_TIMEOUT=30mins
       MESOS_CGROUPS_ENABLE_CFS=true
       MESOS_CGROUPS_LIMIT_SWAP=false
       MESOS_DOCKER_REMOVE_DELAY={{ docker_remove_delay }}


### PR DESCRIPTION
## High Level Description

This increases the Mesos executor registration timeout from 10 minutes to 30 minutes.

## Related Issues

  - [DCOS_OSS-1500](https://jira.mesosphere.com/browse/DCOS_OSS-1500) dcos-config.yaml: increase default MESOS_EXECUTOR_REGISTRATION_TIMEOUT
  - [DCOS_OSS-1463](https://jira.mesosphere.com/browse/DCOS_OSS-1463) Docker Hub image pulls frequently time out as of executor registration timeout

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this intends to be more resilient towards network / download throughput fluctuations in situations when the Mesos fetcher downloads a container image from Docker Hub or from a private registry. This effect is hard to test, reliably.
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]