### PR TITLE
Bump CPython

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ To find the git SHA of any given release, check the latest commit in the version
     - Ubuntu 16.04 LTS:
         - [pyenv-installer](https://github.com/yyuu/pyenv-installer)
         - Python dependencies: `sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils liblzma-dev python3-venv`
-        - Install Python 3.5.2: `pyenv install 3.5.2`
-        - Create DC/OS virtualenv: `pyenv virtualenv 3.5.2 dcos`
+        - Install Python 3.6.3: `pyenv install 3.6.3`
+        - Create DC/OS virtualenv: `pyenv virtualenv 3.6.3 dcos`
         - Activate environment: `pyenv activate dcos`
 1. Over 10GB of free disk space and 8GB of RAM
     - The build makes use of hard links, so if you're using VirtualBox the disk space cannot be a synced folder.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To find the git SHA of any given release, check the latest commit in the version
 1. git 1.8.5+
 1. Docker 1.11+
     - [Install Instructions for various distributions](https://docs.docker.com/engine/installation/). Docker needs to be configured so your user can run docker containers. The command `docker run alpine  /bin/echo 'Hello, World!'` when run at a new terminal as your user should just print `"Hello, World!"`. If it says something like "Unable to find image 'alpine:latest' locally" then re-run and the message should go away.
-1. Python 3.5
+1. Python 3.6
     - Arch Linux: `sudo pacman -S python`
     - Fedora 23 Workstation: Already installed by default / no steps
     - Ubuntu 16.04 LTS:

--- a/build_local.sh
+++ b/build_local.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 # Create a python virtual environment to install the DC/OS tools to
-python3.5 -m venv /tmp/dcos_build_venv
+python3.6 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_local.sh
+++ b/build_local.sh
@@ -11,7 +11,8 @@ docker ps
 # Cleanup from previous build
 rm -rf /tmp/dcos_build_venv
 
-# Force Python stdout/err to be unbuffered.
+# Force Python stdout/err to be unbuffered to have immediate
+# feedback in e.g. a TeamCity build environment.
 export PYTHONUNBUFFERED="notemtpy"
 
 # Write a DC/OS Release tool configuration file which specifies where the build
@@ -29,8 +30,8 @@ options:
 EOF
 fi
 
-# Create a python virtual environment to install the DC/OS tools to
-python3.6 -m venv /tmp/dcos_build_venv
+# Create a Python virtual environment to install the DC/OS tools to.
+python3.5 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_teamcity
+++ b/build_teamcity
@@ -46,7 +46,7 @@ _scope_opened "setup"
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-python3.5 -m venv --clear --copies build/env
+python3.6 -m venv --clear --copies build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}

--- a/build_teamcity
+++ b/build_teamcity
@@ -42,11 +42,13 @@ rm -rf wheelhouse/
 _scope_closed "cleanup"
 
 _scope_opened "setup"
-# Force Python stdout/err to be unbuffered.
+
+# Force Python stdout/err to be unbuffered to
+# have immediate feedback in TeamCity build logs.
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-python3.6 -m venv --clear --copies build/env
+python3.5 -m venv --clear --copies build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}

--- a/dcos_installer/async_server.py
+++ b/dcos_installer/async_server.py
@@ -315,7 +315,7 @@ def build_app(loop):
 
     # Disable all caching for everything, disable once the Web UI gets cache
     # breaking urls for it's assets (still need to not cache the REST responses, index.html though)
-    # TODO(cmaloney): Python 3.5 switch this to `async def` per:
+    # TODO(cmaloney): Python 3.6 switch this to `async def` per:
     #                 http://aiohttp.readthedocs.io/en/stable/web.html#signals
     def no_caching(request, response):
         response.headers['Cache-Control'] = 'no-store, must-revalidate'

--- a/docs/styleguides/python.md
+++ b/docs/styleguides/python.md
@@ -19,7 +19,7 @@ main stake holders of this style guide.
 
 ##### Python Version Requirement
 
-This style guide is written for Python3.5 and above. As new features of the language get standardized, this style guide
+This style guide is written for Python3.6 and above. As new features of the language get standardized, this style guide
 can be revised to adopt new features.
 
 #### Base Style Guide
