### PR TITLE
Increase recovery timeout in agent config.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -428,6 +428,7 @@ package:
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
+      MESOS_RECOVERY_TIMEOUT={{ mesos_recovery_timeout }}
       MESOS_CGROUPS_ENABLE_CFS=true
       MESOS_CGROUPS_LIMIT_SWAP=false
       MESOS_DISALLOW_SHARING_AGENT_PID_NAMESPACE=true

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -141,6 +141,34 @@ def test_invalid_mesos_dns_set_truncate_bit():
         true_false_msg)
 
 
+def test_validate_mesos_recovery_timeout():
+    validate_success(
+        {'mesos_recovery_timeout': '24hrs'})
+
+    validate_success(
+        {'mesos_recovery_timeout': '24.5hrs'})
+
+    validate_error(
+        {'mesos_recovery_timeout': '2.4.5hrs'},
+        'mesos_recovery_timeout',
+        "Invalid decimal format.")
+
+    validate_error(
+        {'mesos_recovery_timeout': 'asdf'},
+        'mesos_recovery_timeout',
+        "Error parsing 'mesos_recovery_timeout' value: asdf.")
+
+    validate_error(
+        {'mesos_recovery_timeout': '9999999999999999999999999999999999999999999ns'},
+        'mesos_recovery_timeout',
+        "Value 9999999999999999999999999999999999999999999 not in supported range.")
+
+    validate_error(
+        {'mesos_recovery_timeout': '1hour'},
+        'mesos_recovery_timeout',
+        "Unit 'hour' not in ['ns', 'us', 'ms', 'secs', 'mins', 'hrs', 'days', 'weeks'].")
+
+
 def test_cluster_docker_credentials():
     validate_error(
         {'cluster_docker_credentials': 'foo'},


### PR DESCRIPTION
## High Level Description

With the latest partition awareness changes, we can increase
the recovery timeout to a much higher value to avoid outages
due to the agent being down for whatever reason.

## Related Issues

  - [CORE-1291](https://jira.mesosphere.com/browse/CORE-1291) Increase the value for `--recovery_timeout` agent flag in DC/OS

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)