### PR TITLE
1.10.1 version string should be 1.10.1.

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -106,7 +106,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.2',
+        'version': '1.10.1',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -983,7 +983,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.2',
+        'dcos_version': '1.10.1',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,


### PR DESCRIPTION
This reverts commit 6771ccf3245e58ea8cd188bac8112db0fd6732d6.

## High Level Description

* https://jira.mesosphere.com/browse/RELEASE-33 

The version string should be 1.10.1

## Related Issues

## Checklist for all PR's

