### PR TITLE
Bump dcos-metrics version

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "1b4e0138bf6615583cf69ccfe7aa5230dfd30917",
+    "ref": "3fbef2648ad5c3d5bb7850a446cf957c091429b4",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This updates metrics in dcos master to include two bugfixes. These are already merged in the 1.9.3 branch. 

## Related Issues

  - [DCOS_OSS-1451](https://jira.dcos.io/browse/DCOS_OSS-1451) Stale datapoints can occur in container metrics
  - [DCOS_OSS-1486](https://jira.dcos.io/browse/DCOS_OSS-1486) Metrics agent crashes when the mesos containers endpoint is missing fields

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-metrics/compare/1b4e0138bf6615583cf69ccfe7aa5230dfd30917...3fbef2648ad5c3d5bb7850a446cf957c091429b4)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/123/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/123/)
