### PR TITLE
[1.10] Train 211

### DIFF
--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -562,7 +562,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/component-management/">https://dcos.io/docs/1.9/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -618,7 +618,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -663,7 +663,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/logging/logging-api/">https://dcos.io/docs/1.9/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -708,7 +708,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -3,20 +3,19 @@ backends:
   dcos_diagnostics:
     server: 'unix:/run/dcos/dcos-diagnostics.sock'
     name: DC/OS Diagnostics
-    reference: >-
-      https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+    reference: 'https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint'
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.9/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/monitoring/logging/logging-api/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-agent.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/metrics/metrics-api/'
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.9/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
   /dcos-metadata/dcos-version.json:
     group: Metadata

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -651,7 +651,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -696,7 +696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1278,7 +1278,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -1376,7 +1376,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/">https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/</a>
+                  <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
                 </td>
               </tr>
             </table>
@@ -1499,7 +1499,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/">https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/</a>
+                  <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
                 </td>
               </tr>
             </table>
@@ -1587,7 +1587,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/component-management/">https://dcos.io/docs/1.9/administration/component-management/</a>
+                  <a href="https://dcos.io/docs/1.10/administering-clusters/component-management/">https://dcos.io/docs/1.10/administering-clusters/component-management/</a>
                 </td>
               </tr>
             </table>
@@ -1696,7 +1696,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint">https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint</a>
                 </td>
               </tr>
             </table>
@@ -1846,7 +1846,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/logging/logging-api/">https://dcos.io/docs/1.9/administration/logging/logging-api/</a>
+                  <a href="https://dcos.io/docs/1.10/monitoring/logging/logging-api/">https://dcos.io/docs/1.10/monitoring/logging/logging-api/</a>
                 </td>
               </tr>
             </table>
@@ -1891,7 +1891,7 @@
                   API Reference:
                 </td>
                 <td>
-                  <a href="https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/">https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/</a>
+                  <a href="https://dcos.io/docs/1.10/metrics/metrics-api/">https://dcos.io/docs/1.10/metrics/metrics-api/</a>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -3,8 +3,7 @@ backends:
   dcos_diagnostics:
     server: '127.0.0.1:1050'
     name: DC/OS Diagnostics
-    reference: >-
-      https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+    reference: 'https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint'
   exhibitor:
     server: '127.0.0.1:8181'
     name: Exhibitor (Zookeeper)
@@ -12,26 +11,26 @@ backends:
   iam:
     server: '127.0.0.1:8101'
     name: DC/OS Authentication (OAuth)
-    reference: 'https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/'
+    reference: 'https://dcos.io/docs/1.10/security/iam-api/'
   log:
     server: 'unix:/run/dcos/dcos-log.sock'
     name: DC/OS Log
-    reference: 'https://dcos.io/docs/1.9/administration/logging/logging-api/'
+    reference: 'https://dcos.io/docs/1.10/monitoring/logging/logging-api/'
   mesos_dns:
     server: '127.0.0.1:8123'
     name: Mesos DNS
-    reference: 'https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/'
+    reference: 'https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/'
   metrics:
     server: 'unix:/run/dcos/dcos-metrics-master.sock'
     name: DC/OS Metrics
-    reference: 'https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/'
+    reference: 'https://dcos.io/docs/1.10/metrics/metrics-api/'
   navstar:
     server: '127.0.0.1:62080'
     name: Navstar
   pkgpanda:
     server: 'unix:/run/dcos/pkgpanda-api.sock'
     name: DC/OS Component Package Manager (Pkgpanda)
-    reference: 'https://dcos.io/docs/1.9/administration/component-management/'
+    reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
   /:
     group: Root

--- a/packages/adminrouter/extra/src/includes/http/agent.conf
+++ b/packages/adminrouter/extra/src/includes/http/agent.conf
@@ -7,13 +7,13 @@ resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 lua_shared_dict tmp 12k;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server unix:/run/dcos/dcos-diagnostics.sock;
 }
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-agent.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -8,13 +8,13 @@ keepalive_timeout 65;
 lua_package_path '$prefix/conf/lib/?.lua;;';
 
 # Name: DC/OS Component Package Manager (Pkgpanda)
-# Reference: https://dcos.io/docs/1.9/administration/component-management/
+# Reference: https://dcos.io/docs/1.10/administering-clusters/component-management/
 upstream pkgpanda {
     server unix:/run/dcos/pkgpanda-api.sock;
 }
 
 # Name: DC/OS Log
-# Reference: https://dcos.io/docs/1.9/administration/logging/logging-api/
+# Reference: https://dcos.io/docs/1.10/monitoring/logging/logging-api/
 upstream log {
     server unix:/run/dcos/dcos-log.sock;
 }

