### PR TITLE
Train 251

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -207,10 +207,12 @@ aws_advanced_source = gen.internals.Source({
         'num_masters': '5',
         'aws_template_upload': 'true',
         'aws_template_storage_bucket_path_autocreate': 'true',
-        'bootstrap_id': lambda: gen.calc.calculate_environment_variable('BOOTSTRAP_ID')
+        'bootstrap_id': lambda: gen.calc.calculate_environment_variable('BOOTSTRAP_ID'),
         # TODO(cmaloney): Add defaults for getting AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY from the
         # environment to set as keys. Not doing for now since they would need to be passed through
         # the `docker run` inside dcos_generate_config.sh
+        'aws_template_storage_access_key_id': '',
+        'aws_template_storage_secret_access_key': '',
     },
     'must': {
         'provider': 'aws',
@@ -222,6 +224,10 @@ aws_advanced_source = gen.internals.Source({
         'bootstrap_url': calculate_base_repository_url,
         'reproducible_artifact_path': calculate_reproducible_artifact_path,
     },
+    'secret': [
+        'aws_template_storage_access_key_id',
+        'aws_template_storage_secret_access_key',
+    ],
     'conditional': {
         'aws_template_upload': {
             'true': {

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -448,18 +448,22 @@ def get_dcosconfig_source_target_and_templates(
 
     sources = [base_source, user_arguments_to_source(user_arguments)] + extra_sources
 
+    # Add builtin variables.
     # TODO(cmaloney): Hash the contents of all the templates rather than using the list of filenames
     # since the filenames might not live in this git repo, or may be locally modified.
     add_builtin('template_filenames', template_filenames)
     add_builtin('config_package_names', list(config_package_names))
-    # TODO(cmaloney): user_arguments needs to be a temporary_str since we need to only include used
-    # arguments inside of it.
-    add_builtin('user_arguments', user_arguments)
 
-    # Add a builtin for expanded_config, so that we won't get unset argument errors. The temporary
-    # value will get replaced with the set of all arguments once calculation is complete
+    # Add placeholders for builtin variables whose values will be calculated after all others, so that we won't get
+    # unset argument errors. The placeholder value with be replaced with the actual value after all other variables are
+    # calculated.
     temporary_str = 'DO NOT USE THIS AS AN ARGUMENT TO OTHER ARGUMENTS. IT IS TEMPORARY'
+    add_builtin('user_arguments_full', temporary_str)
+    add_builtin('user_arguments', temporary_str)
+    add_builtin('config_yaml_full', temporary_str)
+    add_builtin('config_yaml', temporary_str)
     add_builtin('expanded_config', temporary_str)
+    add_builtin('expanded_config_full', temporary_str)
 
     # Note: must come last so the hash of the "base_source" this is beign added to contains all the
     # variables but this.
@@ -526,8 +530,23 @@ def get_late_variables(resolver, sources):
     return late_variables
 
 
+def get_secret_variables(sources):
+    return list(set(var_name for source in sources for var_name in source.secret))
+
+
 def get_final_arguments(resolver):
     return {k: v.value for k, v in resolver.arguments.items() if v.is_finalized}
+
+
+def format_expanded_config(config):
+    return textwrap.indent(json_prettyprint(config), prefix=('  ' * 3))
+
+
+def user_arguments_to_yaml(user_arguments: dict):
+    return textwrap.indent(
+        yaml.dump(user_arguments, default_style='|', default_flow_style=False, indent=2),
+        prefix=('  ' * 3),
+    )
 
 
 def generate(
@@ -545,20 +564,36 @@ def generate(
     resolver = validate_and_raise(sources, targets + extra_targets)
     argument_dict = get_final_arguments(resolver)
     late_variables = get_late_variables(resolver, sources)
+    secret_builtins = ['expanded_config_full', 'user_arguments_full', 'config_yaml_full']
+    secret_variables = set(get_secret_variables(sources) + secret_builtins)
+    masked_value = '**HIDDEN**'
 
-    # expanded_config is a special result which contains all other arguments. It has to come after
-    # the calculation of all the other arguments so it can be filled with everything which was
-    # calculated. Can't be calculated because that would have an infinite recursion problem (the set
-    # of all arguments would want to include itself).
-    # Explicitly / manaully setup so that it'll fit where we want it.
+    # Calculate values for builtin variables.
+    user_arguments_masked = {k: (masked_value if k in secret_variables else v) for k, v in user_arguments.items()}
+    argument_dict['user_arguments_full'] = json_prettyprint(user_arguments)
+    argument_dict['user_arguments'] = json_prettyprint(user_arguments_masked)
+    argument_dict['config_yaml_full'] = user_arguments_to_yaml(user_arguments)
+    argument_dict['config_yaml'] = user_arguments_to_yaml(user_arguments_masked)
+
+    # The expanded_config and expanded_config_full variables contain all other variables and their values.
+    # expanded_config is a copy of expanded_config_full with secret values removed. Calculating these variables' values
+    # must come after the calculation of all other variables to prevent infinite recursion.
     # TODO(cmaloney): Make this late-bound by gen.internals
-    argument_dict['expanded_config'] = textwrap.indent(
-        json_prettyprint(
-            {k: v for k, v in argument_dict.items() if not v.startswith(gen.internals.LATE_BIND_PLACEHOLDER_START)}
-        ),
-        prefix='  ' * 3,
+    expanded_config_full = {
+        k: v for k, v in argument_dict.items()
+        # Omit late-bound variables whose values have not yet been calculated.
+        if not v.startswith(gen.internals.LATE_BIND_PLACEHOLDER_START)
+    }
+    expanded_config_scrubbed = {k: v for k, v in expanded_config_full.items() if k not in secret_variables}
+    argument_dict['expanded_config_full'] = format_expanded_config(expanded_config_full)
+    argument_dict['expanded_config'] = format_expanded_config(expanded_config_scrubbed)
+
+    log.debug(
+        "Final arguments:" + json_prettyprint({
+            # Mask secret config values.
+            k: (masked_value if k in secret_variables else v) for k, v in argument_dict.items()
+        })
     )
-    log.debug("Final arguments:" + json_prettyprint(argument_dict))
 
     # Fill in the template parameters
     # TODO(cmaloney): render_templates should ideally take the template targets.

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -28,7 +28,6 @@ import os
 import re
 import socket
 import string
-import textwrap
 from math import floor
 from subprocess import check_output
 
@@ -404,12 +403,6 @@ def calculate_exhibitor_admin_password_enabled(exhibitor_admin_password):
 
 def calculate_adminrouter_auth_enabled(oauth_enabled):
     return oauth_enabled
-
-
-def calculate_config_yaml(user_arguments):
-    return textwrap.indent(
-        yaml.dump(json.loads(user_arguments), default_style='|', default_flow_style=False, indent=2),
-        prefix='  ' * 3)
 
 
 def calculate_mesos_isolation(enable_gpu_isolation):
@@ -974,7 +967,6 @@ entry = {
         'dcos_l4lb_max_named_ip_erltuple': calculate_dcos_l4lb_max_named_ip_erltuple,
         'mesos_isolation': calculate_mesos_isolation,
         'has_mesos_max_completed_tasks_per_framework': calculate_has_mesos_max_completed_tasks_per_framework,
-        'config_yaml': calculate_config_yaml,
         'mesos_hooks': calculate_mesos_hooks,
         'use_mesos_hooks': calculate_use_mesos_hooks,
         'rexray_config_contents': calculate_rexray_config_contents,
@@ -990,6 +982,10 @@ entry = {
         'check_config_contents': calculate_check_config_contents,
         'check_ld_library_path': '/opt/mesosphere/lib'
     },
+    'secret': [
+        'cluster_docker_credentials',
+        'exhibitor_admin_password',
+    ],
     'conditional': {
         'master_discovery': {
             'master_http_loadbalancer': {},

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -925,9 +925,17 @@ package:
   - path: /etc/user.config.yaml
     content: |
 {{ config_yaml }}
+  - path: /etc/user.config.full.yaml
+    permissions: "0600"
+    content: |
+{{ config_yaml_full }}
   - path: /etc/expanded.config.json
     content: |
 {{ expanded_config }}
+  - path: /etc/expanded.config.full.json
+    permissions: "0600"
+    content: |
+{{ expanded_config_full }}
   - path: /etc_master/dcos-history.env
     content: |
       STATE_SUMMARY_URI=http://leader.mesos:5050/state-summary

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -1,6 +1,7 @@
 import json
 
 import pkg_resources
+import yaml
 
 import gen
 from gen.tests.utils import make_arguments, true_false_msg, validate_error, validate_success
@@ -777,3 +778,18 @@ def test_fault_domain_disabled():
 
     assert generated.arguments['fault_domain_enabled'] == 'false'
     assert 'fault_domain_detect_contents' not in generated.arguments
+
+
+def test_exhibitor_admin_password_obscured():
+    var_name = 'exhibitor_admin_password'
+    var_value = 'secret'
+    generated = gen.generate(make_arguments(new_arguments={var_name: var_value}))
+
+    assert var_name not in json.loads(generated.arguments['expanded_config'])
+    assert json.loads(generated.arguments['expanded_config_full'])[var_name] == var_value
+
+    assert json.loads(generated.arguments['user_arguments'])[var_name] == '**HIDDEN**'
+    assert json.loads(generated.arguments['user_arguments_full'])[var_name] == var_value
+
+    assert yaml.load(generated.arguments['config_yaml'])[var_name] == '**HIDDEN**'
+    assert yaml.load(generated.arguments['config_yaml_full'])[var_name] == var_value

--- a/gen/tests/test_internals.py
+++ b/gen/tests/test_internals.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 import gen.internals
@@ -119,3 +121,28 @@ def test_resolve_late():
     assert resolver.late == {'c'}
 
     # TODO(cmaloney): Test resolved from late variables
+
+
+def test_source_secrets():
+    entry = {
+        'default': {
+            'b': lambda c: c,
+        },
+        'must': {
+            'a': 'a_str',
+        },
+        'secret': [
+            'a',
+            'b',
+            'c',
+        ],
+    }
+
+    # A source may declare secret variables as long as those variables are defined or referenced within that source.
+    Source(entry)
+
+    # A source with an unreferenced secret variable raises an exception.
+    extra_secret_entry = deepcopy(entry)
+    extra_secret_entry['secret'].append('d')
+    with pytest.raises(Exception):
+        Source(extra_secret_entry)

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -6,10 +6,28 @@ from dcos_test_utils import marathon
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
 
+
+def get_exhibitor_admin_password():
+    try:
+        with open('/opt/mesosphere/etc/exhibitor_realm', 'r') as f:
+            exhibitor_realm = f.read().strip()
+    except FileNotFoundError:
+        # Unset. Return the default value.
+        return ''
+
+    creds = exhibitor_realm.split(':')[1].strip()
+    password = creds.split(',')[0].strip()
+    return password
+
+
 # make the expanded config available at import time to allow determining
 # which tests should run before the test suite kicks off
 with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
     expanded_config = json.load(f)
+    # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
+    # Exhibitor's config.
+    # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
+    expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
 
 
 def marathon_test_app(

--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -8,12 +8,12 @@ pushd "/pkg/src/openssl"
 ./Configure "--prefix=$PKG_PATH" \
   --openssldir="$PKG_PATH/etc/ssl" \
   shared \
-  zlib \
   linux-x86_64 \
   no-krb5 \
   no-rc4 \
   no-ssl2 \
   no-ssl3 \
+  no-comp \
   enable-ec_nistp_64_gcc_128 \
   -Wa,--noexecstack \
   -O2 -DFORTIFY_SOURCE=2


### PR DESCRIPTION
🚂 :two: :five: :one: 🚋 

https://github.com/dcos/dcos/pull/2073 **openssl: Disable TLS compression**
> The TLS compression is vulnerable to MITM attack known as CRIME. This PR disables support for TLS compression in openssl library. None of the components using the openssl will be able to run TLS compressed connection.

https://github.com/dcos/dcos/pull/2062 **Remove sensitive config values from diagnostics bundles and build output**

## Related Issues

  - https://jira.mesosphere.com/browse/DCOS-19390
  - https://jira.mesosphere.com/browse/DCOS_OSS-1795
