### PR TITLE
dcos_installer: Don't run genconf validation twice [1.10 backport]

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -7,6 +7,7 @@ import yaml
 import gen
 import ssh.validate
 from gen.build_deploy.bash import onprem_source
+from gen.exceptions import ValidationError
 from pkgpanda.util import load_yaml, write_string, YamlParseError
 
 log = logging.getLogger(__name__)
@@ -43,6 +44,20 @@ def normalize_config_validation(messages):
             validation[key] = 'Must set {}, no way to calculate value.'.format(key)
 
     return validation
+
+
+def normalize_config_validation_exception(error: ValidationError) -> dict:
+    """
+    A ValidationError is transformed to dict and processed by
+    `normalize_config_validation` function.
+
+    Args:
+        exception: An exception raised during the config validation
+    """
+    messages = {}
+    messages['errors'] = error.errors
+    messages['unset'] = error.unset
+    return normalize_config_validation(messages)
 
 
 def make_default_config_if_needed(config_path):

--- a/dcos_installer/config_util.py
+++ b/dcos_installer/config_util.py
@@ -33,11 +33,6 @@ def parent_dirs(filename):
         yield '/'.join(dirs)
 
 
-def do_configure(config):
-    gen_out = onprem_generate(config)
-    make_serve_dir(gen_out)
-
-
 def do_move_atomic(src_dir, dest_dir, filenames):
     assert os.path.exists(src_dir)
     assert os.path.exists(dest_dir)

--- a/dcos_installer/test_config.py
+++ b/dcos_installer/test_config.py
@@ -1,0 +1,17 @@
+from dcos_installer import config
+from gen.exceptions import ValidationError
+
+
+def test_normalize_config_validation_exception():
+    errors = {
+        'key': {'message': 'test'},
+    }
+    validation_error = ValidationError(errors=errors, unset=set(['one', 'two']))
+    normalized = config.normalize_config_validation_exception(validation_error)
+
+    expected = {
+        'key': 'test',
+        'one': 'Must set one, no way to calculate value.',
+        'two': 'Must set two, no way to calculate value.',
+    }
+    assert expected == normalized

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
 deps =
   dnspython
   pytest
+  pytest-catchlog
   PyYAML
   webtest
   webtest-aiohttp==1.1.0


### PR DESCRIPTION
## High Level Description

**1.10 backport**

When a user runs `./dcos_generate_config.sh` they'll get messages produced by gen package twice, i.e.

```
====> EXECUTING CONFIGURATION GENERATION
Generating configuration files...
Generating configuration files...
```

This patch is a minimal change that prevents dupes in the logging output. This PR addresses the issue discovered in https://github.com/mesosphere/dcos-enterprise/pull/1391#issuecomment-327164903

Edit(JP):  This is a backport of #1902 (proper review over there).

## Related Issues

  - [DCOS-18206](https://jira.mesosphere.com/browse/DCOS-18206) gen_extra: Add installer warning for private key on node when installing cluster with custom CA cert

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]