### PR TITLE
[1.10.0] Train 214

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "8702cc371a8773a151ba4ab1545a763c0c24af93",
-    "ref_origin": "v1.10.0-rc.7"
+    "ref": "03ba84aac9ac5a93f641e7bf54993ab6d76f4791",
+    "ref_origin": "v1.10.0-rc.8"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "87f86acca1194fe8dcd2e249a081f150276cd750",
-    "ref_origin" : "dcos-mesos-1.4.0-rc3"
+    "ref": "c968b18baffd52c4f89f3968f73926fa5256fba8",
+    "ref_origin" : "dcos-mesos-1.4.x-60b8d41"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
This is train 214 with patches that are supposed to land in the 1.10.0 release. It contains the following pull requests:
- #1892 (Update DC/OS UI package to 1.10.0-rc.8 (1.10))
- #1900 (Bumped Mesos package to 1.4.x head 60b8d41)