### PR TITLE
dcos-mesos-agent: prefer system libraries for exec'd processes

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -473,7 +473,6 @@ package:
       {
         "PATH": "/usr/bin:/bin",
         "SHELL": "/usr/bin/bash",
-        "SASL_PATH": "/opt/mesosphere/lib/sasl2",
         "LIBPROCESS_NUM_WORKER_THREADS": "8"
       }
   - path: /etc/dcos-log.env

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -473,7 +473,6 @@ package:
       {
         "PATH": "/usr/bin:/bin",
         "SHELL": "/usr/bin/bash",
-        "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
         "SASL_PATH": "/opt/mesosphere/lib/sasl2",
         "LIBPROCESS_NUM_WORKER_THREADS": "8"
       }


### PR DESCRIPTION
## High Level Description

Global modification of the linker's path is confusing, and can result in non-DCOS
binaries being linked against DCOS libraries. This has caused breakage in at
least one instance where a system-provided `curl` linked against an interface-
incompatible older `libcurl` provided by DCOS, causing MESOS_HTTP healthchecks
to fail.

This commit mirrors the path started in dcos/dcos#707, but with the addition of
rpath in 27339e3 that change is no longer necessary. Further, we opt to preserve
the SASL_PATH override, even though it suffers similar concerns, because libsasl2
would require special mesos-only configuration at compilation time in order to
provide for mesos' out-of-the-box authentication, and that library is not
currently part of the mesos build flow.

Fixes DCOS_OSS-1302.

## Related Issues

  - [DCOS_OSS-1302](https://jira.mesosphere.com/browse/DCOS_OSS-1302) `MESOS_HTTP` health-checks are not working
  - dcos/dcos#707  

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I'm unsure how to write a test case for this that doesn't require a fully running system – if someone could provide a pointer or two, I'd be glad to do so!
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


cc @rukletsov @bmahler 
h/t to @rukletsov for pointing me to the right configuration file