### PR TITLE
revert 1.5.1.1 for 1.10.1

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.1.1/marathon-1.5.1.1.tgz",
-    "sha1" : "973037f532ddaf1ec79649de2cf0bb593430b358"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/v1.5.1/marathon-1.5.1.tgz",
+    "sha1" : "babdbfb42da1d9d2611ab8d559046f40b50a867e"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

1.5.1.1 included a single change intended to relax the network name constraint, but instead, relaxed the endpoint name constraint.

It may be fine to relax the endpoint constraint, but it was not intentional, and, if we decide to just go ahead with 1.5.1.1, we should decide that for certain.

Otherwise, may be easiest to just revert the bump to 1.5.1.1 and get Marathon 1.5.2 in the next release of DCOS

## Related Issues

  - [MARATHON-7848](https://jira.dcos.io/browse/MARATHON-7848) Re-allow underscores in networkName in Marathon config.json definitions (this was the change we intended to include in DCOS 1.10.1 by bumping to 1.5.1.1, but that effort failed)
