### PR TITLE
`prereq` images for advanced (zen) CF templates

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -232,7 +232,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}"
+                "{{ os_type }}prereq"
               ]
             }
           ]

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -16,7 +16,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}"
+                "{{ os_type }}prereq"
               ]
             }
           ]

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -78,7 +78,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}"
+                "{{ os_type }}prereq"
               ]
             }
           ]

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -132,60 +132,70 @@ region_to_ami_map = {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
         'el7': 'ami-965345f8',
+        'el7prereq': 'ami-72f93314',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
         'el7': 'ami-8af586e9',
+        'el7prereq': 'ami-cac2b2a9',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
         'el7': 'ami-427d9c20',
+        'el7prereq': 'ami-a0d736c2',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
         'el7': 'ami-2d0cbc42',
+        'el7prereq': 'ami-b371c1dc',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
         'el7': 'ami-e46ea69d',
+        'el7prereq': 'ami-4d4f8634',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
         'el7': 'ami-a5acd0c9',
+        'el7prereq': 'ami-1264187e',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
         'el7': 'ami-771beb0d',
+        'el7prereq': 'ami-b05aadca',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
         'coreos': 'ami-e441fb85',
         'stable': 'ami-e441fb85',
         'el7': 'ami-9923a1f8',
+        'el7prereq': 'ami-9923a1f8',
         'natami': 'ami-fe991b9f'
     },
     'us-west-1': {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
         'el7': 'ami-866151e6',
+        'el7prereq': 'ami-63cafb03',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
         'el7': 'ami-a9b24bd1',
+        'el7prereq': 'ami-1de01e65',
         'natami': 'ami-bb69128b'
     }
 }
@@ -430,7 +440,7 @@ def gen_advanced_template(arguments, variant_prefix, reproducible_artifact_path,
         node_template_id, node_source = groups[node_type]
         local_source = Source()
         local_source.add_must('os_type', os_type)
-        local_source.add_must('region_to_ami_mapping', gen_ami_mapping({"coreos", "el7"}))
+        local_source.add_must('region_to_ami_mapping', gen_ami_mapping({"coreos", "el7", "el7prereq"}))
         params = deepcopy(cf_instance_groups[node_template_id])
         params['report_name'] = aws_advanced_report_names[node_type]
         params['os_type'] = os_type

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -1,10 +1,14 @@
 import logging
 
 import pytest
+from test_helpers import expanded_config
 
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(
+    'advanced' in expanded_config['template_filenames'],
+    reason='Will not work on advanced CF templates, see: https://jira.mesosphere.com/browse/DCOS_OSS-1375')
 def test_pkgpanda_api(dcos_api_session):
 
     def get_and_validate_package_ids(path, node):


### PR DESCRIPTION
Advanced (Zen) CloudFormation instances require that some DC/OS
prerequisites be installed; this PR creates a mapping to `prereq`
images for `el7` and references them in master and agent CF templates.