### PR TITLE
Added exhibitor TLS conf

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -822,9 +822,8 @@ package:
 {% case "static" %}
   - path: /etc_master/dns_config_master
     content: |
-      MASTER_SOURCE=exhibitor_uri
-      EXHIBITOR_URI=http://127.0.0.1:8181/exhibitor/v1/cluster/status
-      EXHIBITOR_ADDRESS=127.0.0.1
+      MASTER_SOURCE=master_list
+      RESOLVERS={{ resolvers_str }}
   - path: /etc/dns_config
     content: |
       MASTER_SOURCE=master_list

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -249,13 +249,6 @@ location = /exhibitor {
     rewrite ^/exhibitor$ $scheme://$http_host/exhibitor/ permanent;
 }
 
-# Group: Exhibitor
-# Description: Exhibitor cluster status (unauthenticated)
-location = /exhibitor/exhibitor/v1/cluster/status {
-    proxy_pass http://exhibitor;
-    rewrite ^/exhibitor/(.*) /$1 break;
-}
-
 # Group: Mesos
 # Description: Redirect to add trailing slash
 # Visibility: hidden

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -115,3 +115,10 @@ location /dcos-metadata/ui-config.json {
     include includes/proxy-headers.conf;
     proxy_pass http://iam;
 }
+
+# Group: Exhibitor
+# Description: Exhibitor cluster status (unauthenticated)
+location = /exhibitor/exhibitor/v1/cluster/status {
+    proxy_pass http://exhibitor;
+    rewrite ^/exhibitor/(.*) /$1 break;
+}

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -64,8 +64,10 @@ def test_if_all_exhibitors_are_in_sync(dcos_api_session):
 
     correct_data = sorted(r.json(), key=lambda k: k['hostname'])
 
-    for zk_ip in dcos_api_session.masters:
-        resp = requests.get('http://{}:8181/exhibitor/v1/cluster/status'.format(zk_ip))
+    for master_node_ip in dcos_api_session.masters:
+        # This relies on the fact that Admin Router always proxies the local
+        # Exhibitor.
+        resp = requests.get('http://{}/exhibitor/exhibitor/v1/cluster/status'.format(master_node_ip), verify=False)
         assert resp.status_code == 200
 
         tested_data = sorted(resp.json(), key=lambda k: k['hostname'])

--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -37,6 +37,10 @@ exhibitor_start_wrapper="$PKG_PATH/usr/exhibitor/start_exhibitor.py"
 envsubst '$PKG_PATH' < /pkg/extra/start_exhibitor.py > "$exhibitor_start_wrapper"
 chmod +x "$exhibitor_start_wrapper"
 
