### PR TITLE
Adding skip checks flag to the upgrade script

### DIFF
--- a/dcos_installer/upgrade.py
+++ b/dcos_installer/upgrade.py
@@ -34,18 +34,9 @@ node_upgrade_template = """#!/bin/bash
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o pipefail -o nounset
 
 source /opt/mesosphere/environment.export
-
-# bash should trap the ERR signal and run err_report, which prints the line number
-# of failure to STDERR.
-
-err_report() {
-    echo "ERROR: Upgrade failed at line ${BASH_LINENO}"
-} >&2
-
-trap err_report ERR
 
 # Check if this is a terminal, and if colors are supported, set some basic
 # colors for outputs
@@ -58,6 +49,15 @@ if [ -t 1 ]; then
     fi
 fi
 
+SKIP_CHECKS=false
+
+if [[ $# -ne 0 ]]; then
+  if [[ "$1" = "skip-checks" ]]; then
+     echo "Skipping checks"
+     SKIP_CHECKS=true
+  fi
+fi
+
 if [[ $EUID -ne 0 ]]; then
     echo "This script must be run as root" 1>&2
     exit 1
@@ -65,28 +65,28 @@ fi
 
 # check for version of dc/os upgrading from
 found_version=`grep "version" /opt/mesosphere/etc/dcos-version.json | cut -d '"' -f 4`
-if [ "$found_version" != "{{ installed_cluster_version }}" ]; then
+if [[ "$found_version" != "{{ installed_cluster_version }}" ]]; then
     echo "ERROR: Expecting to upgrade DC/OS from {{ installed_cluster_version }} to {{ installer_version }}." \
          "Version found on node: $found_version"
     exit 1
 fi
 
-# Check if the node has node/cluster checks and run them
-if [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
-    # command exists
-    output=$(dcos-diagnostics check node-poststart)
-    if [ $? -ne 0 ]; then
-        echo "Cannot proceed with upgrade, node checks failed"
-        echo $output
-        exit 1
-    fi
+if [[ "$SKIP_CHECKS" = "false" ]]; then
+   # Check if the node has node/cluster checks and run them
+   if [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
+      # command exists
+      if ! output="$(dcos-diagnostics check node-poststart 2>&1)"; then
+          echo "Cannot proceed with upgrade, node checks failed"
+          echo >&2 "$output"
+          exit 1
+      fi
 
-    clusteroutput=$(dcos-diagnostics check cluster)
-    if [ $? -ne 0 ]; then
-        echo "Cannot proceed with upgrade, cluster checks failed"
-        echo $clusteroutput
-        exit 1
-    fi
+      if ! clusteroutput="$(dcos-diagnostics check cluster 2>&1)"; then
+          echo "Cannot proceed with upgrade, cluster checks failed"
+          echo >&2 "$clusteroutput"
+          exit 1
+      fi
+   fi
 fi
 
 # Determine this node's role.
@@ -114,17 +114,19 @@ echo "Upgrading DC/OS $role_name {{ installed_cluster_version }} -> {{ installer
 pkgpanda fetch --repository-url={{ bootstrap_url }} {{ cluster_packages }} > /dev/null
 pkgpanda activate --no-block {{ cluster_packages }} > /dev/null
 
-T=300
-until OUT=$(dcos-diagnostics check node-poststart && dcos-diagnostics check cluster) || [[ T -eq 0 ]]; do
-    sleep 1
-    let T=T-1
-done
-RETCODE=$?
-if [ $RETCODE -ne 0 ]; then
-    echo "Node upgrade not successful, checks failed"
-    echo $OUT
+if [[ "$SKIP_CHECKS" = "false" ]]; then
+    T=300
+    until OUT="$(dcos-diagnostics check node-poststart && dcos-diagnostics check cluster 2>&1)" || [[ $T -eq 0 ]]; do
+      sleep 1
+      let T=T-1
+    done
+    RETCODE=$?
+    if [[ $RETCODE -ne 0 ]]; then
+       echo "Node upgrade not successful, checks failed"
+       echo >&2 "$OUT"
+    fi
+    exit $RETCODE
 fi
-exit $RETCODE
 """
 
 


### PR DESCRIPTION
## High Level Description

Fix error handling for the upgrade script. 
Remove the workaround which we had earlier for trapping error codes, now all the individual statements have the fixes
Add functionality to skip checks

Related changes in the test infra:
https://github.com/dcos/dcos-test-utils/pull/8

## Related Issues
https://jira.mesosphere.com/browse/DCOS-17844 

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
