### PR TITLE
Bumped Mesos and mesos-modules to master.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "11b2e62489dd3efe98046d06ef9fa43fb51e8d47",
+      "ref": "9adfabc5d07048f55c3da5a1bad17d2109750f0e",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -3,11 +3,6 @@
 These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
 
 <li>[20e5654a294f599b637efadf32206e7b15398081] Set LIBPROCESS_IP into docker container.
-<li>[098743933a99925cfccb19f132393fa9f236c31e] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
+<li>[77ae0475cc692acb359afad6a26f4566460af2ec] Mesos UI: updated the URL generation to make it work with adminrouter.
 <li>[f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[17979fea307b7c094c2bac8e5a3f25af33208a0c] Updated mesos containerizer to ignore GPU isolator creation failure.
-
-<h2>Patches to cherry-pick on top of Mesos 1.4.0 only</h2>
-<li>[2f3a182d91952f0db30883acda0ef222affa6477] Included nested command check output in the executor logs.
-<li>[86ee162326172bffcf7f264c5e46ce3d155c1636] Made the log output handling of TCP and HTTP checks consistent.
-<li>[b0fd885dbf02a61b5635184df19905695b4bba96] Raised the logging level of some check and health check messages.
+<li>[1adcbaf630abe383fc3b7b28f8fdbf0bfa212d1b] Updated mesos containerizer to ignore GPU isolator creation failure.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "d0e70d3ffd213a46fd59072e0d10afb91dd069ff",
-    "ref_origin" : "dcos-mesos-1.4.0"
+    "ref": "09df58e9a83dbebf1ae8b32c28cb450294d92612",
+    "ref_origin" : "dcos-mesos-master-28f8827"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High Level Description

Bumps Mesos and mesos-modules to the HEAD of their `master` branches.

## Related Issues

  - [MESOS-8014](https://issues.apache.org/jira/browse/MESOS-8014) Provide HTTP authenticatee interface re/usable for the scheduler library.
  - ...

## Checklist for all PR's

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: the changes are covered by the Mesos and DC/OS test suite.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] [mesos-modules changelog](https://github.com/dcos/dcos-mesos-modules/compare/11b2e62489dd3efe98046d06ef9fa43fb51e8d47...9adfabc5d07048f55c3da5a1bad17d2109750f0e)
  - [X] [mesos changelog](https://github.com/apache/mesos/compare/1.4.0...28f8827)
  - [X] [Test Results](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/1892/)