+exhibitor_artifact_permission_setter="$PKG_PATH/bin/set_exhibitor_file_permissions.py"
+envsubst '$PKG_PATH' < /pkg/extra/set_exhibitor_file_permissions.py > "$exhibitor_artifact_permission_setter"
+chmod +x "$exhibitor_artifact_permission_setter"
+
 mkdir -p "$PKG_PATH/usr/zookeeper/build/lib/"
 cp /pkg/src/log4j/log4j-systemd-journal-appender-1.3.2.jar "$PKG_PATH/usr/zookeeper/lib/"
 # DCOS-308: Renaming "jna-4.2.2" to "log4j-jna-4.2.2.jar" will

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -4,7 +4,7 @@
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "f6654479de96e898e7ed20a5fbef6b18ac88ff24",
+      "ref": "2c0f5e2a9d9962d0b02dd022fe8980a95cb5f53b",
       "ref_origin": "master"
     },
     "zookeeper": {

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -19,4 +19,9 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor
 EnvironmentFile=-/opt/mesosphere/etc/exhibitor-extras
+# Execute ExecStartPre directives as root
+PermissionsStartOnly=true
+# Execute a python script, as root, that sets file permissions to some exact set if those files exist.
+ExecStartPre=$PKG_PATH/bin/set_exhibitor_file_permissions.py
+# Start Exhibitor
 ExecStart=$PKG_PATH/usr/exhibitor/start_exhibitor.py

--- a/packages/exhibitor/extra/set_exhibitor_file_permissions.py
+++ b/packages/exhibitor/extra/set_exhibitor_file_permissions.py
@@ -1,0 +1,17 @@
+#!/opt/mesosphere/bin/python
+import os
+import shutil
+
+# Normalize owner and file permissions of the Exhibitor TLS file artifacts
+# (as opposed to simply erroring out upon detecting too wide file
+# permissions).
+truststore_path = '/var/lib/dcos/exhibitor-tls-artifacts/truststore.jks'
+clientstore_path = '/var/lib/dcos/exhibitor-tls-artifacts/clientstore.jks'
+serverstore_path = '/var/lib/dcos/exhibitor-tls-artifacts/serverstore.jks'
+
+if os.path.exists(truststore_path) and \
+   os.path.exists(clientstore_path) and \
+   os.path.exists(serverstore_path):
+    for file_path in [truststore_path, clientstore_path, serverstore_path]:
+        shutil.chown(file_path, user='root', group='dcos_exhibitor')
+        os.chmod(file_path, 0o640)

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -175,7 +175,24 @@ else:
     print("ERROR: No known exhibitor backend:", exhibitor_backend)
     sys.exit(1)
 
+truststore_path = '/var/lib/dcos/exhibitor-tls-artifacts/truststore.jks'
+clientstore_path = '/var/lib/dcos/exhibitor-tls-artifacts/clientstore.jks'
+serverstore_path = '/var/lib/dcos/exhibitor-tls-artifacts/serverstore.jks'
+
+exhibitor_env = os.environ.copy()
+if os.path.exists(truststore_path) and \
+   os.path.exists(clientstore_path) and \
+   os.path.exists(serverstore_path):
+    exhibitor_env['EXHIBITOR_TLS_TRUSTSTORE_PATH'] = truststore_path
+    exhibitor_env['EXHIBITOR_TLS_TRUSTSTORE_PASSWORD'] = 'not-relevant-for-security'
+    exhibitor_env['EXHIBITOR_TLS_CLIENT_KEYSTORE_PATH'] = clientstore_path
+    exhibitor_env['EXHIBITOR_TLS_CLIENT_KEYSTORE_PASSWORD'] = 'not-relevant-for-security'
+    exhibitor_env['EXHIBITOR_TLS_SERVER_KEYSTORE_PATH'] = serverstore_path
+    exhibitor_env['EXHIBITOR_TLS_SERVER_KEYSTORE_PASSWORD'] = 'not-relevant-for-security'
+    exhibitor_env['EXHIBITOR_TLS_REQUIRE_CLIENT_CERT'] = 'true'
+    exhibitor_env['EXHIBITOR_TLS_VERIFY_PEER_CERT'] = 'true'
+
 # Start exhibitor
 print("Running exhibitor as command:", exhibitor_cmdline)
 sys.stdout.flush()
-os.execv('/opt/mesosphere/bin/java', exhibitor_cmdline)
+os.execve('/opt/mesosphere/bin/java', exhibitor_cmdline, exhibitor_env)


### PR DESCRIPTION
## High Level Description

**This PR revives  https://github.com/dcos/dcos/pull/1984 - please see the original for context and great discussions.**

This PR bumps Exhibitor and adds bootstrap infrastructure for Exhibitor TLS support in DC/OS Enterprise. It also makes the `/exhibitor/exhibitor/v1/cluster/status` an unauthenticated endpoint.

## Related Issues

  - [DCOS-17894](https://jira.mesosphere.com/browse/DCOS-17894) Encrypt & authenticate cross-Exhibitor communication (1.11)
  - [DCOS_OSS-1545](https://jira.mesosphere.com/browse/DCOS_OSS-1545) Admin Router: Investigate whether `/exhibitor/v1/cluster/status` still needs to be unathenticated

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The existing tests should fail if anything is broken by this bump.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [exhibitor](https://github.com/dcos/exhibitor/compare/f6654479de96e898e7ed20a5fbef6b18ac88ff24...2c0f5e2a9d9962d0b02dd022fe8980a95cb5f53b)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___