### PR TITLE
Adds installation of DC/OS build specific python-gdb.py file

### DIFF
--- a/packages/python/build
+++ b/packages/python/build
@@ -13,6 +13,9 @@ export CPPFLAGS=-I/opt/mesosphere/include
 make -j$NUM_CORES
 make install
 
+# Install the build specific gdb helper artefact
+cp python-gdb.py "$PKG_PATH/share/"
+
 # Remove some big things we don't use at all
 rm -rf "$PKG_PATH/lib/python3.6/test"
 


### PR DESCRIPTION
## High Level Description

With this change our DC/OS installations will include the python build specific gdb helper script `python-gdb.py`. This will allow us to interact and debug python based components of DC/OS.

Most Linux distributions bundle this file in a dedicated python-dbg (or similar) package, so it is understandable that it is not part of what `make install` installs into $prefix. As we do however bundle our own build of python and do not currently provide a debug build and or additional debug package, there is no usable python-gdb.py file available.

Please note that the path the file usually goes to is somewhere in '/usr/share/gdb/[...]', so I decided to put in in `$PKG_PATH/share/` as well, although the gdb autoloader wont pick it up automatically from there. This seems to be the most sane solution here, without cluttering `bin/`.

## Related Issues
  - [SOAK-22](https://jira.mesosphere.com/browse/SOAK-22) Debugging DC/OS components that use our bundled python interpreter

## Checklist for all PR's

  - [x] *Included a test which will fail if code is reverted but test is not. If there is no test please explain here*:
I am not sure how infrastructural changes like this should be tested. If we do have a test framework for things like this, please point me in the right direction and I will make sure to add a test case!