### PR TITLE
bump dcos diagnostics

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -766,21 +766,6 @@ package:
                   "Port": 8123,
                   "Uri": "/v1/version",
                   "Role": ["master"]
-              },
-              {
-                  "Port": 15055,
-                  "Uri": "/history/last",
-                  "Role": ["master"]
-              },
-              {
-                  "Port": 15055,
-                  "Uri": "/history/minute",
-                  "Role": ["master"]
-              },
-              {
-                  "Port": 15055,
-                  "Uri": "/history/hour",
-                  "Role": ["master"]
               }
           ],
           "LocalFiles": [

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "4dcba18b90502de2944ebc951cfc968fe40cddea",
+    "ref": "ee34de99a4311b7ffb4562d6389995629307c4b0",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -574,6 +574,10 @@ def _download_bundle_from_master(dcos_api_session, master_index):
             # get a list of all files in a zip archive.
             archived_items = z.namelist()
 
+            # validate all files in zip archive are not empty
+            for item in archived_items:
+                assert z.getinfo(item).file_size, 'item {} is empty'.format(item)
+
             # make sure all required log files for master node are in place.
             for master_ip in dcos_api_session.masters:
                 master_folder = master_ip + '_master/'


### PR DESCRIPTION
## High-level description

bump dcos-diagnostics to the latest sha

The new features and bug fixes in dcos-diagnostics:
 - improve error messages in diagnostics bundle `summaryErrorReport.log`
 - handle error responses (non 200 code) when collecting logs for diagnostics bundle
 - if the `summaryErrorReport.log` is empty, do not include this file into a diagnostics bundle
 - update integration test to make sure there are no empty files in a diagnostics bundle
 - remove history service endpoints from diagnostics bundle in OSS since it's running behind the adminrouter [now](https://github.com/dcos/dcos/commit/e2f986a49759a1109b17657b8a4753e1008a32c2#diff-ee8c631a232fb776584c0b43f493138e)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1856](https://jira.mesosphere.com/browse/DCOS_OSS-1856)


## Related tickets (optional)

Other tickets related to this change:

  - N/A


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-diagnostics](https://github.com/dcos/dcos-diagnostics/compare/4dcba18b90502de2944ebc951cfc968fe40cddea...ee34de99a4311b7ffb4562d6389995629307c4b0)
  - [X] Test Results: [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-diagnostics-pulls/47/)
  - [X] Code Coverage (if available): [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-diagnostics-pulls/47/)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).

  
  
  
  