### PR TITLE
Admin Router: Prevent forwarding dcos-* cookies to upstreams

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -22,6 +22,7 @@ location / {
 location ~ ^/system/v1/leader/mesos(?<url>.*)$ {
     access_by_lua_block {
         auth.access_system_mesosleader_endpoint();
+        util.clear_dcos_cookies();
     }
 
     include includes/http-11.conf;
@@ -39,6 +40,7 @@ location ~ ^/system/v1/leader/marathon(?<url>.*)$ {
     rewrite_by_lua_block {
         auth.access_system_marathonleader_endpoint();
         mleader.resolve();
+        util.clear_dcos_cookies();
     }
 
     include includes/http-11.conf;
@@ -53,6 +55,7 @@ location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0
     rewrite_by_lua_block {
         auth.access_system_agent_endpoint();
         agent.resolve();
+        util.clear_dcos_cookies();
     }
     rewrite ^/agent/[0-9a-zA-Z-]+(.*)$ $1 break;
 
@@ -74,6 +77,7 @@ location = /mesos_dns {
 location /mesos_dns/ {
     access_by_lua_block {
         auth.access_mesosdns_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
@@ -107,6 +111,7 @@ location /dcos-history-service/ {
     rewrite_by_lua_block {
         auth.access_historyservice_endpoint();
         historyservice.resolve();
+        util.clear_dcos_cookies();
     }
     proxy_pass $historyservice_upstream;
 }
@@ -157,6 +162,7 @@ location ~ ^/service/(?<service_path>.+) {
         -- TODO (prozlach): not sure if passing auth during init wouldn't
         -- be cleaner. On the other hand passing it here is more explicit.
         service.recursive_resolve(auth, ngx.var.service_path);
+        util.clear_dcos_cookies();
     }
 
     include includes/proxy-headers.conf;
@@ -190,6 +196,7 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
     rewrite_by_lua_block {
         auth.access_agent_endpoint();
         agent.resolve();
+        util.clear_dcos_cookies();
     }
 
     more_clear_input_headers Accept-Encoding;
@@ -208,6 +215,7 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
 location /navstar/lashup/key {
     access_by_lua_block {
         auth.access_lashupkey_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     proxy_pass http://navstar/lashup/key;
@@ -239,6 +247,7 @@ location = /mesos {
 location /mesos/ {
     access_by_lua_block {
         auth.access_mesos_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     rewrite ^/mesos/(.*) /$1 break;
@@ -250,6 +259,7 @@ location /mesos/ {
 location /cosmos/service/ {
     access_by_lua_block {
         auth.access_cosmosservice_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     include includes/http-11.conf;
@@ -263,6 +273,7 @@ location /cosmos/service/ {
 location /package/ {
     access_by_lua_block {
         auth.access_package_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     include includes/disable-request-response-buffering.conf;
@@ -276,6 +287,7 @@ location /package/ {
 location /capabilities {
     access_by_lua_block {
         auth.access_capabilities_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     include includes/http-11.conf;
@@ -286,9 +298,12 @@ location /capabilities {
 # Group: Authentication
 # Description: Access Control Service
 location /acs/api/v1 {
-    # Enforce access restriction to Auth API.
+    # Enforce access restriction to Auth API. Due to the fact that we need to
+    # issue a subrequest in auth.access_acsapi_endpoint(), this block needs to
+    # be access_by_lua_block instead of rewrite_by_lua_block
     access_by_lua_block {
         auth.access_acsapi_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
     include includes/disable-response_caching.conf;

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -3,6 +3,7 @@
 location /pkgpanda/ {
     access_by_lua_block {
         auth.access_pkgpanda_endpoint();
+        util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
 
@@ -15,6 +16,7 @@ location /pkgpanda/ {
 location /system/health/v1 {
     access_by_lua_block {
         auth.access_system_health_endpoint();
+        util.clear_dcos_cookies();
     }
 
     include includes/proxy-headers.conf;
@@ -26,6 +28,7 @@ location /system/health/v1 {
 location /system/v1/logs/ {
     access_by_lua_block {
         auth.access_system_logs_endpoint();
+        util.clear_dcos_cookies();
     }
 
     include includes/proxy-headers.conf;
@@ -39,6 +42,7 @@ location /system/v1/logs/ {
 location /system/v1/metrics/ {
     access_by_lua_block {
         auth.access_system_metrics_endpoint();
+        util.clear_dcos_cookies();
     }
 
     include includes/proxy-headers.conf;
@@ -50,7 +54,9 @@ location /system/v1/metrics/ {
 location /exhibitor/ {
     access_by_lua_block {
         auth.access_exhibitor_endpoint();
+        util.clear_dcos_cookies();
     }
+
     include includes/proxy-headers.conf;
 
     proxy_pass http://exhibitor/;
@@ -92,6 +98,9 @@ location = /login {
 # Group: Authentication
 # Description: Access Control Service (unauthenticated)
 location /acs/api/v1/auth/ {
+    access_by_lua_block {
+        util.clear_dcos_cookies();
+    }
     include includes/proxy-headers.conf;
     proxy_pass http://iam;
 }
@@ -100,6 +109,9 @@ location /acs/api/v1/auth/ {
 # Group: Metadata
 # Description: DC/OS GUI configuration (unauthenticated)
 location /dcos-metadata/ui-config.json {
+    access_by_lua_block {
+        util.clear_dcos_cookies();
+    }
     include includes/proxy-headers.conf;
     proxy_pass http://iam;
 }

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -25,6 +25,7 @@ endpoint_tests:
         locations:
           - /acs/api/v1/auth/reflect/me
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /acs/api/v1/auth/reflect/me
@@ -45,6 +46,7 @@ endpoint_tests:
         locations:
           - /dcos-metadata/ui-config.json
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /dcos-metadata/ui-config.json

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -2,6 +2,7 @@ endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /exhibitor/foo/bar
@@ -37,6 +38,7 @@ endpoint_tests:
 ######### /service endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
@@ -192,6 +194,7 @@ endpoint_tests:
 ######### /agent endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
@@ -226,9 +229,21 @@ endpoint_tests:
 ######### /system/health/ endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/health/v1/foo/bar
+    type:
+      - agent
+  - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /system/health/v1/foo/bar
+    type:
+      - master
+  - tests:
       # Check Open/EE config for this test:
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.0
@@ -247,6 +262,7 @@ endpoint_tests:
 # Agent A
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
@@ -280,6 +296,7 @@ endpoint_tests:
 # Agent B
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs/foo/bar?key=value&var=num
@@ -314,6 +331,7 @@ endpoint_tests:
 ######### /system/v1/leader endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
@@ -348,9 +366,21 @@ endpoint_tests:
 ######### /system/v1/logs endpoint
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: true
         jwt_should_be_forwarded: skip
         test_paths:
           - /system/v1/logs/foo/bar
+    type:
+      - agent
+  - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /system/v1/logs/foo/bar
+    type:
+      - master
+  - tests:
       is_upstream_correct:
         test_paths:
           - /system/v1/logs/foo/bar
@@ -374,6 +404,7 @@ endpoint_tests:
 ######### /cosmos/service
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /cosmos/service/foo/bar
@@ -395,6 +426,7 @@ endpoint_tests:
 ######### /capabilities
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /capabilities
@@ -417,6 +449,7 @@ endpoint_tests:
         test_paths:
           - /acs/api/v1/reflect/me
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /acs/api/v1/reflect/me
@@ -435,6 +468,7 @@ endpoint_tests:
 ######### /package
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /package/foo/bar
@@ -455,6 +489,7 @@ endpoint_tests:
 ######### /navstar/lashup/key
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /navstar/lashup/key
@@ -473,6 +508,7 @@ endpoint_tests:
 ######### /dcos-history-service/foo/bar
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: skip
         test_paths:
           - /dcos-history-service/foo/bar
@@ -491,6 +527,7 @@ endpoint_tests:
 ######### /mesos_dns
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: false
         test_paths:
           - /mesos_dns/v1/reflect/me
@@ -513,6 +550,7 @@ endpoint_tests:
 ######### /mesos
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /mesos/reflect/me
@@ -534,10 +572,6 @@ endpoint_tests:
 
 ######### /pkgpanda
   - tests:
-      are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
-        test_paths:
-          - /pkgpanda/foo/bar
       is_upstream_correct:
         test_paths:
           - /pkgpanda/foo/bar
@@ -551,6 +585,11 @@ endpoint_tests:
       - master
       - agent
   - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /pkgpanda/foo/bar
       is_location_header_rewritten:
         basepath: /pkgpanda/foo/bar
         endpoint_id: http:///run/dcos/pkgpanda-api.sock
@@ -560,6 +599,11 @@ endpoint_tests:
     type:
       - master
   - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: true
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /pkgpanda/foo/bar
       is_location_header_rewritten:
         basepath: /pkgpanda/foo/bar
         endpoint_id: http:///run/dcos/pkgpanda-api.sock
@@ -587,10 +631,6 @@ endpoint_tests:
 
 ######### /system/v1/metrics endpoint
   - tests:
-      are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
-        test_paths:
-          - /system/v1/metrics/foo/bar
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.0
         test_paths:
@@ -602,6 +642,11 @@ endpoint_tests:
       - master
       - agent
   - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: true
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /system/v1/metrics/foo/bar
       is_upstream_correct:
         test_paths:
           - /system/v1/metrics/foo/bar
@@ -610,6 +655,11 @@ endpoint_tests:
     type:
       - agent
   - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        jwt_should_be_forwarded: skip
+        test_paths:
+          - /system/v1/metrics/foo/bar
       is_upstream_correct:
         test_paths:
           - /system/v1/metrics/foo/bar
@@ -624,6 +674,7 @@ endpoint_tests:
 ######### /marathon
   - tests:
       are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
         jwt_should_be_forwarded: true
         test_paths:
           - /marathon/


### PR DESCRIPTION
## High Level Description

This PR introduces removing `dcos-*` cookies for upstream requests.

For technical motivation - please check the linked Jira issue
For technical implementation details - please check the description of the function `util.clear_dcos_cookies` in `lib/util.lua` file

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-12015 `Admin Router: remove auth cookie after translating it into Authorization header`

## Related PRs:

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1298
