### PR TITLE
Updating Owners.json

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -1,12 +1,18 @@
 {
   "amitaekbote": {"slack": "amitaekbote"},
   "adam-mesos": {"slack": "adam"},
+  "asridharan ": {"slack": "avinash"},
   "branden": {"slack": "branden"},
+  "gpaul": {"slack": "gpaul"},
+  "jgehrcke": {"slack": "jp"},
+  "klueska": {"slack": "klueska"},
   "lingmann": {"slack": "jeremy"},
   "MatApple": {"slack": "mat"},
+  "mnaboka": {"slack": "mnaboka"},
   "mellenburg": {"slack": "mellenburg"},
   "meichstedt": {"slack": "matthias.eichstedt"},
   "orlandohohmeier": {"slack": "orlando"},
   "orsenthil" : {"slack": "skumaran"},
-  "spahl": {"slack": "seb"}
+  "spahl": {"slack": "seb"},
+  "vespian": {"slack": "prozlach"}
 }


### PR DESCRIPTION
## High Level Description

- DCOS_OSS-1793 - Expand owners. json

**A concept of owners for dcos/dcos**

In dcos/dcos repo, we have owners.json file which gives the members certain privileges equivalent to being a committer of the repo. 

An owner can

* Test Enterprise Update for any PR.  Owner is authorized to do bump-ee on any PR.
* Can add a “ship-it” label manually, thereby including PR to an integration train. This is useful when we to override mergebot automated process.
* Could merge a train or PR to repo with a “merge-it” command.

As we expand mergebot capabilities, owners can delegate many committer-like operations to bot, and concentrate on important work like reviewing PRs and reviewing Integration Tests for DCOS.

If you are tech-lead of the component/team, and you submit or review PRs to dcos/dcos repo, you can request to be a member in owners file. Please make a comment in this Pull Request.
