### PR TITLE
Add Mesos work dir config params

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -113,6 +113,11 @@ def validate_url(url: str):
         ) from ex
 
 
+def validate_absolute_path(path):
+    if not path.startswith('/'):
+        raise AssertionError('Must be an absolute filesystem path starting with /')
+
+
 def validate_ip_list(json_str: str):
     nodes_list = validate_json_list(json_str)
     check_duplicates(nodes_list)
@@ -891,7 +896,9 @@ entry = {
         lambda check_config: validate_check_config(check_config),
         lambda custom_checks: validate_check_config(custom_checks),
         lambda custom_checks, check_config: validate_custom_checks(custom_checks, check_config),
-        lambda fault_domain_enabled: validate_true_false(fault_domain_enabled)
+        lambda fault_domain_enabled: validate_true_false(fault_domain_enabled),
+        lambda mesos_master_work_dir: validate_absolute_path(mesos_master_work_dir),
+        lambda mesos_agent_work_dir: validate_absolute_path(mesos_agent_work_dir),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -979,7 +986,9 @@ entry = {
         'check_config': calculate_check_config,
         'custom_checks': '{}',
         'check_search_path': CHECK_SEARCH_PATH,
-        'fault_domain_enabled': 'false'
+        'fault_domain_enabled': 'false',
+        'mesos_master_work_dir': '/var/lib/dcos/mesos/master',
+        'mesos_agent_work_dir': '/var/lib/mesos/slave',
     },
     'must': {
         'custom_auth': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -393,7 +393,7 @@ package:
       MESOS_REGISTRY_STRICT=false
       MESOS_SLAVE_REMOVAL_RATE_LIMIT=1/20mins
       MESOS_OFFER_TIMEOUT=2mins
-      MESOS_WORK_DIR=/var/lib/dcos/mesos/master
+      MESOS_WORK_DIR={{ mesos_master_work_dir }}
       MESOS_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       MESOS_WEIGHTS={{ weights }}
       MESOS_QUORUM={{ master_quorum }}
@@ -423,7 +423,7 @@ package:
       MESOS_IMAGE_PROVIDERS=docker
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
-      MESOS_WORK_DIR=/var/lib/mesos/slave
+      MESOS_WORK_DIR={{ mesos_agent_work_dir }}
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -705,3 +705,34 @@ def test_validate_custom_checks():
             'node check names: node-check-1, node-check-2.'
         ),
     )
+
+
+def test_validate_mesos_work_dir():
+    validate_success({
+        'mesos_master_work_dir': '/var/foo',
+        'mesos_agent_work_dir': '/var/foo',
+    })
+
+    # Relative path.
+    validate_error(
+        {'mesos_master_work_dir': 'foo'},
+        'mesos_master_work_dir',
+        'Must be an absolute filesystem path starting with /',
+    )
+    validate_error(
+        {'mesos_agent_work_dir': 'foo'},
+        'mesos_agent_work_dir',
+        'Must be an absolute filesystem path starting with /',
+    )
+
+    # Empty work dir.
+    validate_error(
+        {'mesos_master_work_dir': ''},
+        'mesos_master_work_dir',
+        'Must be an absolute filesystem path starting with /',
+    )
+    validate_error(
+        {'mesos_agent_work_dir': ''},
+        'mesos_agent_work_dir',
+        'Must be an absolute filesystem path starting with /',
+    )


### PR DESCRIPTION
## High Level Description

This adds two `config.yaml` parameters that can override the location of the work directory for Mesos masters and agents: `mesos_master_work_dir` and `mesos_agent_work_dir`.

## Related Issues

  - [DCOS_OSS-1586](https://jira.mesosphere.com/browse/DCOS_OSS-1586) Configurable Mesos work dir location

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]