### PR TITLE
Train 238

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -73,7 +73,6 @@ aws_base_source = Source(entry={
         # template variable for the generating advanced template cloud configs
         'cloud_config': '{{ cloud_config }}',
         'rexray_config_preset': 'aws',
-        'fault_domain_enabled': 'true',
         'fault_domain_detect_contents': calculate_fault_domain_detect_contents('aws')
     },
     'conditional': {

--- a/gen/build_deploy/azure.py
+++ b/gen/build_deploy/azure.py
@@ -59,7 +59,6 @@ azure_base_source = Source(entry={
         'master_cloud_config': '{{ master_cloud_config }}',
         'slave_cloud_config': '{{ slave_cloud_config }}',
         'slave_public_cloud_config': '{{ slave_public_cloud_config }}',
-        'fault_domain_enabled': 'true',
         'fault_domain_detect_contents': yaml.dump(
             pkg_resources.resource_string('gen', 'fault-domain-detect/azure.sh').decode())
     },

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -10,7 +10,6 @@ from typing import List
 
 import checksumdir
 import pkg_resources
-import yaml
 
 import dcos_installer.config_util
 import gen.build_deploy.util as util
@@ -25,21 +24,6 @@ from gen.calc import (
 )
 from gen.internals import Source
 from pkgpanda.util import logger
-
-
-def calculate_fault_domain_detect_contents(fault_domain_detect_filename, fault_domain_enabled):
-    if fault_domain_enabled == 'false':
-        return ''
-    return yaml.dump(open(fault_domain_detect_filename, encoding='utf-8').read())
-
-
-def calculate_fault_domain_enabled(fault_domain_detect_filename):
-    try:
-        with open(fault_domain_detect_filename):
-            pass
-    except FileNotFoundError:
-        return 'false'
-    return 'true'
 
 
 def calculate_custom_check_bins_provided(custom_check_bins_dir):
@@ -97,14 +81,11 @@ onprem_source = Source(entry={
         'resolvers': '["8.8.8.8", "8.8.4.4"]',
         'ip_detect_filename': 'genconf/ip-detect',
         'bootstrap_id': lambda: calculate_environment_variable('BOOTSTRAP_ID'),
-        'enable_docker_gc': 'false',
-        'fault_domain_detect_contents': calculate_fault_domain_detect_contents
+        'enable_docker_gc': 'false'
     },
     'must': {
         'provider': 'onprem',
         'package_ids': calculate_package_ids,
-        'fault_domain_detect_filename': 'genconf/fault_domain_detect',
-        'fault_domain_enabled': calculate_fault_domain_enabled,
         'custom_check_bins_dir': 'genconf/check_bins/',
         'custom_check_bins_package_name': 'custom-check-bins',
         'custom_check_bins_provided': calculate_custom_check_bins_provided,

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -858,6 +858,12 @@ def validate_custom_checks(custom_checks, check_config):
         raise AssertionError(msg)
 
 
+def calculate_fault_domain_detect_contents(fault_domain_detect_filename):
+    if os.path.exists(fault_domain_detect_filename):
+        return yaml.dump(open(fault_domain_detect_filename, encoding='utf-8').read())
+    return ''
+
+
 __dcos_overlay_network_default_name = 'dcos'
 
 
@@ -1003,11 +1009,13 @@ entry = {
         'check_config': calculate_check_config,
         'custom_checks': '{}',
         'check_search_path': CHECK_SEARCH_PATH,
-        'fault_domain_enabled': 'false',
         'mesos_master_work_dir': '/var/lib/dcos/mesos/master',
         'mesos_agent_work_dir': '/var/lib/mesos/slave',
+        'fault_domain_detect_filename': 'genconf/fault_domain_detect',
+        'fault_domain_detect_contents': calculate_fault_domain_detect_contents
     },
     'must': {
+        'fault_domain_enabled': 'false',
         'custom_auth': 'false',
         'master_quorum': lambda num_masters: str(floor(int(num_masters) / 2) + 1),
         'resolvers_str': calculate_resolvers_str,

--- a/gen/tests/test_validation.py
+++ b/gen/tests/test_validation.py
@@ -1,5 +1,7 @@
 import json
 
+import pkg_resources
+
 import gen
 from gen.tests.utils import make_arguments, true_false_msg, validate_error, validate_success
 
@@ -764,3 +766,14 @@ def test_validate_mesos_work_dir():
         'mesos_agent_work_dir',
         'Must be an absolute filesystem path starting with /',
     )
+
+
+def test_fault_domain_disabled():
+    arguments = make_arguments(new_arguments={
+        'fault_domain_detect_filename': pkg_resources.resource_filename('gen', 'fault-domain-detect/aws.sh')
+    })
+
+    generated = gen.generate(arguments=arguments)
+
+    assert generated.arguments['fault_domain_enabled'] == 'false'
+    assert 'fault_domain_detect_contents' not in generated.arguments

--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -12,12 +12,15 @@ DEV_PATH := /usr/local/src
 DCOSAR_AR_LOCAL_PATH := $(CURDIR)
 DCOSAR_AR_CTR_MOUNT := /usr/local/adminrouter/nginx/conf/
 
-# Detect the docker network interface bridge name.
-BRIDGE_DEVNAME := $(shell docker network inspect -f '{{ index .Options "com.docker.network.bridge.name" }}' bridge | awk 'NF')
-
-# Detect the docker network interface bridge IP.
-# Using a docker container for this allows the docker daemon to run locally or remotely in a VM, like docker-machine.
-BRIDGE_IP := $(shell docker run --net=host --rm alpine ifconfig $(BRIDGE_DEVNAME) | grep 'inet addr:' | cut -d: -f2 | cut -d' ' -f1)
+# Allow for overriding DNS resolver used by AR devkit with a one specified by
+# the user. Google's DNS servers sometimes time out/are not super-reliable :(
+ifdef LOCAL_DNS
+    $(info Using `$(LOCAL_DNS)` resolver for resolving hostnames in the container)
+    DNS_DOCKER_OPTS := --dns=$(LOCAL_DNS)
+else
+    $(info Using default resolvers for resolving hostnames in the container)
+    DNS_DOCKER_OPTS := --dns=8.8.8.8 --dns=8.8.4.4
+endif
 
 # Vary the name of the container on the per-flavour basis.
 # The way we detect the repository flavour is consistent with how test harness
@@ -28,10 +31,6 @@ else
     DEVKIT_NAME=adminrouter-devkit-open
 endif
 
-# FIXME: some problems with dns queries timing out, use hosts caching dns as a
-# workaround for now
-# DNS_DOCKER_OPTS := --dns=8.8.8.8 --dns=8.8.4.4
-DNS_DOCKER_OPTS := --dns=$(BRIDGE_IP) --dns=8.8.8.8 --dns=8.8.4.4
 DEVKIT_BASE_DOCKER_OPTS := --name $(DEVKIT_NAME) \
 	$(DNS_DOCKER_OPTS) \
 	-e NUM_CORES=2 \

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -702,6 +702,93 @@
             </table>
           </div>
         </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/internal/acs/api/v1/</code></span>
+            </h3>
+            <span class="route-desc">Access Control Service policy query (unauthenticated, internal-only)</span>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Rewrite:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Regex:
+                      </td>
+                      <td>
+                        <code>^/internal/(.*)</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Replacement:
+                      </td>
+                      <td>
+                        <code>/$1</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Type:
+                      </td>
+                      <td>
+                        <code>break</code>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Proxy:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Path:
+                      </td>
+                      <td>
+                        <code>http://$backend/internal/acs/api/v1/</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Server:
+                      </td>
+                      <td>
+                        <code>127.0.0.1:8101</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Backend:
+                      </td>
+                      <td>
+                        DC/OS Authentication (OAuth)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        API Reference:
+                      </td>
+                      <td>
+                        <a href="https://dcos.io/docs/1.10/security/iam-api/">https://dcos.io/docs/1.10/security/iam-api/</a>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
         <li class="route route-type-redirect">
           <div class="heading">
             <h3>
@@ -1706,7 +1793,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;type&gt;(/logs|/metrics/v0))(?&lt;url&gt;.*)</code></span>
+              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;url&gt;/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)</code></span>
             </h3>
             <span class="route-desc">System proxy to a specific agent node</span>
           </div>
@@ -1723,7 +1810,7 @@
                         Regex:
                       </td>
                       <td>
-                        <code>^/agent/[0-9a-zA-Z-]+(.*)$</code>
+                        <code>^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*)</code>
                       </td>
                     </tr>
                     <tr>
@@ -1731,7 +1818,40 @@
                         Replacement:
                       </td>
                       <td>
-                        <code>$1</code>
+                        <code>/system/v1$url</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Type:
+                      </td>
+                      <td>
+                        <code>break</code>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Rewrite:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Regex:
+                      </td>
+                      <td>
+                        <code>^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Replacement:
+                      </td>
+                      <td>
+                        <code>/dcos-metadata/dcos-version.json</code>
                       </td>
                     </tr>
                     <tr>
@@ -1756,7 +1876,7 @@
                         Path:
                       </td>
                       <td>
-                        <code>$agentaddr:$adminrouter_agent_port/system/v1$type$url$is_args$query_string</code>
+                        <code>$agentaddr:$adminrouter_agent_port</code>
                       </td>
                     </tr>
                   </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -75,6 +75,18 @@ routes:
       path: 'http://$backend/acs/api/v1/auth/'
       backend: iam
     path: /acs/api/v1/auth/
+  /internal/acs/api/v1/:
+    group: Authentication
+    matcher: path
+    description: 'Access Control Service policy query (unauthenticated, internal-only)'
+    proxy:
+      path: 'http://$backend/internal/acs/api/v1/'
+      backend: iam
+    rewrites:
+      - regex: ^/internal/(.*)
+        replacement: /$1
+        type: break
+    path: /internal/acs/api/v1/
   /login:
     group: Authentication
     matcher: exact
@@ -293,19 +305,21 @@ routes:
       path: 'http://$backend/system/health/v1'
       backend: dcos_diagnostics
     path: /system/health/v1
-  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0))(?<url>.*)':
+  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)':
     group: System
     matcher: regex
     description: System proxy to a specific agent node
     proxy:
