### PR TITLE
Train 221

### DIFF
--- a/dcos_installer/check.py
+++ b/dcos_installer/check.py
@@ -63,7 +63,7 @@ class CheckRunnerResult:
         return 'error' in response.keys()
 
     @staticmethod
-    def _validate_check_error_response(response):
+    def _validate_check_runner_error_response(response):
         if 'error' not in response.keys():
             raise Exception('Check runner error response is missing expected key \'error\'')
 

--- a/dcos_installer/test_check.py
+++ b/dcos_installer/test_check.py
@@ -1,0 +1,58 @@
+import pytest
+
+from dcos_installer import check
+
+
+def assert_check_runner_error(check_runner_response):
+    crr = check.CheckRunnerResult(check_runner_response)
+    assert crr.is_error
+    assert crr.error_message == check_runner_response['error']
+
+
+def assert_check_runner_result(check_runner_response):
+    crr = check.CheckRunnerResult(check_runner_response)
+    assert not crr.is_error
+    assert crr.status == check_runner_response['status']
+    assert crr.status_text == crr.statuses[crr.status]
+    assert crr.checks == {
+        name: check.Check(
+            name=name,
+            status=result['status'],
+            status_text=crr.statuses[result['status']],
+            output=result['output'])
+        for name, result in check_runner_response['checks'].items()
+    }
+
+
+def test_check_runner_result():
+    assert_check_runner_result({'status': 0, 'checks': {}})
+    assert_check_runner_result({
+        'status': 0,
+        'checks': {
+            'foo': {
+                'status': 0,
+                'output': '',
+            },
+            'bar': {
+                'status': 0,
+                'output': 'bar output',
+            },
+        },
+    })
+    assert_check_runner_error({'error': 'something failed'})
+
+    # Assert unexpected keys and values expected in a success response raise an exception.
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0, 'checks': []})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'status': 0, 'checks': {'foo': {}}})
+
+    # Assert missing or unexpected keys and values expected in an error response raise an exception.
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'error': 'Something failed.', 'status': 3})
+    with pytest.raises(Exception):
+        check.CheckRunnerResult({'error': 'Something failed.', 'checks': {}})

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "8825756e8aa465557d8de3f03116d6d80087b010",
+    "ref": "f7c1446b86349ac07693d279a4db0d5d6238a1c3",
     "ref_origin": "master"
   }
 }

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave-public
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'


### PR DESCRIPTION
## High Level Description

- https://github.com/dcos/dcos/pull/1936 Fix method name in installer
- https://github.com/dcos/dcos/pull/1930 Bump dcos-test-utils to dev cli branch
- https://github.com/dcos/dcos/pull/1921 Removed leader.mesos prerequisite for dcos-mesos-slave

Note that there would be a failure on security=permissive on the corresponding ee-bump, except the test is muted during this PR. See https://jira.mesosphere.com/browse/DCOS-18789 
