### PR TITLE
Enable @mesosphere-mergebot merge-it

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,6 +3,7 @@
    "ship-it": false,
    "test": false,
    "bump-ee": true,
+   "merge-it": true,
     "label": {
         "enabled": true,
         "default": "Work In Progress",


### PR DESCRIPTION
## High Level Description

```
@mesosphere-megebot merge-it
```

Will enabled automated merging of open `dcos/dcos` and corresponding `mesosphere/dcos-enterprise` PR.  Only [owners](https://github.com/dcos/dcos/blob/master/owners.json) will be able to issue the command, and all status checks **must-be** green in-order for the bot to merge-it.