### PR TITLE
Admin Router: Substitute `JWT` with "DC/OS authentication token" in Admin Router docs and docstrings

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -473,10 +473,10 @@ be reachable only in their relative location
 
 ## Authorization and authentication
 
-DC/OS uses JWT at the core of its authentication and authorization features and
-Admin Router performs a vital role in facilitating it. Lots of services which
-constitute DC/OS do not have their own authorizers and rely on Admin Router to
-provide them with authn/authn+authz enforcement.
+DC/OS uses DC/OS authentication token at the core of its authentication and
+authorization features and Admin Router performs a vital role in facilitating
+it. Lots of services which constitute DC/OS do not have their own authorizers
+and rely on Admin Router to provide them with authn/authn+authz enforcement.
 
 Authn and authz code differs considerably between Open Source and Enterprise
 versions of Admin Router. This documentation focuses on describing common and
@@ -486,13 +486,15 @@ README.md in EE Admin Router repository.
 ### Authentication
 
 For Admin Router to establish the identity of the subject issuing a request, it
-looks for JWT in the request. It may be present in the following places:
+looks for DC/OS authentication token in the request. It may be present in the
+following places:
 * request headers: client needs to set `Authorization` header with
   `token=<token payload>` value.
 * client sets `dcos-acs-auth-cookie` cookie with the token payload as a value
 
 In the case when both request header and the cookie is set, request header
-token takes priority. Admin Router does not issue JWT itself as this is
+token takes priority. Admin Router does not issue DC/OS authentication token
+itself as this is
 the task of the IAM service. Please consult DC/OS documentation for more
 details.
 
@@ -500,8 +502,8 @@ Currently, DC/OS uses/sets the following mandatory claims:
 * `uid` which is ID of the user/subject making the request as defined in IAM
 * `exp` claim as defined in section 4.1.4 of RFC7519
 
-If the JWT signature is valid and token has not expired, then uid claim is used
-while communicating with IAM to make authz decisions.
+If the DC/OS authentication token signature is valid and token has not expired,
+then uid claim is used while communicating with IAM to make authz decisions.
 
 The way tokens are validated is shared between EE and Open, with the only
 difference being the signing algorithm used by the tokens. In case of Open it's
@@ -514,9 +516,10 @@ that is required to finish the authn.
 ### Authorization
 
 Open Source Admin Router performs authorization basing on the sole fact that
-user identity was transferred to Open Source IAM. This is done in by checking if
-the user with given `uid` extracted from JWT claim is present and active in the
-IAM using the `do_authn_and_authz_or_exit` LUA auth module method.
+user identity was transferred to Open Source IAM. This is done in by checking
+if the user with given `uid` extracted from DC/OS authentication token claim is
+present and active in the IAM using the `do_authn_and_authz_or_exit` LUA auth
+module method.
 
 ### Parameter-less interface
 
