### PR TITLE
Marathon 1.5.2 bump

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.1.2/marathon-1.5.1.2.tgz",
-    "sha1" : "fa12da2e4f4d1183aa393dc7c7d0fe07d8e2c863"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.2/marathon-1.5.2.tgz",
+    "sha1" : "456ed58e95e3367776130f68d0048bd7ee7fcc7c"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High Level Description

What features does this change enable? What bugs does this change fix? High-Level description of how things changed.

## Related Issues

### Fixed issues
- [MARATHON-7790](https://jira.mesosphere.com/browse/MARATHON-7790) Migrate UnreachableStrategy Saved in Instances
- Change `Int.MaxValue` to 8 for maximum concurrency during migration (#5676) (#5701)
- [MARATHON-7848](https://jira.mesosphere.com/browse/MARATHON-7848) Allow underscore for network names (#5687)
- [MARATHON-7788](https://jira.mesosphere.com/browse/MARATHON-7788) Store a flag node in ZK to indicate that Marathon performs data migration (#5662)
- [MARATHON-7852](https://jira.mesosphere.com/browse/MARATHON-7852) Switch to use Debian Slim base image (#5668)
- Extend the set of command-line flags returned by /v2/info (#5612)
- [MARATHON-7784](https://jira.mesosphere.com/browse/MARATHON-7784) Do not ignore exceptions when resolving apps and pods in GroupRepository (#5607)
- Update Mesos version to 1.4.0 which is used for building packages and Docker images (#5606)
- [MARATHON-7763](https://jira.mesosphere.com/browse/MARATHON-7763) Do sync before reading from or writing to ZooKeeper (#5566)
- Fixes bug in which some Condition values were improperly read (#5555) (#5557)
- Added an option to disable a plugin (#5524)

## Checklist for all PR's

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/compare/v1.5.1...releases/1.5
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/2/
  - [x] Code Coverage (if available): [link to code coverage report]
