### PR TITLE
Train 205

### DIFF
--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.4.0-12/cosmos-server-0.4.0-12-one-jar.jar",
-    "sha1": "068cf8bee47311a774a949701a85d8cf9979a35e"
+    "url": "https://downloads.dcos.io/cosmos/0.4.1-14/cosmos-server-0.4.1-14-one-jar.jar",
+    "sha1": "61e5b8ac089ee3598941f27d751fa64013fd29c9"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "69815aeeca29f5da76c04e6144705a7d8ce5b2da",
-    "ref_origin": "v1.10.0-rc.4"
+    "ref": "9b25a1c4253f9e48ee58a4341d44ef2167bb484d",
+    "ref_origin": "v1.10.0-rc.5"
   }
 }

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-706-g27c2744.tgz",
-    "sha1" : "655d8777ff71d2c0fd1e1a0032b33313290077dc"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-713-g14280a6.tgz",
+    "sha1" : "95d0ef88237ba14b7cde0f7af52d77d2ed1c5896"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "e4922ff91aecc3ae310af3fcb52f59ad96266337",
-    "ref_origin" : "dcos-mesos-1.4.x-b6413990"
+    "ref": "33240d706765deb857bcc8b0b65b50d302aa17c9",
+    "ref_origin" : "dcos-mesos-1.4.x-e185d805"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
This is train 205 targeted for 1.10 beta2. It includes the following pull requests:

- #1832 (Update cosmos version to 0.4.1)
- #1834 (Bumped the Mesos package to recent 1.4.x.)
- #1835 (Update Marathon to 1.5.0-SNAPSHOT-713-g14280a6)
- #1839 ([next beta]: Bump UI for 1.10)