-      path: >-
-        $agentaddr:$adminrouter_agent_port/system/v1$type$url$is_args$query_string
+      path: '$agentaddr:$adminrouter_agent_port'
     rewrites:
-      - regex: '^/agent/[0-9a-zA-Z-]+(.*)$'
-        replacement: $1
+      - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*)'
+        replacement: /system/v1$url
+        type: break
+      - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json'
+        replacement: /dcos-metadata/dcos-version.json
         type: break
     path: >-
-      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<type>(/logs|/metrics/v0))(?<url>.*)
+      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)
   /system/v1/leader/marathon(?<url>.*):
     group: System
     matcher: regex

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -94,6 +94,7 @@ location /internal/mesos_dns/ {
     # Do not send original request headers upstream, see
     # https://github.com/openresty/lua-nginx-module#ngxlocationcapture
     proxy_pass_request_headers off;
+    proxy_set_header User-Agent "Master Admin Router";
 
     include includes/proxy-headers.conf;
 
@@ -102,6 +103,25 @@ location /internal/mesos_dns/ {
     proxy_connect_timeout 2s;
     proxy_read_timeout 3s;
     proxy_pass http://mesos_dns/;
+}
+
+# Group: Authentication
+# Description: Access Control Service policy query (unauthenticated, internal-only)
+location /internal/acs/api/v1/ {
+    # This location does not require authentication. It is
+    # meant to serve only nginx' subrequests, via the 'internal' directive.
+    # http://nginx.org/en/docs/http/ngx_http_core_module.html#internal
+    internal;
+
+    # Do not send original request headers upstream, see
+    # https://github.com/openresty/lua-nginx-module#ngxlocationcapture
+    proxy_pass_request_headers off;
+    proxy_set_header User-Agent "Master Admin Router";
+
+    include includes/proxy-headers.conf;
+
+    rewrite ^/internal/(.*) /$1 break;
+    proxy_pass http://iam;
 }
 
 # Group: History

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -40,7 +40,8 @@ local function do_authn_and_authz_or_exit()
     local uid = validate_jwt_or_exit()
 
     -- Authz using authn :)
