### PR TITLE
gen: validate telemetry is enabled for all beta releases

### DIFF
--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -206,7 +206,7 @@ azure_dcos_source = Source({
 azure_acs_source = Source({
     'must': {
         'ui_tracking': 'false',
-        'telemetry_enabled': 'false',
+        'telemetry_enabled': 'true',
         'exhibitor_azure_prefix': Late("[[[variables('masterPublicIPAddressName')]]]"),
         'exhibitor_azure_account_name': Late("[[[variables('masterStorageAccountExhibitorName')]]]"),
         'exhibitor_azure_account_key': Late(

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -835,6 +835,12 @@ def validate_custom_checks(custom_checks, check_config):
         raise AssertionError(msg)
 
 
+def validate_telemetry_enabled(telemetry_enabled, dcos_version):
+    validate_true_false(telemetry_enabled)
+    if 'beta' in dcos_version and telemetry_enabled == 'false':
+        raise AssertionError("telemetry_enabled must be true for all beta releases")
+
+
 __dcos_overlay_network_default_name = 'dcos'
 
 
@@ -857,7 +863,7 @@ entry = {
         validate_mesos_dns_ip_sources,
         lambda mesos_dns_set_truncate_bit: validate_true_false(mesos_dns_set_truncate_bit),
         validate_mesos_log_retention_mb,
-        lambda telemetry_enabled: validate_true_false(telemetry_enabled),
+        validate_telemetry_enabled,
         lambda master_dns_bindall: validate_true_false(master_dns_bindall),
         validate_os_type,
         validate_dcos_overlay_network,

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -29,9 +29,9 @@ def validate_error_multikey(new_arguments, keys, message, unset=None):
 
 def test_invalid_telemetry_enabled():
     err_msg = "Must be one of 'true', 'false'. Got 'foo'."
-    validate_error(
+    validate_error_multikey(
         {'telemetry_enabled': 'foo'},
-        'telemetry_enabled',
+        ['telemetry_enabled', 'dcos_version'],
         err_msg)
 
 


### PR DESCRIPTION
## High Level Description

The config validation requires telemetry to be enabled by default for all DC/OS beta releases.

## Related Issues

  - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
