### PR TITLE
Update CentOS Docker packages

### DIFF
--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -52,10 +52,10 @@ echo ">>> Removing tty requirement for sudo"
 sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 
 echo ">>> Install Docker"
-curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-1.13.1-1.el7.centos.x86_64.rpm \
-  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-1.13.1-1.el7.centos.x86_64.rpm
-curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-selinux-1.13.1-1.el7.centos.noarch.rpm \
-  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-1.13.1-1.el7.centos.noarch.rpm
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-17.05.0.ce-1.el7.centos.x86_64.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-17.05.0.ce-1.el7.centos.x86_64.rpm
+curl -fLsSv --retry 20 -Y 100000 -y 60 -o /tmp/docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch.rpm \
+  https://yum.dockerproject.org/repo/main/centos/7/Packages/docker-engine-selinux-17.05.0.ce-1.el7.centos.noarch.rpm
 yum -y localinstall /tmp/docker*.rpm || true
 systemctl enable docker
 

--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -424,7 +424,7 @@ ExecStart=
 ExecStart=/usr/bin/dockerd --storage-driver=overlay
 EOF
 
-sudo yum install -y docker-engine-1.13.1 docker-engine-selinux-1.13.1
+sudo yum install -y docker-engine-17.05.0.ce docker-engine-selinux-17.05.0.ce
 sudo systemctl start docker
 sudo systemctl enable docker
 


### PR DESCRIPTION
Update the `docker-engine` packages pulled by CentOS to `17.05.0.ce` (latest).