--- a/packages/adminrouter/extra/src/includes/http/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/master.conf
@@ -27,13 +27,13 @@ init_worker_by_lua '
 ';
 
 # Name: DC/OS Metrics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/metrics/metrics-api/
+# Reference: https://dcos.io/docs/1.10/metrics/metrics-api/
 upstream metrics {
     server unix:/run/dcos/dcos-metrics-master.sock;
 }
 
 # Name: Mesos DNS
-# Reference: https://dcos.io/docs/1.9/usage/service-discovery/mesos-dns/http-interface/
+# Reference: https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/
 upstream mesos_dns {
     server 127.0.0.1:8123;
 }

--- a/packages/adminrouter/extra/src/includes/http/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/http/open/master.conf
@@ -1,13 +1,13 @@
 proxy_cache_path /tmp/nginx-mesos-cache levels=1:2 keys_zone=mesos:1m inactive=10m;
 
 # Name: DC/OS Diagnostics
-# Reference: https://dcos.io/docs/1.9/administration/monitoring/#system-health-http-api-endpoint
+# Reference: https://dcos.io/docs/1.10/monitoring/#system-health-http-api-endpoint
 upstream dcos_diagnostics {
     server 127.0.0.1:1050;
 }
 
 # Name: DC/OS Authentication (OAuth)
-# Reference: https://dcos.io/docs/1.9/administration/id-and-access-mgt/iam-api/
+# Reference: https://dcos.io/docs/1.10/security/iam-api/
 upstream iam {
     server 127.0.0.1:8101;
 }

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -30,7 +30,7 @@ def lb_enabled():
 
 
 @retrying.retry(wait_fixed=2000,
-                stop_max_delay=1200 * 1000,
+                stop_max_delay=5 * 60 * 1000,
                 retry_on_result=lambda ret: ret is None)
 def ensure_routable(cmd, host, port):
     proxy_uri = 'http://{}:{}/run_cmd'.format(host, port)