-    res = ngx.location.capture("/acs/api/v1/users/" .. uid)
+    res = ngx.location.capture("/internal/acs/api/v1/users/" .. uid)
+
     if res.status == ngx.HTTP_NOT_FOUND then
         ngx.log(ngx.ERR, "User not found: `" .. uid .. "`")
         return authcommon.exit_401()

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -59,9 +59,9 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    local headers = {["User-Agent"] = "Master Admin Router"}
     if auth_token ~= nil then
-        headers = {["Authorization"] = "token=" .. auth_token}
+        headers["Authorization"] = "token=" .. auth_token
     end
 
     -- Use cosocket-based HTTP library, as ngx subrequests are not available

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -6,10 +6,30 @@ import time
 import pytest
 import requests
 
-from generic_test_code.common import assert_endpoint_response
+from generic_test_code.common import assert_endpoint_response, verify_header
 from util import GuardedSubprocess, SearchCriteria, auth_type_str, jwt_type_str
 
 EXHIBITOR_PATH = "/exhibitor/foo/bar"
+
+
+class TestAuthzIAMBackendQueryCommon:
+    def test_if_master_ar_sets_correct_useragent_while_quering_iam(
+            self, master_ar_process_pertest, mocker, valid_user_header):
+        mocker.send_command(endpoint_id='http://127.0.0.1:8101',
+                            func_name='record_requests')
+
+        assert_endpoint_response(
+            master_ar_process_pertest,
+            '/mesos_dns/v1/reflect/me',
+            200,
+            headers=valid_user_header,
+            )
+
+        r_reqs = mocker.send_command(endpoint_id='http://127.0.0.1:8101',
+                                     func_name='get_recorded_requests')
+
+        assert len(r_reqs) == 1
+        verify_header(r_reqs[0]['headers'], 'User-Agent', 'Master Admin Router')
 
 
 class TestAuthnJWTValidator:


### PR DESCRIPTION
# Train 238

- https://github.com/dcos/dcos/pull/1989 – **disable fault domain**
> set `fault_domain_enabled` to `false` in all cases.
- https://github.com/dcos/dcos/pull/2007 – **Admin Router: Make AR send proper `User-Agent` header** 
> All requests originating from the Admin Router must have the User-Agent header properly set. As part of this PR the /internal/acs/api/v1/ endpoint has been moved into the shared master.conf file. This way we deduplicate the code a bit and keep the change DRY without changing the behaviour of AR.
>
>Additionally, a small change to Makefile is introduced - the DNS server used for hostnames resolving inside the container defaults now to Google's servers (8.8.8.8 and 8.8.4.4) unless it's overridden by the LOCAL_DNS environment variable. The previous auto-detection approach did not work in networks with external gateways/routers as there is no host-local DNS there.

## Related Issues
- https://jira.mesosphere.com/browse/DCOS_OSS-1445 Admin Router: AR should set unique user agent while doing requests to backend IAM/Mesos/Marathon