### PR TITLE
Removed leader.mesos prerequisite for dcos-mesos-slave.

### DIFF
--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "8702cc371a8773a151ba4ab1545a763c0c24af93",
-    "ref_origin": "v1.10.0-rc.7"
+    "ref": "03ba84aac9ac5a93f641e7bf54993ab6d76f4791",
+    "ref_origin": "v1.10.0-rc.8"
   }
 }

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'


### PR DESCRIPTION
## High Level Description

Since DC/OS 1.8+ agents do not depend on `leader.mesos` (e.g. we can start a   --master=zk1:2181), we should thus not have this prerequisite as it can result in outages. 