### PR TITLE
Rename py.test to pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The tests can be run via Pytest while SSH'd as root into a master node of the cl
 
     ```
     cd /opt/mesosphere/active/dcos-integration-test
-    py.test
+    pytest
     ```
 
 ## Using DC/OS Docker

--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -103,7 +103,7 @@ test: clean-devkit-container devkit
 		$(DEVKIT_DOCKER_OPTS) \
 		--privileged \
 		mesosphere/$(DEVKIT_NAME):full /bin/bash -x -c " \
- 			py.test \
+ 			pytest \
  		"
 
 .PHONY: api-docs

--- a/packages/dcos-integration-test/extra/util/run_integration_test.sh
+++ b/packages/dcos-integration-test/extra/util/run_integration_test.sh
@@ -12,5 +12,5 @@ while true; do
     sleep 1
 done
 pushd ${DCOS_PYTEST_DIR:='/opt/mesosphere/active/dcos-integration-test'}
-eval ${DCOS_PYTEST_CMD:='py.test -vv'}
+eval ${DCOS_PYTEST_CMD:='pytest -vv'}
 popd

--- a/test_util/run-all
+++ b/test_util/run-all
@@ -95,7 +95,7 @@ export PUBLIC_SLAVE_HOSTS=192.168.65.60
 export TEAMCITY_VERSION="${TEAMCITY_VERSION:-}"
 export DCOS_DEFAULT_OS_USER=root
 cd /opt/mesosphere/active/dcos-integration-test
-/opt/mesosphere/bin/dcos-shell py.test -vv -rs ${CI_FLAGS:-}
+/opt/mesosphere/bin/dcos-shell pytest -vv -rs ${CI_FLAGS:-}
 EOF
 chmod +x test_wrapper.sh
 echo "Running integration test"

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
   webtest-aiohttp==1.1.0
   schema
 commands=
-  py.test --basetemp={envtmpdir} {posargs}
+  pytest --basetemp={envtmpdir} {posargs}
 
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a
@@ -71,7 +71,7 @@ deps =
   schema
 changedir=pkgpanda/build/tests
 commands=
-  py.test --basetemp={envtmpdir} {posargs} build_integration_test.py
+  pytest --basetemp={envtmpdir} {posargs} build_integration_test.py
 
 [testenv:py35-bootstrap]
 passenv =
@@ -81,4 +81,4 @@ deps=
 changedir=packages/bootstrap/extra
 commands=
   pip install .
-  py.test --basetemp={envtmpdir} {posargs}
+  pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
## High Level Description

[pytest project](https://docs.pytest.org/en/latest/changelog.html) recommends `pytest` entry point over `py.test`. (https://github.com/pytest-dev/pytest/issues/1629, https://github.com/pytest-dev/pytest/pull/1633) 

```
Introduce pytest command as recommended entry point. Note that py.test still works and is not scheduled for removal. Closes proposal #1629. Thanks @obestwalter and @davehunt for the complete PR (#1633).
```
