### PR TITLE
Revert CentOS AMI update

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -153,6 +153,8 @@ DC/OS AMIs (with prereqs)
 
 Update to CentOS 7.4.1708 (no DC/OS prereqs)
 
+Note: these do not work with the CloudFormation zen templates
+
 * ap-northeast-1: ami-965345f8
 * ap-southeast-1: ami-8af586e9
 * ap-southeast-2: ami-427d9c20

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -127,65 +127,66 @@ aws_region_names = [
         'id': 'ap-southeast-2'
     }]
 
+
 region_to_ami_map = {
     'ap-northeast-1': {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
-        'el7': 'ami-965345f8',
+        'el7': 'ami-e21fd884',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
-        'el7': 'ami-8af586e9',
+        'el7': 'ami-3b8ee058',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
-        'el7': 'ami-427d9c20',
+        'el7': 'ami-c2e501a0',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
-        'el7': 'ami-2d0cbc42',
+        'el7': 'ami-868531e9',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
-        'el7': 'ami-e46ea69d',
+        'el7': 'ami-5f03c426',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
-        'el7': 'ami-a5acd0c9',
+        'el7': 'ami-5d2f5d31',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
-        'el7': 'ami-771beb0d',
+        'el7': 'ami-abb1a2d0',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
         'coreos': 'ami-e441fb85',
         'stable': 'ami-e441fb85',
-        'el7': 'ami-9923a1f8',
-        'natami': 'ami-fe991b9f'
+        'el7': 'ami-e58c0f84',
+        'natami': ''
     },
     'us-west-1': {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
-        'el7': 'ami-866151e6',
+        'el7': 'ami-f6427596',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
-        'el7': 'ami-a9b24bd1',
+        'el7': 'ami-6eed1a16',
         'natami': 'ami-bb69128b'
     }
 }


### PR DESCRIPTION
## High Level Description
Hopefully temporary revert of the CentOS AMI update because the plain image doesn't work with the install scripts + the Zen templates do not work.

## Related Issues

- Need https://jira.mesosphere.com/browse/QUALITY-1608 before we can use these (those changes will be in dcos-launch)
- Zen templates https://jira.mesosphere.com/browse/DCOS_OSS-1803

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
