### PR TITLE
Bumped Mesos and mesos-modules.

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -306,10 +306,18 @@ def test_log_v2_task_logs(dcos_api_session):
         "cpus": 0.1,
         "instances": 1,
         "mem": 128,
+        "healthChecks": [
+            {
+                "protocol": "COMMAND",
+                "command": {
+                    "value": "grep -q STDOUT_LOG stdout;grep -q STDERR_LOG stderr"
+                }
+            }
+        ],
         "cmd": "echo STDOUT_LOG; echo STDERR_LOG >&2;sleep 999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=False):
+    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         response = dcos_api_session.logs.get('v2/task/{}/file/stdout'.format(task_id))
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
@@ -359,10 +367,18 @@ def test_log_v2_api(dcos_api_session):
         "cpus": 0.1,
         "instances": 1,
         "mem": 128,
+        "healthChecks": [
+            {
+                "protocol": "COMMAND",
+                "command": {
+                    "value": "test -f test"
+                }
+            }
+        ],
         "cmd": "echo \"one\ntwo\nthree\nfour\nfive\n\">test;sleep 9999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=False):
+    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         # skip 2 entries from the beggining
         response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=2'.format(task_id))
         check_response_ok(response, {})

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "34eb3a5f996f706450b4e0818ae381a97d358b96",
+      "ref": "e2baac24fc1f14f1f038298ec3210288999d265c",
       "ref_origin": "master"
     }
   },

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "9adfabc5d07048f55c3da5a1bad17d2109750f0e",
+      "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
       "ref_origin": "master"
     }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "09df58e9a83dbebf1ae8b32c28cb450294d92612",
-    "ref_origin" : "dcos-mesos-master-28f8827"
+    "ref": "dc243c64da2eb6984a6d65af67e1918c04742074",
+    "ref_origin" : "dcos-mesos-master-ae08193"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Mesos is now bumped to the latest master (ae08193).

## High-level description

- Bumped Mesos to latest master (apache/mesos@ae08193).
- Bumped dcos-mesos-modules to latest master (dcos/dcos-mesos-modules@6ffea42)
- Bumped dcos-net to handle TASK_STARTING: https://github.com/dcos/dcos-net/pull/21

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1912](https://jira.mesosphere.com/browse/DCOS_OSS-1912) Bump mesos and mesos-modules packages to latest master
  - [DCOS_OSS-1924](https://jira.mesosphere.com/browse/DCOS_OSS-1924) Same set of tests fails reproducibly with current Mesos bump PR
  - [DCOS_OSS-1932](https://jira.mesosphere.com/browse/DCOS_OSS-1932) flaky test test_dcos_log.test_log_v2_api

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [mesos changelog](https://github.com/mesosphere/mesos/compare/09df58e9a83dbebf1ae8b32c28cb450294d92612...dc243c64da2eb6984a6d65af67e1918c04742074) and  [mesos-modules changelog](https://github.com/dcos/dcos-mesos-modules/compare/9adfabc5d07048f55c3da5a1bad17d2109750f0e...6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8)
  - [X] Test Results: [Apache Mesos Jenkins CI Job](https://builds.apache.org/job/Mesos-Buildbot/4509/) - lacks the two last commits but :+1: on internal CI and will update the link as soon as I have a new build.
  - [X] dcos-net bump includes https://github.com/dcos/dcos-net/pull/21