### PR TITLE
Install jq because it is useful to have as an essential tool

### DIFF
--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -21,6 +21,7 @@ echo -e "\nUseDNS no" >> /etc/ssh/sshd_config
 
 echo ">>> Installing DC/OS dependencies and essential packages"
 yum -y --tolerant install perl tar xz unzip curl bind-utils net-tools ipset libtool-ltdl rsync nfs-utils
+curl -L -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x ./jq && mv ./jq /usr/bin
 
 echo ">>> Set up filesystem mounts"
 cat << 'EOF' > /etc/systemd/system/dcos_vol_setup.service


### PR DESCRIPTION
jq is a useful tool to have on all nodes because:
1. It is a useful companion for the dcos-cli tool
2. It is required by the dcos-postflight script from the dcos-docker project that you maybe want to run on your cloud instances during cluster deployment.