### PR TITLE
Bump dcos-vagrant

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -160,9 +160,6 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
 @pytest.mark.skipif(
     test_helpers.expanded_config.get('security') == 'strict',
     reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('platform') == 'vagrant',
-    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_octarine(dcos_api_session, timeout=30):
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -195,9 +195,6 @@ def test_if_navstar_l4lb_disabled(dcos_api_session):
     assert str(data).find('9999') == -1
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('platform') == 'vagrant',
-    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_ip_per_container(dcos_api_session):
     '''Test if we are able to connect to a task with ip-per-container mode
     '''

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -246,9 +246,6 @@ def test_service_discovery_docker_host(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('platform') == 'vagrant',
-    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_bridge(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
@@ -258,9 +255,6 @@ def test_service_discovery_docker_bridge(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('platform') == 'vagrant',
-    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
@@ -270,9 +264,6 @@ def test_service_discovery_docker_overlay(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('platform') == 'vagrant',
-    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -33,7 +33,7 @@ else
 fi
 
 # Pin to just the right dcos-vagrant commit
-git -C dcos-vagrant checkout -qf 3f216d6558d84f94f337d97ed0c6a92286242480
+git -C dcos-vagrant checkout -qf 8e15ef498b2dca62f29fb1c0950b5ae854315e53
 
 cp ../dcos_generate_config.sh dcos-vagrant/dcos_generate_config.sh
 


### PR DESCRIPTION
## Changes
- Upgrade dcos-vagrant
    - Enhance mesos-memory to emulate systemd environment of dcos-mesos-slave[-public] by parsing EnvironmentFiles
    - Upgrade to dcos-vagrant-box 0.9.2 (Centos 7.3.1611, Docker 1.13.1)
    - Don't fail dcos-postflight if STATUS_CMD fails (print error)
    - Upgrade dcos-postflight script to use `dcos-diagnostics check node-poststart` and parse its output with `jq`
    - Move scripts from /usr/local/sbin -> /usr/sbin so they're in the PATH for vagrant SSH
- Unskip dcos-vagrant tests muted by [DCOS_OSS-1531](https://jira.mesosphere.com/browse/DCOS_OSS-1531)

## Related Issues

  - [DCOS_OSS-1523](https://jira.mesosphere.com/browse/DCOS_OSS-1523) DC/OS Vagrant: Improve how memory resources are defined for agents
  - [DCOS_OSS-1524](https://jira.mesosphere.com/browse/DCOS_OSS-1524) dcos-diagnostics --diag returns false positives during DC/OS install. 
  - [DCOS_OSS-1532](https://jira.mesosphere.com/browse/DCOS_OSS-1532) Undo DCOS_OSS-1531 (unmute/unskip tests)