### PR TITLE
Prevent dcos_vol_setup from formatting partitions while services are starting

### DIFF
--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -26,6 +26,8 @@ echo ">>> Set up filesystem mounts"
 cat << 'EOF' > /etc/systemd/system/dcos_vol_setup.service
 [Unit]
 Description=Initial setup of volume mounts
+DefaultDependencies=no
+Before=local-fs-pre.target
 
 [Service]
 Type=oneshot
@@ -35,7 +37,7 @@ ExecStart=/usr/local/sbin/dcos_vol_setup.sh /dev/xvdg /dcos/volume0
 ExecStart=/usr/local/sbin/dcos_vol_setup.sh /dev/xvdh /var/log
 
 [Install]
-WantedBy=local-fs.target
+RequiredBy=local-fs-pre.target
 EOF
 systemctl enable dcos_vol_setup
 


### PR DESCRIPTION
## High Level Description

This PR updates the dcos_vol_setup.service dependencies so that it starts as early as possible in the boot sequence. It also simplifies dcos_vol_setup.sh - the systemd manipulations and /var/log migration are no longer necessary now that dcos_vol_setup.service is running early.

Because dcos_vol_setup.service did not include DefaultDependencies=no, it was implicitly running with After=basic.target which is fairly late in the systemd targets. Many other services are started after basic.target - like dockerd and chrony - which in some cases were left in a bad state because file systems were being formatted while the services were initializing.

Coincidentally, dcos_vol_setup was failing prematurely because it was receiving SIGPIPE when trying to write to stdout/stderr when systemd-journald was restarted (https://bugs.freedesktop.org/show_bug.cgi?id=84923). systemd-journald was being restarted in two places:
1. dcos_vol_setup.sh - this PR removes all systemctl usage from dcos_vol_setup.sh
2. cloud-final.service - the userdata generated by `dcos_generate_config.sh --aws-cloudformation` includes a runcmd directive `systemctl restart systemd-journald`:
```#cloud-config
"runcmd":
- - |-
    systemctl
  - |-
    restart
  - |-
    systemd-journald.service
- - |-
...
```

## Related Issues

  - [DCOS_OSS-1043](https://jira.dcos.io/browse/DCOS_OSS-1043) dcos_vol_setup fails to set up /var/log - breaking cronyd and navstar

## Checklist for all PR's

  - [  ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR fixes an intermittent failure that happens early in the boot up of AWS instances and cannot be reproduced at will.
  - [ x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs): I recognize that Before, After, etc are discouraged, but I don't know of another way to ensure early execution of dcos_vol_setup.

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).