### PR TITLE
Update package/cosmos api usage in integration tests 

### DIFF
--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -134,7 +134,7 @@ def test_packaging_api(dcos_api_session):
     """Test the Cosmos API (/package) wrapper
     """
     _skipif_insufficient_resources(dcos_api_session, KAFKA_PACKAGE_REQUIREMENTS)
-    install_response = dcos_api_session.cosmos.install_package('kafka', '1.1.9-0.10.0.0')
+    install_response = dcos_api_session.cosmos.install_package('kafka', package_version='1.1.9-0.10.0.0')
     data = install_response.json()
 
     dcos_api_session.marathon.poll_marathon_for_app_deployment(data['appId'], 1,
@@ -144,7 +144,7 @@ def test_packaging_api(dcos_api_session):
     packages = list_response.json()['packages']
     assert len(packages) == 1 and packages[0]['appId'] == data['appId']
 
-    dcos_api_session.cosmos.uninstall_package('kafka', data['appId'])
+    dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
 
     list_response = dcos_api_session.cosmos.list_packages()
     packages = list_response.json()['packages']

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "449eb8018468c0eafbc85342b68639ac89e8f6be",
+    "ref": "8825756e8aa465557d8de3f03116d6d80087b010",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High Level Description

This is the same as https://github.com/dcos/dcos/pull/1833 (PR to master)

I had the interface wrong on the `dcos_api_session.cosmos` endpoint in `dcos-test-utils`, where install didn't take all of the options, and install and uninstall had some options as required when only the packageName is required. 

## Related Issues

This is all ultimately to support the tweeter integration test
https://github.com/mesosphere/dcos-enterprise/pull/1303

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
