### PR TITLE
java: bump java package to the latest patchlevel

### DIFF
--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.com/java/jdk-8u121-linux-x64.tar.gz",
-      "sha1": "11f5925366234506730c095a2fd151d8f1212db7"
+      "url": "https://downloads.mesosphere.io/java/jdk-8u152-linux-x64.tar.gz",
+      "sha1": "1a3c0f86fcfdec6156f8256c87fbdcc04caea242"
     }
   },
   "environment": {


### PR DESCRIPTION
## High-level description

This PR bump Java to the latest patchlevel.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS-19399](https://jira.mesosphere.com/browse/DCOS-19399)  `Update DC/OS Java JDK 8 to latest version`

## Related PRs:

EE Bump: https://github.com/mesosphere/dcos-enterprise/pull/1761
