### PR TITLE
Admin Router: Make AR send proper `User-Agent` header

### DIFF
--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -12,12 +12,15 @@ DEV_PATH := /usr/local/src
 DCOSAR_AR_LOCAL_PATH := $(CURDIR)
 DCOSAR_AR_CTR_MOUNT := /usr/local/adminrouter/nginx/conf/
 
-# Detect the docker network interface bridge name.
-BRIDGE_DEVNAME := $(shell docker network inspect -f '{{ index .Options "com.docker.network.bridge.name" }}' bridge | awk 'NF')
-
-# Detect the docker network interface bridge IP.
-# Using a docker container for this allows the docker daemon to run locally or remotely in a VM, like docker-machine.
-BRIDGE_IP := $(shell docker run --net=host --rm alpine ifconfig $(BRIDGE_DEVNAME) | grep 'inet addr:' | cut -d: -f2 | cut -d' ' -f1)
+# Allow for overriding DNS resolver used by AR devkit with a one specified by
+# the user. Google's DNS servers sometimes time out/are not super-reliable :(
+ifdef LOCAL_DNS
+    $(info Using `$(LOCAL_DNS)` resolver for resolving hostnames in the container)
+    DNS_DOCKER_OPTS := --dns=$(LOCAL_DNS)
+else
+    $(info Using default resolvers for resolving hostnames in the container)
+    DNS_DOCKER_OPTS := --dns=8.8.8.8 --dns=8.8.4.4
+endif
 
 # Vary the name of the container on the per-flavour basis.
 # The way we detect the repository flavour is consistent with how test harness
@@ -28,10 +31,6 @@ else
     DEVKIT_NAME=adminrouter-devkit-open
 endif
 
-# FIXME: some problems with dns queries timing out, use hosts caching dns as a
-# workaround for now
-# DNS_DOCKER_OPTS := --dns=8.8.8.8 --dns=8.8.4.4
-DNS_DOCKER_OPTS := --dns=$(BRIDGE_IP) --dns=8.8.8.8 --dns=8.8.4.4
 DEVKIT_BASE_DOCKER_OPTS := --name $(DEVKIT_NAME) \
 	$(DNS_DOCKER_OPTS) \
 	-e NUM_CORES=2 \

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -702,6 +702,93 @@
             </table>
           </div>
         </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/internal/acs/api/v1/</code></span>
+            </h3>
+            <span class="route-desc">Access Control Service policy query (unauthenticated, internal-only)</span>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Rewrite:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Regex:
+                      </td>
+                      <td>
+                        <code>^/internal/(.*)</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Replacement:
+                      </td>
+                      <td>
+                        <code>/$1</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Type:
+                      </td>
+                      <td>
+                        <code>break</code>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Proxy:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Path:
+                      </td>
+                      <td>
+                        <code>http://$backend/internal/acs/api/v1/</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Server:
+                      </td>
+                      <td>
+                        <code>127.0.0.1:8101</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Backend:
+                      </td>
+                      <td>
+                        DC/OS Authentication (OAuth)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        API Reference:
+                      </td>
+                      <td>
+                        <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
         <li class="route route-type-redirect">
           <div class="heading">
             <h3>
@@ -1706,7 +1793,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;type&gt;(/logs|/metrics/v0))(?&lt;url&gt;.*)</code></span>
+              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;url&gt;/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)</code></span>
             </h3>
             <span class="route-desc">System proxy to a specific agent node</span>
           </div>
@@ -1723,7 +1810,7 @@
                         Regex:
                       </td>
                       <td>
-                        <code>^/agent/[0-9a-zA-Z-]+(.*)$</code>
+                        <code>^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*)</code>
                       </td>
                     </tr>
                     <tr>
@@ -1731,7 +1818,40 @@
                         Replacement:
                       </td>
                       <td>
-                        <code>$1</code>
+                        <code>/system/v1$url</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Type:
+                      </td>
+                      <td>
+                        <code>break</code>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Rewrite:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Regex:
+                      </td>
+                      <td>
+                        <code>^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Replacement:
+                      </td>
+                      <td>
+                        <code>/dcos-metadata/dcos-version.json</code>
                       </td>
                     </tr>
                     <tr>
@@ -1756,7 +1876,7 @@
                         Path:
                       </td>
                       <td>
-                        <code>$agentaddr:$adminrouter_agent_port/system/v1$type$url$is_args$query_string</code>
+                        <code>$agentaddr:$adminrouter_agent_port</code>
                       </td>
                     </tr>
                   </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -75,6 +75,18 @@ routes:
       path: 'http://$backend/acs/api/v1/auth/'
       backend: iam
     path: /acs/api/v1/auth/
+  /internal/acs/api/v1/:
+    group: Authentication
+    matcher: path
+    description: 'Access Control Service policy query (unauthenticated, internal-only)'
+    proxy:
+      path: 'http://$backend/internal/acs/api/v1/'
+      backend: iam
+    rewrites:
+      - regex: ^/internal/(.*)
+        replacement: /$1
+        type: break
+    path: /internal/acs/api/v1/
   /login:
     group: Authentication
     matcher: exact
