### PR TITLE
Update CentOS AMIs to version 7.4-1708

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -124,3 +124,50 @@ Base (source) AMI:
 
 DC/OS AMI's:
 * us-gov-west-1: ami-e58c0f84
+
+#### dcos-centos7-201709252313
+
+Update to CentOS 7.4.1708
+
+Base (source) AMI from centos:
+* ami-a9b24bd1
+
+DC/OS AMIs (with prereqs)
+
+* ap-northeast-1:ami-72f93314
+* ap-northeast-2:ami-94b369fa
+* ap-south-1:ami-ac1455c3
+* ap-southeast-1:ami-cac2b2a9
+* ap-southeast-2:ami-a0d736c2
+* ca-central-1:ami-7d7ac319
+* eu-central-1:ami-b371c1dc
+* eu-west-1:ami-4d4f8634
+* eu-west-2:ami-0b889b6f
+* sa-east-1:ami-1264187e
+* us-east-1:ami-b05aadca
+* us-east-2:ami-08765b6d
+* us-west-1:ami-63cafb03
+* us-west-2:ami-1de01e65
+
+#### centos7-201709262005
+
+Update to CentOS 7.4.1708 (no DC/OS prereqs)
+
+* ap-northeast-1: ami-965345f8
+* ap-southeast-1: ami-8af586e9
+* ap-southeast-2: ami-427d9c20
+* eu-central-1: ami-2d0cbc42
+* eu-west-1: ami-e46ea69d
+* sa-east-1: ami-a5acd0c9
+* us-east-1: ami-771beb0d
+* us-west-1: ami-866151e6
+* us-west-2: ami-a9b24bd1
+
+#### dcos-centos7-201710122205
+
+Update GovCloud CentOS AMI to 7.4
+
+DC/OS AMIs (with prereqs)
+
+* us-gov-west-1: ami-9923a1f8
+

--- a/cloud_images/centos7/create_base_ami.sh
+++ b/cloud_images/centos7/create_base_ami.sh
@@ -27,7 +27,7 @@ mount "$PARTITION" "$ROOTFS"
 
 rpm --root="$ROOTFS" --initdb
 rpm --root="$ROOTFS" -ivh \
-  http://mirrors.kernel.org/centos/7.2.1511/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm
+  http://mirrors.kernel.org/centos/7.4.1708/os/x86_64/Packages/centos-release-7-4.1708.el7.centos.x86_64.rpm
 yum --installroot="$ROOTFS" --nogpgcheck -y groupinstall core
 yum --installroot="$ROOTFS" --nogpgcheck -y install openssh-server grub2 tuned kernel chrony
 yum --installroot="$ROOTFS" -C -y remove NetworkManager firewalld --setopt="clean_requirements_on_remove=1"

--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -7,7 +7,8 @@ export AWS_PROFILE=${AWS_PROFILE:-"development"}
 # Base CentOS 7 AMI and region
 export SOURCE_AMI=${SOURCE_AMI:-"ami-31a8ca51"}
 export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
-
+# Version upgraded to in install_prereqs.sh
+export CENTOS_VERSION=${CENTOS_VERSION:-"7.4.1708"}
 # Comma separated string of AWS regions to copy the resulting DC/OS AMI to
 export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
 

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -2,9 +2,9 @@
 set -o errexit -o nounset -o pipefail
 
 echo ">>> Kernel: $(uname -r)"
-echo ">>> Updating system to 7.3.1611"
+echo ">>> Updating system to $CENTOS_VERSION"
 sed -i -e 's/^mirrorlist=/#mirrorlist=/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
