### PR TITLE
add journald directory ownership/permissions check

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -717,6 +717,11 @@ def calculate_check_config(check_time):
                     'timeout': '1s',
                     'roles': ['agent']
                 },
+                'journald_dir_permissions': {
+                    'description': 'Journald directory has the right owners and permissions',
+                    'cmd': ['/opt/mesosphere/bin/dcos-checks', 'journald'],
+                    'timeout': '1s',
+                },
             },
             'prestart': [],
             'poststart': [
@@ -729,6 +734,7 @@ def calculate_check_config(check_time):
                 'ip_detect_script',
                 'mesos_master_replog_synchronized',
                 'mesos_agent_registered_with_masters',
+                'journald_dir_permissions',
             ],
         },
     }

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-checks.git",
-    "ref": "422e531a6f180495c2569cf7a9ea407e67de4e3a",
+    "ref": "e707916d48efaeff45451ecb7213e07cab86afef",
     "ref_origin": "master"
   },
   "state_directory": true,


### PR DESCRIPTION
## High Level Description

EE DC/OS [PR](https://github.com/mesosphere/dcos-enterprise/pull/1322)

Add a new check command to dcos-checks and node-poststart config to verify the journald directory has the right owner / group and the permission bits are set correctly.

## Related Issues

  - [DCOS_OSS-1362](https://jira.mesosphere.com/browse/DCOS_OSS-1362)
  - [DCOS-16568](https://jira.mesosphere.com/browse/DCOS-16568)
  - [DCOS_OSS-1240](https://jira.mesosphere.com/browse/DCOS_OSS-1240)

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: when a new check added to the config, the cli command `dcos-diagnostics check node-poststart` will invoke all checks from `node-poststart`. The test is already [added](https://github.com/dcos/dcos/blob/master/packages/dcos-integration-test/extra/test_dcos_diagnostics.py#L655-L674).
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-checks](https://github.com/dcos/dcos-checks/compare/422e531a6f180495c2569cf7a9ea407e67de4e3a...e707916d48efaeff45451ecb7213e07cab86afef)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
