### PR TITLE
Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "c93051702b7710d9e56340eff0fab02e45d2a9b7",
+    "ref": "5bbbb585d8e600073f6dc8946a3c0b4476ab7fff",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This PR adds `task_id` and `task_name` to the `dimensions` hash in the  `/v0/containers/container-id/app` endpoint. 

## Related Issues

  - [DCOS-17956](https://jira.mesosphere.com/browse/DCOS-17956) Include task name as a dimension in /container/app endpoint in dcos-metrics

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/c93051702b7710d9e56340eff0fab02e45d2a9b7...5bbbb585d8e600073f6dc8946a3c0b4476ab7fff)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/128/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-master/128/cobertura/)