### PR TITLE
Bump Marathon to 1.6.0-pre-19

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.5.0-SNAPSHOT-713-g14280a6.tgz",
-    "sha1" : "95d0ef88237ba14b7cde0f7af52d77d2ed1c5896"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/snapshots/marathon-1.6.0-pre-19-g7501d6f.tgz",
+    "sha1" : "4f2aefd7bbc10de8d3d2150f009ee2a1c645bcb8"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
We updated the Scala version and need to bump dcos plugins

## High Level Description

It bumps to the latest marathon 1.6.0 snapshot build for DCOS 1.11

## Related Issues

  - [MARATHON-7223](https://jira.mesosphere.com/browse/MARATHON-7229) Upgrade Scala to 2.12

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: (library upgrades)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

