### PR TITLE
Bumped the Mesos package to recent 1.4.x.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -430,6 +430,7 @@ package:
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
       MESOS_CGROUPS_ENABLE_CFS=true
       MESOS_CGROUPS_LIMIT_SWAP=false
+      MESOS_DISALLOW_SHARING_AGENT_PID_NAMESPACE=true
       MESOS_DOCKER_REMOVE_DELAY={{ docker_remove_delay }}
       MESOS_DOCKER_STOP_TIMEOUT={{ docker_stop_timeout }}
       MESOS_DOCKER_STORE_DIR=/var/lib/mesos/slave/store/docker

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "5ce334c9b83a682e5a07b726e4aee430d4bc2a65",
-    "ref_origin" : "dcos-mesos-master-d9c90bf1"
+    "ref": "e4922ff91aecc3ae310af3fcb52f59ad96266337",
+    "ref_origin" : "dcos-mesos-1.4.x-b6413990"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

This patch updates the Mesos package to use the latest from the Apache Mesos `1.4.x` branch.

## Related Issues

  - [MESOS-7871](https://issues.apache.org/jira/browse/MESOS-7871) Agent fails assertion during request to '/state'
  - [MESOS-6950](https://issues.apache.org/jira/browse/MESOS-6950) Launching two tasks with the same Docker image simultaneously may cause a staging dir never cleaned up
  - [CORE-1225](https://jira.mesosphere.com/browse/CORE-1225) Support shared PID namespace in Mesos.
  - [CORE-1274](https://jira.mesosphere.com/browse/CORE-1274) Enable the Mesos Agent flag 'disallow_sharing_agent_pid_namespace' in DC/OS for security concern.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The Mesos changes include a test which verifies the fix to the issue listed above, MESOS-7871. The new Mesos flag enabled by this PR, `DISALLOW_SHARING_AGENT_PID_NAMESPACE`, has unit/integration tests in Mesos to verify its functionality; [here](https://github.com/apache/mesos/blob/8ff09b2ad0c36237d6d347fdb650f9b8054fac47/src/tests/containerizer/isolator_tests.cpp#L160~%23L214), [here](https://github.com/apache/mesos/blob/d38ac582e8cf8599f2f749fda74c70a5a76674e6/src/tests/containerizer/nested_mesos_containerizer_tests.cpp#L830~#L969), [here](https://github.com/apache/mesos/blob/b64139900d6fab7cdc6aacefec8f4b744839e467/src/tests/default_executor_tests.cpp#L1376~#L1545), and [here](https://github.com/apache/mesos/blob/e2f3804fa849811917d0894a18ad02c056d166b6/src/tests/containerizer/isolator_tests.cpp#L224~#L252).
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/5ce334c9b83a682e5a07b726e4aee430d4bc2a65...b64139900d6fab7cdc6aacefec8f4b744839e467)
  - [x] Test Results: [Mesosphere CI results](https://jenkins.mesosphere.com/service/jenkins//job/mesos/job/Mesos_CI-build/1587)
  - [ ] Code Coverage (if available): [link to code coverage report]