### PR TITLE
bumping the marathon to version 1.4.6

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.5/marathon-1.4.5.tgz",
-    "sha1": "b73f862c678db1e744df5261fb7f91e100b9a0d5"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.6/marathon-1.4.6.tgz",
+    "sha1": "2cf376dd77618a2c9a373fb0ddfba90339fb25ea"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

The release resolves a large number of bugs and customer issues from version 1.4.5.   Most significantly this includes:  quick response to unreachable strategy, marathon losing tasks on leadership switch, and a race condition bug.   This also resolves a security issue with HTTP TRACE in marathon.

## Related Issues

- [MARATHON-7681](https://jira.mesosphere.com/browse/MARATHON-7681) - Fixes an issue in WorkQueue that could cause Marathon to drop exceptions and become unresponsive.
- [MARATHON-7653](https://jira.mesosphere.com/browse/MARATHON-7653) - Fixes an issue in which Marathon could become unresponsive when pod status wasn't available
- [MARATHON-7629](https://jira.mesosphere.com/browse/MARATHON-7629) - Fixes issue in which Marathon could get into an infinite kill loop, in certain situations
- [MARATHON-7469](https://jira.mesosphere.com/browse/MARATHON-7469) - Fixes a bug in which a new leading Marathon would kill tasks launched by an ongoing deployment during the former leader.
- [MARATHON-7472](https://jira.mesosphere.com/browse/MARATHON-7472), [MARATHON-7358](https://jira.mesosphere.com/browse/MARATHON-7358) - Further improve deployment performance by removing unnecessary thread blocking.
- [MARATHON-7617](https://jira.mesosphere.com/browse/MARATHON-7617) - Capture storage cache layer metrics, by category
- [MARATHON-7536](https://jira.mesosphere.com/browse/MARATHON-7536) - Disable HTTP TRACE method in API
- [MARATHON-7566](https://jira.mesosphere.com/browse/MARATHON-7566) - Fix a regression in which content-type was required for the ping endpoint
- [MARATHON-7334](https://jira.mesosphere.com/browse/MARATHON-7334) - Fix a regression in which `fetch[].destPath` was ignored
- Replace lock with non-blocking concurrent data structure in WorkQueue, evidently the source of some contention looking at thread dump from [MARATHON-7400](https://jira.mesosphere.com/browse/MARATHON-7400)
- [MARATHON-7433](https://jira.mesosphere.com/browse/MARATHON-7433) - Fix a group deployment issue which would cause non-root groups without a nested group to be ignored.
- [MARATHON-7462](https://jira.mesosphere.com/browse/MARATHON-7462) - Fix a race condition in WorkQueue which caused various issues, such as dropped events and could cause components of Marathon to become unresponsive.
- [MARATHON-7628](https://jira.mesosphere.com/browse/MARATHON-7462) - Added `agentId` to the pod status
- [MARATHON-7458](https://jira.mesosphere.com/browse/MARATHON-7458) - Reset root group cache when elected as leader
- [MARATHON_EE-1590](https://jira.mesosphere.com/browse/MARATHON_EE-1590) - Change unreachableStrategy to be able to start instant replacement tasks
- [MARATHON_EE-1591](https://jira.mesosphere.com/browse/MARATHON_EE-1591) - Allow migration from previous UnreachableStrategy default

More details with the marathon 1.4.6 [release notes](https://github.com/mesosphere/marathon/releases/tag/v1.4.6):

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [marathon commits since 1.4.5](https://github.com/mesosphere/marathon/compare/cf04e2eb375e90cafc9c5a0e0c19d224b83321da...8619c5696c778ccd012f9406838bb89418b75aa7)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.4/48/
  - [x] Code Coverage (if available): https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.4/48/artifact/target/scala-2.11/scoverage-report/overview.html

