### PR TITLE
use correct url path per variant

### DIFF
--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -288,13 +288,13 @@ def gen_buttons(build_name, reproducible_artifact_path, tag, commit, download_ur
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
             download_url=download_url,
             reproducible_artifact_path=reproducible_artifact_path,
-            arm_template_name='dcos-{}master.azuredeploy.json'.format(x)))
+            arm_template_name='{}dcos-{}master.azuredeploy.json'.format(pkgpanda.util.variant_prefix(bootstrap_name), x)))
         for x in [1, 3, 5]]
     acs_urls = [
         encode_url_as_param(DOWNLOAD_URL_TEMPLATE.format(
             download_url=download_url,
             reproducible_artifact_path=reproducible_artifact_path,
-            arm_template_name='acs-{}master.azuredeploy.json'.format(x)))
+            arm_template_name='{}acs-{}master.azuredeploy.json'.format(pkgpanda.util.variant_prefix(bootstrap_name), x)))
         for x in [1, 3, 5]]
 
     return gen.template.parse_resources('azure/templates/azure.html').render({


### PR DESCRIPTION
This allow for the correct path when using either EE or Open.

## High Level Description

When deploying DC/OS, if Open is used this works fine but when EE is used this uses the incorrect path. This build was used to confirm the correct behavior when adding the variant variable.

**NOTE**: Only promote this if this passes in EE. 

## Related Issues

  - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]