### PR TITLE
 PR template: add "Corresponding DC/OS tickets" section, cosmetic updates

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,15 @@
 
 What features does this change enable? What bugs does this change fix? High-Level description of how things changed.
 
-## Related Issues
+## Corresponding DC/OS ticket(s)
+
+These DC/OS JIRA ticket(s) must be updated in the moment this PR lands:
+
+  - https://jira.mesosphere.com/browse/DCOS_OSS-<number>
+
+## Related tickets
+
+These tickets are related to this change:
 
   - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
   - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,19 +3,18 @@
 What features does this change enable? What bugs does this change fix?
 
 
-## Corresponding DC/OS tickets
+## Corresponding DC/OS tickets (obligatory)
 
-These DC/OS JIRA ticket(s) must be updated in the moment this PR lands:
-
-  - https://jira.mesosphere.com/browse/DCOS_OSS-<number>
-
-
-## Related tickets
-
-These tickets are related to this change:
+These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
 
   - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
-  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
+
+
+## Related tickets (optional)
+
+Other tickets related to this change:
+
+  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
 
 
 ## Checklist for all PRs

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
-## High Level Description
+## High-level description
 
-What features does this change enable? What bugs does this change fix? High-Level description of how things changed.
+What features does this change enable? What bugs does this change fix?
 
-## Corresponding DC/OS ticket(s)
+
+## Corresponding DC/OS tickets
 
 These DC/OS JIRA ticket(s) must be updated in the moment this PR lands:
 
   - https://jira.mesosphere.com/browse/DCOS_OSS-<number>
+
 
 ## Related tickets
 
@@ -15,11 +17,13 @@ These tickets are related to this change:
   - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
   - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
 
-## Checklist for all PR's
+
+## Checklist for all PRs
 
   - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
   - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
   - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
+
 
 ## Checklist for component/package updates:
 
@@ -31,11 +35,12 @@ If you are changing components or packages in DC/OS (e.g. you are bumping the sh
 ___
 **PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**
 
-## Instructions and Review Process
+
+## Instructions and review process
 
 **What is the review process and when will my changes land?**
 
-All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).
+All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).
 
 Reviewers should be:
 * Developers who understand the code being modified.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ These DC/OS JIRA ticket(s) must be updated in the moment this PR lands:
 
 These tickets are related to this change:
 
-  - [DCOS_OSS-<number>](https://jira.dcos.io/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
+  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.
   - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
 
 


### PR DESCRIPTION
## High Level Description

This is a follow-up pull request on the discussion that arised in https://github.com/dcos/dcos/pull/2000. This PR intends to supersede #2000.

The `Corresponding DC/OS tickets` section is meant to simplify the work of closing tickets right after merging a PR. The hope is that this section makes it more likely that every pull request has at least one such ticket associated, easily discoverable from the PR description. This paves the pathway towards a workflow in which we are auto-closing tickets upon merge.

## Related Issues

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]