### PR TITLE
Bump Marathon to 1.4.7.

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.6/marathon-1.4.6.tgz",
-    "sha1": "2cf376dd77618a2c9a373fb0ddfba90339fb25ea"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.7/marathon-1.4.7.tgz",
+    "sha1": "0f627797dabf8f30dba9217a7bccd56269e6b789"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

## Related Issues

* [MARATHON-7715](https://jira.mesosphere.com/browse/MARATHON-7715) - Marathon would not notice an unreachable / lost resident task was gone, or that a reservation should be released, unless if it was idle. This is has been resolved.
* [MARATHON-1703](https://jira.mesosphere.com/browse/MARATHON-1703) - Resident task instance placement now properly respects constraints which rely on the placement state of instance peers (such as hostname:UNIQUE).
* [MARATHON-7707](https://jira.mesosphere.com/browse/MARATHON-7707) - Resident task instance agentId and host name values are now properly updated on re-launch.
* [MARATHON-7654](https://jira.mesosphere.com/browse/MARATHON-7654) - Marathon resident task re-launch requests are no longer denied by Mesos for having the same id as another unreachable task (because Marathon no longer re-uses task ids).

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [1.4.6 to 1.4.7](https://github.com/mesosphere/marathon/commit/2dd635d168ac68c03e36917f4d837ca9670e2a30)
  - [x] Test Results: [Jenkins](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.4/73/)
  - [ ] Code Coverage (if available): [link to code coverage report]
