### PR TITLE
Support adding custom check executables during onprem installation

### DIFF
--- a/dcos_installer/config_util.py
+++ b/dcos_installer/config_util.py
@@ -19,8 +19,21 @@ def make_serve_dir(gen_out):
     subprocess.check_call(['mkdir', '-p', SERVE_DIR])
     gen.build_deploy.bash.generate(gen_out, SERVE_DIR)
 
-    # Get bootstrap from artifacts
-    fetch_artifacts(gen_out.arguments['bootstrap_id'], gen_out.cluster_packages, gen_out.config_package_ids)
+    # Copy artifacts out of the cache.
+    generated_packages = gen_out.config_package_ids + [gen_out.arguments['custom_check_bins_package_id']]
+    cached_packages = sorted(
+        info['filename'] for info in gen_out.cluster_packages.values() if info['id'] not in generated_packages
+    )
+    bootstrap_files = [
+        "bootstrap/{}.bootstrap.tar.xz".format(gen_out.arguments['bootstrap_id']),
+        "bootstrap/{}.active.json".format(gen_out.arguments['bootstrap_id'])
+    ]
+    fetch_artifacts(
+        bootstrap_files + cached_packages,
+        ARTIFACT_DIR,
+        SERVE_DIR,
+    )
+
     # Write some package metadata
     pkgpanda.util.write_json(CLUSTER_PACKAGES_PATH, gen_out.cluster_packages)
 
@@ -81,31 +94,21 @@ def do_move_atomic(src_dir, dest_dir, filenames):
         rollback()
 
 
-def fetch_artifacts(bootstrap_id, cluster_packages, config_package_ids):
-    filenames = [
-        "bootstrap/{}.bootstrap.tar.xz".format(bootstrap_id),
-        "bootstrap/{}.active.json".format(bootstrap_id)
-    ] + sorted(
-        # Onprem config packages are created by genconf. They aren't available in the cache.
-        info['filename'] for info in cluster_packages.values() if info['id'] not in config_package_ids
-    )
-    dest_dir = SERVE_DIR
-    container_cache_dir = ARTIFACT_DIR
-
-    # If all the targets already exist, no-op
+def fetch_artifacts(filenames, src_dir, dest_dir):
+    # If all the dest files already exist, no-op
     dest_files = [dest_dir + '/' + filename for filename in filenames]
     if all(map(os.path.exists, dest_files)):
         return
 
-    # Make sure the internal cache files exist
-    src_files = [container_cache_dir + '/' + filename for filename in filenames]
+    # Make sure the source files exist
+    src_files = [src_dir + '/' + filename for filename in filenames]
     for filename in src_files:
         if not os.path.exists(filename):
             log.error("Internal Error: %s not found. Should have been in the installer container.", filename)
             raise FileNotFoundError(filename)
 
     subprocess.check_call(['mkdir', '-p', dest_dir])
-    do_move_atomic(container_cache_dir, dest_dir, filenames)
+    do_move_atomic(src_dir, dest_dir, filenames)
 
 
 def installer_latest_complete_artifact(variant_str):

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -2,18 +2,27 @@
 
 import json
 import os
+import os.path
+import shutil
 import subprocess
 import tempfile
+from typing import List
 
+import checksumdir
 import pkg_resources
 import yaml
 
 import dcos_installer.config_util
 import gen.build_deploy.util as util
 import gen.template
+import gen.util
 import pkgpanda
 import pkgpanda.util
-from gen.calc import calculate_environment_variable
+from gen.calc import (
+    calculate_environment_variable,
+    CHECK_SEARCH_PATH as DEFAULT_CHECK_SEARCH_PATH,
+    validate_true_false,
+)
 from gen.internals import Source
 from pkgpanda.util import logger
 
@@ -33,7 +42,56 @@ def calculate_fault_domain_enabled(fault_domain_detect_filename):
     return 'true'
 
 
