### PR TITLE
Remove sensitive config values from diagnostics bundles and build output

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -207,10 +207,12 @@ aws_advanced_source = gen.internals.Source({
         'num_masters': '5',
         'aws_template_upload': 'true',
         'aws_template_storage_bucket_path_autocreate': 'true',
-        'bootstrap_id': lambda: gen.calc.calculate_environment_variable('BOOTSTRAP_ID')
+        'bootstrap_id': lambda: gen.calc.calculate_environment_variable('BOOTSTRAP_ID'),
         # TODO(cmaloney): Add defaults for getting AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY from the
         # environment to set as keys. Not doing for now since they would need to be passed through
         # the `docker run` inside dcos_generate_config.sh
+        'aws_template_storage_access_key_id': '',
+        'aws_template_storage_secret_access_key': '',
     },
     'must': {
         'provider': 'aws',
@@ -222,6 +224,10 @@ aws_advanced_source = gen.internals.Source({
         'bootstrap_url': calculate_base_repository_url,
         'reproducible_artifact_path': calculate_reproducible_artifact_path,
     },
+    'secret': [
+        'aws_template_storage_access_key_id',
+        'aws_template_storage_secret_access_key',
+    ],
     'conditional': {
         'aws_template_upload': {
             'true': {

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -531,7 +531,7 @@ def get_late_variables(resolver, sources):
 
 
 def get_secret_variables(sources):
-    return list(set().union(*(source.secret for source in sources)))
+    return list(set(var_name for source in sources for var_name in source.secret))
 
 
 def get_final_arguments(resolver):

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -448,18 +448,22 @@ def get_dcosconfig_source_target_and_templates(
 
     sources = [base_source, user_arguments_to_source(user_arguments)] + extra_sources
 
+    # Add builtin variables.
     # TODO(cmaloney): Hash the contents of all the templates rather than using the list of filenames
     # since the filenames might not live in this git repo, or may be locally modified.
     add_builtin('template_filenames', template_filenames)
     add_builtin('config_package_names', list(config_package_names))
-    # TODO(cmaloney): user_arguments needs to be a temporary_str since we need to only include used
-    # arguments inside of it.
-    add_builtin('user_arguments', user_arguments)
 
-    # Add a builtin for expanded_config, so that we won't get unset argument errors. The temporary
-    # value will get replaced with the set of all arguments once calculation is complete
+    # Add placeholders for builtin variables whose values will be calculated after all others, so that we won't get
+    # unset argument errors. The placeholder value with be replaced with the actual value after all other variables are
+    # calculated.
     temporary_str = 'DO NOT USE THIS AS AN ARGUMENT TO OTHER ARGUMENTS. IT IS TEMPORARY'
+    add_builtin('user_arguments_full', temporary_str)
+    add_builtin('user_arguments', temporary_str)
+    add_builtin('config_yaml_full', temporary_str)
+    add_builtin('config_yaml', temporary_str)
     add_builtin('expanded_config', temporary_str)
+    add_builtin('expanded_config_full', temporary_str)
 
     # Note: must come last so the hash of the "base_source" this is beign added to contains all the
     # variables but this.
@@ -526,8 +530,23 @@ def get_late_variables(resolver, sources):
     return late_variables
 
 
+def get_secret_variables(sources):
+    return list(set().union(*(source.secret for source in sources)))
+
+
 def get_final_arguments(resolver):
     return {k: v.value for k, v in resolver.arguments.items() if v.is_finalized}
+
+
+def format_expanded_config(config):
+    return textwrap.indent(json_prettyprint(config), prefix=('  ' * 3))
+
+
+def user_arguments_to_yaml(user_arguments: dict):
+    return textwrap.indent(
+        yaml.dump(user_arguments, default_style='|', default_flow_style=False, indent=2),
+        prefix=('  ' * 3),
+    )
 
 
 def generate(
@@ -545,20 +564,36 @@ def generate(
     resolver = validate_and_raise(sources, targets + extra_targets)
     argument_dict = get_final_arguments(resolver)
     late_variables = get_late_variables(resolver, sources)
+    secret_builtins = ['expanded_config_full', 'user_arguments_full', 'config_yaml_full']
+    secret_variables = set(get_secret_variables(sources) + secret_builtins)
+    masked_value = '**HIDDEN**'
 
-    # expanded_config is a special result which contains all other arguments. It has to come after
-    # the calculation of all the other arguments so it can be filled with everything which was
-    # calculated. Can't be calculated because that would have an infinite recursion problem (the set
-    # of all arguments would want to include itself).
-    # Explicitly / manaully setup so that it'll fit where we want it.
+    # Calculate values for builtin variables.
+    user_arguments_masked = {k: (masked_value if k in secret_variables else v) for k, v in user_arguments.items()}
+    argument_dict['user_arguments_full'] = json_prettyprint(user_arguments)
+    argument_dict['user_arguments'] = json_prettyprint(user_arguments_masked)
+    argument_dict['config_yaml_full'] = user_arguments_to_yaml(user_arguments)
+    argument_dict['config_yaml'] = user_arguments_to_yaml(user_arguments_masked)
+
+    # The expanded_config and expanded_config_full variables contain all other variables and their values.
+    # expanded_config is a copy of expanded_config_full with secret values removed. Calculating these variables' values
+    # must come after the calculation of all other variables to prevent infinite recursion.
     # TODO(cmaloney): Make this late-bound by gen.internals
-    argument_dict['expanded_config'] = textwrap.indent(
-        json_prettyprint(
-            {k: v for k, v in argument_dict.items() if not v.startswith(gen.internals.LATE_BIND_PLACEHOLDER_START)}
-        ),
-        prefix='  ' * 3,
+    expanded_config_full = {
+        k: v for k, v in argument_dict.items()
+        # Omit late-bound variables whose values have not yet been calculated.
+        if not v.startswith(gen.internals.LATE_BIND_PLACEHOLDER_START)
+    }
+    expanded_config_scrubbed = {k: v for k, v in expanded_config_full.items() if k not in secret_variables}
+    argument_dict['expanded_config_full'] = format_expanded_config(expanded_config_full)
+    argument_dict['expanded_config'] = format_expanded_config(expanded_config_scrubbed)
+
+    log.debug(
+        "Final arguments:" + json_prettyprint({
+            # Mask secret config values.
+            k: (masked_value if k in secret_variables else v) for k, v in argument_dict.items()
+        })
     )
-    log.debug("Final arguments:" + json_prettyprint(argument_dict))
 
     # Fill in the template parameters
     # TODO(cmaloney): render_templates should ideally take the template targets.

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -983,6 +983,7 @@ entry = {
         'check_ld_library_path': '/opt/mesosphere/lib'
     },
     'secret': [
+        'cluster_docker_credentials',
         'exhibitor_admin_password',
     ],
     'conditional': {

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -28,7 +28,6 @@ import os
 import re
 import socket
 import string
-import textwrap
 from math import floor
 from subprocess import check_output
 
@@ -404,12 +403,6 @@ def calculate_exhibitor_admin_password_enabled(exhibitor_admin_password):
 
 def calculate_adminrouter_auth_enabled(oauth_enabled):
     return oauth_enabled
-
-
-def calculate_config_yaml(user_arguments):
-    return textwrap.indent(
-        yaml.dump(json.loads(user_arguments), default_style='|', default_flow_style=False, indent=2),
-        prefix='  ' * 3)
 
 
 def calculate_mesos_isolation(enable_gpu_isolation):
@@ -974,7 +967,6 @@ entry = {
         'dcos_l4lb_max_named_ip_erltuple': calculate_dcos_l4lb_max_named_ip_erltuple,
         'mesos_isolation': calculate_mesos_isolation,
         'has_mesos_max_completed_tasks_per_framework': calculate_has_mesos_max_completed_tasks_per_framework,
-        'config_yaml': calculate_config_yaml,
         'mesos_hooks': calculate_mesos_hooks,
         'use_mesos_hooks': calculate_use_mesos_hooks,
         'rexray_config_contents': calculate_rexray_config_contents,

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -982,6 +982,9 @@ entry = {
         'check_config_contents': calculate_check_config_contents,
         'check_ld_library_path': '/opt/mesosphere/lib'
     },
+    'secret': [
+        'exhibitor_admin_password',
+    ],
     'conditional': {
         'master_discovery': {
             'master_http_loadbalancer': {},

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -925,9 +925,17 @@ package:
   - path: /etc/user.config.yaml
     content: |
 {{ config_yaml }}
+  - path: /etc/user.config.full.yaml
+    permissions: "0600"
+    content: |
+{{ config_yaml_full }}
   - path: /etc/expanded.config.json
     content: |
 {{ expanded_config }}
+  - path: /etc/expanded.config.full.json
+    permissions: "0600"
+    content: |
+{{ expanded_config_full }}
   - path: /etc_master/dcos-history.env
     content: |
       STATE_SUMMARY_URI=http://leader.mesos:5050/state-summary

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -312,12 +312,11 @@ class Source:
             if name in self.setters:
                 del self.setters[name]
 
+        # Remove setters and secrets from self that are defined by scope.
         for name in scope.get('must', dict()).keys():
             del_setter(name)
-
         for name in scope.get('default', dict()).keys():
             del_setter(name)
-
         self.secret = list(set(self.secret) - set(scope.get('secret', list())))
 
         for name, cond_options in scope.get('conditional', dict()).items():

--- a/gen/internals.py
+++ b/gen/internals.py
@@ -246,16 +246,14 @@ class Target:
 
 
 class Source:
-    """ Object to define how arguments can be specified, including argument
-    calculation, default values, validation, and any conditional variations
-    of those three
-    """
+    """Defines config arguments, including calculation, defaults, validation, and whether arguments are secrets."""
     def __init__(self, entry=None, is_user=False):
         """ Entry is a dict of the following form:
         {
           'validate': [validate_my_arg_fn],
           'default': {arg: value},  # may be overridden by user args
-          'must': {arg: value}  # may NOT be overridden by user args
+          'must': {arg: value},  # may NOT be overridden by user args
+          'secret': [arg],
           'conditional': {arg: {val_1: add_entry_1, val_2: add_entry_2}}
         }
         validate_my_arg_fn: a function that will be called against the argument names it uses
@@ -263,27 +261,47 @@ class Source:
         """
         self.setters = dict()
         self.validate = list()
+        self.secret = list()
         self.is_user = is_user
         if entry:
             self.add_entry(entry, False)
 
     def add_setter(self, name, value, is_optional, conditions):
-        self.setters.setdefault(name, list()).append(Setter(name, value, is_optional, conditions, self.is_user))
+        self.setters.setdefault(name, list()).append(
+            Setter(name, value, is_optional, conditions, self.is_user)
+        )
 
     def add_conditional_scope(self, scope, conditions):
         # TODO(cmaloney): 'defaults' are the same as 'can' and 'must' is identical to 'arguments' except
         # that one takes functions and one takes strings. Simplify to just 'can', 'must'.
-        assert scope.keys() <= {'validate', 'default', 'must', 'conditional'}
+        assert scope.keys() <= {'validate', 'default', 'must', 'secret', 'conditional'}
 
         self.validate += scope.get('validate', list())
+        self.secret += scope.get('secret', list())
 
-        for name, fn in scope.get('must', dict()).items():
+        must = scope.get('must', dict())
+        default = scope.get('default', dict())
+        conditional = scope.get('conditional', dict())
+
+        for name, fn in must.items():
             self.add_setter(name, fn, False, conditions)
 
-        for name, fn in scope.get('default', dict()).items():
+        for name, fn in default.items():
             self.add_setter(name, fn, True, conditions)
 
-        for name, cond_options in scope.get('conditional', dict()).items():
+        # Assert that all secret params are referenced somewhere in this scope.
+        setter_params = set()
+        for setter_list in self.setters.values():
+            for setter in setter_list:
+                for param in setter.parameters:
+                    setter_params.add(param)
+        all_variables = set(self.setters.keys()).union(setter_params)
+        for name in self.secret:
+            assert name in all_variables, (
+                "Secret variable '{}' must be defined or referenced as a parameter in this scope".format(name)
+            )
+
+        for name, cond_options in conditional.items():
             for value, sub_scope in cond_options.items():
                 self.add_conditional_scope(sub_scope, conditions + [(name, value)])
 
@@ -299,6 +317,8 @@ class Source:
 
         for name in scope.get('default', dict()).keys():
             del_setter(name)
+
+        self.secret = list(set(self.secret) - set(scope.get('secret', list())))
 
         for name, cond_options in scope.get('conditional', dict()).items():
             if name in self.setters:

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -1,6 +1,7 @@
 import json
 
 import pkg_resources
+import yaml
 
 import gen
 from gen.tests.utils import make_arguments, true_false_msg, validate_error, validate_success
@@ -777,3 +778,18 @@ def test_fault_domain_disabled():
 
     assert generated.arguments['fault_domain_enabled'] == 'false'
     assert 'fault_domain_detect_contents' not in generated.arguments
+
+
+def test_exhibitor_admin_password_obscured():
+    var_name = 'exhibitor_admin_password'
+    var_value = 'secret'
+    generated = gen.generate(make_arguments(new_arguments={var_name: var_value}))
+
+    assert var_name not in json.loads(generated.arguments['expanded_config'])
+    assert json.loads(generated.arguments['expanded_config_full'])[var_name] == var_value
+
+    assert json.loads(generated.arguments['user_arguments'])[var_name] == '**HIDDEN**'
+    assert json.loads(generated.arguments['user_arguments_full'])[var_name] == var_value
+
+    assert yaml.load(generated.arguments['config_yaml'])[var_name] == '**HIDDEN**'
+    assert yaml.load(generated.arguments['config_yaml_full'])[var_name] == var_value

--- a/gen/tests/test_internals.py
+++ b/gen/tests/test_internals.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 import gen.internals
@@ -119,3 +121,28 @@ def test_resolve_late():
     assert resolver.late == {'c'}
 
     # TODO(cmaloney): Test resolved from late variables
+
+
+def test_source_secrets():
+    entry = {
+        'default': {
+            'b': lambda c: c,
+        },
+        'must': {
+            'a': 'a_str',
+        },
+        'secret': [
+            'a',
+            'b',
+            'c',
+        ],
+    }
+
+    # A source may declare secret variables as long as those variables are defined or referenced within that source.
+    Source(entry)
+
+    # A source with an unreferenced secret variable raises an exception.
+    extra_secret_entry = deepcopy(entry)
+    extra_secret_entry['secret'].append('d')
+    with pytest.raises(Exception):
+        Source(extra_secret_entry)

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -6,10 +6,28 @@ from dcos_test_utils import marathon
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
 
+
+def get_exhibitor_admin_password():
+    try:
+        with open('/opt/mesosphere/etc/exhibitor_realm', 'r') as f:
+            exhibitor_realm = f.read().strip()
+    except FileNotFoundError:
+        # Unset. Return the default value.
+        return ''
+
+    creds = exhibitor_realm.split(':')[1].strip()
+    password = creds.split(',')[0].strip()
+    return password
+
+
 # make the expanded config available at import time to allow determining
 # which tests should run before the test suite kicks off
 with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
     expanded_config = json.load(f)
+    # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
+    # Exhibitor's config.
+    # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
+    expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
 
 
 def marathon_test_app(


### PR DESCRIPTION
## High Level Description

This adds support for tagging gen config variables as "secret", which removes them from diagnostics bundles and build output.

Secret variables are omitted from `/opt/mesosphere/etc/expanded.config.json`, and their values are masked in `/opt/mesosphere/etc/user.config.yaml` and when they're printed to the console. New files `/opt/mesosphere/etc/user.config.full.yaml` and `/opt/mesosphere/etc/expanded.config.full.json` are added which include secret variables, and these files are only readable by root. 

This also tags some existing config variables as secret:
* `cluster_docker_credentials`
* `exhibitor_admin_password`
* `aws_template_storage_access_key_id`
* `aws_template_storage_secret_access_key`

## Related Issues

  - [DCOS_OSS-1795](https://jira.mesosphere.com/browse/DCOS_OSS-1795) Sensitive config values in diagnostics bundles

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]