### PR TITLE
[1.10] Train 228

### DIFF
--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.4.1-14/cosmos-server-0.4.1-14-one-jar.jar",
-    "sha1": "61e5b8ac089ee3598941f27d751fa64013fd29c9"
+    "url": "https://downloads.dcos.io/cosmos/0.4.2-15/cosmos-server-0.4.2-15-one-jar.jar",
+    "sha1": "61fe1b398b5ddffaff1a1a23256534fbba8e445f"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/libsodium/buildinfo.json
+++ b/packages/libsodium/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.9.tar.gz",
+    "url": "https://github.com/jedisct1/libsodium/releases/download/1.0.9/libsodium-1.0.9.tar.gz",
     "sha1": "6e886fa6c7b0c0dc8a9039f49e1b04532401a6ae"
   }
 }

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave-public
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -19,7 +19,6 @@ EnvironmentFile=-/var/lib/dcos/mesos-slave-common
 EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
 ExecStartPre=/bin/ping -c1 ready.spartan
-ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'


### PR DESCRIPTION
This is train 228 intended for 1.10.1 release. It is comprised of the following pull requests:

* #1906 Fetch libsodium binary from github
* #1945 [1.10.1] Removed leader.mesos prerequisite for dcos-mesos-slave(-public)
* #1954 Release cosmos v0.4.2
