### PR TITLE
adminrouter: add alternative authentication header

### DIFF
--- a/packages/adminrouter/extra/src/lib/auth/common.lua
+++ b/packages/adminrouter/extra/src/lib/auth/common.lua
@@ -65,6 +65,10 @@ local function validate_jwt(secret_key)
     if auth_header ~= nil then
         ngx.log(ngx.DEBUG, "Authorization header found. Attempt to extract token.")
         _, _, token = string.find(auth_header, "token=(.+)")
+        --- Also check for alternative bearer header format used by the likes of kubernetes
+        if token == nil then
+            _, _, token = string.find(auth_header, "Bearer (.+)")
+        end
     else
         ngx.log(ngx.DEBUG, "Authorization header not found.")
         -- Presence of Authorization header overrides cookie method entirely.

--- a/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_auth.py
@@ -212,6 +212,21 @@ class TestAuthnJWTValidator:
             headers=auth_header,
             )
 
+    def test_valid_auth_token_with_bearer_header(
+            self,
+            master_ar_process_perclass,
+            jwt_generator,
+            ):
+        # We accept "forever tokens"
+        token = jwt_generator(uid='test')
+        auth_header = {'Authorization': 'Bearer {}'.format(token)}
+        assert_endpoint_response(
+            master_ar_process_perclass,
+            EXHIBITOR_PATH,
+            200,
+            headers=auth_header,
+            )
+
 
 class TestAuthCustomErrorPages:
     def test_correct_401_page_content(self, master_ar_process_pertest, repo_is_ee):


### PR DESCRIPTION
## High Level Description

This allows a client to use an alternative notation for the
authorization header:

`Authorization: Bearer TOKEN`

An example of clients using that notation is kubectl

## Related Issues

  - [KUB-115](https://jira.mesosphere.com/browse/KUB-115) Expose the Kubernetes API to adminrouter

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): In PR
  - [x] Test Results: In PR
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
