### PR TITLE
[1.10.1] Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "a9fa069993c8b5a5cb0bb57484d4568efc09acc4",
+    "ref": "74c87c68631573f90ab921b2d1fc3f0cb216f019",
     "ref_origin": "1.10.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High Level Description

This feature updates dcos-metrics, adding a regression test that was missing from the last version. 

## Related Issues

  - [DCOS_OSS-1562](https://jira.dcos.io/browse/DCOS_OSS-1562) Regression test for http fallback in dcos-metrics

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/a9fa069993c8b5a5cb0bb57484d4568efc09acc4...74c87c68631573f90ab921b2d1fc3f0cb216f019)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-branch/6/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-metrics/job/public-dcos-metrics-branch/6/cobertura/)
