### PR TITLE
Bump the Mesos package to include critical backports.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -21,3 +21,23 @@
 <li>[378e209c0e34c955e23505e2fb32b879794cdf8e] Added 'executor_reregister_timeout' agent flag to the tests.
 <li>[815e9dd6620ad1f13d6a326079e9b61c2484294d] Introduced executor reconnect retries on the agent.
 <li>[beb19ab9d6d42ae92e1868094af23f69ad553443] Made the executor driver drop some messages when not connected.
+
+<H3>Critical backports from Mesos 1.1.x and 1.2.x branches</H3>
+<li>[55899ec435a7cae1961c64f275a40d989d1ca8e3] Fixed a crash on the master upon receiving an invalid inverse offer.
+<li>[bead9f592bc3b64b94b6b0019e11be0d200f20bf] Fixed health check bug when running agents with `docker_mesos_image`.
+<li>[4cf39808a8d81e54b69258095e3185493d775544] Fixed the image signature check for Nexus Registry.
+<li>[30d0e46ce0674a31477b804f850ad233287876e2] Fixed docker fetcher 3xx redirect errors by header attached.
+<li>[1a403cce844b4a6ebf0ccee2591aeca0f05e4e99] Fixed provisioner recover blockage by non-existing rootfses dir.
+<li>[6027f2621d1e6a59c1900b0ee56c0b6d417a385a] Don't crash when re-registering executor from an unknown framework.
+<li>[67b6f2a8504277ade2b5e66305a3b3c1bbeaf8ba] Don't crash the agent when an unknown executor re-registers.
+<li>[33de5301fc1f25de8c0e6fa88aa7604b9d088297] Added logging of executor re-registration messages.
+<li>[faede67f2b46636df8c85c23a561743fc85d9e3d] Fixed a crash in libprocess when failing to decode a request path.
+<li>[6ca32629de7e613a8ce208a8423caf4de0868499] Rejected libprocess HTTP requests with empty path.
+<li>[47aa5275fdfb157f35f7ea530fa3c91c1591c4cb] Fixed cherry-pick build error.
+<li>[e1c25310a3ac3aff1e4bf87d2c780bf2e2091c48] Fixed member access issue introduced by a cherry-pick.
+<li>[6d8e86341f87a3bd210a145e7e351cf701355d2b] Preventing agent recovery failing from unsuccessful `docker rm`.
+<li>[5e6f462e2d9ab0acde0834c3a94aa8141037a148] Set the `LIBPROCESS_IP` env variable before starting the fetcher.
+<li>[6413b3ff5340c333959b2266a1a5c98ae4a7adbb] Added logging in docker executor on `docker stop` failure.
+<li>[97d3f4eadced34e03b93bd01e203cd47b480ee36] Enabled retries for `killTask` in docker executor.
+<li>[59e719a82e4739bd7de6de6afce0ec8c8a46be0d] Created staging dir only when needed.
+<li>[0a581996f37d53cd346b4bafd4324ec72b0488aa] Fixed an OOM due to a send loop for SSL sockets.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "beb19ab9d6d42ae92e1868094af23f69ad553443",
+    "ref": "0a581996f37d53cd346b4bafd4324ec72b0488aa",
     "ref_origin" : "dcos-mesos-1.0.4"
   },
   "environment": {


### PR DESCRIPTION
This patch bumps the Mesos package to include critical backports
to the officially unsupported 1.0.x branch: most (not all) critical
bugs and all critical security vulnerabilities fixed in Mesos 1.4.0.

## High Level Description

This PR brings to DC/OS 1.8.x fixes for critical issues that happened after Mesos 1.0.x release had been discontinued. Since DC/OS 1.8.x is still in use, we want to ensure that the bundled Mesos package has all critical updates.

## Related Issues
  - [MESOS-5172](https://issues.apache.org/jira/browse/MESOS-5172) Registry puller cannot fetch blobs correctly from http Redirect 3xx urls.
  - [MESOS-6743](https://issues.apache.org/jira/browse/MESOS-6743) Docker executor hangs forever if `docker stop` fails.
  - [MESOS-6950](https://issues.apache.org/jira/browse/MESOS-6950) Launching two tasks with the same Docker image simultaneously may cause a staging dir never cleaned up.
  - [MESOS-7210](https://issues.apache.org/jira/browse/MESOS-7210) HTTP health check doesn't work when mesos runs with --docker_mesos_image.
  - [MESOS-7350](https://issues.apache.org/jira/browse/MESOS-7350) Failed to pull image from Nexus Registry due to signature missing.
  - [MESOS-7471](https://issues.apache.org/jira/browse/MESOS-7471) Provisioner recover should not always assume 'rootfses' dir exists.
  - [MESOS-7689](https://issues.apache.org/jira/browse/MESOS-7689) Libprocess can crash on malformed request paths for libprocess messages.
  - [MESOS-7690](https://issues.apache.org/jira/browse/MESOS-7690) The agent can crash when an unknown executor tries to register.
  - [MESOS-7119](https://issues.apache.org/jira/browse/MESOS-7119) Mesos master crash while accepting inverse offer.
  - [MESOS-7777](https://issues.apache.org/jira/browse/MESOS-7777) Agent failed to recover due to mount namespace leakage in Docker 1.12/1.13.
  - [MESOS-7796](https://issues.apache.org/jira/browse/MESOS-7796) LIBPROCESS_IP isn't passed on to the fetcher.
  - [MESOS-7934](https://issues.apache.org/jira/browse/MESOS-7934) OOM due to LibeventSSLSocket send incorrectly returning 0 after shutdown.

Requesting @vinodkone and @adam-mesos to review.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. Those fixes are covered by respective Mesos tests, which are sometimes manual, e.g., hanging docker stop simulation issue.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/55899ec435a7cae1961c64f275a40d989d1ca8e3...mesosphere:59e719a82e4739bd7de6de6afce0ec8c8a46be0d)
  - [x] Test Results: `make check` on Mac OS and Fedora 25
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
