### PR TITLE
[1.10] Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "47994c8da289cd01aba64ec484b927b4520969f3",
+    "ref": "c93051702b7710d9e56340eff0fab02e45d2a9b7",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This is a metrics bump PR. It includes a workaround for an issue which meant that nested app metrics were not discoverable. 

## Related Issues

  - [DCOS-18195](https://jira.mesosphere.com/browse/DCOS-18195) Nested container IDs don't appear in dcos-metrics /containers endpoint

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-metrics/compare/47994c8da289cd01aba64ec484b927b4520969f3...c93051702b7710d9e56340eff0fab02e45d2a9b7)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-metrics%2Fpublic-dcos-metrics-master/detail/public-dcos-metrics-master/126/tests)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/126/cobertura/)