+def calculate_custom_check_bins_provided(custom_check_bins_dir):
+    if os.path.isdir(custom_check_bins_dir):
+        return 'true'
+    return 'false'
+
+
+def calculate_custom_check_bins_hash(custom_check_bins_provided, custom_check_bins_dir):
+    if custom_check_bins_provided == 'true':
+        return checksumdir.dirhash(custom_check_bins_dir, 'sha1')
+    return ''
+
+
+def calculate_custom_check_bins_package_id(
+        custom_check_bins_provided,
+        custom_check_bins_package_name,
+        custom_check_bins_hash):
+    if custom_check_bins_provided == 'true':
+        assert custom_check_bins_hash
+        return '{}--{}'.format(custom_check_bins_package_name, custom_check_bins_hash)
+    return ''
+
+
+def calculate_check_search_path(custom_check_bins_provided, custom_check_bins_package_id):
+    if custom_check_bins_provided == 'true':
+        assert custom_check_bins_package_id != ''
+        return DEFAULT_CHECK_SEARCH_PATH + ':/opt/mesosphere/packages/{}'.format(custom_check_bins_package_id)
+    return DEFAULT_CHECK_SEARCH_PATH
+
+
+def calculate_package_ids(bootstrap_variant, custom_check_bins_provided, custom_check_bins_package_id):
+    package_ids = dcos_installer.config_util.installer_latest_complete_artifact(bootstrap_variant)['packages']
+    if custom_check_bins_provided == 'true':
+        assert custom_check_bins_package_id != ''
+        package_ids.append(custom_check_bins_package_id)
+    return json.dumps(package_ids)
+
+
+def validate_custom_check_bins_dir(custom_check_bins_dir):
+    assert len(custom_check_bins_dir) > 0, 'custom_check_bins_dir must be a valid directory name'
+    if os.path.exists(custom_check_bins_dir):
+        assert os.path.isdir(custom_check_bins_dir), '{} must be a directory'.format(custom_check_bins_dir)
+        for entry in os.scandir(custom_check_bins_dir):
+            assert entry.is_file(), '{} must not contain any subdirectories'.format(custom_check_bins_dir)
+
+
 onprem_source = Source(entry={
+    'validate': [
+        validate_custom_check_bins_dir,
+        lambda custom_check_bins_provided: validate_true_false(custom_check_bins_provided),
+    ],
     'default': {
         'platform': 'onprem',
         'resolvers': '["8.8.8.8", "8.8.4.4"]',
@@ -44,11 +102,15 @@ onprem_source = Source(entry={
     },
     'must': {
         'provider': 'onprem',
-        'package_ids': lambda bootstrap_variant: json.dumps(
-            dcos_installer.config_util.installer_latest_complete_artifact(bootstrap_variant)['packages']
-        ),
-        'fault_domain_enabled': calculate_fault_domain_enabled,
+        'package_ids': calculate_package_ids,
         'fault_domain_detect_filename': 'genconf/fault_domain_detect',
+        'fault_domain_enabled': calculate_fault_domain_enabled,
+        'custom_check_bins_dir': 'genconf/check_bins/',
+        'custom_check_bins_package_name': 'custom-check-bins',
+        'custom_check_bins_provided': calculate_custom_check_bins_provided,
+        'custom_check_bins_hash': calculate_custom_check_bins_hash,
+        'custom_check_bins_package_id': calculate_custom_check_bins_package_id,
+        'check_search_path': calculate_check_search_path,
     }
 })
 
@@ -532,17 +594,26 @@ fi
 
 def generate(gen_out, output_dir):
     print("Generating Bash configuration files for DC/OS")
-    make_bash(gen_out)
-    util.do_bundle_onprem(['dcos_install.sh'], gen_out, output_dir)
+    extra_files = make_bash(gen_out)
+    util.do_bundle_onprem(extra_files, gen_out, output_dir)
 
 
-def make_bash(gen_out):
-    """
-    Reformat the cloud-config into bash heredocs
-    Assert the cloud-config is only write_files
-    """
+def make_bash(gen_out) -> List[str]:
+    """Build bash deployment artifacts and return a list of their filenames."""
+    artifacts = []
+
+    # Build custom check bins package
+    if gen_out.arguments['custom_check_bins_provided'] == 'true':
+        package_filename = 'packages/{}/{}.tar.xz'.format(
+            gen_out.arguments['custom_check_bins_package_name'],
+            gen_out.arguments['custom_check_bins_package_id'],
+        )
+        make_custom_check_bins_package(gen_out.arguments['custom_check_bins_dir'], package_filename)
+        artifacts.append(package_filename)
+
     setup_flags = ""
     cloud_config = gen_out.templates['cloud-config.yaml']
+    # Assert the cloud-config is only write_files.
     assert len(cloud_config) == 1
     for file_dict in cloud_config['write_files']:
         # NOTE: setup-packages is explicitly disallowed. Should all be in extra
@@ -593,9 +664,32 @@ def make_bash(gen_out):
         'setup_services': setup_services})
 
     # Output the dcos install script
-    pkgpanda.util.write_string('dcos_install.sh', bash_script)
+    install_script_filename = 'dcos_install.sh'
+    pkgpanda.util.write_string(install_script_filename, bash_script)
+    artifacts.append(install_script_filename)
 
-    return 'dcos_install.sh'
+    return artifacts
+
+
+def make_custom_check_bins_package(source_dir, package_filename):
+    with gen.util.pkgpanda_package_tmpdir() as tmpdir:
+        tmp_source_dir = os.path.join(tmpdir, 'check_bins')
+        shutil.copytree(source_dir, tmp_source_dir)
+
+        # Apply permissions
+        for entry in os.scandir(tmp_source_dir):
+            # source_dir should have no subdirs.
+            assert entry.is_file()
+            os.chmod(entry.path, 0o755)
+
+        # Add an empty pkginfo.json.
+        pkginfo_filename = os.path.join(tmp_source_dir, 'pkginfo.json')
+        assert not os.path.isfile(pkginfo_filename)
+        with open(pkginfo_filename, 'w') as f:
+            f.write('{}')
+        os.chmod(pkginfo_filename, 0o644)
+
+        gen.util.make_pkgpanda_package(tmp_source_dir, package_filename)
 
 
 def make_installer_docker(variant, variant_info, installer_info):

