### PR TITLE
Fix tests for 1.9 (backports)

### DIFF
--- a/packages/dcos-integration-test/extra/test_ec2.py
+++ b/packages/dcos-integration-test/extra/test_ec2.py
@@ -4,8 +4,12 @@ import uuid
 
 import pytest
 
+from test_helpers import expanded_config
 
-@pytest.mark.ccm
+
+@pytest.mark.skipif(
+    not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),
+    reason='Must be run in an AWS environment!')
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 

--- a/test_util/dcos_api_session.py
+++ b/test_util/dcos_api_session.py
@@ -15,7 +15,7 @@ import requests
 import retrying
 
 import test_util.marathon
-from test_util.helpers import ApiClientSession, Url
+from test_util.helpers import ApiClientSession, RetryCommonHttpErrorsMixin, Url
 
 
 def get_args_from_env():
@@ -99,7 +99,7 @@ class ARNodeApiClientMixin:
                                    query=query, fragment=fragment, port=port, **kwargs)
 
 
-class DcosApiSession(ARNodeApiClientMixin, ApiClientSession):
+class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSession):
     def __init__(self, dcos_url: str, masters: list, public_masters: list,
                  slaves: list, public_slaves: list, default_os_user: str,
                  auth_user: Optional[DcosUser], exhibitor_admin_password: Optional[str]=None):

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import requests
 import retrying
 
-from test_util.helpers import ApiClientSession, RetryCommonHttpErrorsMixin, path_join
+from test_util.helpers import ApiClientSession, path_join, RetryCommonHttpErrorsMixin
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
 REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}

--- a/test_util/marathon.py
+++ b/test_util/marathon.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import requests
 import retrying
 
-from test_util.helpers import ApiClientSession, path_join
+from test_util.helpers import ApiClientSession, RetryCommonHttpErrorsMixin, path_join
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
 REQUIRED_HEADERS = {'Accept': 'application/json, text/plain, */*'}
@@ -102,7 +102,7 @@ def get_test_app_in_ucr(healthcheck='HTTP'):
     return app, test_uuid
 
 
-class Marathon(ApiClientSession):
+class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
     def __init__(self, default_url, default_os_user='root', session=None):
         super().__init__(default_url)
         if session is not None:


### PR DESCRIPTION
## High Level Description

* Adds simple disconnections retry decorator for more robust test cases
* makes ec2 tests skip when not applicable

## Related Issues

* https://jira.mesosphere.com/browse/DCOS_OSS-1682
* https://jira.mesosphere.com/browse/DCOS_OSS-1683
* https://jira.mesosphere.com/browse/DCOS_OSS-1686


## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this makes the tests actually pass!
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
