### PR TITLE
Train 244

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -124,3 +124,50 @@ Base (source) AMI:
 
 DC/OS AMI's:
 * us-gov-west-1: ami-e58c0f84
+
+#### dcos-centos7-201709252313
+
+Update to CentOS 7.4.1708
+
+Base (source) AMI from centos:
+* ami-a9b24bd1
+
+DC/OS AMIs (with prereqs)
+
+* ap-northeast-1:ami-72f93314
+* ap-northeast-2:ami-94b369fa
+* ap-south-1:ami-ac1455c3
+* ap-southeast-1:ami-cac2b2a9
+* ap-southeast-2:ami-a0d736c2
+* ca-central-1:ami-7d7ac319
+* eu-central-1:ami-b371c1dc
+* eu-west-1:ami-4d4f8634
+* eu-west-2:ami-0b889b6f
+* sa-east-1:ami-1264187e
+* us-east-1:ami-b05aadca
+* us-east-2:ami-08765b6d
+* us-west-1:ami-63cafb03
+* us-west-2:ami-1de01e65
+
+#### centos7-201709262005
+
+Update to CentOS 7.4.1708 (no DC/OS prereqs)
+
+* ap-northeast-1: ami-965345f8
+* ap-southeast-1: ami-8af586e9
+* ap-southeast-2: ami-427d9c20
+* eu-central-1: ami-2d0cbc42
+* eu-west-1: ami-e46ea69d
+* sa-east-1: ami-a5acd0c9
+* us-east-1: ami-771beb0d
+* us-west-1: ami-866151e6
+* us-west-2: ami-a9b24bd1
+
+#### dcos-centos7-201710122205
+
+Update GovCloud CentOS AMI to 7.4
+
+DC/OS AMIs (with prereqs)
+
+* us-gov-west-1: ami-9923a1f8
+

--- a/cloud_images/centos7/create_base_ami.sh
+++ b/cloud_images/centos7/create_base_ami.sh
@@ -27,7 +27,7 @@ mount "$PARTITION" "$ROOTFS"
 
 rpm --root="$ROOTFS" --initdb
 rpm --root="$ROOTFS" -ivh \
-  http://mirrors.kernel.org/centos/7.2.1511/os/x86_64/Packages/centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm
+  http://mirrors.kernel.org/centos/7.4.1708/os/x86_64/Packages/centos-release-7-4.1708.el7.centos.x86_64.rpm
 yum --installroot="$ROOTFS" --nogpgcheck -y groupinstall core
 yum --installroot="$ROOTFS" --nogpgcheck -y install openssh-server grub2 tuned kernel chrony
 yum --installroot="$ROOTFS" -C -y remove NetworkManager firewalld --setopt="clean_requirements_on_remove=1"

--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -7,7 +7,8 @@ export AWS_PROFILE=${AWS_PROFILE:-"development"}
 # Base CentOS 7 AMI and region
 export SOURCE_AMI=${SOURCE_AMI:-"ami-31a8ca51"}
 export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
-
+# Version upgraded to in install_prereqs.sh
+export CENTOS_VERSION=${CENTOS_VERSION:-"7.4.1708"}
 # Comma separated string of AWS regions to copy the resulting DC/OS AMI to
 export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
 

--- a/cloud_images/centos7/install_prereqs.sh
+++ b/cloud_images/centos7/install_prereqs.sh
@@ -2,9 +2,9 @@
 set -o errexit -o nounset -o pipefail
 
 echo ">>> Kernel: $(uname -r)"
-echo ">>> Updating system to 7.3.1611"
+echo ">>> Updating system to $CENTOS_VERSION"
 sed -i -e 's/^mirrorlist=/#mirrorlist=/' -e 's/^#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
-yum -y --releasever=7.3.1611 update
+yum -y --releasever=$CENTOS_VERSION update
 sed -i -e 's/^#mirrorlist=/mirrorlist=/' -e 's/^baseurl=/#baseurl=/' /etc/yum.repos.d/CentOS-Base.repo
 
 echo ">>> Disabling SELinux"

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -1,6 +1,7 @@
 {
   "min_packer_version": "0.10.1",
   "variables": {
+    "centos_version": "{{env `CENTOS_VERSION`}}",
     "cloud_builder_version": "0.1",
     "deploy_regions": "{{env `DEPLOY_REGIONS`}}",
     "source_ami": "{{env `SOURCE_AMI`}}",
@@ -94,7 +95,7 @@
       "inline": [
         "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
         "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_prereqs.sh",
-        "sudo /tmp/install_prereqs.sh"
+        "sudo CENTOS_VERSION={{user `centos_version`}} /tmp/install_prereqs.sh"
       ]
     }
   ]

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -127,66 +127,65 @@ aws_region_names = [
         'id': 'ap-southeast-2'
     }]
 