--- a/gen/build_deploy/util.py
+++ b/gen/build_deploy/util.py
@@ -1,5 +1,6 @@
 import json
 import os
+import os.path
 import shutil
 from datetime import datetime
 from subprocess import check_output
@@ -38,7 +39,7 @@ def do_bundle_onprem(extra_files, gen_out, output_dir):
 
     # Copy the extra_files
     for filename in extra_files:
-        shutil.copy(filename, output_dir + filename)
+        copy_makedirs(filename, output_dir + filename)
 
     # Copy the config packages
     for package_name in json.loads(gen_out.arguments['config_package_names']):

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -41,6 +41,9 @@ from pkgpanda import PackageId
 from pkgpanda.util import hash_checkout
 
 
+CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
+
+
 def type_str(value):
     return type(value).__name__
 
@@ -975,6 +978,7 @@ entry = {
         'gpus_are_scarce': 'true',
         'check_config': calculate_check_config,
         'custom_checks': '{}',
+        'check_search_path': CHECK_SEARCH_PATH,
         'fault_domain_enabled': 'false'
     },
     'must': {
@@ -1021,7 +1025,6 @@ entry = {
         'profile_symlink_target_dir': calculate_profile_symlink_target_dir,
         'fair_sharing_excluded_resource_names': calculate_fair_sharing_excluded_resource_names,
         'check_config_contents': calculate_check_config_contents,
-        'check_search_path': '/opt/mesosphere/bin:/usr/bin:/bin:/sbin',
         'check_ld_library_path': '/opt/mesosphere/lib'
     },
     'conditional': {

--- a/gen/util.py
+++ b/gen/util.py
@@ -1,0 +1,26 @@
+import logging
+import os
+import os.path
+
+from tempfile import TemporaryDirectory
+
+from pkgpanda.util import make_tar
+
+
+def pkgpanda_package_tmpdir():
+    # Forcibly set umask so that os.makedirs() always makes directories with
+    # uniform permissions
+    os.umask(0o000)
+    return TemporaryDirectory("gen_tmp_pkg")
+
+
+def make_pkgpanda_package(contents_dir, package_filename):
+    # Make the package top level directory readable by users other than the owner (root).
+    os.chmod(contents_dir, 0o755)
+
+    # Ensure the output directory exists
+    if os.path.dirname(package_filename):
+        os.makedirs(os.path.dirname(package_filename), exist_ok=True)
+
+    make_tar(package_filename, contents_dir)
+    logging.info("Package filename: %s", package_filename)

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "f0e7cc0eddce6672f45fbb930c0f967023a99fb1",
+    "ref": "f2ea907c1857c166aa733a9292c46ad190b413ed",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -10,7 +10,7 @@ for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 
-for package in aiohttp chardet coloredlogs docker-py humanfriendly multidict oauthlib \
-    waitress websocket-client; do
+for package in aiohttp chardet checksumdir coloredlogs docker-py humanfriendly multidict \
+    oauthlib waitress websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -83,6 +83,11 @@
       "url": "https://pypi.python.org/packages/source/c/chardet/chardet-2.3.0.tar.gz",
       "sha1": "50af8f8771ecbeb7a22567129c6c281b8bec3b1c"
     },
+    "checksumdir": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/84/8b/0e800a118ed64091245feddef0159d7979bb42915f65db5d2dafd6b12864/checksumdir-1.1.4.tar.gz",
+      "sha1": "8179d445521bcd7930d036f708caa014a65d9960"
+    },
     "coloredlogs": {
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/source/c/coloredlogs/coloredlogs-3.5.tar.gz",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'azure-mgmt-resource==0.30.0rc4',
         'boto3',
         'botocore',
+        'checksumdir',
         'coloredlogs',
         'docopt',
         'passlib',


### PR DESCRIPTION
## High Level Description

This PR allows onprem installations to include a set of custom executables that can be called from custom checks defined in `config.yaml`. Any executables found in `genconf/check_bins/` will be distributed to cluster nodes and added to the check runner's search path.

## Related Issues

  - [DCOS_OSS-1275](https://jira.mesosphere.com/browse/DCOS_OSS-1275) Support adding custom check executables during onprem installation

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The installer CLI integration test was updated to use custom check bins and run against this PR. See https://github.com/mesosphere/advanced-tests/pull/10 and https://teamcity.mesosphere.io/viewLog.html?buildId=799718&buildTypeId=DcOs_Open_Test_IntegrationTest_InstallerCli
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-diagnostics/compare/f0e7cc0eddce6672f45fbb930c0f967023a99fb1...f2ea907c1857c166aa733a9292c46ad190b413ed
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-diagnostics-pulls/38/
  - [x] Code Coverage (if available): https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-diagnostics-pulls/38/