### PR TITLE
Add .advancedtestsrc for installer-cli and upgrade tests

### DIFF
--- a/.advancedtestsrc
+++ b/.advancedtestsrc
@@ -1,0 +1,10 @@
+[upgrade]
+TEST_LAUNCH_CONFIG_INSTALLER_URL=https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh
+TEST_CREATE_CLUSTER=true
+TEST_UPGRADE_ENTERPRISE=false
+TEST_UPGRADE_USE_CHECKS=true
+
+[installer-cli]
+TEST_CREATE_CLUSTER=true
+TEST_CUSTOM_CHECKS=true
+TEST_INSTALL_PREREQS=false


### PR DESCRIPTION
What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

Corresponding Advanced tests PR to introduce support for this file: https://github.com/mesosphere/advanced-tests/pull/17