### PR TITLE
Bump 1.9 api links to 1.10

### DIFF
--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -562,7 +562,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/component-management/">https://dcos.io/docs/1.9/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -618,7 +618,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -663,7 +663,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/logging/logging-api/">https://dcos.io/docs/1.9/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -708,7 +708,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -562,7 +562,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -618,7 +618,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -663,7 +663,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -708,7 +708,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -4,19 +4,19 @@ backends:
     server: 'unix:/run/dcos/dcos-diagnostics.sock'
     name: DC/OS Diagnostics
     reference: >-
-      https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+      https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.9/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/administration/logging/logging-api/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-agent.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/'
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.9/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administration/component-management/'
 routes:
   /dcos-metadata/dcos-version.json:
     group: Metadata

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -3,20 +3,19 @@ backends:
   dcos_diagnostics:
     server: 'unix:/run/dcos/dcos-diagnostics.sock'
     name: DC/OS Diagnostics
-    reference: >-
-      https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
+    reference: 'https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint'
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.10/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/monitoring/logging/logging-api/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-agent.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/metrics/metrics-api/'
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.10/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
   /dcos-metadata/dcos-version.json:
     group: Metadata

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -651,7 +651,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -696,7 +696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1278,7 +1278,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
                 </td>
               </tr>
             </table>
@@ -1376,7 +1376,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1499,7 +1499,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
                 </td>
               </tr>
             </table>
@@ -1587,7 +1587,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/component-management/">https://dcos.io/docs/1.9/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -1696,7 +1696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -1846,7 +1846,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/logging/logging-api/">https://dcos.io/docs/1.9/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -1891,7 +1891,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -651,7 +651,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -696,7 +696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1278,7 +1278,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -1376,7 +1376,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1499,7 +1499,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -1587,7 +1587,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/component-management/">https://dcos.io/docs/1.10/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -1696,7 +1696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -1846,7 +1846,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/logging/logging-api/">https://dcos.io/docs/1.10/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -1891,7 +1891,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -3,8 +3,7 @@ backends:
   dcos_diagnostics:
     server: '127.0.0.1:1050'
     name: DC/OS Diagnostics
-    reference: >-
-      https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
+    reference: 'https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint'
   exhibitor:
     server: '127.0.0.1:8181'
     name: Exhibitor (Zookeeper)
@@ -12,26 +11,26 @@ backends:
   iam:
     server: '127.0.0.1:8101'
     name: DC/OS Authentication (OAuth)
-    reference: 'https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/'
+    reference: 'https://dcos.io/docs/1.10/security/iam-api/'
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.10/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/monitoring/logging/logging-api/'
   mesos_dns:
     server: '127.0.0.1:8123'
     name: Mesos DNS
-    reference: 'https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/'
+    reference: 'https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-master.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/metrics/metrics-api/'
   navstar:
     server: '127.0.0.1:62080'
     name: Navstar
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.10/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
   /:
     group: Root

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -4,7 +4,7 @@ backends:
     server: '127.0.0.1:1050'
     name: DC/OS Diagnostics
     reference: >-
-      https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+      https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
   exhibitor:
     server: '127.0.0.1:8181'
     name: Exhibitor (Zookeeper)
@@ -12,26 +12,26 @@ backends:
   iam:
     server: '127.0.0.1:8101'
     name: DC/OS Authentication (OAuth)
-    reference: 'https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/'
+    reference: 'https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/'
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.9/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/administration/logging/logging-api/'
   mesos_dns:
     server: '127.0.0.1:8123'
     name: Mesos DNS
-    reference: 'https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/'
+    reference: 'https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-master.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/'
   navstar:
     server: '127.0.0.1:62080'
     name: Navstar
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.9/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administration/component-management/'
 routes:
   /:
     group: Root

