### PR TITLE
Bump dcos-test-utils

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "90d9c23b75cbb56d8d24a44d7667d713d1e7b2e1",
+    "ref": "944d9a20fa39cc855827d90f027f23c51c1cd036",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description
Bump dcos-test-utils to:
* leverage more accurate waiting for marathon
* fix dcoscli issue on coreos (broken downstream EE simple CF test)

## Corresponding DC/OS tickets

https://jira.mesosphere.com/browse/DCOS-18578


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-test-utils/compare/90d9c23b75cbb56d8d24a44d7667d713d1e7b2e1...944d9a20fa39cc855827d90f027f23c51c1cd036
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=857230&tab=buildResultsDiv&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
