### PR TITLE
[1.9.5] Train 227

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/v1.4.7/marathon-1.4.7.tgz",
-    "sha1": "0f627797dabf8f30dba9217a7bccd56269e6b789"
+    "url": "https://downloads.mesosphere.io/marathon/v1.4.8/marathon-1.4.8.tgz",
+    "sha1": "dd1c3a8e796ca48e1fa229620bae1081303e55be"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/navstar/buildinfo.json
+++ b/packages/navstar/buildinfo.json
@@ -4,7 +4,7 @@
     "navstar": {
       "kind": "git",
       "git": "https://github.com/dcos/navstar.git",
-      "ref": "bfc09c9eca064cacc275be04bd65c98361f2504a",
+      "ref": "73a35a8d4642ef7a126a973b6c10eec331745add",
       "ref_origin": "dcos/1.9"
     }
   },


### PR DESCRIPTION
This is train 227, meant to land before the 1.9.5 release. It contains the following pull requests:

* #1955 (Marathon 1.4.8)
* #1939 (Navstar bump)