--- a/packages/adminrouter/extra/src/includes/http/agent.conf
+++ b/packages/adminrouter/extra/src/includes/http/agent.conf
@@ -7,13 +7,13 @@ resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 lua_shared_dict tmp 12k;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server unix:/run/dcos/dcos-diagnostics.sock;
 }
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-agent.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/agent.conf
+++ b/packages/adminrouter/extra/src/includes/http/agent.conf
@@ -7,13 +7,13 @@ resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 lua_shared_dict tmp 12k;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server unix:/run/dcos/dcos-diagnostics.sock;
 }
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-agent.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -8,13 +8,13 @@ keepalive_timeout 65;
 lua_package_path '$prefix/conf/lib/?.lua;;';
 
 # Name: DC/OS Component Package Manager (Pkgpanda)
-# Reference: https://dcos.io/docs/1.9/administration/component-management/
+# Reference: https://dcos.io/docs/1.10/administration/component-management/
 upstream pkgpanda {
     server unix:/run/dcos/pkgpanda-api.sock;
 }
 
 # Name: DC/OS Log
-# Reference: https://dcos.io/docs/1.9/administration/logging/logging-api/
+# Reference: https://dcos.io/docs/1.10/administration/logging/logging-api/
 upstream log {
     server unix:/run/dcos/dcos-log.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -8,13 +8,13 @@ keepalive_timeout 65;
 lua_package_path '$prefix/conf/lib/?.lua;;';
 
 # Name: DC/OS Component Package Manager (Pkgpanda)
-# Reference: https://dcos.io/docs/1.10/administration/component-management/
+# Reference: https://dcos.io/docs/1.10/administering-clusters/component-management/
 upstream pkgpanda {
     server unix:/run/dcos/pkgpanda-api.sock;
 }
 
 # Name: DC/OS Log
-# Reference: https://dcos.io/docs/1.10/administration/logging/logging-api/
+# Reference: https://dcos.io/docs/1.10/monitoring/logging/logging-api/
 upstream log {
     server unix:/run/dcos/dcos-log.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/master.conf
@@ -27,13 +27,13 @@ init_worker_by_lua '
 ';
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-master.sock;
 }
 
 # Name: Mesos DNS
-# Reference: https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/
+# Reference: https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/
 upstream mesos_dns {
     server 127.0.0.1:8123;
 }

--- a/packages/adminrouter/extra/src/includes/http/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/master.conf
@@ -27,13 +27,13 @@ init_worker_by_lua '
 ';
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/administration/monitoring/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-master.sock;
 }
 
 # Name: Mesos DNS
-# Reference: https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/
+# Reference: https://dcos.io/docs/1.10/usage/service-discovery/mesos-dns/http-interface/
 upstream mesos_dns {
     server 127.0.0.1:8123;
 }

--- a/packages/adminrouter/extra/src/includes/http/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/open/master.conf
@@ -1,13 +1,13 @@
 proxy_cache_path /tmp/nginx-mesos-cache levels=1:2 keys_zone=mesos:1m inactive=10m;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server 127.0.0.1:1050;
 }
 
 # Name: DC/OS Authentication (OAuth)
-# Reference: https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/
+# Reference: https://dcos.io/docs/1.10/security/iam-api/
 upstream iam {
     server 127.0.0.1:8101;
 }

--- a/packages/adminrouter/extra/src/includes/http/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/open/master.conf
@@ -1,13 +1,13 @@
 proxy_cache_path /tmp/nginx-mesos-cache levels=1:2 keys_zone=mesos:1m inactive=10m;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/administration/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server 127.0.0.1:1050;
 }
 
 # Name: DC/OS Authentication (OAuth)
-# Reference: https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/
+# Reference: https://dcos.io/docs/1.10/administration/id-and-access-mgt/iam-api/
 upstream iam {
     server 127.0.0.1:8101;
 }


### PR DESCRIPTION
## High Level Description

API docs need to point to the right place for 1.10.

@vespian who else should review this minor change?

JIRA: https://jira.mesosphere.com/browse/DCOS-18244