@@ -293,19 +305,21 @@ routes:
       path: 'http://$backend/system/health/v1'
       backend: dcos_diagnostics
     path: /system/health/v1
-  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0))(?<url>.*)':
+  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)':
     group: System
     matcher: regex
     description: System proxy to a specific agent node
     proxy:
-      path: >-
-        $agentaddr:$adminrouter_agent_port/system/v1$type$url$is_args$query_string
+      path: '$agentaddr:$adminrouter_agent_port'
     rewrites:
-      - regex: '^/agent/[0-9a-zA-Z-]+(.*)$'
-        replacement: $1
+      - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*)'
+        replacement: /system/v1$url
+        type: break
+      - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json'
+        replacement: /dcos-metadata/dcos-version.json
         type: break
     path: >-
-      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0))(?<url>.*)
+      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)
   /system/v1/leader/marathon(?<url>.*):
     group: System
     matcher: regex

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -94,6 +94,7 @@ location /internal/mesos_dns/ {
     # Do not send original request headers upstream, see
     # https://github.com/openresty/lua-nginx-module#ngxlocationcapture
     proxy_pass_request_headers off;
+    proxy_set_header User-Agent "Master Admin Router";
 
     include includes/proxy-headers.conf;
 
@@ -102,6 +103,25 @@ location /internal/mesos_dns/ {
     proxy_connect_timeout 2s;
     proxy_read_timeout 3s;
     proxy_pass http://mesos_dns/;
+}
+
+# Group: Authentication
+# Description: Access Control Service policy query (unauthenticated, internal-only)
+location /internal/acs/api/v1/ {
+    # This location does not require authentication. It is
+    # meant to serve only nginx' subrequests, via the 'internal' directive.
+    # http://nginx.org/en/docs/http/ngx_http_core_module.html#internal
+    internal;
+
+    # Do not send original request headers upstream, see
+    # https://github.com/openresty/lua-nginx-module#ngxlocationcapture
+    proxy_pass_request_headers off;
+    proxy_set_header User-Agent "Master Admin Router";
+
+    include includes/proxy-headers.conf;
+
+    rewrite ^/internal/(.*) /$1 break;
+    proxy_pass http://iam;
 }
 
 # Group: History

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -40,7 +40,8 @@ local function do_authn_and_authz_or_exit()
     local uid = validate_jwt_or_exit()
 
     -- Authz using authn :)
-    res = ngx.location.capture("/acs/api/v1/users/" .. uid)
+    res = ngx.location.capture("/internal/acs/api/v1/users/" .. uid)
+
     if res.status == ngx.HTTP_NOT_FOUND then
         ngx.log(ngx.ERR, "User not found: `" .. uid .. "`")
         return authcommon.exit_401()

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -59,9 +59,9 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    local headers = {["User-Agent"] = "Master Admin Router"}
     if auth_token ~= nil then
-        headers = {["Authorization"] = "token=" .. auth_token}
+        headers["Authorization"] = "token=" .. auth_token
     end
 
     -- Use cosocket-based HTTP library, as ngx subrequests are not available

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -6,10 +6,30 @@ import time
 import pytest
 import requests
 
-from generic_test_code.common import assert_endpoint_response
+from generic_test_code.common import assert_endpoint_response, verify_header
 from util import GuardedSubprocess, SearchCriteria, auth_type_str, jwt_type_str
 
 EXHIBITOR_PATH = "/exhibitor/foo/bar"
+
+
+class TestAuthzIAMBackendQueryCommon:
+    def test_if_master_ar_sets_correct_useragent_while_quering_iam(
+            self, master_ar_process_pertest, mocker, valid_user_header):
+        mocker.send_command(endpoint_id='http://127.0.0.1:8101',
+                            func_name='record_requests')
+
+        assert_endpoint_response(
+            master_ar_process_pertest,
+            '/mesos_dns/v1/reflect/me',
+            200,
+            headers=valid_user_header,
+            )
+
+        r_reqs = mocker.send_command(endpoint_id='http://127.0.0.1:8101',
+                                     func_name='get_recorded_requests')
+
+        assert len(r_reqs) == 1
+        verify_header(r_reqs[0]['headers'], 'User-Agent', 'Master Admin Router')
 
 
 class TestAuthnJWTValidator:


### PR DESCRIPTION
## High Level Description

All requests originating from the Admin Router must have the User-Agent header properly set. As part of this PR the `/internal/acs/api/v1/` endpoint has been moved into the shared `master.conf` file. This way we deduplicate the code a bit and keep the change DRY without changing the behaviour of AR.

Additionally, a small change to Makefile is introduced - the DNS server used for hostnames resolving inside the container defaults now to Google's servers (`8.8.8.8` and `8.8.4.4`) unless it's overridden by the `LOCAL_DNS` environment variable. The previous auto-detection approach did not work in networks with external gateways/routers as there is no host-local DNS there.

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS_OSS-1445 `Admin Router: AR should set unique user agent while doing requests to backend IAM/Mesos/Marathon`
 
## Related PRs

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1541