### PR TITLE
Bumped Mesos to include health check logging improvements.

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -6,3 +6,8 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[098743933a99925cfccb19f132393fa9f236c31e] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6] Revert "Fixed the broken metrics information of master in WebUI."
 <li>[17979fea307b7c094c2bac8e5a3f25af33208a0c] Updated mesos containerizer to ignore GPU isolator creation failure.
+
+<h2>Patches to cherry-pick on top of Mesos 1.4.0-rc1 only</h2>
+<li>[2f3a182d91952f0db30883acda0ef222affa6477] Included nested command check output in the executor logs.
+<li>[86ee162326172bffcf7f264c5e46ce3d155c1636] Made the log output handling of TCP and HTTP checks consistent.
+<li>[b0fd885dbf02a61b5635184df19905695b4bba96] Raised the logging level of some check and health check messages.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "33240d706765deb857bcc8b0b65b50d302aa17c9",
-    "ref_origin" : "dcos-mesos-1.4.x-e185d805"
+    "ref": "b0fd885dbf02a61b5635184df19905695b4bba96",
+    "ref_origin" : "dcos-mesos-1.4.0-rc1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

This PR is meant to be merged after pull/1855. It incorporates three additional commits into the Mesos package which update the logging of Mesos checks/health checks.

## Related Issues

  - [MESOS-7861](https://issues.apache.org/jira/browse/MESOS-7861) Include check output in the DefaultExecutor log

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The changes included here only change logging output of the Mesos default executor; we believe new tests are not necessary for this update.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff compared to pull/1855](https://github.com/mesosphere/mesos/compare/c98337b635d81de324e093402b7545011778eeb7...b0fd885dbf02a61b5635184df19905695b4bba96)
  - [x] Test Results: [Mesos CI results](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1613/)
  - [ ] Code Coverage (if available): [link to code coverage report]