### PR TITLE
[1.10] Train 230

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -7,6 +7,7 @@ import yaml
 import gen
 import ssh.validate
 from gen.build_deploy.bash import onprem_source
+from gen.exceptions import ValidationError
 from pkgpanda.util import load_yaml, write_string, YamlParseError
 
 log = logging.getLogger(__name__)
@@ -43,6 +44,20 @@ def normalize_config_validation(messages):
             validation[key] = 'Must set {}, no way to calculate value.'.format(key)
 
     return validation
+
+
+def normalize_config_validation_exception(error: ValidationError) -> dict:
+    """
+    A ValidationError is transformed to dict and processed by
+    `normalize_config_validation` function.
+
+    Args:
+        exception: An exception raised during the config validation
+    """
+    messages = {}
+    messages['errors'] = error.errors
+    messages['unset'] = error.unset
+    return normalize_config_validation(messages)
 
 
 def make_default_config_if_needed(config_path):

--- a/dcos_installer/config_util.py
+++ b/dcos_installer/config_util.py
@@ -33,11 +33,6 @@ def parent_dirs(filename):
         yield '/'.join(dirs)
 
 
-def do_configure(config):
-    gen_out = onprem_generate(config)
-    make_serve_dir(gen_out)
-
-
 def do_move_atomic(src_dir, dest_dir, filenames):
     assert os.path.exists(src_dir)
     assert os.path.exists(dest_dir)

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -106,7 +106,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.0',
+        'version': '1.10.1',
         'variant': 'some-variant'
     }
 

--- a/dcos_installer/test_config.py
+++ b/dcos_installer/test_config.py
@@ -1,0 +1,17 @@
+from dcos_installer import config
+from gen.exceptions import ValidationError
+
+
+def test_normalize_config_validation_exception():
+    errors = {
+        'key': {'message': 'test'},
+    }
+    validation_error = ValidationError(errors=errors, unset=set(['one', 'two']))
+    normalized = config.normalize_config_validation_exception(validation_error)
+
+    expected = {
+        'key': 'test',
+        'one': 'Must set one, no way to calculate value.',
+        'two': 'Must set two, no way to calculate value.',
+    }
+    assert expected == normalized

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -983,7 +983,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.0',
+        'dcos_version': '1.10.1',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -758,6 +758,9 @@ package:
                   "Location": "/opt/mesosphere/etc/user.config.yaml"
               },
               {
+                  "Location": "/var/lib/dcos/cluster-id"
+              },
+              {
                   "Location": "/var/lib/dcos/exhibitor/zookeeper/snapshot/myid",
                   "Role": ["master"]
               },

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -508,7 +508,8 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
-                             'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json']
+                             'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
+                             'var/lib/dcos/cluster-id.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
 deps =
   dnspython
   pytest
+  pytest-catchlog
   PyYAML
   webtest
   webtest-aiohttp==1.1.0


### PR DESCRIPTION
This is train 230 meant for the 1.10.1 release. It includes the following pull requests:

- #1908 (Add cluster ID to diagnostics bundle for 1.10)
- #1959 (dcos_installer: Don't run genconf validation twice [1.10 backport])
- #1972 (Bump DC/OS version to 1.10.1)