### PR TITLE
Bump exhibitor to update aws sdk version to support unpublished govcloud regions

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "8887bfff076f4d48dcae2ddb3e3159bda4787783",
+      "ref": "4965c0c9e3e2150dd5bd5af44d55204bb605a5ba",
       "ref_origin": "master"
     },
     "zookeeper": {

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "2c0f5e2a9d9962d0b02dd022fe8980a95cb5f53b",
+      "ref": "8887bfff076f4d48dcae2ddb3e3159bda4787783",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
## High-level description

Bump Exhibitor for:
- AWS SDK setting of region, with support for endpoint override.
- Enable specifying the Endpoint Suffix in the azure connection string

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1940](https://jira.mesosphere.com/browse/DCOS_OSS-1940) exhibitor: bump aws sdk version to support unpublished govcloud regions
  - [DCOS_OSS-1941](https://jira.mesosphere.com/browse/DCOS_OSS-1941) exhibitor: enable specifying the Endpoint Suffix in the azure connection string

## Related tickets (optional)

None that I am aware of at this time.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [exhibitor](https://github.com/dcos/exhibitor/compare/2c0f5e2a9d9962d0b02dd022fe8980a95cb5f53b...4965c0c9e3e2150dd5bd5af44d55204bb605a5ba)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]