@@ -644,9 +647,9 @@ hostnames used in the upstream definitions. In Admin Router, we use
 [a workaround](https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/)
 to overcome this limitation, so that hostnames used in
 [`proxy_pass`](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
-configuration directives are guaranteed to be re-resolved periodically, either according to
-the TTL emitted by the DNS server or, if given, according to the `valid=`
-argument of the
+configuration directives are guaranteed to be re-resolved periodically, either
+according to the TTL emitted by the DNS server or, if given, according to the
+`valid=` argument of the
 [resolver](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver)
 configuration.
 
@@ -747,7 +750,7 @@ cleanup and the cleanup ordering itself.
 Tracking the chain of fixtures and how they use each other may provide better
 understanding of how the test harness works.
 
-### JWT
+### DC/OS authentication token
 The DC/OS IAM relies on JSON Web Tokens (JWTs) for transmitting authentication
 data between DC/OS components. Open repository flavour uses JWTs of type HS256,
 while EE relies on JWTs of type RS256. Test harness needs to have a way to
@@ -834,7 +837,7 @@ endpoint_tests:
         test_paths:
           - /exhibitor/foo/bar
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /exhibitor/foo/bar
       is_upstream_correct:
@@ -905,14 +908,14 @@ The syntax is as follows:
       * Response code is 200.
       * Standard set of headers is present in the request to the upstream (
         `X-Forwarded-For`, `X-Forwarded-Proto`, `X-Real-IP`).
-      * Depending on the value of `jwt_should_be_forwarded` parameter:
+      * Depending on the value of `auth_token_is_forwarded` parameter:
         * `true` - The `Authorization` header is present in the upstream
           request.
         * `false` - The `Authorization` header is absent in the upstream
           request.
         * `skip` - The presence of the `Authorization` header is not checked.
     * Supports the following parameters:
-      * `jwt_should_be_forwarded` - see above.
+      * `auth_token_is_forwarded` - see above.
       * `test_paths` - list of AR locations that should be tested.
   * `is_upstream_correct`
     * Calls `generic_correct_upstream_dest_test` generic test underneath.
@@ -1303,13 +1306,13 @@ Steps are as follows:
   * `X-Forwarded-For`
   * `X-Forwarded-Proto`
 
-  On top of that, our SchmetterlingDB does not need a JWT, so it is going to be
-  more secure if we do not pass it in upstream request. Generic test to confirm
-  this behaviour:
+  On top of that, our SchmetterlingDB does not need a DC/OS authentication
+  token, so it is going to be more secure if we do not pass it in upstream
+  request. Generic test to confirm this behaviour:
   ```
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: false
+        auth_token_is_forwarded: false
         test_paths:
           - /schmetterlingdb/stats/foo/bar
           - /schmetterlingdb/foo/bar
@@ -1487,7 +1490,7 @@ To sum up, our test configuration should look as follows:
       - master
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: false
+        auth_token_is_forwarded: false
         test_paths:
           - /schmetterlingdb/stats/foo/bar
           - /schmetterlingdb/foo/bar
@@ -1547,7 +1550,7 @@ which can be simplified into:
           - path: /schmetterlingdb
             code: 307
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: false
+        auth_token_is_forwarded: false
         test_paths:
           - /schmetterlingdb/stats/foo/bar
           - /schmetterlingdb/foo/bar
@@ -1746,7 +1749,8 @@ The test can be split into a series of steps/stages:
   # pull in all the necessary mocks into the scope:
   # * nginx_class - AR class. Automatically adjusted to repository flavour.
   # * dns_server_mock - programmable DNS server
-  # * valid_user_header - JWT that will be accepted by AR authn/authz code
+  # * valid_user_header - DC/OS authentication token that will be accepted by
+  #   AR authn/authz code
   def test_if_temp_dns_borkage_does_not_disrupt_mesosleader_caching(
           self, nginx_class, dns_server_mock, valid_user_header):
       # Let's try to put all non-essential stuff outside of context managers

--- a/packages/adminrouter/extra/src/lib/auth/common.lua
+++ b/packages/adminrouter/extra/src/lib/auth/common.lua
@@ -118,7 +118,7 @@ local function validate_jwt(secret_key)
         return nil, 401
     end
 
-    ngx.log(ngx.NOTICE, "UID from valid JWT: `".. uid .. "`")
+    ngx.log(ngx.NOTICE, "DC/OS authentication token: `".. uid .. "`")
     return uid, nil
 end
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -27,8 +27,8 @@ def ping_mesos_agent(ar,
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is invalid.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is invalid.
         expect_status (int): HTTP status to expect
         endpoint_id (str): if expect_status==200 - id of the endpoint that
             should respoind to the request
@@ -74,8 +74,9 @@ def generic_response_headers_verify_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         assert_headers (dict): additional headers to test where key is the
             asserted header name and value is expected value
@@ -106,8 +107,9 @@ def generic_upstream_headers_verify_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         assert_headers (dict): additional headers to test where key is the
             asserted header name and value is expected value
@@ -143,8 +145,9 @@ def generic_correct_upstream_dest_test(ar, auth_header, path, endpoint_id):
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         path (str): path for which request should be made
         endpoint_id (str): id of the endpoint where the upstream request should
             have been sent
@@ -168,8 +171,9 @@ def generic_correct_upstream_request_test(
 
     Arguments:
         ar: Admin Router object, an instance of runner.(ee|open).Nginx
-        auth_header (dict): headers dict that contains JWT. The auth data it
-            contains is valid and the request should be accepted.
+        auth_header (dict): headers dict that contains DC/OS authentication
+            token. The auth data it contains is valid and the request should be
+            accepted.
         given_path (str): path for which request should be made
         expected_path (str): path that is expected to be sent to upstream
         http_ver (str): http version string that the upstream request should be
@@ -223,7 +227,7 @@ def generic_location_header_during_redirect_is_adjusted_test(
         mocker (Mocker): instance of the Mocker class, used for controlling
             upstream HTTP endpoint/mock
         ar: Admin Router object, an instance of `runner.(ee|open).Nginx`.
-        auth_header (dict): headers dict that contains JWT.
+        auth_header (dict): headers dict that contains DC/OS authentication token.
         endpoint_id (str): id of the endpoint where the upstream request should
             have been sent.
         basepath (str): the URI used by the test harness to issue the request

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -141,8 +141,8 @@ def _verify_is_upstream_req_ok_test_conf(t_config):
 
 
 def _verify_are_upstream_req_headers_ok(t_config):
-    assert 'jwt_should_be_forwarded' in t_config
-    assert t_config['jwt_should_be_forwarded'] in [True, False, 'skip']
+    assert 'auth_token_is_forwarded' in t_config
+    assert t_config['auth_token_is_forwarded'] in [True, False, 'skip']
 
     assert 'test_paths' in t_config
     for p in t_config['test_paths']:
@@ -224,7 +224,7 @@ def _testdata_to_are_upstream_req_headers_ok_testdata(tests_config, node_type):
         h = x['tests']['are_upstream_req_headers_ok']
 
         for p in h['test_paths']:
-            e = (p, h['jwt_should_be_forwarded'])
+            e = (p, h['auth_token_is_forwarded'])
             res.append(e)
 
     return res

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_auth.py
@@ -26,7 +26,7 @@ class TestAuthzIAMBackendQuery:
             )
 
         log_messages = {
-            'UID from valid JWT: `bozydar`': SearchCriteria(1, True),
+            'DC/OS authentication token: `bozydar`': SearchCriteria(1, True),
             "Unexpected response from IAM: ":
                 SearchCriteria(1, True),
             }

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -25,7 +25,7 @@ endpoint_tests:
         locations:
           - /acs/api/v1/auth/reflect/me
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /acs/api/v1/auth/reflect/me
       is_upstream_correct:
@@ -45,7 +45,7 @@ endpoint_tests:
         locations:
           - /dcos-metadata/ui-config.json
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /dcos-metadata/ui-config.json
       is_upstream_correct:

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -89,7 +89,7 @@ class TestAuthnJWTValidator:
             "No auth token in request.": SearchCriteria(0, True),
             "Invalid token. Reason: invalid jwt string":
                 SearchCriteria(0, True),
-            "UID from valid JWT: `test`": SearchCriteria(1, True),
+            "DC/OS authentication token: `test`": SearchCriteria(1, True),
             }
 
         token = jwt_generator(uid='test')
@@ -103,7 +103,7 @@ class TestAuthnJWTValidator:
 
     def test_valid_auth_token(self, master_ar_process_perclass, valid_user_header):
         log_messages = {
-            "UID from valid JWT: `bozydar`": SearchCriteria(1, True),
+            "DC/OS authentication token: `bozydar`": SearchCriteria(1, True),
             }
         assert_endpoint_response(
             master_ar_process_perclass,
@@ -120,8 +120,8 @@ class TestAuthnJWTValidator:
             jwt_generator,
             ):
         log_messages = {
-            "UID from valid JWT: `bozydar`": SearchCriteria(1, True),
-            "UID from valid JWT: `test`": SearchCriteria(0, True),
+            "DC/OS authentication token: `bozydar`": SearchCriteria(1, True),
+            "DC/OS authentication token: `test`": SearchCriteria(0, True),
             }
 
         token = jwt_generator(uid='test')

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -2,7 +2,7 @@ endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /exhibitor/foo/bar
       is_upstream_correct:
@@ -37,7 +37,7 @@ endpoint_tests:
 ######### /service endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
       is_upstream_correct:
@@ -192,7 +192,7 @@ endpoint_tests:
 ######### /agent endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
           - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
@@ -226,7 +226,7 @@ endpoint_tests:
 ######### /system/health/ endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/health/v1/foo/bar
       # Check Open/EE config for this test:
@@ -247,7 +247,7 @@ endpoint_tests:
 # Agent A
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/foo/bar?key=value&var=num
@@ -280,7 +280,7 @@ endpoint_tests:
 # Agent B
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs/foo/bar?key=value&var=num
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0/foo/bar?key=value&var=num
@@ -314,7 +314,7 @@ endpoint_tests:
 ######### /system/v1/leader endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
           - /system/v1/leader/marathon/foo/bar?key=value&var=num
@@ -348,7 +348,7 @@ endpoint_tests:
 ######### /system/v1/logs endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/logs/foo/bar
       is_upstream_correct:
@@ -374,7 +374,7 @@ endpoint_tests:
 ######### /cosmos/service
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /cosmos/service/foo/bar
       is_upstream_correct:
@@ -395,7 +395,7 @@ endpoint_tests:
 ######### /capabilities
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /capabilities
       is_upstream_correct:
@@ -417,7 +417,7 @@ endpoint_tests:
         test_paths:
           - /acs/api/v1/reflect/me
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /acs/api/v1/reflect/me
       is_upstream_correct:
@@ -435,7 +435,7 @@ endpoint_tests:
 ######### /package
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /package/foo/bar
       is_upstream_correct:
@@ -455,7 +455,7 @@ endpoint_tests:
 ######### /navstar/lashup/key
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /navstar/lashup/key
       is_upstream_correct:
@@ -473,7 +473,7 @@ endpoint_tests:
 ######### /dcos-history-service/foo/bar
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /dcos-history-service/foo/bar
       is_upstream_correct:
@@ -491,7 +491,7 @@ endpoint_tests:
 ######### /mesos_dns
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: false
+        auth_token_is_forwarded: false
         test_paths:
           - /mesos_dns/v1/reflect/me
       is_upstream_correct:
@@ -513,7 +513,7 @@ endpoint_tests:
 ######### /mesos
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /mesos/reflect/me
       is_upstream_correct:
@@ -535,7 +535,7 @@ endpoint_tests:
 ######### /pkgpanda
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /pkgpanda/foo/bar
       is_upstream_correct:
@@ -588,7 +588,7 @@ endpoint_tests:
 ######### /system/v1/metrics endpoint
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: skip
+        auth_token_is_forwarded: skip
         test_paths:
           - /system/v1/metrics/foo/bar
       is_upstream_req_ok:
@@ -624,7 +624,7 @@ endpoint_tests:
 ######### /marathon
   - tests:
       are_upstream_req_headers_ok:
-        jwt_should_be_forwarded: true
+        auth_token_is_forwarded: true
         test_paths:
           - /marathon/
           - /marathon/v2/reflect/me


### PR DESCRIPTION
## High Level Description

Please check the Jira issue for details.

## Related Issues

 - https://jira.mesosphere.com/browse/DCOS_OSS-1572 `Admin Router: Replace JWT with `DC/OS authentication token` in AR docs`

## Related PRs:
EE DC/OS PR: 