### PR TITLE
bump navstar for 1.10

### DIFF
--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "c4e9ea6f18f8fa256139a0b66771f1349302ab52",
+      "ref": "dcfb1e1c64ec757ea766668c0a8f3615f5bdc264",
       "ref_origin": "master"
     }
   },


### PR DESCRIPTION
## High Level Description

- Fix inconsistent state error in minuteman

## Related Issues

  - [DCOS_OSS-1472](https://jira.mesosphere.com/browse/DCOS_OSS-1472) Inconsistent state of minuteman

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated        https://github.com/dcos/navstar/compare/c4e9ea6f18f8fa256139a0b66771f1349302ab52...dcfb1e1c64ec757ea766668c0a8f3615f5bdc264
  - [x] Test Results: https://circleci.com/gh/dcos/navstar/459
  - [x] Code Coverage (if available): https://codecov.io/gh/dcos/navstar/pull/91
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
