### PR TITLE
[next beta] Bump dcos-metrics version

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "3fbef2648ad5c3d5bb7850a446cf957c091429b4",
+    "ref": "47994c8da289cd01aba64ec484b927b4520969f3",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This bump allows metrics to attempt to fall back to http after an https call to Mesos state fails (which can happen during disabled->permissive upgrades), and adds task information to the container metrics endpoint in dcos-metrics.

## Related Issues

  - [DCOS_OSS-1542](https://jira.dcos.io/browse/DCOS_OSS-1542) Fall back to HTTP when polling Mesos state in dcos-metrics
  - [DCOS-17813](https://jira.mesosphere.com/browse/DCOS-17813) Include task name as a dimension via dcos-metrics API

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. (DCOS-17813 is fully covered; DCOS_OSS-1542 should have another test added for completeness, but I didn't want to hold this PR up further while we moved things round to accomodate that. There is a ticket to track this [here](https://jira.mesosphere.com/browse/DCOS_OSS-1562))
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-metrics/compare/3fbef2648ad5c3d5bb7850a446cf957c091429b4...47994c8da289cd01aba64ec484b927b4520969f3)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/125/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/125/)