### PR TITLE
Remove cosmos object storage

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -774,10 +774,6 @@ package:
               }
           ]
         }
-  - path: /etc/cosmos.env
-    content: |
-      COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG={{ cosmos_staged_package_storage_uri_flag }}
-      COSMOS_PACKAGE_STORAGE_URI_FLAG={{ cosmos_package_storage_uri_flag }}
   - path: /etc/adminrouter.env
     content: |
       ADMINROUTER_ACTIVATE_AUTH_MODULE={{ adminrouter_auth_enabled }}

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -22,7 +22,6 @@ PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/proxy.env
-EnvironmentFile=/opt/mesosphere/etc/cosmos.env
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
 ExecStart=/opt/mesosphere/bin/java \\
@@ -31,7 +30,5 @@ ExecStart=/opt/mesosphere/bin/java \\
     -classpath ${PKG_PATH}/usr/cosmos.jar \\
     com.simontuffs.onejar.Boot \\
     -admin.port=127.0.0.1:9990 \\
-    -io.github.benwhitehead.finch.httpInterface=127.0.0.1:7070 \\
-    \${COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG} \\
-    \${COSMOS_PACKAGE_STORAGE_URI_FLAG}
+    -com.mesosphere.cosmos.httpInterface=127.0.0.1:7070
 EOF

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,7 +5,7 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://s3.us-east-2.amazonaws.com/takirala-universe-package-dcos/cosmos-enterprise_2.12-0.5.0-SNAPSHOT-one-jar.jar",
+    "url": "https://downloads.dcos.io/cosmos/0.4.1-14/cosmos-server-0.4.1-14-one-jar.jar",
     "sha1": "4320fe2f3391e9a9b78a583a6e75106a430a6dc6"
   },
   "username": "dcos_cosmos",

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "url",
     "url": "https://downloads.dcos.io/cosmos/0.4.1-14/cosmos-server-0.4.1-14-one-jar.jar",
-    "sha1": "4320fe2f3391e9a9b78a583a6e75106a430a6dc6"
+    "sha1": "61e5b8ac089ee3598941f27d751fa64013fd29c9"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.4.1-14/cosmos-server-0.4.1-14-one-jar.jar",
-    "sha1": "61e5b8ac089ee3598941f27d751fa64013fd29c9"
+    "url": "https://s3.us-east-2.amazonaws.com/takirala-universe-package-dcos/cosmos-enterprise_2.12-0.5.0-SNAPSHOT-one-jar.jar",
+    "sha1": "4320fe2f3391e9a9b78a583a6e75106a430a6dc6"
   },
   "username": "dcos_cosmos",
   "state_directory": true

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -155,42 +155,6 @@ def test_if_we_have_capabilities(dcos_api_session):
     assert {'name': 'PACKAGE_MANAGEMENT'} in r.json()['capabilities']
 
 
-def test_cosmos_package_add(dcos_api_session):
-    r = dcos_api_session.post(
-        '/package/add',
-        headers={
-            'Accept': (
-                'application/vnd.dcos.package.add-response+json;'
-                'charset=utf-8;version=v1'
-            ),
-            'Content-Type': (
-                'application/vnd.dcos.package.add-request+json;'
-                'charset=utf-8;version=v1'
-            )
-        },
-        json={
-            'packageName': 'cassandra',
-            'packageVersion': '1.0.20-3.0.10'
-        }
-    )
-
-    if (expanded_config['cosmos_staged_package_storage_uri_flag'] and
-            expanded_config['cosmos_package_storage_uri_flag']):
-        # if the config is enabled then Cosmos should accept the request and
-        # return 202
-        assert r.status_code == 202, 'status = {}, content = {}'.format(
-            r.status_code,
-            r.content
-        )
-    else:
-        # if the config is disabled then Cosmos should accept the request and
-        # return Not Implemented 501
-        assert r.status_code == 501, 'status = {}, content = {}'.format(
-            r.status_code,
-            r.content
-        )
-
-
 def test_if_overlay_master_is_up(dcos_api_session):
     r = dcos_api_session.get('/mesos/overlay-master/state')
     assert r.ok, "status_code: {}, content: {}".format(r.status_code, r.content)

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -6,8 +6,6 @@ import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 
-from test_helpers import expanded_config
-
 
 def test_if_dcos_ui_is_up(dcos_api_session):
     r = dcos_api_session.get('/')


### PR DESCRIPTION
## High Level Description

Enterprise Cosmos doesn't need a object store any more as this functionality is moved to package registry. Remove object store configuration from DC/OS. The current `cosmos` `master` ignores this flags, and this PR removes those unused flags from dcos.

## Related Issues

  - [DCOS-18769](https://jira.mesosphere.com/browse/DCOS-18769) Remove object store configuration from DC/OS.

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: 
     https://github.com/dcos/dcos/blob/master/packages/dcos-integration-test/extra/test_endpoints.py#L158
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
