### PR TITLE
skip vagrant tests for DCOS_OSS-1532

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -160,6 +160,9 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
 @pytest.mark.skipif(
     test_helpers.expanded_config.get('security') == 'strict',
     reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('platform') == 'vagrant',
+    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_octarine(dcos_api_session, timeout=30):
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -195,6 +195,9 @@ def test_if_navstar_l4lb_disabled(dcos_api_session):
     assert str(data).find('9999') == -1
 
 
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('platform') == 'vagrant',
+    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_ip_per_container(dcos_api_session):
     '''Test if we are able to connect to a task with ip-per-container mode
     '''

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -246,6 +246,9 @@ def test_service_discovery_docker_host(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSHost])
 
 
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('platform') == 'vagrant',
+    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_bridge(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
@@ -255,6 +258,9 @@ def test_service_discovery_docker_bridge(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
 
 
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('platform') == 'vagrant',
+    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
@@ -264,6 +270,9 @@ def test_service_discovery_docker_overlay(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('platform') == 'vagrant',
+    reason='See: https://jira.mesosphere.com/browse/DCOS_OSS-1532')
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,


### PR DESCRIPTION
## High Level Description
Vagrant tests are blocking AdminRouter changes in the following cases:
test_octarine
test_service_discovery_docker_bridge
test_service_discovery_docker_overlay
test_service_discovery_docker_overlay_port_mapping
test_ip_per_container

As per the tickets below, these failures are being treated as vagrant specific and therefore are being skipped until a fix can be introduced in dcos-vagrant

## Related Issues
https://jira.mesosphere.com/browse/DCOS_OSS-1531
https://jira.mesosphere.com/browse/DCOS_OSS-1532

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: skipping tests, not adding features
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)