### PR TITLE
Admin Router: Pin pytest

### DIFF
--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -9,5 +9,5 @@ pyroute2==0.4.11
 pytest-mccabe==0.1
 pytest-pythonpath==0.7.1
 pytest-timeout==1.2.0
-pytest>=3.0.4
+pytest==3.0.4
 requests==2.13.0


### PR DESCRIPTION
## High-level description

Due to the changes in the latest pytest, there seems to be a conflict in command line arguments. This PR pins pytest to 3.0.4 just like it was pinned for 1.10 and current master.

## Corresponding DC/OS tickets (obligatory)

  - https://jira.mesosphere.com/browse/DCOS_OSS-1910 `Admin Router: pin pytest for 3.0.4`

## Related PRs:

DC/OS EE PR: https://github.com/mesosphere/dcos-enterprise/pull/1777


