### PR TITLE
openssl: Disable TLS compression [1.10]

### DIFF
--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -8,12 +8,12 @@ pushd "/pkg/src/openssl"
 ./Configure "--prefix=$PKG_PATH" \
   --openssldir="$PKG_PATH/etc/ssl" \
   shared \
-  zlib \
   linux-x86_64 \
   no-krb5 \
   no-rc4 \
   no-ssl2 \
   no-ssl3 \
+  no-comp \
   enable-ec_nistp_64_gcc_128 \
   -Wa,--noexecstack \
   -O2 -DFORTIFY_SOURCE=2


### PR DESCRIPTION
## High Level Description

This is a backport of https://github.com/dcos/dcos/pull/2073
Backport JIRA: https://jira.mesosphere.com/browse/DCOS-19452

The TLS compression is vulnerable to MITM attack known as [CRIME](https://en.wikipedia.org/wiki/CRIME). This PR disables support for TLS compression in `openssl` library. None of the components using the `openssl` will be able to run TLS compressed connection.

## Related Issues

  - [DCOS-19390](https://jira.mesosphere.com/browse/DCOS-19390) Disable TLS compression for mesos TLS interface

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]