### PR TITLE
Updated the default disk watch interval to 5 seconds in Mesos

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -419,6 +419,7 @@ package:
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
       MESOS_CONTAINER_LOGGER=com_mesosphere_mesos_JournaldLogger
       MESOS_ISOLATION={{ mesos_isolation }}
+      MESOS_DISK_WATCH_INTERVAL=5secs
       MESOS_DOCKER_VOLUME_CHECKPOINT_DIR=/var/lib/mesos/isolators/docker/volume
       MESOS_IMAGE_PROVIDERS=docker
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni


### PR DESCRIPTION
## High Level Description

This change makes the Mesos agents to check disk usage every 5 seconds
and GC completed top-level containers when there's not enough headroom.
It alleviates CORE-1289, and together with the following patch the problem
should be fixed:
https://issues.apache.org/jira/browse/MESOS-7939

## Related Issues

  - [CORE-1289](https://jira.mesosphere.com/browse/CORE-1289) Agent unable to recover due to no space left on disk.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: No test included since it is a configuration change. Manually tested on soak110 and this change made the problematic agent recovered from an out-of-disk state.
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___