### PR TITLE
Fix slave server autoscaling group dependency

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -695,7 +695,7 @@
     },
     "SlaveServerGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
-      "DependsOn" : "GatewayToInternet",
+      "DependsOn" : ["PrivateOutboundNetworkAclEntry", "NATInstance"],
       "Properties" : {
         "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PrivateSubnet", "AvailabilityZone" ] }],
         "LaunchConfigurationName" : { "Ref" : "SlaveLaunchConfig" },


### PR DESCRIPTION
Depending on GatewayToInternet alone was not viable
as it could happen that the autoscaling group may come
up before the networking rules that would actually allow
the private agents to download DC/OS

## Related Issues
https://jira.mesosphere.com/browse/QUALITY-1516

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: fixes a rare race condition
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)