### PR TITLE
1.9 train 202

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -104,7 +104,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.9.2',
+        'version': '1.9.3',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -726,7 +726,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.9.2',
+        'dcos_version': '1.9.3',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -733,6 +733,9 @@ package:
                   "Location": "/opt/mesosphere/etc/user.config.yaml"
               },
               {
+                  "Location": "/var/lib/dcos/cluster-id"
+              },
+              {
                   "Location": "/var/lib/dcos/exhibitor/zookeeper/snapshot/myid",
                   "Role": ["master"]
               },

--- a/packages/dcos-integration-test/extra/test_3dt.py
+++ b/packages/dcos-integration-test/extra/test_3dt.py
@@ -522,7 +522,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz', '3dt-health.json',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
-                             'opt/mesosphere/etc/user.config.yaml.gz']
+                             'opt/mesosphere/etc/user.config.yaml.gz', 'var/lib/dcos/cluster-id.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.5/marathon-1.4.5.tgz",
-    "sha1": "b73f862c678db1e744df5261fb7f91e100b9a0d5"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.6/marathon-1.4.6.tgz",
+    "sha1": "2cf376dd77618a2c9a373fb0ddfba90339fb25ea"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

* #1807 - Add cluster-id file to diagnostics bundle
* #1814 - Bump version to 1.9.3
* #1820 -  bumping the marathon to version 1.4.6



