### PR TITLE
test_networking.test_vip test is flaky [3]

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -17,7 +17,13 @@ from dcos_test_utils import marathon
 
 log = logging.getLogger(__name__)
 
-GLOBAL_PORT_POOL = collections.defaultdict(lambda: list(range(10000, 32000)))
+# NOTE: linux kernel 3.10.0-327 (rh/centos 7.2) and 3.10.0-514 (rh/centos 7.3)
+# drop outgoing vxlan tcp packets if the destination port is in the range
+# from 14849 (0x3a01) to 15103 (0x3aff).
+# For more information please see the following link:
+# https://jira.mesosphere.com/browse/DCOS_OSS-1463?focusedCommentId=119792#comment-119792
+# TODO: please check this port range on newer linux kernel
+GLOBAL_PORT_POOL = collections.defaultdict(lambda: list(range(10000, 14849)) + list(range(15104, 32000)))
 
 
 def unused_port(network):


### PR DESCRIPTION
## High Level Description

Remove port range from 14849 to 15103 from global port pool. We hope that we will revert this patch in the future when we will support centos 7.4.  

Linux kernel 3.10.0-327 (centos 7.2) and 3.10.0-514 (centos 7.3) drops outgoing lxlan tcp packets if the destination port is in the range from 14849 to 15103. It's 255-port range, from 0x3a01 to 0x3aff. it's not iptables or something like that, it's somewhere in interface driver. ICMP and UPD work fine. If you start another tcp server outside the range 14849-15103 in the same container it will work. We didn't find the exact line where this bug is happening in linux kernel, but we haven't seen this bug on linux kernel 3.10.0-693 (centos 7.4).

## Related Issues

  - [DCOS_OSS-1463](https://jira.mesosphere.com/browse/DCOS_OSS-1463) test_networking.test_vip test is flaky

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
