### PR TITLE
Adds vip test for pods

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -1,4 +1,5 @@
 import contextlib
+import enum
 import json
 import logging
 import threading
@@ -16,6 +17,163 @@ from dcos_test_utils import marathon
 log = logging.getLogger(__name__)
 
 GLOBAL_PORT_POOL = iter(range(10000, 32000))
+
+
+class Container(enum.Enum):
+    POD = 'POD'
+
+
+class MarathonApp():
+    def __init__(self, container, network, host, vip):
+        if container == Container.POD:
+            self.__class__ = MarathonPod
+            return MarathonPod.__init__(self, network, host, vip)
+        self._network = network
+        self._container = container
+        if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
+            # both of these cases will rely on marathon to assign ports
+            self.app, self.uuid = test_helpers.marathon_test_app(
+                network=network,
+                host_constraint=host,
+                vip=vip,
+                container_type=container,
+                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
+        elif network == marathon.Network.USER:
+            self.app, self.uuid = test_helpers.marathon_test_app(
+                network=network,
+                host_port=unused_port(),
+                host_constraint=host,
+                vip=vip,
+                container_type=container,
+                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
+        # allow this app to run on public slaves
+        self.app['acceptedResourceRoles'] = ['*', 'slave_public']
+        self.id = self.app['id']
+
+    def __str__(self):
+        return str(self.app)
+
+    def deploy(self, dcos_api_session):
+        return dcos_api_session.marathon.post('v2/apps', json=self.app).raise_for_status()
+
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=20 * 60 * 1000,
+        retry_on_result=lambda res: res is False)
+    def wait(self, dcos_api_session):
+        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        r.raise_for_status()
+        self._info = r.json()
+        return self._info['app']['tasksHealthy'] == self.app['instances']
+
+    def info(self, dcos_api_session):
+        try:
+            if self._info['app']['tasksHealthy'] != self.app['instances']:
+                raise
+        except:
+            self.wait(dcos_api_session)
+        return self._info
+
+    def hostport(self, dcos_api_session):
+        info = self.info(dcos_api_session)
+        task = info['app']['tasks'][0]
+        if self._network == marathon.Network.USER:
+            host = task['ipAddresses'][0]['ipAddress']
+            if self._container == marathon.Container.DOCKER:
+                port = task['ports'][0]
+            else:
+                port = self.app['ipAddress']['discovery']['ports'][0]['number']
+        else:
+            host = task['host']
+            port = task['ports'][0]
+        return host, port
+
+    def purge(self, dcos_api_session):
+        return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
+
+
+class MarathonPod():
+    def __init__(self, network, host, vip):
+        self._network = network
+        container_port = 0
+        if network is not marathon.Network.HOST:
+            container_port = unused_port()
+        # ENDPOINT_TEST will be computed from the `endpoints` definition. See [1], [2]
+        # [1] https://dcos.io/docs/1.9/deploying-services/pods/technical-overview/#environment-variables
+        # [2] https://github.com/mesosphere/marathon/blob/v1.5.0/
+        #     src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala#L420-L443
+        port = '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port
+        self.uuid = uuid.uuid4().hex
+        self.id = '/integration-test-{}'.format(self.uuid)
+        self.app = {
+            'id': self.id,
+            'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
+            'containers': [{
+                'name': 'app-{}'.format(self.uuid),
+                'resources': {'cpus': 0.01, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
+                'exec': {'command': {
+                    'shell': '/opt/mesosphere/bin/dcos-shell python '
+                             '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py '
+                             '{}'.format(port)
+                }},
+                'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
+                'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
+                'environment': {'DCOS_TEST_UUID': self.uuid, 'HOME': '/'}
+            }],
+            'networks': [{'mode': 'host'}],
+            'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
+        }
+        if host is not None:
+            self.app['scheduling']['placement']['constraints'] = \
+                [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+        if vip is not None:
+            self.app['containers'][0]['endpoints'][0]['labels'] = \
+                {'VIP_0': vip}
+        if network == marathon.Network.USER:
+            del self.app['containers'][0]['endpoints'][0]['hostPort']
+            self.app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+            self.app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
+        elif network == marathon.Network.BRIDGE:
+            self.app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+            self.app['networks'] = [{'mode': 'container/bridge'}]
+
+    def __str__(self):
+        return str(self.app)
+
+    def deploy(self, dcos_api_session):
+        return dcos_api_session.marathon.post('v2/pods', json=self.app).raise_for_status()
+
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=20 * 60 * 1000,
+        retry_on_result=lambda res: res is False)
+    def wait(self, dcos_api_session):
+        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        r.raise_for_status()
+        self._info = r.json()
+        return self._info['status'] == 'STABLE'
+
+    def info(self, dcos_api_session):
+        try:
+            if self._info['status'] != 'STABLE':
+                raise
+        except:
+            self.wait(dcos_api_session)
+        return self._info
+
+    def hostport(self, dcos_api_session):
+        info = self.info(dcos_api_session)
+        if self._network == marathon.Network.USER:
+            host = info['instances'][0]['networks'][0]['addresses'][0]
+            port = self.app['containers'][0]['endpoints'][0]['containerPort']
+        else:
+            host = info['instances'][0]['agentHostname']
+            port = info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
+        return host, port
+
+    def purge(self, dcos_api_session):
+        return dcos_api_session.marathon.delete('v2/pods/{}'.format(self.id))
 
 
 def unused_port():
@@ -40,38 +198,21 @@ def ensure_routable(cmd, host, port):
     return json.loads(response['output'])
 
 
-def vip_app(container: marathon.Container, network: marathon.Network, host: str, vip: str):
-    # user_net_port is only actually used for USER network because this cannot be assigned
-    # by marathon
-    if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
-        # both of these cases will rely on marathon to assign ports
-        return test_helpers.marathon_test_app(
-            network=network,
-            host_constraint=host,
-            vip=vip,
-            container_type=container,
-            healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
-    elif network == marathon.Network.USER:
-        return test_helpers.marathon_test_app(
-            network=network,
-            host_port=unused_port(),
-            host_constraint=host,
-            vip=vip,
-            container_type=container,
-            healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
-    else:
-        raise AssertionError('Unexpected network: {}'.format(network.value))
-
-
 def generate_vip_app_permutations():
     """ Generate all possible network interface permutations for applying vips
     """
+    containers = \
+        [marathon.Container.NONE, marathon.Container.MESOS,
+         marathon.Container.DOCKER, Container.POD]
+    networks = \
+        [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
     return [(container, vip_net, proxy_net)
-            for container in [marathon.Container.NONE, marathon.Container.MESOS, marathon.Container.DOCKER]
-            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
-            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            for container in containers
+            for vip_net in networks
+            for proxy_net in networks
             # only DOCKER containers support BRIDGE network
-            if marathon.Network.BRIDGE not in (vip_net, proxy_net) or container == marathon.Container.DOCKER]
+            if marathon.Network.BRIDGE not in (vip_net, proxy_net) \
+            or container == marathon.Container.DOCKER]
 
 
 @pytest.mark.slow
@@ -102,27 +243,17 @@ def test_vip(dcos_api_session,
     for vip, hosts, cmd, origin_app, proxy_app in tests:
         log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
         log.info("Remote command: {}".format(cmd))
-        proxy_info = dcos_api_session.marathon.get('v2/apps/{}'.format(proxy_app['id'])).json()
-        proxy_task_info = proxy_info['app']['tasks'][0]
-        if proxy_net == marathon.Network.USER:
-            proxy_host = proxy_task_info['ipAddresses'][0]['ipAddress']
-            if container == marathon.Container.DOCKER:
-                proxy_port = proxy_task_info['ports'][0]
-            else:
-                proxy_port = proxy_app['ipAddress']['discovery']['ports'][0]['number']
-        else:
-            proxy_host = proxy_task_info['host']
-            proxy_port = proxy_task_info['ports'][0]
+        proxy_host, proxy_port = proxy_app.hostport(dcos_api_session)
         try:
-            ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app['env']['DCOS_TEST_UUID']
+            ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app.uuid
         except Exception as e:
             log.error('Exception: {}'.format(e))
             errors = errors + 1
         finally:
-            log.info('Purging application: {}'.format(origin_app['id']))
-            dcos_api_session.marathon.delete('v2/apps/{}'.format(origin_app['id'])).raise_for_status()
-            log.info('Purging application: {}'.format(proxy_app['id']))
-            dcos_api_session.marathon.delete('v2/apps/{}'.format(proxy_app['id'])).raise_for_status()
+            log.info('Purging application: {}'.format(origin_app.id))
+            origin_app.purge(dcos_api_session)
+            log.info('Purging application: {}'.format(proxy_app.id))
+            origin_app.purge(dcos_api_session)
     assert errors == 0
 
 
@@ -135,23 +266,24 @@ def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
         # We do not need the service endpoints because we have deterministically assigned them
         log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
         log.info("Origin app: {}".format(origin_app))
-        dcos_api_session.marathon.post('v2/apps', json=origin_app).raise_for_status()
+        origin_app.deploy(dcos_api_session)
         log.info("Proxy app: {}".format(proxy_app))
-        dcos_api_session.marathon.post('v2/apps', json=proxy_app).raise_for_status()
+        proxy_app.deploy(dcos_api_session)
     for vip, hosts, cmd, origin_app, proxy_app in tests:
         log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info('Deploying origin app: {}'.format(origin_app['id']))
-        wait_for_tasks_healthy(dcos_api_session, origin_app)
-        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
-        wait_for_tasks_healthy(dcos_api_session, proxy_app)
+        log.info('Deploying origin app: {}'.format(origin_app.id))
+        origin_app.wait(dcos_api_session)
+        log.info('Deploying proxy app: {}'.format(proxy_app.id))
+        proxy_app.wait(dcos_api_session)
         log.info('Apps are ready')
     return tests
 
 
 def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip, same_host):
+    slaves = dcos_api_session.slaves + dcos_api_session.public_slaves
     vip_port = unused_port()
-    origin_host = dcos_api_session.all_slaves[0]
-    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
+    origin_host = slaves[0]
+    proxy_host = slaves[0] if same_host else slaves[1]
     if named_vip:
         vip = '/namedvip:{}'.format(vip_port)
         vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
@@ -159,157 +291,10 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
         vip = '1.1.1.7:{}'.format(vip_port)
         vipaddr = vip
     cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-    origin_app, origin_app_uuid = vip_app(container, vip_net, origin_host, vip)
-    proxy_app, proxy_app_uuid = vip_app(container, proxy_net, proxy_host, None)
-    # allow these apps to run on public slaves
-    origin_app['acceptedResourceRoles'] = ['*', 'slave_public']
-    proxy_app['acceptedResourceRoles'] = ['*', 'slave_public']
+    origin_app = MarathonApp(container, vip_net, origin_host, vip)
+    proxy_app = MarathonApp(container, proxy_net, proxy_host, None)
     hosts = list(set([origin_host, proxy_host]))
     return (vip, hosts, cmd, origin_app, proxy_app)
-
-
-def pod_vip_app(network: marathon.Network, host: str, vip: str):
-    ''' Creates a single app in docker container in pod
-    '''
-    container_port = 0
-    if network is not marathon.Network.HOST:
-        container_port = unused_port(network)
-    test_uuid = uuid.uuid4().hex
-    app = {
-        'id': '/integration-test-{}'.format(test_uuid),
-        'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
-        'containers': [{
-            'name': 'app-{}'.format(test_uuid),
-            'resources': {'cpus': 0.01, 'mem': 32},
-            'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
-            'exec': {'command': {
-                'shell': '/opt/mesosphere/bin/dcos-shell python '
-                         '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
-                             '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port)
-            }},
-            'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
-            'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
-            'environment': {'DCOS_TEST_UUID': test_uuid, 'HOME': '/'}
-        }],
-        'networks': [{'mode': 'host'}],
-        'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
-    }
-    if host is not None:
-        app['scheduling']['placement']['constraints'] = [{
-            'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
-    if vip is not None:
-        app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
-    if network == marathon.Network.USER:
-        del app['containers'][0]['endpoints'][0]['hostPort']
-        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
-        app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
-    elif network == marathon.Network.BRIDGE:
-        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
-        app['networks'] = [{'mode': 'container/bridge'}]
-    return app, test_uuid
-
-
-def generate_pod_vip_app_permutations():
-    """ Generate all possible network interface permutations for applying vips
-    """
-    return [(vip_net, proxy_net)
-            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
-            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]]
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-@pytest.mark.parametrize('vip_net,proxy_net', generate_pod_vip_app_permutations())
-def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: marathon.Network):
-    """ Same as test_vip but for pods
-        * containers: UCR
-        * networks: USER, HOST
-        * vips: named and unnamed vip
-    """
-    errors = 0
-    tests = setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net)
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info("Remote command: {}".format(cmd))
-        proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(proxy_app['id'])).json()
-        log.info(proxy_info)
-        if proxy_net == marathon.Network.USER:
-            proxy_host = proxy_info['instances'][0]['networks'][0]['addresses'][0]
-            proxy_port = proxy_app['containers'][0]['endpoints'][0]['containerPort']
-        else:
-            proxy_host = proxy_info['instances'][0]['agentHostname']
-            proxy_port = proxy_info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
-        try:
-            assert ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == \
-                origin_app['containers'][0]['environment']['DCOS_TEST_UUID']
-        except Exception as ex:
-            log.error('Exception: {}'.format(ex))
-            errors = errors + 1
-        finally:
-            log.info('Purging application: {}'.format(origin_app['id']))
-            dcos_api_session.marathon.delete('v2/pods/{}'.format(origin_app['id']))
-            log.info('Purging application: {}'.format(proxy_app['id']))
-            dcos_api_session.marathon.delete('v2/pods/{}'.format(proxy_app['id']))
-    assert errors == 0
-
-
-def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
-    if len(dcos_api_session.all_slaves) < 2 and vip_net is marathon.Network.BRIDGE:
-        return []
-    same_hosts = [True, False] if vip_net is not marathon.Network.BRIDGE else [False]
-    tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
-             for named_vip in [True, False]
-             for same_host in same_hosts]
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
-        log.info("Origin app: {}".format(origin_app))
-        dcos_api_session.marathon.post('v2/pods', json=origin_app).raise_for_status()
-        log.info("Proxy app: {}".format(proxy_app))
-        dcos_api_session.marathon.post('v2/pods', json=proxy_app).raise_for_status()
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info('Deploying origin app: {}'.format(origin_app['id']))
-        wait_for_pod_tasks_healthy(dcos_api_session, origin_app)
-        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
-        wait_for_pod_tasks_healthy(dcos_api_session, proxy_app)
-        log.info('Apps are ready')
-    return tests
-
-
-def pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host):
-    origin_host = dcos_api_session.all_slaves[0]
-    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
-    if named_vip:
-        vip_port = unused_port('namedvip')
-        vip = '/namedvip:{}'.format(vip_port)
-        vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
-    else:
-        vip_port = unused_port('1.1.1.7')
-        vip = '1.1.1.7:{}'.format(vip_port)
-        vipaddr = vip
-    cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-    origin_app, origin_app_uuid = pod_vip_app(vip_net, origin_host, vip)
-    proxy_app, proxy_app_uuid = pod_vip_app(proxy_net, proxy_host, None)
-    hosts = list(set([origin_host, proxy_host]))
-    return (vip, hosts, cmd, origin_app, proxy_app)
-
-
-@retrying.retry(
-    wait_fixed=5000,
-    stop_max_delay=20 * 60 * 1000,
-    retry_on_result=lambda res: res is False)
-def wait_for_tasks_healthy(dcos_api_session, app_definition):
-    info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
-    return info['app']['tasksHealthy'] == app_definition['instances']
-
-
-@retrying.retry(
-    wait_fixed=5000,
-    stop_max_delay=20 * 60 * 1000,
-    retry_on_result=lambda res: res is False)
-def wait_for_pod_tasks_healthy(dcos_api_session, pod_definition):
-    proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(pod_definition['id'])).json()
-    return 'status' in proxy_info and proxy_info['status'] == 'STABLE'
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import logging
 import threading
