### PR TITLE
QUALITY-1607: `pkgpanda fetch --force-reinstall` to recover from modified local packages

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -188,7 +188,7 @@ class Package:
     def __repr__(self):
         return str(self.__id)
 
-    def __lt__(self,other):
+    def __lt__(self, other):
         return (self.name < other.name)
 
 
@@ -779,10 +779,11 @@ class Install:
                                           "to try activating multiple versions of the same file. "
                                           "One of the package files is {2}. "
                                           "This might also be caused by modified content of an installed "
-                                          "package. You can try to fix it by using `pkgpanda fetch --force-reinstall ...` "
+                                          "package. You can try to fix it by using "
+                                          "`pkgpanda fetch --force-reinstall ...` "
                                           "on the packge(s) stated in this message.".format(ex.dest,
-                                                                                    self.__roles,
-                                                                                    ex.src))
+                                                                                            self.__roles,
+                                                                                            ex.src))
 
             # Add to the active folder
             os.symlink(package.path, os.path.join(self._make_abs("active.new"), package.name))

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -465,7 +465,7 @@ def symlink_tree(src, dest):
         else:
             try:
                 os.symlink(src_path, dest_path)
-            except FileNotFoundError as ex:
+            except (FileNotFoundError, FileExistsError) as ex:
                 raise ConflictingFile(src_path, dest_path, ex) from ex
 
 
@@ -777,7 +777,10 @@ class Install:
                     raise ValidationError("Two packages are trying to install the same file {0} or "
                                           "two roles in the set of roles {1} are causing a package "
                                           "to try activating multiple versions of the same file. "
-                                          "One of the package files is {2}.".format(ex.dest,
+                                          "One of the package files is {2}. "
+                                          "This might also be caused by modified content of an installed "
+                                          "package. You can try to fix it by using `pkgpanda fetch --force-reinstall ...` "
+                                          "on the packge(s) stated in this message.".format(ex.dest,
                                                                                     self.__roles,
                                                                                     ex.src))
 

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -188,6 +188,9 @@ class Package:
     def __repr__(self):
         return str(self.__id)
 
+    def __lt__(self,other):
+        return (self.name < other.name)
+
 
 def expand_require(require: Union[str, dict]):
     name = None
@@ -737,7 +740,7 @@ class Install:
             return list(map(lambda name: os.path.splitext(name)[0], service_files))
 
         # Add the folders, config in each package.
-        for package in packages:
+        for package in sorted(packages):
             # Package folders
             # NOTE: Since active is at the end of the folder list it will be
             # removed by the zip. This is the desired behavior, since it will be

--- a/pkgpanda/actions.py
+++ b/pkgpanda/actions.py
@@ -65,7 +65,7 @@ def swap_active_package(install, repository, package_id, systemd, block_systemd)
     activate_packages(install, repository, new_active, systemd, block_systemd)
 
 
-def fetch_package(repository, repository_url, package_id, work_dir):
+def fetch_package(repository, repository_url, package_id, work_dir, force_reinstall=False):
     """Fetch package_id from repository_url into repository.
 
     repository: pkgpanda.Repository
@@ -82,11 +82,12 @@ def fetch_package(repository, repository_url, package_id, work_dir):
     sys.stdout.write("\rFetching: {0}".format(package_id))
     sys.stdout.flush()
     try:
-        repository.add(fetcher, package_id)
+        if repository.add(fetcher, package_id, warn_added=False, force_reinstall=force_reinstall):
+            sys.stdout.write("\rFetched: {0}".format(package_id))
+        else:
+            sys.stdout.write("\rDid not fetch, already there: {0}".format(package_id))
     except FetchError as ex:
         raise Exception("Unable to fetch package {0}: {1}".format(package_id, ex)) from ex
-    else:
-        sys.stdout.write("\rFetched: {0}".format(package_id))
     finally:
         sys.stdout.write("\n")
         sys.stdout.flush()

--- a/pkgpanda/cli.py
+++ b/pkgpanda/cli.py
@@ -24,6 +24,8 @@ Options:
                                 repository directory [default: {default_repository}]
     --rooted-systemd            Use $ROOT/dcos.target.wants for systemd management
                                 rather than /etc/systemd/system/dcos.target.wants
+    --force-reinstall           Forces a package to be fetched again, instead of ignoring
+                                it when the same package was previously installed.
 """
 
 import os
@@ -173,7 +175,8 @@ def main():
                     repository,
                     arguments['--repository-url'],
                     package_id,
-                    os.getcwd())
+                    os.getcwd(),
+                    arguments['--force-reinstall'])
             sys.exit(0)
 
         if arguments['activate']:


