### PR TITLE
[DCOS_OSS-1516] Link to DC/OS Docker Quick Start rather than setting all environment …

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,36 +147,9 @@ One way to run the integration tests is to use [DC/OS Docker](https://github.com
 
 1. Setup DC/OS in containers using [DC/OS Docker](https://github.com/dcos/dcos-docker).
 
-1. `exec` into the master node
+One way to do this is to use the [DC/OS Docker Quick Start tool](https://github.com/dcos/dcos-docker#quick-start).
 
-	```
-	docker exec -it dcos-docker-master1 /bin/bash
-	```
-
-1. Configure the tests
-
-    ```
-	export DCOS_DNS_ADDRESS=http://172.17.0.2
-	export MASTER_HOSTS=172.17.0.2
-	export PUBLIC_MASTER_HOSTS=172.17.0.2
-	export SLAVE_HOSTS=172.17.0.3
-	export PUBLIC_SLAVE_HOSTS=172.17.0.4
-	export DCOS_PROVIDER=onprem
-	export DNS_SEARCH=false
-	export DCOS_LOGIN_PW=admin
-	export PYTHONUNBUFFERED=true
-	export PYTHONDONTWRITEBYTECODE=true
-	export DCOS_LOGIN_UNAME=admin
-	export TEST_DCOS_RESILIENCY=false
-	source /opt/mesosphere/environment.export
-    ```
-
-1. Run the tests with Pytest
-
-    ```
-    cd /opt/mesosphere/active/dcos-integration-test
-    py.test
-    ```
+2. Run `make test`.
 
 # Build
 


### PR DESCRIPTION
…variables

## High Level Description

This changes the guide for running the integration tests with DC/OS Docker.
This proposal is to use the `make test` command which is maintained rather than a set of commands in the README which must be updated when the test requirements are changed.

As a bonus, it also means that the instructions in this `README` apply to Enterprise DC/OS.

## Related Issues

  - [DCOS_OSS-1516](https://jira.dcos.io/browse/DCOS_OSS-1516) Update DC/OS README integration test instructions to remove setting extraneous environment variables.
  - [DCOS-17636](https://jira.mesosphere.com/browse/DCOS-17636) Update various tools to account for DC/OS Enterprise tests now needing HOSTS environment variables.

## Checklist for all PR's

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Although there is no test here, the DC/OS Docker CI will fail if this does not work. This makes the documentation "tested" to some extent.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)