+import uuid
 from collections import deque
 from subprocess import check_output
 
@@ -167,6 +168,129 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
     return (vip, hosts, cmd, origin_app, proxy_app)
 
 
+def pod_vip_app(network: marathon.Network, host: str, vip: str):
+    ''' Creates a single app in docker container in pod
+    '''
+    container_port = 0
+    if network is not marathon.Network.HOST:
+        container_port = unused_port(network)
+    test_uuid = uuid.uuid4().hex
+    app = {
+        'id': '/integration-test-{}'.format(test_uuid),
+        'placement': {'acceptedResourceRoles': ['*', 'slave_public']},
+        'containers': [{
+            'name': 'app-{}'.format(test_uuid),
+            'resources': {'cpus': 0.01, 'mem': 32},
+            'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
+            'exec': {'command': {
+                'shell': '/opt/mesosphere/bin/dcos-shell python '
+                         '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
+                             '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port)
+            }},
+            'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
+            'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
+            'environment': {'DCOS_TEST_UUID': test_uuid, 'HOME': '/'}
+        }],
+        'networks': [{'mode': 'host'}],
+        'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
+    }
+    if host is not None:
+        app['placement']['constraints'] = [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+    if vip is not None:
+        app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
+    if network == marathon.Network.USER:
+        del app['containers'][0]['endpoints'][0]['hostPort']
+        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+        app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
+    elif network == marathon.Network.BRIDGE:
+        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+        app['networks'] = [{'mode': 'container/bridge'}]
+    return app, test_uuid
+
+
+def generate_pod_vip_app_permutations():
+    """ Generate all possible network interface permutations for applying vips
+    """
+    return [(vip_net, proxy_net)
+            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]]
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
+@pytest.mark.parametrize('vip_net,proxy_net', generate_pod_vip_app_permutations())
+def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: marathon.Network):
+    """ Same as test_vip but for pods
+        * containers: UCR
+        * networks: USER, HOST
+        * vips: named and unnamed vip
+    """
+    errors = 0
+    tests = setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net)
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info("Remote command: {}".format(cmd))
+        proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(proxy_app['id'])).json()
+        log.info(proxy_info)
+        if proxy_net == marathon.Network.USER:
+            proxy_host = proxy_info['instances'][0]['networks'][0]['addresses'][0]
+            proxy_port = proxy_app['containers'][0]['endpoints'][0]['containerPort']
+        else:
+            proxy_host = proxy_info['instances'][0]['agentHostname']
+            proxy_port = proxy_info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
+        try:
+            assert ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == \
+                origin_app['containers'][0]['environment']['DCOS_TEST_UUID']
+        except Exception as ex:
+            log.error('Exception: {}'.format(ex))
+            errors = errors + 1
+        finally:
+            log.info('Purging application: {}'.format(origin_app['id']))
+            dcos_api_session.marathon.delete('v2/pods/{}'.format(origin_app['id']))
+            log.info('Purging application: {}'.format(proxy_app['id']))
+            dcos_api_session.marathon.delete('v2/pods/{}'.format(proxy_app['id']))
+    assert errors == 0
+
+
+def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
+    same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
+             for named_vip in [True, False]
+             for same_host in same_hosts]
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
+        log.info("Origin app: {}".format(origin_app))
+        dcos_api_session.marathon.post('v2/pods', json=origin_app).raise_for_status()
+        log.info("Proxy app: {}".format(proxy_app))
+        dcos_api_session.marathon.post('v2/pods', json=proxy_app).raise_for_status()
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info('Deploying origin app: {}'.format(origin_app['id']))
+        wait_for_pod_tasks_healthy(dcos_api_session, origin_app)
+        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
+        wait_for_pod_tasks_healthy(dcos_api_session, proxy_app)
+        log.info('Apps are ready')
+    return tests
+
+
+def pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host):
+    origin_host = dcos_api_session.all_slaves[0]
+    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
+    if named_vip:
+        vip_port = unused_port('namedvip')
+        vip = '/namedvip:{}'.format(vip_port)
+        vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
+    else:
+        vip_port = unused_port('1.1.1.7')
+        vip = '1.1.1.7:{}'.format(vip_port)
+        vipaddr = vip
+    cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
+    origin_app, origin_app_uuid = pod_vip_app(vip_net, origin_host, vip)
+    proxy_app, proxy_app_uuid = pod_vip_app(proxy_net, proxy_host, None)
+    hosts = list(set([origin_host, proxy_host]))
+    return (vip, hosts, cmd, origin_app, proxy_app)
+
+
 @retrying.retry(
     wait_fixed=5000,
     stop_max_delay=20 * 60 * 1000,
@@ -174,6 +298,15 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
 def wait_for_tasks_healthy(dcos_api_session, app_definition):
     info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
     return info['app']['tasksHealthy'] == app_definition['instances']
+
+
+@retrying.retry(
+    wait_fixed=5000,
+    stop_max_delay=20 * 60 * 1000,
+    retry_on_result=lambda res: res is False)
+def wait_for_pod_tasks_healthy(dcos_api_session, pod_definition):
+    proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(pod_definition['id'])).json()
+    return 'status' in proxy_info and proxy_info['status'] == 'STABLE'
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -177,7 +177,7 @@ def pod_vip_app(network: marathon.Network, host: str, vip: str):
     test_uuid = uuid.uuid4().hex
     app = {
         'id': '/integration-test-{}'.format(test_uuid),
-        'placement': {'acceptedResourceRoles': ['*', 'slave_public']},
+        'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
         'containers': [{
             'name': 'app-{}'.format(test_uuid),
             'resources': {'cpus': 0.01, 'mem': 32},
@@ -195,7 +195,8 @@ def pod_vip_app(network: marathon.Network, host: str, vip: str):
         'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
     }
     if host is not None:
-        app['placement']['constraints'] = [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+        app['scheduling']['placement']['constraints'] = [{
+            'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
     if vip is not None:
         app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
     if network == marathon.Network.USER:
@@ -253,7 +254,9 @@ def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: maratho
 
 
 def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
-    same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    if len(dcos_api_session.all_slaves) < 2 and vip_net is marathon.Network.BRIDGE:
+        return []
+    same_hosts = [True, False] if vip_net is not marathon.Network.BRIDGE else [False]
     tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
              for named_vip in [True, False]
              for same_host in same_hosts]


### PR DESCRIPTION
## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

## Related Issues

  - [DCOS-13978](https://jira.mesosphere.com/browse/DCOS-13978) minuteman tests for pods

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).