### PR DESCRIPTION
## High Level Description
### `fetch --force-reinstall` feature
This change will add a new flag to `pkgpanda fetch`, which allows an operator to forcefully overwrite an already fetched package, without manually deleting it from the nodes disk. This is especially useful for the python package, which cannot be (temporarily) removed to re-fetch it, without breaking `pkgpanda` and other tools relying on that exact DC/OS provided python installation. 
For a actual use-case in which this is desirable, please see the linked (internal) [SOAK-28](https://jira.mesosphere.com/browse/SOAK-28) ticket. Basically it allows operators to recover  a modified DC/OS installation and not have to necessarily install a node from scratch, in some cases.

### reproducible `activate` runs
Also this PR adds an order on pkgpanda Package objects, so these can be sorted, which is useful to allow (a failing) `pkgpanda activate` to be reproducible across multiple runs.
The key on which the package objects are ordered doesn't really matter, as long as they do not change across invocations of the function, so `name` is doing fine.

## Related Issues

  - [SOAK-28](https://jira.mesosphere.com/browse/SOAK-28) while investigation this internally, we needed to debug pkgpandas behavior
  - [QUALITY-1607](https://jira.mesosphere.com/browse/QUALITY-1607) tracks the issue on DC/OS  to allow easier detection and resolution of these kind of errors by operators
  - [DCOS_OSS-1644)](https://jira.mesosphere.com/browse/DCOS_OSS-1644) tracks the improvements on DC/OS  installer or upgrade scripts to allow easier detection and resolution of these kind of errors by operators

## Example output
```
[root@int-master1-test110 mesosphere]# touch /opt/mesosphere/packages/python--6fd09648eded002b46ab08542af7cd7910f60f46/bin/chardetect
[root@int-master1-test110 mesosphere]# bash /tmp/dcos_node_upgrade.sh
Upgrading DC/OS master 1.10.1 -> 1.10.1
Validation Error: Two packages are trying to install the same file /opt/mesosphere/bin.new/chardetect or two roles in the set of roles ['master'] are causing a package to try activating multiple versions of the same file. One of the package files is /opt/mesosphere/packages/python--6fd09648eded002b46ab08542af7cd7910f60f46/bin/chardetect. This might also be caused by modified content of an installed package. You can try to fix it by using `pkgpanda fetch --force-reinstall ...` on the packge(s) stated in this message.
[root@int-master1-test110 mesosphere]# pkgpanda fetch --repository-url=http://172.31.4.196:8080 python--6fd09648eded002b46ab08542af7cd7910f60f46
Did not fetch, already there: python--6fd09648eded002b46ab08542af7cd7910f60f46
[root@int-master1-test110 mesosphere]#
[root@int-master1-test110 mesosphere]#
[root@int-master1-test110 mesosphere]# pkgpanda fetch --force-reinstall --repository-url=http://172.31.4.196:8080 python--6fd09648eded002b46ab08542af7cd7910f60f46
Fetched: python--6fd09648eded002b46ab08542af7cd7910f60f466
[root@int-master1-test110 mesosphere]# bash /tmp/dcos_node_upgrade.sh
Upgrading DC/OS master 1.10.1 -> 1.10.1
[root@int-master1-test110 mesosphere]#
```