### PR TITLE
gen/dcos-config.yaml: Add cluster ID to diagnostics bundle

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -756,6 +756,9 @@ package:
                   "Location": "/opt/mesosphere/etc/user.config.yaml"
               },
               {
+                  "Location": "/var/lib/dcos/cluster-id"
+              },
+              {
                   "Location": "/var/lib/dcos/exhibitor/zookeeper/snapshot/myid",
                   "Role": ["master"]
               },

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -508,7 +508,8 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
-                             'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json']
+                             'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
+                             'var/lib/dcos/cluster-id.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',


### PR DESCRIPTION
## High Level Description

This is a manual port of https://github.com/dcos/dcos/pull/1908 to the master branch.

#1806 did not get merged into master before 1.10 was cut. Hence this PR.

## Related Issues

  - [DCOS_OSS-1627](https://jira.mesosphere.com/browse/DCOS_OSS-1627) cluster_id not available in diagnotic bundle

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
