### PR TITLE
[next-beta] DCOS-UI: Update package for 1.10

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "466ffcd51f6e66c12bcb497cea8abd1840e70c5e",
-    "ref_origin": "v1.10.0-rc.3"
+    "ref": "69815aeeca29f5da76c04e6144705a7d8ce5b2da",
+    "ref_origin": "v1.10.0-rc.4"
   }
 }


### PR DESCRIPTION
## High Level Description

Update the DC/OS UI package to include the latest fixes and improvements.

**DCOS-UI release**: https://github.com/dcos/dcos-ui/releases/tag/v1.10.0-rc.4

## Related Issues

- [DCOS_OSS-940 **HIGH**](https://jira.mesosphere.com/browse/DCOS_OSS-940): Show unreachable tasks in task table
- [DCOS-17205 **BLOCKER**](https://jira.mesosphere.com/browse/DCOS-17205): CLI command for SDK update is only available on Enterprise edition
- [DCOS-16636 **HIGH**](https://jira.mesosphere.com/browse/DCOS-16636): Adjust universe setup/teardown scripts for system tests
- [DCOS-17389 **HIGH**](https://jira.mesosphere.com/browse/DCOS-17389): Update CLI install command for OSX/Linux
- [DCOS-17301 **HIGH**](https://jira.mesosphere.com/browse/DCOS-17301): Show all tasks for a Framework running in a nested folder
- [DCOS-17463 **BLOCKER**](https://jira.mesosphere.com/browse/DCOS-17463): SDK tasks default to healthy if RUNNING and not 'unhealthy'
- [DCOS-16564 **BLOCKER**](https://jira.mesosphere.com/browse/DCOS-16564): Remove all restart commands for SDK services
- [DCOS-17566 **HIGH**](https://jira.mesosphere.com/browse/DCOS-17566): Fix broken link to Catalog from Service Create Modal
- [DCOS-16225 **HIGH**](https://jira.mesosphere.com/browse/DCOS-16225): Mention the CLI explicitly when pointing user to CLI commands
- [DCOS-15073 **MEDIUM**](https://jira.mesosphere.com/browse/DCOS-15073): Add external volume system test
- [DCOS_OSS-1320 **MEDIUM**](https://jira.mesosphere.com/browse/DCOS_OSS-1320): Correct the update service CLI command
- [DCOS-17383 **HIGH**](https://jira.mesosphere.com/browse/DCOS-17383): Fix incorrect file location for dashboard system test
- [DCOS-14850 **HIGH**](https://jira.mesosphere.com/browse/DCOS-14850): Fix GPU to integer
- [DCOS-16400 **MEDIUM**](https://jira.mesosphere.com/browse/DCOS-16400): Remove SDK.get in favor of direct import
- [DCOS-17284 **BLOCKER**](https://jira.mesosphere.com/browse/DCOS-17284): Remove Docker object if no image set
- [DCOS-14469 **HIGH**](https://jira.mesosphere.com/browse/DCOS-14469): Fix issue where containers were shown twice on a POD
- [DCOS_OSS-1272 **HIGH**](https://jira.mesosphere.com/browse/DCOS_OSS-1272): Retain port value if requirePorts is set to false

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-ui/compare/v1.10.0-rc.3...v1.10.0-rc.4)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