-
 region_to_ami_map = {
     'ap-northeast-1': {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
-        'el7': 'ami-e21fd884',
+        'el7': 'ami-965345f8',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
-        'el7': 'ami-3b8ee058',
+        'el7': 'ami-8af586e9',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
-        'el7': 'ami-c2e501a0',
+        'el7': 'ami-427d9c20',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
-        'el7': 'ami-868531e9',
+        'el7': 'ami-2d0cbc42',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
-        'el7': 'ami-5f03c426',
+        'el7': 'ami-e46ea69d',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
-        'el7': 'ami-5d2f5d31',
+        'el7': 'ami-a5acd0c9',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
-        'el7': 'ami-abb1a2d0',
+        'el7': 'ami-771beb0d',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
         'coreos': 'ami-e441fb85',
         'stable': 'ami-e441fb85',
-        'el7': 'ami-e58c0f84',
-        'natami': ''
+        'el7': 'ami-9923a1f8',
+        'natami': 'ami-fe991b9f'
     },
     'us-west-1': {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
-        'el7': 'ami-f6427596',
+        'el7': 'ami-866151e6',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
-        'el7': 'ami-6eed1a16',
+        'el7': 'ami-a9b24bd1',
         'natami': 'ami-bb69128b'
     }
 }

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -774,10 +774,6 @@ package:
               }
           ]
         }
-  - path: /etc/cosmos.env
-    content: |
-      COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG={{ cosmos_staged_package_storage_uri_flag }}
-      COSMOS_PACKAGE_STORAGE_URI_FLAG={{ cosmos_package_storage_uri_flag }}
   - path: /etc/adminrouter.env
     content: |
       ADMINROUTER_ACTIVATE_AUTH_MODULE={{ adminrouter_auth_enabled }}

--- a/packages/cosmos/build
+++ b/packages/cosmos/build
@@ -22,7 +22,6 @@ PermissionsStartOnly=True
 User=dcos_cosmos
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/proxy.env
-EnvironmentFile=/opt/mesosphere/etc/cosmos.env
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cosmos
 ExecStart=/opt/mesosphere/bin/java \\
@@ -31,7 +30,5 @@ ExecStart=/opt/mesosphere/bin/java \\
     -classpath ${PKG_PATH}/usr/cosmos.jar \\
     com.simontuffs.onejar.Boot \\
     -admin.port=127.0.0.1:9990 \\
-    -io.github.benwhitehead.finch.httpInterface=127.0.0.1:7070 \\
-    \${COSMOS_STAGED_PACKAGE_STORAGE_URI_FLAG} \\
-    \${COSMOS_PACKAGE_STORAGE_URI_FLAG}
+    -com.mesosphere.cosmos.httpInterface=127.0.0.1:7070
 EOF

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -6,8 +6,6 @@ import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 
-from test_helpers import expanded_config
-
 
 def test_if_dcos_ui_is_up(dcos_api_session):
     r = dcos_api_session.get('/')
@@ -153,42 +151,6 @@ def test_if_we_have_capabilities(dcos_api_session):
     )
     assert r.status_code == 200
     assert {'name': 'PACKAGE_MANAGEMENT'} in r.json()['capabilities']
-
-
-def test_cosmos_package_add(dcos_api_session):
-    r = dcos_api_session.post(
-        '/package/add',
-        headers={
-            'Accept': (
-                'application/vnd.dcos.package.add-response+json;'
-                'charset=utf-8;version=v1'
-            ),
-            'Content-Type': (
-                'application/vnd.dcos.package.add-request+json;'
-                'charset=utf-8;version=v1'
-            )
-        },
-        json={
-            'packageName': 'cassandra',
-            'packageVersion': '1.0.20-3.0.10'
-        }
-    )
-
-    if (expanded_config['cosmos_staged_package_storage_uri_flag'] and
-            expanded_config['cosmos_package_storage_uri_flag']):
-        # if the config is enabled then Cosmos should accept the request and
-        # return 202
-        assert r.status_code == 202, 'status = {}, content = {}'.format(
-            r.status_code,
-            r.content
-        )
-    else:
-        # if the config is disabled then Cosmos should accept the request and
-        # return Not Implemented 501
-        assert r.status_code == 501, 'status = {}, content = {}'.format(
-            r.status_code,
-            r.content
-        )
 
 
 def test_if_overlay_master_is_up(dcos_api_session):

--- a/packages/dcos-oauth/buildinfo.json
+++ b/packages/dcos-oauth/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-oauth.git",
-    "ref": "2b7b0a5aa3810b4f517a5b18516a4bbd30e28fee",
+    "ref": "67fe686cbca439a9e872a18e382a0eb51bf737c4",
     "ref_origin": "master"
   },
   "username": "dcos_oauth",

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "03ba84aac9ac5a93f641e7bf54993ab6d76f4791",
-    "ref_origin": "v1.10.0-rc.8"
+    "ref": "29b6fa1677a46885ce00c3f3a4c0944e9e2840d4",
+    "ref_origin": "v1.11.0-rc.1"
   }
 }


### PR DESCRIPTION
## 🚂:two::four::four::train:

- https://github.com/dcos/dcos/pull/1971 – **Bump dcos-ui package to 1.11-rc.1**
- https://github.com/dcos/dcos/pull/1987 – **Remove cosmos object storage**
> Enterprise Cosmos doesn't need a object store any more as this functionality is moved to package registry. Remove object store configuration from DC/OS. The current cosmos master ignores this flags, and this PR removes those unused flags from dcos.
- https://github.com/dcos/dcos/pull/2038 – **dcos-oauth: bump for increased zk connection timeout**
> This PR bumps dcos-oauth to increase the ZooKeeper connection timeout from 1s to 60s. It also includes a bump from Go 1.6 to Go 1.7.
- https://github.com/dcos/dcos/pull/2040 – **Update CentOS AMIs to version 7.4-1708**

