### PR TITLE
Remove commit references from Mesos cherry-pick list

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -6,8 +6,3 @@ These commits can be found in the repository at <a href="https://github.com/meso
 <li>[098743933a99925cfccb19f132393fa9f236c31e] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6] Revert "Fixed the broken metrics information of master in WebUI."
 <li>[17979fea307b7c094c2bac8e5a3f25af33208a0c] Updated mesos containerizer to ignore GPU isolator creation failure.
-
-<h2>Patches to cherry-pick on top of Mesos 1.4.0 only</h2>
-<li>[2f3a182d91952f0db30883acda0ef222affa6477] Included nested command check output in the executor logs.
-<li>[86ee162326172bffcf7f264c5e46ce3d155c1636] Made the log output handling of TCP and HTTP checks consistent.
-<li>[b0fd885dbf02a61b5635184df19905695b4bba96] Raised the logging level of some check and health check messages.


### PR DESCRIPTION
These commits have made their way to Mesos upstream.

https://github.com/apache/mesos/commit/0a01bc38eba08da8ef8b4ae152c95a57c39d73f3
https://github.com/apache/mesos/commit/6d778fa45a73723b857db9b2ce92c3d15fb3373f
https://github.com/apache/mesos/commit/8347ec09f15989b822f48c000043c6547c25b5f4