### PR TITLE
1.9 train 265

### DIFF
--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.com/java/jdk-8u121-linux-x64.tar.gz",
-      "sha1": "11f5925366234506730c095a2fd151d8f1212db7"
+      "url": "https://downloads.mesosphere.io/java/jdk-8u152-linux-x64.tar.gz",
+      "sha1": "1a3c0f86fcfdec6156f8256c87fbdcc04caea242"
     }
   },
   "environment": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "def524d5bf9c8d02a4307aa745e654706a848b33",
-    "ref_origin" : "dcos-mesos-1.2.x-d95a031"
+    "ref": "7fdb5cb179a15a63240590a2c3e0a6cdbdab89b5",
+    "ref_origin" : "dcos-mesos-1.2.x-f8706e5"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2k.tar.gz",
-    "sha1": "5f26a624479c51847ebd2f22bb9f84b3b44dcb44"
+    "url": "https://openssl.org/source/openssl-1.0.2m.tar.gz",
+    "sha1": "27fb00641260f97eaa587eb2b80fab3647f6013b"
   }
 }


### PR DESCRIPTION
## High-level description

* #2104 - Bumped Mesos to latest 1.2.x (f8706e5).
* #2130 - java: bump java package to the latest patchlevel
* #2122 -  openssl: bump to 1.0.2m