### PR TITLE
Admin Router: more robust devkit building

### DIFF
--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -41,7 +41,7 @@ DEVKIT_DOCKER_OPTS := $(DEVKIT_BASE_DOCKER_OPTS) \
 .PHONY: clean-devkit-container
 clean-devkit-container:
 	@# Let's suppress ALL the output:
-	@docker rm -vf $(DEVKIT_NAME) &> /dev/null || true
+	@docker rm -vf $(DEVKIT_NAME) || true
 
 .PHONY: clean-containers
 clean-containers: clean-devkit-container
@@ -56,26 +56,11 @@ devkit:
 	@if $$(docker images | grep mesosphere/$(DEVKIT_NAME) | grep -q full); then \
 		echo "Devkit image is present, not rebuilding it."; \
 	else \
-		echo "Building devkit image"; \
-		docker build \
-			--rm --force-rm \
-			-t mesosphere/$(DEVKIT_NAME):noresty \
-			-f ../../docker/Dockerfile \
-				../../docker/ && \
-		docker run \
-			$(DEVKIT_BASE_DOCKER_OPTS) \
-			mesosphere/$(DEVKIT_NAME):noresty \
-				/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT" && \
-		docker commit $$(docker ps -a -q -f name=$(DEVKIT_NAME)) \
-			mesosphere/$(DEVKIT_NAME):full && \
-		docker rm $(DEVKIT_NAME) && \
-		docker rmi -f mesosphere/$(DEVKIT_NAME):noresty; \
+		$(MAKE) update-devkit; \
 	fi
 
 .PHONY: update-devkit
 update-devkit: clean-devkit-container
-	@# Let's suppress ALL the output:
-	@docker rm $(DEVKIT_NAME) &> /dev/null || true
 	@docker build \
 		--rm --force-rm \
 		-t mesosphere/$(DEVKIT_NAME):noresty \
@@ -87,18 +72,18 @@ update-devkit: clean-devkit-container
 			/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT" && \
 	docker commit $$(docker ps -a -q -f name=$(DEVKIT_NAME)) \
 		mesosphere/$(DEVKIT_NAME):full
-	@docker rm $(DEVKIT_NAME)
+	@docker rm -f $(DEVKIT_NAME)
 	@docker rmi -f mesosphere/$(DEVKIT_NAME):noresty
 
 .PHONY: shell
-shell: clean-devkit-container devkit
+shell: devkit clean-containers
 	@docker run --rm -it \
 		$(DEVKIT_DOCKER_OPTS) \
 		--privileged \
 		mesosphere/$(DEVKIT_NAME):full /bin/bash
 
 .PHONY: test
-test: clean-devkit-container devkit
+test: devkit clean-containers
 	@docker run \
 		$(DEVKIT_DOCKER_OPTS) \
 		--privileged \
@@ -107,7 +92,7 @@ test: clean-devkit-container devkit
  		"
 
 .PHONY: api-docs
-api-docs: clean-devkit-container devkit
+api-docs: devkit clean-containers
 	@mkdir -p $(SRC_DIR)/$(API_DOCS_DIR)
 	@for prefix in nginx.master nginx.agent ; do \
 		echo "Generating $(API_DOCS_DIR)/$${prefix}.yaml" >&2 && \
@@ -120,7 +105,7 @@ api-docs: clean-devkit-container devkit
 
 .PHONY: check-api-docs
 DOCS_TEXT := See https://github.com/dcos/dcos/tree/master/packages/adminrouter/extra/src\#endpoints-documentation for more info.
-check-api-docs: api-docs
+check-api-docs: api-docs clean-containers
 ifneq ($(shell git update-index --refresh; echo $$?),0)
 	$(error "Found local changes. Please run `make api-docs` and commit the result. $(DOCS_TEXT)")
 endif
@@ -133,7 +118,7 @@ endif
 	@echo 'No changes found -- Admin Router API docs are up to date.' >&2
 
 .PHONY: lint
-lint: clean-devkit-container devkit
+lint: devkit clean-containers
 	@docker run \
 		$(DEVKIT_DOCKER_OPTS) \
 		mesosphere/$(DEVKIT_NAME):full /bin/bash -x -c "flake8"


### PR DESCRIPTION
## High-level description

This PR enables more robust devkit building.

As DCOS-19707 has shown, in some rare cases it is possible that the intermediate devkit container still lingers while the next CI is launched on the Agent. Changes made here should prevent it from happening for both gen_extra and Admin Router devkits.

Even though this PR only touches/changes Admin Router Makefile, I have named both EE and Open PRs the same for clarity. The EE PR adjusts the `gen_extra` devkit, the EE Admin Router's Makefile inherits the changes from the Open Adminrouter's one.

See the Jira and its comments for more details.

## Corresponding DC/OS tickets

 * https://jira.mesosphere.com/browse/DCOS-19707 `continuous-integration/jenkins/pr-head fails on seemingly unrelated changes`

## Related PRs:

EE DC/OS PR: https://github.com/mesosphere/dcos-enterprise/pull/1784