@@ -68,22 +68,25 @@ def vip_app(container: marathon.Container, network: marathon.Network, host: str,
 def generate_vip_app_permutations():
     """ Generate all possible network interface permutations for applying vips
     """
-    network_options = [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
-    permutations = []
-    for container in [marathon.Container.NONE, marathon.Container.MESOS, marathon.Container.DOCKER]:
-        for vip_net in network_options:
-            for proxy_net in network_options:
-                if container != marathon.Container.DOCKER and marathon.Network.BRIDGE in (vip_net, proxy_net):
-                    # only DOCKER containers support BRIDGE network
-                    continue
-                permutations.append((container, vip_net, proxy_net))
-    return permutations
+    return [(container, vip_net, proxy_net)
+            for container in [marathon.Container.NONE, marathon.Container.MESOS, marathon.Container.DOCKER]
+            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            # only DOCKER containers support BRIDGE network
+            if marathon.Network.BRIDGE not in (vip_net, proxy_net) or container == marathon.Container.DOCKER]
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-@pytest.mark.parametrize('container,vip_net,proxy_net', generate_vip_app_permutations())
-def test_vip(dcos_api_session, container: marathon.Container, vip_net: marathon.Network, proxy_net: marathon.Network):
+@pytest.mark.skipif(
+    not lb_enabled(),
+    reason='Load Balancer disabled')
+@pytest.mark.parametrize(
+    'container,vip_net,proxy_net',
+    generate_vip_app_permutations())
+def test_vip(dcos_api_session,
+             container: marathon.Container,
+             vip_net: marathon.Network,
+             proxy_net: marathon.Network):
     '''Test VIPs between the following source and destination configurations:
         * containers: DOCKER, UCR and NONE
         * networks: USER, BRIDGE (docker only), HOST
@@ -96,9 +99,11 @@ def test_vip(dcos_api_session, container: marathon.Container, vip_net: marathon.
     proxy container that will ping the origin container VIP and then assert
     that the expected origin app UUID was returned
     '''
-    failure_stack = []
-    for test in setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
-        cmd, origin_app, proxy_app, proxy_net = test
+    errors = 0
+    tests = setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net)
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info("Remote command: {}".format(cmd))
         proxy_info = dcos_api_session.marathon.get('v2/apps/{}'.format(proxy_app['id'])).json()
         proxy_task_info = proxy_info['app']['tasks'][0]
         if proxy_net == marathon.Network.USER:
@@ -112,53 +117,58 @@ def test_vip(dcos_api_session, container: marathon.Container, vip_net: marathon.
             proxy_port = proxy_task_info['ports'][0]
         try:
             ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app['env']['DCOS_TEST_UUID']
-        except Exception as ex:
-            failure_stack.append('RemoteCommand:{}\n\nOriginApp:{}\n\nProxyApp:{}\n\nException:'.format(*test))
-            failure_stack.append(str(repr(ex)))
-        dcos_api_session.marathon.delete('v2/apps/{}'.format(origin_app['id']))
-        dcos_api_session.marathon.delete('v2/apps/{}'.format(proxy_app['id']))
-    if len(failure_stack) > 0:
-        raise AssertionError('\n******************************************\n'.join(failure_stack))
+        except Exception as e:
+            log.error('Exception: {}'.format(e))
+            errors = errors + 1
+        finally:
+            log.info('Purging application: {}'.format(origin_app['id']))
+            dcos_api_session.marathon.delete('v2/apps/{}'.format(origin_app['id'])).raise_for_status()
+            log.info('Purging application: {}'.format(proxy_app['id']))
+            dcos_api_session.marathon.delete('v2/apps/{}'.format(proxy_app['id'])).raise_for_status()
+    assert errors == 0
 
 
 def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
-    if len(dcos_api_session.all_slaves) < 2:
-        pytest.skip('must have more than one agent for this test!')
-    apps = list()
-    tests = list()
-    for named_vip in (True, False):
-        for same_host in (True, False):
-            if named_vip:
-                origin_host = dcos_api_session.all_slaves[0]
-                proxy_host = dcos_api_session.all_slaves[1]
-                vip_port = unused_port('namedvip')
-                vip = '/namedvip:{}'.format(vip_port)
-                vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
-            else:
-                origin_host = dcos_api_session.all_slaves[1]
-                proxy_host = dcos_api_session.all_slaves[0]
-                vip_port = unused_port('1.1.1.7')
-                vip = '1.1.1.7:{}'.format(vip_port)
-                vipaddr = vip
-            if same_host:
-                proxy_host = origin_host
-            cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-            origin_app, origin_app_uuid = vip_app(container, vip_net, origin_host, vip)
-            proxy_app, proxy_app_uuid = vip_app(container, proxy_net, proxy_host, None)
-            # allow these apps to run on public slaves
-            origin_app['acceptedResourceRoles'] = ['*', 'slave_public']
-            proxy_app['acceptedResourceRoles'] = ['*', 'slave_public']
-            # We do not need the service endpoints because we have deterministically assigned them
-            for app_definition in (origin_app, proxy_app):
-                r = dcos_api_session.marathon.post('v2/apps', json=app_definition)
-                r.raise_for_status()
-                apps.append(app_definition)
-            tests.append((cmd, origin_app, proxy_app, proxy_net))
-        log.info('Deploying origin app')
+    same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    tests = [vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip, same_host)
+             for named_vip in [True, False]
+             for same_host in same_hosts]
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        # We do not need the service endpoints because we have deterministically assigned them
+        log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
+        log.info("Origin app: {}".format(origin_app))
+        dcos_api_session.marathon.post('v2/apps', json=origin_app).raise_for_status()
+        log.info("Proxy app: {}".format(proxy_app))
+        dcos_api_session.marathon.post('v2/apps', json=proxy_app).raise_for_status()
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info('Deploying origin app: {}'.format(origin_app['id']))
         wait_for_tasks_healthy(dcos_api_session, origin_app)
-        log.info('Origin app successful, deploying proxy app..')
+        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
         wait_for_tasks_healthy(dcos_api_session, proxy_app)
+        log.info('Apps are ready')
     return tests
+
+
+def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip, same_host):
+    origin_host = dcos_api_session.all_slaves[0]
+    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
+    if named_vip:
+        vip_port = unused_port('namedvip')
+        vip = '/namedvip:{}'.format(vip_port)
+        vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
+    else:
+        vip_port = unused_port('1.1.1.7')
+        vip = '1.1.1.7:{}'.format(vip_port)
+        vipaddr = vip
+    cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
+    origin_app, origin_app_uuid = vip_app(container, vip_net, origin_host, vip)
+    proxy_app, proxy_app_uuid = vip_app(container, proxy_net, proxy_host, None)
+    # allow these apps to run on public slaves
+    origin_app['acceptedResourceRoles'] = ['*', 'slave_public']
+    proxy_app['acceptedResourceRoles'] = ['*', 'slave_public']
+    hosts = list(set([origin_host, proxy_host]))
+    return (vip, hosts, cmd, origin_app, proxy_app)
 
 
 @retrying.retry(
@@ -166,10 +176,8 @@ def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
     stop_max_delay=20 * 60 * 1000,
     retry_on_result=lambda res: res is False)
 def wait_for_tasks_healthy(dcos_api_session, app_definition):
-    proxy_info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
-    if proxy_info['app']['tasksHealthy'] == app_definition['instances']:
-        return True
-    return False
+    info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
+    return info['app']['tasksHealthy'] == app_definition['instances']
 
 
 @retrying.retry(wait_fixed=2000,


### PR DESCRIPTION
This is train 211. It includes:

- #1875 (Bump 1.9 api links to 1.10)
- #1873 (test_networking.test_vip test is flaky [2])