-yum -y --releasever=7.3.1611 update
+yum -y --releasever=$CENTOS_VERSION update
 sed -i -e 's/^#mirrorlist=/mirrorlist=/' -e 's/^baseurl=/#baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
 
 echo ">>> Disabling SELinux"

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -1,6 +1,7 @@
 {
   "min_packer_version": "0.10.1",
   "variables": {
+    "centos_version": "{{env `CENTOS_VERSION`}}",
     "cloud_builder_version": "0.1",
     "deploy_regions": "{{env `DEPLOY_REGIONS`}}",
     "source_ami": "{{env `SOURCE_AMI`}}",
@@ -94,7 +95,7 @@
       "inline": [
         "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
         "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_prereqs.sh",
-        "sudo /tmp/install_prereqs.sh"
+        "sudo CENTOS_VERSION={{user `centos_version`}} /tmp/install_prereqs.sh"
       ]
     }
   ]

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -127,66 +127,65 @@ aws_region_names = [
         'id': 'ap-southeast-2'
     }]
 
-
 region_to_ami_map = {
     'ap-northeast-1': {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
-        'el7': 'ami-e21fd884',
+        'el7': 'ami-965345f8',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
-        'el7': 'ami-3b8ee058',
+        'el7': 'ami-8af586e9',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
-        'el7': 'ami-c2e501a0',
+        'el7': 'ami-427d9c20',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
-        'el7': 'ami-868531e9',
+        'el7': 'ami-2d0cbc42',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
-        'el7': 'ami-5f03c426',
+        'el7': 'ami-e46ea69d',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
-        'el7': 'ami-5d2f5d31',
+        'el7': 'ami-a5acd0c9',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
-        'el7': 'ami-abb1a2d0',
+        'el7': 'ami-771beb0d',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
         'coreos': 'ami-e441fb85',
         'stable': 'ami-e441fb85',
-        'el7': 'ami-e58c0f84',
-        'natami': ''
+        'el7': 'ami-9923a1f8',
+        'natami': 'ami-fe991b9f'
     },
     'us-west-1': {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
-        'el7': 'ami-f6427596',
+        'el7': 'ami-866151e6',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
-        'el7': 'ami-6eed1a16',
+        'el7': 'ami-a9b24bd1',
         'natami': 'ami-bb69128b'
     }
 }


### PR DESCRIPTION
Screwed up a rebase on the original PR https://github.com/dcos/dcos/pull/1961. See comments over there for what was done to test these. 

## High level description 

Doing this via changing the build scripts in the cloud_images dcos package to read in environment variable for `CENTOS_VERSION`.

- Defaults to 7.4.1708 (initial hard-coded value) in scripts, and is also set to 7.4 in TeamCity.

Manually-kicked-off CI job that created the DC/OS-ready AMIs:
https://teamcity.mesosphere.io/repository/download/DcosIo_Dcos_BuildCloudBaseImages_AwsBuildAndPublishCentOS7baseImage/798303:id/cloud_images/centos7/artifacts.txt

GovCloud DC/OS-ready AMIs generated with https://teamcity.mesosphere.io/viewLog.html?buildId=816581&tab=buildResultsDiv&buildTypeId=DcosIo_Dcos_BuildCloudBaseImages_AwsBuildAndPublishCentOS7baseImagesForGovcloud

Details of testing are in the comments below, but the images were tested manually by bringing up different types of clusters and then running the integration tests.

## Related Issues

This is in support of
 - https://jira.mesosphere.com/browse/DCOS_OSS-1646
Generating images that will be added to dcos-launch configuration.

## Squashed commits

- update changelog
- update CI script to update to 7.4
- update packer to use CENTOS_VERSION environment variable

set CENTOS_VERSION in user variables

explicitly pass CENTOS_VERSION in inline cmd

add centos 7.4 AMIs to changelog

create_base_ami.sh updates to 7.4 instead of 7.2

correct AMI name for dcos-centos7

update centos AMIs to 7.4

update govcloud us-gov-west-1 CentOS AMI to 7.4

update changelog for govcloud

add NAT AMI for govcloud region

Default to CentOS 7.4 to match default TeamCity CENTOS_VERSION

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
