### PR TITLE
Fix method name in installer

### DIFF
--- a/dcos_installer/check.py
+++ b/dcos_installer/check.py
@@ -63,7 +63,7 @@ class CheckRunnerResult:
         return 'error' in response.keys()
 
     @staticmethod
-    def _validate_check_error_response(response):
+    def _validate_check_runner_error_response(response):
         if 'error' not in response.keys():
             raise Exception('Check runner error response is missing expected key \'error\'')
 

--- a/dcos_installer/test_check.py
+++ b/dcos_installer/test_check.py
@@ -1,0 +1,58 @@
+import pytest
+
+from dcos_installer import check
+
+
+def assert_check_runner_error(check_runner_response):
+    crr = check.CheckRunnerResult(check_runner_response)
+    assert crr.is_error
+    assert crr.error_message == check_runner_response['error']
+
+
+def assert_check_runner_result(check_runner_response):
+    crr = check.CheckRunnerResult(check_runner_response)
+    assert not crr.is_error
+    assert crr.status == check_runner_response['status']
+    assert crr.status_text == crr.statuses[crr.status]
+    assert crr.checks == {
+        name: check.Check(
+            name=name,
+            status=result['status'],
+            status_text=crr.statuses[result['status']],
+            output=result['output'])
+        for name, result in check_runner_response['checks'].items()
+    }
+
+
+def test_check_runner_result():
+    assert_check_runner_result({'status': 0, 'checks': {}})
+    assert_check_runner_result({
+        'status': 0,
+        'checks': {
+            'foo': {
+                'status': 0,
+                'output': '',
+            },
+            'bar': {
+                'status': 0,
+                'output': 'bar output',
+            },
+        },
+    })
+    assert_check_runner_error({'error': 'something failed'})
+
+    # Assert unexpected keys and values expected in a success response raise an exception.
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0, 'checks': []})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0, 'checks': {'foo': {}}})
+
+    # Assert missing or unexpected keys and values expected in an error response raise an exception.
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'error': 'Something failed.', 'status': 3})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'error': 'Something failed.', 'checks': {}})


### PR DESCRIPTION
## High Level Description

This causes the installer to print a descriptive error to the console when checks fail during `--postflight`, instead of a confusing traceback.

## Related Issues

  - [DCOS_OSS-1661](https://jira.mesosphere.com/browse/DCOS_OSS-1661) Installer prints large traceback when checks fail during --postflight

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]