### PR TITLE
Fix mount failure handling

### DIFF
--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -67,7 +67,7 @@ function main {
       rm -rf /var/log
       mkdir -p /var/log
       echo -n "Mounting: $device to $mount_location"
-      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location"; done
+      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location" || :; done
       echo
       systemd-tmpfiles --create --prefix /var/log/journal || :
       systemctl restart systemd-journald || :
@@ -75,7 +75,7 @@ function main {
       systemctl is-enabled chronyd > /dev/null && systemctl start chronyd || :
     else
       echo -n "Mounting: $device to $mount_location"
-      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location"; done
+      until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location" || :; done
       echo
     fi
   else

--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -57,10 +57,6 @@ function main {
       mkdir -p /var/log-prep
       mount $device /var/log-prep
       mkdir -p /var/log-prep/journal
-      systemctl is-active chronyd > /dev/null && systemctl stop chronyd || :
-      systemctl is-active tuned > /dev/null && systemctl stop tuned || :
-      # rsyslog shouldn't be active but in case it is stop it as well
-      systemctl is-active rsyslog > /dev/null && systemctl stop rsyslog || :
       cp -a /var/log/. /var/log-prep/
       umount /var/log-prep
       rmdir /var/log-prep
@@ -71,8 +67,6 @@ function main {
       echo
       systemd-tmpfiles --create --prefix /var/log/journal || :
       systemctl restart systemd-journald || :
-      systemctl is-enabled tuned > /dev/null && systemctl start tuned || :
-      systemctl is-enabled chronyd > /dev/null && systemctl start chronyd || :
     else
       echo -n "Mounting: $device to $mount_location"
       until grep ^$device /etc/mtab > /dev/null; do sleep 1; echo -n .; mount "$mount_location" || :; done

--- a/cloud_images/centos7/dcos_vol_setup.sh
+++ b/cloud_images/centos7/dcos_vol_setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
 
+# ignore SIGPIPE when losing our reader during systemd-journald restart
+trap '' PIPE
+
 export device=${1:-}
 export mount_location=${2:-}
 

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -25,6 +25,7 @@ yum -y --tolerant install perl tar xz unzip curl bind-utils net-tools ipset libt
 echo ">>> Set up filesystem mounts"
 cat << 'EOF' > /etc/systemd/system/dcos_vol_setup.service
 [Unit]
+Before=docker.service chronyd.service tuned.service rsyslog.service dcos-mesos-master.service dcos-mesos-slave.service dcos-mesos-slave-public.service
 Description=Initial setup of volume mounts
 
 [Service]


### PR DESCRIPTION
## High Level Description

Fixes a bug where the loop would get interrupted by a failed mount command rendering the entire until loop useless. The idea is to keep retrying until the mount succeeds (or systemd times out the service unit and kills the script). Instead a single mount failure would currently abort the script (`set -e`).

No longer makes the script fail on SIGPIPE (reverts to bash default behaviour).

Moves dependency handling to the systemd unit instead of stopping/restarting services in the volume mount script itself.