### PR TITLE
1.8.10 train 222

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -21,3 +21,23 @@
 <li>[378e209c0e34c955e23505e2fb32b879794cdf8e] Added 'executor_reregister_timeout' agent flag to the tests.
 <li>[815e9dd6620ad1f13d6a326079e9b61c2484294d] Introduced executor reconnect retries on the agent.
 <li>[beb19ab9d6d42ae92e1868094af23f69ad553443] Made the executor driver drop some messages when not connected.
+
+<H3>Critical backports from Mesos 1.1.x and 1.2.x branches</H3>
+<li>[55899ec435a7cae1961c64f275a40d989d1ca8e3] Fixed a crash on the master upon receiving an invalid inverse offer.
+<li>[bead9f592bc3b64b94b6b0019e11be0d200f20bf] Fixed health check bug when running agents with `docker_mesos_image`.
+<li>[4cf39808a8d81e54b69258095e3185493d775544] Fixed the image signature check for Nexus Registry.
+<li>[30d0e46ce0674a31477b804f850ad233287876e2] Fixed docker fetcher 3xx redirect errors by header attached.
+<li>[1a403cce844b4a6ebf0ccee2591aeca0f05e4e99] Fixed provisioner recover blockage by non-existing rootfses dir.
+<li>[6027f2621d1e6a59c1900b0ee56c0b6d417a385a] Don't crash when re-registering executor from an unknown framework.
+<li>[67b6f2a8504277ade2b5e66305a3b3c1bbeaf8ba] Don't crash the agent when an unknown executor re-registers.
+<li>[33de5301fc1f25de8c0e6fa88aa7604b9d088297] Added logging of executor re-registration messages.
+<li>[faede67f2b46636df8c85c23a561743fc85d9e3d] Fixed a crash in libprocess when failing to decode a request path.
+<li>[6ca32629de7e613a8ce208a8423caf4de0868499] Rejected libprocess HTTP requests with empty path.
+<li>[47aa5275fdfb157f35f7ea530fa3c91c1591c4cb] Fixed cherry-pick build error.
+<li>[e1c25310a3ac3aff1e4bf87d2c780bf2e2091c48] Fixed member access issue introduced by a cherry-pick.
+<li>[6d8e86341f87a3bd210a145e7e351cf701355d2b] Preventing agent recovery failing from unsuccessful `docker rm`.
+<li>[5e6f462e2d9ab0acde0834c3a94aa8141037a148] Set the `LIBPROCESS_IP` env variable before starting the fetcher.
+<li>[6413b3ff5340c333959b2266a1a5c98ae4a7adbb] Added logging in docker executor on `docker stop` failure.
+<li>[97d3f4eadced34e03b93bd01e203cd47b480ee36] Enabled retries for `killTask` in docker executor.
+<li>[59e719a82e4739bd7de6de6afce0ec8c8a46be0d] Created staging dir only when needed.
+<li>[0a581996f37d53cd346b4bafd4324ec72b0488aa] Fixed an OOM due to a send loop for SSL sockets.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "beb19ab9d6d42ae92e1868094af23f69ad553443",
+    "ref": "0a581996f37d53cd346b4bafd4324ec72b0488aa",
     "ref_origin" : "dcos-mesos-1.0.4"
   },
   "environment": {

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave-public
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'


### PR DESCRIPTION
## High Level Description

* #1851 - Bump the Mesos package to include critical backports.
* #1947 - [1.8.10] Removed leader.mesos prerequisite for dcos-mesos-slave(-public)