@@ -152,7 +152,7 @@ from test_util.helpers import (CI_CREDENTIALS,
     ```
 
 
-* Adding Types. Since our code-base is Python3.5+ compatible, we have the choice of introducing types, validating
+* Adding Types. Since our code-base is Python3.6+ compatible, we have the choice of introducing types, validating
   with mypy.
 
 ```

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -30,7 +30,7 @@ def validate_arguments_strings(arguments: dict):
         raise ValidationError(errors, set())
 
 
-# TODO (cmaloney): Python 3.5, add checking valid_values is Iterable[str]
+# TODO (cmaloney): Python 3.6, add checking valid_values is Iterable[str]
 def validate_one_of(val: str, valid_values) -> None:
     """Test if object `val` is a member of container `valid_values`.
     Raise a AssertionError if it is not a member. The exception message contains

--- a/packages/bootstrap/build
+++ b/packages/bootstrap/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/extra

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='support@mesosphere.io',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5'],
+        'Programming Language :: Python :: 3.6'],
     entry_points={
         'console_scripts': [
             'bootstrap=dcos_internal_utils.cli:main'

--- a/packages/boto/build
+++ b/packages/boto/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 for package in futures jmespath botocore boto3 s3transfer; do

--- a/packages/boto/buildinfo.json
+++ b/packages/boto/buildinfo.json
@@ -23,8 +23,8 @@
     },
     "s3transfer": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/4b/4c/42ea1dba46deea23fbcb7a51c794f9a02f87b8df7a28a9a8dc5ef57baa21/s3transfer-0.1.9-py2.py3-none-any.whl",
-      "sha1": "94bf6b560939dd8fdd9cc5b9d3d192a121df3b75"
+      "url": "https://pypi.python.org/packages/53/a8/dbee2c13508a4f1060ec44a0889d6766508912905a16edb593f628e92db1/s3transfer-0.1.11-py2.py3-none-any.whl",
+      "sha1": "3569560d886f48b0e0e9286fc1c733902f6bd91e"
     }
   }
 }

--- a/packages/boto/buildinfo.json
+++ b/packages/boto/buildinfo.json
@@ -3,8 +3,8 @@
   "sources": {
     "boto3": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/18/8c/ea1a772e28584f790d4833bdfff6db93e05522fea3348af1c2c4221b8c01/boto3-1.4.1-py2.py3-none-any.whl",
-      "sha1": "adaac3153c9fe0310f2a66dd54326db8d01189fd"
+      "url": "https://pypi.python.org/packages/7d/09/66fef826fb13a2cee74a1df56c269d2794a90ece49c3b77113b733e4b91d/boto3-1.4.8-py2.py3-none-any.whl",
+      "sha1": "1e5ca3a1a91ec124615362806452aac6b547ccf2"
     },
     "jmespath": {
       "kind": "url",
@@ -18,8 +18,8 @@
     },
     "botocore": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/28/b1/a246f8a8115d064427ef7c822051acd25059e0c5d5fad4cdc6916b1ca605/botocore-1.4.78-py2.py3-none-any.whl",
-      "sha1": "14ec9018643c295428e443329e7bddaa8a869a55"
+      "url": "https://pypi.python.org/packages/4c/5a/8bca1ef99a82ffaa5b7f0debeab2b86cba2a6f38c5f4cf0e984f95b89f01/botocore-1.8.1-py2.py3-none-any.whl",
+      "sha1": "3ed7a866a3ec928f54a033f50db930c076e41713"
     },
     "s3transfer": {
       "kind": "url",

--- a/packages/curl/build
+++ b/packages/curl/build
@@ -40,7 +40,7 @@ pushd /pkg/src/curl
             --without-spnego \
             --without-winidn \
             --without-winssl \
-            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.5/site-packages/requests/cacert.pem \
+            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.6/site-packages/requests/cacert.pem \
             --with-ca-path=/var/lib/dcos/pki/tls/certs
 make -j$NUM_CORES
 make install

--- a/packages/curl/build
+++ b/packages/curl/build
@@ -40,7 +40,7 @@ pushd /pkg/src/curl
             --without-spnego \
             --without-winidn \
             --without-winssl \
-            --with-ca-bundle=/opt/mesosphere/active/python-requests/lib/python3.6/site-packages/requests/cacert.pem \
+            --with-ca-bundle=/opt/mesosphere/active/python-certifi/lib/python3.6/site-packages/certifi/cacert.pem \
             --with-ca-path=/var/lib/dcos/pki/tls/certs
 make -j$NUM_CORES
 make install

--- a/packages/dcos-history/build
+++ b/packages/dcos-history/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Copy from the ro /pkg/extra to a rw folder.

--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -18,7 +18,6 @@ add_headers_cb = None
 try:
     import dcos_auth_python
     log.info('dcos_auth_python module detected; applying settings')
-    global add_headers_cb
     add_headers_cb = dcos_auth_python.get_auth_headers
 except ImportError:
     log.info('no dcos_auth_python module detected; using defaults')

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -10,7 +10,7 @@ for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 
-for package in aiohttp chardet checksumdir coloredlogs docker-py humanfriendly multidict \
+for package in aiohttp checksumdir coloredlogs docker-py humanfriendly multidict \
     oauthlib waitress websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -4,7 +4,7 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
-for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
+for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
     azure-mgmt-network azure-storage beautifulsoup4 certifi docutils keyring msrest \
     msrestazure py requests-oauthlib schema webob; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -5,7 +5,7 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
 for package in analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
-    azure-mgmt-network azure-storage beautifulsoup4 certifi docutils enum34 keyring msrest \
+    azure-mgmt-network azure-storage beautifulsoup4 certifi docutils keyring msrest \
     msrestazure py requests-oauthlib schema webob; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -5,7 +5,7 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
 for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
-    azure-mgmt-network azure-storage beautifulsoup4 certifi docutils keyring msrest \
+    azure-mgmt-network azure-storage beautifulsoup4 docutils keyring msrest \
     msrestazure py requests-oauthlib schema webob; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done

--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -70,8 +70,8 @@
     },
     "certifi": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/db/60/1ed0106bde7b14b363b15b17cc308aad93ba57d3582570f3ad7180ae0fae/certifi-2016.2.28-py2.py3-none-any.whl",
-      "sha1": "23b05f0c710004493ef65f9aa25aa44829f02aae"
+      "url": "https://pypi.python.org/packages/40/66/06130724e8205fc8c105db7edb92871c7fff7d31324d7f4405c762624a43/certifi-2017.7.27.1-py2.py3-none-any.whl",
+      "sha1": "aeb9761eb1231d8309a0b593747d0c95303467b5"
     },
     "chardet": {
       "kind": "url_extract",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -55,13 +55,13 @@
     },
     "msrest": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/f5/b6/176a2109be5354bbcb31bf52e32ed91b1fc398f1a30ed12db0b429c64928/msrest-0.4.0-py3-none-any.whl",
-      "sha1": "fdd0ae8546202f817f1bbddf2828bc0af1720514"
+      "url": "https://pypi.python.org/packages/a4/79/956d2475af557ccc7de76ef67087fc8e7b591162748ab7783d88e9b685d7/msrest-0.4.17-py2.py3-none-any.whl",
+      "sha1": "f979991d34fdb8389abfddb4a73f6eef753abc47"
     },
     "msrestazure": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/d3/37/6bf15f4e322bd2aa84ed98630a6e265f04784e40124aac5dae2e000553b0/msrestazure-0.4.1-py3-none-any.whl",
-      "sha1": "dfa52c208f423a1614a1a5dd2910e0a2295f1cb7"
+      "url": "https://pypi.python.org/packages/34/3d/4ed39efc7e833a84fa07561903750e64dcbd0cbea59b5be19ebd608f15fe/msrestazure-0.4.15-py2.py3-none-any.whl",
+      "sha1": "eb9bbdadbc1897950b95bb2e653dcc8cce2e50f6"
     },
     "beautifulsoup4": {
       "kind": "url",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -10,6 +10,7 @@
     "python-docopt",
     "python-isodate",
     "python-jinja2",
+    "python-jwt",
     "python-markupsafe",
     "python-passlib",
     "python-pyyaml",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -5,6 +5,7 @@
     "flask",
     "pytest",
     "python",
+    "python-certifi",
     "python-cryptography",
     "python-dateutil",
     "python-docopt",
@@ -74,11 +75,6 @@
       "kind": "url",
       "url": "https://pypi.python.org/packages/3.4/b/beautifulsoup4/beautifulsoup4-4.4.1-py3-none-any.whl",
       "sha1": "774554b2c16c334f2220800950026384cae713ac"
-    },
-    "certifi": {
-      "kind": "url",
-      "url": "https://pypi.python.org/packages/40/66/06130724e8205fc8c105db7edb92871c7fff7d31324d7f4405c762624a43/certifi-2017.7.27.1-py2.py3-none-any.whl",
-      "sha1": "aeb9761eb1231d8309a0b593747d0c95303467b5"
     },
     "checksumdir": {
       "kind": "url_extract",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -18,6 +18,11 @@
     "teamcity-messages"
   ],
   "sources": {
+    "adal": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/24/e9/35e48db18de35310ea3ba17c7f401e7c2099ad7ce31a0dbc881411ea7c16/adal-0.4.7-py2.py3-none-any.whl",
+      "sha1": "bb158afaf52a2cc7f6c25b86fefe1e5344d7b21d"
+    },
     "aiohttp": {
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/55/9d/38fb3cb174f4723b50a3f0593e18a51418c9a73a7857fdcaee46b83ff1c4/aiohttp-0.22.5.tar.gz",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -6,6 +6,7 @@
     "pytest",
     "python",
     "python-cryptography",
+    "python-dateutil",
     "python-docopt",
     "python-isodate",
     "python-jinja2",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -80,11 +80,6 @@
       "url": "https://pypi.python.org/packages/40/66/06130724e8205fc8c105db7edb92871c7fff7d31324d7f4405c762624a43/certifi-2017.7.27.1-py2.py3-none-any.whl",
       "sha1": "aeb9761eb1231d8309a0b593747d0c95303467b5"
     },
-    "chardet": {
-      "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/c/chardet/chardet-2.3.0.tar.gz",
-      "sha1": "50af8f8771ecbeb7a22567129c6c281b8bec3b1c"
-    },
     "checksumdir": {
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/84/8b/0e800a118ed64091245feddef0159d7979bb42915f65db5d2dafd6b12864/checksumdir-1.1.4.tar.gz",

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -53,11 +53,6 @@
       "url": "https://pypi.python.org/packages/cf/23/ef729d6ef3a9d19732d480eaaf94a72799a99a38ed25eda10f8e68ffd408/azure_storage-0.32.0-py3-none-any.whl",
       "sha1": "3cc425a291fe6359f6d786aa040059004082795d"
     },
-    "enum34": {
-        "kind": "url",
-        "url": "https://pypi.python.org/packages/af/42/cb9355df32c69b553e72a2e28daee25d1611d2c0d9c272aa1d34204205b2/enum34-1.1.6-py3-none-any.whl",
-        "sha1": "d8746baffb8d5f6af9aacc4d563d202f0bb9c334"
-    },
     "msrest": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/f5/b6/176a2109be5354bbcb31bf52e32ed91b1fc398f1a30ed12db0b429c64928/msrest-0.4.0-py3-none-any.whl",

--- a/packages/dcos-image/build
+++ b/packages/dcos-image/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/dcos-test-utils/build
+++ b/packages/dcos-test-utils/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Copy from the ro /pkg/extra to a rw folder.

--- a/packages/dnspython/build
+++ b/packages/dnspython/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/flask/build
+++ b/packages/flask/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Build all the packages. We'd use pip to install them but that fails badly.

--- a/packages/pytest/build
+++ b/packages/pytest/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-azure-mgmt-resource/build
+++ b/packages/python-azure-mgmt-resource/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-certifi/build
+++ b/packages/python-certifi/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-certifi/buildinfo.json
+++ b/packages/python-certifi/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "url",
+    "url": "https://pypi.python.org/packages/29/9b/25ef61e948321296f029f53c9f67cc2b54e224db509eb67ce17e0df6044a/certifi-2017.11.5-py2.py3-none-any.whl",
+    "sha1": "0e09a6f85d5f93ec1012ae8de014af2fecb7e2ea"
+  }
+}

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -5,10 +5,11 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 export PKG_CONFIG_PATH=/opt/mesosphere/lib/pkgconfig
 
-for package in cryptography cffi; do
-  pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
-done
-
 for package in pyasn1; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
+
+for package in pycparser cffi cryptography; do
+  pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
+done
+

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 export PKG_CONFIG_PATH=/opt/mesosphere/lib/pkgconfig

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -9,6 +9,6 @@ for package in cryptography cffi; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
 done
 
-for package in idna pyasn1; do
+for package in pyasn1; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -5,7 +5,7 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 export PKG_CONFIG_PATH=/opt/mesosphere/lib/pkgconfig
 
-for package in pyasn1; do
+for package in asn1crypto; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -9,7 +9,7 @@ for package in asn1crypto; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 
-for package in pycparser cffi cryptography; do
+for package in cffi cryptography; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
 done
 

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -3,13 +3,13 @@
   "sources": {
     "cryptography": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/99/df/71c7260003f5c469cec3db4c547115df39e9ce6c719a99e067ba0e78fd8a/cryptography-1.7.2.tar.gz",
-      "sha1": "2b5bc62fda71992633f83164b1a74c16a784acdf"
+      "url": "https://pypi.python.org/packages/f3/7c/ec4f94489719803cb14d35e9625d1f5a613b9c4b8d01ee52a4c77485e681/cryptography-2.1.3.tar.gz",
+      "sha1": "066acf8315cab631eb735188e20bef37c5848582"
     },
-    "pyasn1": {
+    "asn1crypto": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/07/4c/9a0927b81958997c1a4b2f88f70a48e622471b61fcd00d5039054fe881df/pyasn1-0.2.2-py2.py3-none-any.whl",
-      "sha1": "bdf5ef86a3a102fe9feece461b93b7e1717080e9"
+      "url": "https://pypi.python.org/packages/5e/85/d9b46c307ff2b5504432425cd99e2d9f13ab7a9835ba45c93da299cb1ec8/asn1crypto-0.23.0-py2.py3-none-any.whl",
+      "sha1": "664233097c6bee3d9ae1802a411ba4f629116406"
     },
     "cffi": {
       "kind": "url_extract",

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -15,6 +15,12 @@
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/a1/32/e3d6c3a8b5461b903651dd6ce958ed03c093d2e00128e3f33ea69f1d7965/cffi-1.9.1.tar.gz",
       "sha1": "16265a4b305d433fb9089b19278502e904b0cb43"
+    },
+    "pycparser": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/8c/2d/aad7f16146f4197a11f8e91fb81df177adcc2073d36a17b1491fd09df6ed/pycparser-2.18.tar.gz",
+      "sha1": "1c75af69ae6273b1f1f531744f87d060965ed85d"
     }
+
   }
 }

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["python", "libffi"],
+  "requires": ["python", "libffi", "python-idna"],
   "sources": {
     "cryptography": {
       "kind": "url_extract",
@@ -15,11 +15,6 @@
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/a1/32/e3d6c3a8b5461b903651dd6ce958ed03c093d2e00128e3f33ea69f1d7965/cffi-1.9.1.tar.gz",
       "sha1": "16265a4b305d433fb9089b19278502e904b0cb43"
-    },
-    "idna": {
-      "kind": "url",
-      "url": "https://pypi.python.org/packages/71/02/dee75fc3e6f7455bf69221164f94586ee13552c5f33c8002335667a3d122/idna-2.1-py2.py3-none-any.whl",
-      "sha1": "ef95a0f1627b85fbfb74eaba4fbb82f0c1b9d6d6"
     }
   }
 }

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["python", "libffi", "python-idna"],
+  "requires": ["python", "libffi", "python-idna", "python-pycparser"],
   "sources": {
     "cryptography": {
       "kind": "url_extract",
@@ -15,12 +15,6 @@
       "kind": "url_extract",
       "url": "https://pypi.python.org/packages/a1/32/e3d6c3a8b5461b903651dd6ce958ed03c093d2e00128e3f33ea69f1d7965/cffi-1.9.1.tar.gz",
       "sha1": "16265a4b305d433fb9089b19278502e904b0cb43"
-    },
-    "pycparser": {
-      "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/8c/2d/aad7f16146f4197a11f8e91fb81df177adcc2073d36a17b1491fd09df6ed/pycparser-2.18.tar.gz",
-      "sha1": "1c75af69ae6273b1f1f531744f87d060965ed85d"
     }
-
   }
 }

--- a/packages/python-dateutil/build
+++ b/packages/python-dateutil/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-docopt/build
+++ b/packages/python-docopt/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-gunicorn/build
+++ b/packages/python-gunicorn/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-idna/build
+++ b/packages/python-idna/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-idna/build
+++ b/packages/python-idna/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-idna/buildinfo.json
+++ b/packages/python-idna/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "url",
+    "url": "https://pypi.python.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl",
+    "sha1": "a75f31778ea0bbf218d7ae085f4f961d004d6ff2"
+  }
+}

--- a/packages/python-isodate/build
+++ b/packages/python-isodate/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-jinja2/build
+++ b/packages/python-jinja2/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-jwt/build
+++ b/packages/python-jwt/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-jwt/build
+++ b/packages/python-jwt/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-jwt/buildinfo.json
+++ b/packages/python-jwt/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://pypi.python.org/packages/2.7/P/PyJWT/PyJWT-1.4.0-py2.py3-none-any.whl",
-    "sha1": "5e9ad9706fe8157cf0d183ddd21b7f0c5ea481fe"
+    "url": "https://pypi.python.org/packages/8a/a6/4d931a2c77a224d27c78382f4ce8ec07542d4426ea2793bea77a689273c2/PyJWT-1.5.3-py2.py3-none-any.whl",
+    "sha1": "b1985b2c7b78d768c078f03987a919ddb2b98435"
   }
 }

--- a/packages/python-jwt/buildinfo.json
+++ b/packages/python-jwt/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "url",
+    "url": "https://pypi.python.org/packages/2.7/P/PyJWT/PyJWT-1.4.0-py2.py3-none-any.whl",
+    "sha1": "5e9ad9706fe8157cf0d183ddd21b7f0c5ea481fe"
+  }
+}

--- a/packages/python-kazoo/build
+++ b/packages/python-kazoo/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-markupsafe/build
+++ b/packages/python-markupsafe/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-passlib/build
+++ b/packages/python-passlib/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python-pycparser/build
+++ b/packages/python-pycparser/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-pycparser/buildinfo.json
+++ b/packages/python-pycparser/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/8c/2d/aad7f16146f4197a11f8e91fb81df177adcc2073d36a17b1491fd09df6ed/pycparser-2.18.tar.gz",
+      "sha1": "1c75af69ae6273b1f1f531744f87d060965ed85d"
+  }
+}

--- a/packages/python-pyyaml/build
+++ b/packages/python-pyyaml/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-requests/build
+++ b/packages/python-requests/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-requests/build
+++ b/packages/python-requests/build
@@ -3,6 +3,6 @@ source /opt/mesosphere/environment.export
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
-for package in urllib3 requests; do
+for package in chardet urllib3 requests; do
     pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done

--- a/packages/python-requests/build
+++ b/packages/python-requests/build
@@ -3,4 +3,6 @@ source /opt/mesosphere/environment.export
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
-pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME
+for package in urllib3 requests; do
+    pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
+done

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz",
-    "sha1": "1b9a2395402692262fc61fa15bedbc3e112b1029"
+    "url": "https://pypi.python.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz",
+    "sha1": "f5e1dbba5a12ff2df063333fd2bf071e24659b63"
   }
 }

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -1,8 +1,15 @@
 {
   "requires": ["python"],
-  "single_source": {
-    "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz",
-    "sha1": "f5e1dbba5a12ff2df063333fd2bf071e24659b63"
+  "sources": {
+    "requests": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/49/df/50aa1999ab9bde74656c2919d9c0c085fd2b3775fd3eca826012bef76d8c/requests-2.18.4-py2.py3-none-any.whl",
+      "sha1": "52ccdd6ee808bddd0c6eabc6eda79e79381266df"
+    },
+    "urllib3": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/63/cb/6965947c13a94236f6d4b8223e21beb4d576dc72e8130bd7880f600839b8/urllib3-1.22-py2.py3-none-any.whl",
+      "sha1": "ae6715ae61c34b72d5e0c3241abfb20c2c4d1313"
+    }
   }
 }

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz",
-    "sha1": "f5e1dbba5a12ff2df063333fd2bf071e24659b63"
+    "url": "https://pypi.python.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz",
+    "sha1": "1b9a2395402692262fc61fa15bedbc3e112b1029"
   }
 }

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -10,6 +10,11 @@
       "kind": "url",
       "url": "https://pypi.python.org/packages/63/cb/6965947c13a94236f6d4b8223e21beb4d576dc72e8130bd7880f600839b8/urllib3-1.22-py2.py3-none-any.whl",
       "sha1": "ae6715ae61c34b72d5e0c3241abfb20c2c4d1313"
+    },
+    "chardet": {
+      "kind": "url",
+      "url": "https://pypi.python.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl",
+      "sha1": "96faab7de7e9a71b37f22adb64daf2898e967e3e"
     }
   }
 }

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["python"],
+  "requires": ["python", "python-idna"],
   "sources": {
     "requests": {
       "kind": "url",

--- a/packages/python-retrying/build
+++ b/packages/python-retrying/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-tox/build
+++ b/packages/python-tox/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/python/build
+++ b/packages/python/build
@@ -12,7 +12,7 @@ make -j$NUM_CORES
 make install
 
 # Remove some big things we don't use at all
-rm -rf "$PKG_PATH/lib/python3.5/test"
+rm -rf "$PKG_PATH/lib/python3.6/test"
 
 # TODO(cmaloney): This sort of stripping static libraries should be a generic
 # mkpanda option to apply to any package.
@@ -23,7 +23,7 @@ find "$PKG_PATH/lib/" ! -type d -name "*.a" -exec rm -f -- '{}' +
 # Note(JP): For making pip upgrade itself reliably, it's best
 # to run pip as a module (python -m pip).
 export LD_LIBRARY_PATH=$PKG_PATH/lib
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/setuptools/*.whl
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip/*.whl
 echo "pip version: $($PKG_PATH/bin/pip3 --version)"

--- a/packages/python/build
+++ b/packages/python/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Build
+set -ex
+
 mkdir -p build
 pushd build
 
@@ -18,14 +20,24 @@ rm -rf "$PKG_PATH/lib/python3.6/test"
 # mkpanda option to apply to any package.
 find "$PKG_PATH/lib/" ! -type d -name "*.a" -exec rm -f -- '{}' +
 
-
 # Take control of setuptools and pip version.
 # Note(JP): For making pip upgrade itself reliably, it's best
 # to run pip as a module (python -m pip).
 export LD_LIBRARY_PATH=$PKG_PATH/lib
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/setuptools/*.whl
-$PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip/*.whl
+
+# Install pip from git checkout, because we need the fix for
+# https://github.com/pypa/pip/issues/373 i.e. we need the patch
+# https://github.com/pypa/pip/pull/4495 for subsequent pip
+# invocations. For _this_ pip invocation here (for upgrading pip...),
+# however, the bug pip/issues/373 is present and needs to be worked
+# around by manually creating the egg directory as a _relative_ path
+# `opt/mesosphere/active.....pip-10.0.0.dev0-py3.6.egg-info`.
+ABSDIR="$PKG_PATH/lib/python3.6/site-packages/pip-10.0.0.dev0-py3.6.egg-info"
+RELDIR="${ABSDIR:1}"
+mkdir -p $RELDIR
+$PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip
 echo "pip version: $($PKG_PATH/bin/pip3 --version)"
 
 
@@ -37,3 +49,12 @@ ln -fs "$PKG_PATH/bin/pip3" "$PKG_PATH/bin/pip"
 ln -fs "$PKG_PATH/bin/python3-config" "$PKG_PATH/bin/python-config"
 ln -fs "$PKG_PATH/bin/idle3" "$PKG_PATH/bin/idle"
 ln -fs "$PKG_PATH/bin/pydoc3"  "$PKG_PATH/bin/pydoc"
+
+# Install Cython as part of the pgkpanda python package so that
+# it is available as a build dependency for all other pkgpanda
+# packages that pull in this package here as a dependency.
+# The Cython installation via pip actually suffers from pip/issues/373
+# which is one reason why we install the unreleased pip-10.0.0.dev0
+# above.
+$PKG_PATH/bin/python3 -m pip install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/cython
+

--- a/packages/python/build
+++ b/packages/python/build
@@ -31,7 +31,7 @@ echo "pip version: $($PKG_PATH/bin/pip3 --version)"
 
 # Setup helper symlinks, force overwrite if link name exists.
 ln -fs "$PKG_PATH/bin/python3" "$PKG_PATH/bin/python"
-ln -fs "$PKG_PATH/bin/easy_install-3.5" "$PKG_PATH/bin/easy_install-3"
+ln -fs "$PKG_PATH/bin/easy_install-3.6" "$PKG_PATH/bin/easy_install-3"
 ln -fs "$PKG_PATH/bin/easy_install-3" "$PKG_PATH/bin/easy_install"
 ln -fs "$PKG_PATH/bin/pip3" "$PKG_PATH/bin/pip"
 ln -fs "$PKG_PATH/bin/python3-config" "$PKG_PATH/bin/python-config"

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -10,15 +10,21 @@
       "url": "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz",
       "sha1": "6c71b14bdbc4d8aa0cfd59d4b6dc356d46abfdf5"
     },
+    "cython": {
+      "kind": "url_extract",
+      "url": "https://pypi.python.org/packages/ee/2a/c4d2cdd19c84c32d978d18e9355d1ba9982a383de87d0fcb5928553d37f4/Cython-0.27.3.tar.gz",
+      "sha1": "688aa815301dd9e710cd847528de31099f3b52c4"
+    },
     "setuptools": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/0c/5d/309113d5359654094f7423ad9c32ac55255b83304f36d0fa96129f28db83/setuptools-27.2.0-py2.py3-none-any.whl",
-      "sha1": "e3e473b1a56dce0bb1892a004153cbaad6ddca8c"
+      "url": "https://pypi.python.org/packages/0f/40/b3c98aa32bc91d3d8c573443a29aa482d77268d77132b63f09d8385b21ff/setuptools-37.0.0-py2.py3-none-any.whl",
+      "sha1": "da26335ea77a8680a983a3cfb57f304447c26df5"
     },
     "pip": {
-      "kind": "url",
-      "url": "https://pypi.python.org/packages/9c/32/004ce0852e0a127f07f358b715015763273799bd798956fa930814b60f39/pip-8.1.2-py2.py3-none-any.whl",
-      "sha1": "112a41bf8e06c41420b105c5f702ecc7f53ab6c4"
+      "kind": "git",
+      "git": "git@github.com:pypa/pip.git",
+      "ref": "8ed4ac1fe6e2a05db41585c10a7b46f16bc60666",
+      "ref_origin": "master"
     }
   }
 }

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -1,14 +1,14 @@
 {
   "requires": ["openssl"],
   "environment": {
-    "PYTHONPATH": "/opt/mesosphere/lib/python3.5/site-packages",
+    "PYTHONPATH": "/opt/mesosphere/lib/python3.6/site-packages",
     "PYTHONUNBUFFERED": "true"
   },
   "sources": {
     "python": {
       "kind": "url_extract",
-      "url": "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz",
-      "sha1": "4843aabacec5bc0cdd3e1f778faa926e532794d2"
+      "url": "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz",
+      "sha1": "6c71b14bdbc4d8aa0cfd59d4b6dc356d46abfdf5"
     },
     "setuptools": {
       "kind": "url",

--- a/packages/six/build
+++ b/packages/six/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --no-index --target="$LIB_INSTALL_DIR" /pkg/src/$PKG_NAME/*.whl

--- a/packages/teamcity-messages/build
+++ b/packages/teamcity-messages/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /opt/mesosphere/environment.export
-export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.5/site-packages"
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/release/__init__.py
+++ b/release/__init__.py
@@ -551,7 +551,7 @@ def _build_builders(package_store):
         msg_fmt = "Package-defined builders overlap with global: `{}`"
         raise pkgpanda.build.BuildError(msg_fmt.format(overlap))
 
-    # FIXME: with python3.5 it is going to be: union_d12 = {**d1, **d2}
+    # FIXME: with python3.6 it is going to be: union_d12 = {**d1, **d2}
     all_builders = global_builders.copy()
     all_builders.update(pkg_builders)
     for name, path in all_builders.items():

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'py',
         'pytest',
         'pyyaml',
-        'requests==2.18.4',
+        'requests==2.10.0',
         'retrying',
         'schema',
         'keyring==9.1',  # FIXME: pin keyring to prevent dbus dep

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'flask-compress',
         'urllib3',
         'chardet',
+        'pyjwt',
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.17',
         'msrestazure==0.4.15',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=[
         'dcos_installer',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'coloredlogs',
         'Flask',
         'flask-compress',
+        'urllib3',
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.17',
         'msrestazure==0.4.15',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'py',
         'pytest',
         'pyyaml',
-        'requests==2.10.0',
+        'requests==2.18.4',
         'retrying',
         'schema',
         'keyring==9.1',  # FIXME: pin keyring to prevent dbus dep

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
         'Flask',
         'flask-compress',
         # Pins taken from 'azure==2.0.0rc4'
-        'msrest==0.4.0',
-        'msrestazure==0.4.1',
+        'msrest==0.4.17',
+        'msrestazure==0.4.15',
         'azure-common==1.1.4',
         'azure-storage==0.32.0',
         'azure-mgmt-network==0.30.0rc4',
@@ -54,7 +54,7 @@ setup(
         'py',
         'pytest',
         'pyyaml',
-        'requests==2.10.0',
+        'requests==2.18.4',
         'retrying',
         'schema',
         'keyring==9.1',  # FIXME: pin keyring to prevent dbus dep

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'Flask',
         'flask-compress',
         'urllib3',
+        'chardet',
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.17',
         'msrestazure==0.4.15',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'flask-compress',
         'urllib3',
         'chardet',
-        'pyjwt',
+        'PyJWT',
         # Pins taken from 'azure==2.0.0rc4'
         'msrest==0.4.17',
         'msrestazure==0.4.15',


### PR DESCRIPTION
Corresponding downstream pull request: https://github.com/mesosphere/dcos-enterprise/pull/1750

This mainly addresses https://jira.mesosphere.com/browse/DCOS_OSS-1285 ("Platform: update from CPython 3.5.2 to 3.6.3"). This change on the other hand required quite a few small other changes.

Some notes:
- The history service code contained an unnecessary `global` statement which is a SyntaxError with Python 3.6.
- The update to CPython 3.6 rendered the usage of `enum34` invalid (it does not and will never support CPython 3.6). Removal of `enum34` required updating the Python Azure libs, which on the other hand required `adal` which requires PyJWT and quite some other things.
- The update to `requests` required changing the way we include its CA bundle during `curl` build time (this is now provided by `certifi`).
- Cython (previously a downstream package) is now build together with the python pkgpanda package in upstream. So that it is available to all Python package builds.
- We install python packages using `pip`'s command line flag `--prefix=$PKG_PATH` which is not so frequently used elsewhere. In the 9.0.1 release this is [subject to a bug ](https://github.com/pypa/pip/issues/373) which affected the installation of Cython (and potentially of future Python packages). I have pulled in a newer, yet unreleased version of `pip` to address that.

A similar commit from Cody, back in 2016: https://github.com/dcos/dcos/commit/903e7941ed6a971d7a133049a32ccd262acaa188#diff-5b1d4d7df658ea18c1e4451bd1049a7d
