### PR TITLE
dcos-oauth: bump for increased zk connection timeout

### DIFF
--- a/packages/dcos-oauth/buildinfo.json
+++ b/packages/dcos-oauth/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-oauth.git",
-    "ref": "2b7b0a5aa3810b4f517a5b18516a4bbd30e28fee",
+    "ref": "67fe686cbca439a9e872a18e382a0eb51bf737c4",
     "ref_origin": "master"
   },
   "username": "dcos_oauth",


### PR DESCRIPTION
## High Level Description

This PR bumps dcos-oauth to increase the ZooKeeper connection timeout from 1s to 60s. It also includes a bump from Go 1.6 to Go 1.7.

## Related Issues

  - [DCOS_OSS-1788](https://jira.mesosphere.com/browse/DCOS_OSS-1788) Flakey Integration Test Failures on dcos-docker: 500 Server Error

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This just bumps a timeout from 1s to 60s.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-oauth/compare/2b7b0a5aa3810b4f517a5b18516a4bbd30e28fee...67fe686cbca439a9e872a18e382a0eb51bf737c4
  - [ ] Test Results: The dcos-oauth project has no CI configured.
  - [ ] Code Coverage (if available): [link to code coverage report]
___
