### PR TITLE
fix race condition in dcos-log integration test

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -306,10 +306,18 @@ def test_log_v2_task_logs(dcos_api_session):
         "cpus": 0.1,
         "instances": 1,
         "mem": 128,
+        "healthChecks": [
+            {
+                "protocol": "COMMAND",
+                "command": {
+                    "value": "grep -q STDOUT_LOG stdout;grep -q STDERR_LOG stderr"
+                }
+            }
+        ],
         "cmd": "echo STDOUT_LOG; echo STDERR_LOG >&2;sleep 999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=False):
+    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         response = dcos_api_session.logs.get('v2/task/{}/file/stdout'.format(task_id))
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
@@ -359,10 +367,18 @@ def test_log_v2_api(dcos_api_session):
         "cpus": 0.1,
         "instances": 1,
         "mem": 128,
+        "healthChecks": [
+            {
+                "protocol": "COMMAND",
+                "command": {
+                    "value": "test -f test"
+                }
+            }
+        ],
         "cmd": "echo \"one\ntwo\nthree\nfour\nfive\n\">test;sleep 9999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=False):
+    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         # skip 2 entries from the beggining
         response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=2'.format(task_id))
         check_response_ok(response, {})


### PR DESCRIPTION
## High-level description

Fix a race condition by adding a health check to deployed marathon tasks.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1932](https://jira.mesosphere.com/browse/DCOS_OSS-1932)


## Related tickets (optional)

Other tickets related to this change:

N/A


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A
  - [ ] Test Results: N/A
  - [ ] Code Coverage (if available): N/A
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
