### PR TITLE
Admin Router: Minimizing software version information reported by the AR

### DIFF
--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -40,8 +40,8 @@ DEVKIT_DOCKER_OPTS := $(DEVKIT_BASE_DOCKER_OPTS) \
 
 .PHONY: clean-devkit-container
 clean-devkit-container:
-	@# Let's suppress ALL the output:
-	@docker rm -vf $(DEVKIT_NAME) || true
+	@# `@` char only mutes stdout, here we need to mute stderr as well:
+	@docker rm -vf $(DEVKIT_NAME) &> /dev/null || true
 
 .PHONY: clean-containers
 clean-containers: clean-devkit-container

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -5,6 +5,8 @@ default_type application/octet-stream;
 sendfile on;
 keepalive_timeout 65;
 
+server_tokens off;
+
 lua_package_path '$prefix/conf/lib/?.lua;;';
 
 # Name: DC/OS Component Package Manager (Pkgpanda)

--- a/packages/adminrouter/extra/src/includes/server/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/agent.conf
@@ -1,0 +1,3 @@
+location / {
+    return 404;
+}

--- a/packages/adminrouter/extra/src/nginx.agent.conf
+++ b/packages/adminrouter/extra/src/nginx.agent.conf
@@ -10,6 +10,7 @@ http {
         server_name agent.mesos;
 
         include includes/server/common.conf;
+        include includes/server/agent.conf;
         include includes/server/open/agent.conf;
 
         include /opt/mesosphere/etc/adminrouter-listen-open.conf;

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -513,6 +513,8 @@ class GenericTestMasterClass:
         headers_present = {}
         headers_absent = []
 
+        headers_present['Server'] = "openresty"
+
         if caching_headers_test is True:
             headers_present['Cache-Control'] = "no-cache, no-store, must-revalidate"
             headers_present['Pragma'] = "no-cache"
@@ -623,6 +625,8 @@ class GenericTestAgentClass:
 
         headers_present = {}
         headers_absent = []
+
+        headers_present['Server'] = "openresty"
 
         if caching_headers_test is True:
             headers_present['Cache-Control'] = "no-cache, no-store, must-revalidate"

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -42,6 +42,10 @@ endpoint_tests:
       - master
 ######### /dcos-metadata/ui-config.json
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /dcos-metadata/ui-config.json
       is_unauthed_access_permitted:
         locations:
           - /dcos-metadata/ui-config.json

--- a/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
@@ -1,5 +1,8 @@
 # Copyright (C) Mesosphere, Inc. See LICENSE file for details.
 
+import pytest
+import requests
+
 from generic_test_code.common import generic_response_headers_verify_test
 
 
@@ -24,3 +27,21 @@ class TestLogsEndpoint:
             '/system/v1/logs/foo/bar',
             assert_headers=accel_buff_header,
             )
+
+
+class TestAgentMisc:
+    @pytest.mark.parametrize('path', ['/', '/foo', '/foo/bar'])
+    def test_if_document_root_is_not_served_by_the_agent_ar(
+            self,
+            agent_ar_process,
+            valid_user_header,
+            path):
+
+        url = agent_ar_process.make_url_from_path(path)
+        resp = requests.get(
+            url,
+            allow_redirects=False,
+            headers=valid_user_header
+            )
+
+        assert resp.status_code == 404

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -1,6 +1,10 @@
 endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /exhibitor/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: skip
@@ -37,6 +41,10 @@ endpoint_tests:
 
 ######### /service endpoint
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /service/scheduler-alwaysthere/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -193,6 +201,11 @@ endpoint_tests:
 
 ######### /agent endpoint
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
+          - /slave/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -244,6 +257,10 @@ endpoint_tests:
     type:
       - master
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/health/v1/foo/bar
       # Check Open/EE config for this test:
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.0
@@ -261,6 +278,11 @@ endpoint_tests:
 ######### /system/v1/agent/ endpoint
 # Agent A
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/foo/bar?key=value&var=num
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: skip
@@ -334,6 +356,11 @@ endpoint_tests:
 
 ######### /system/v1/leader endpoint
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/v1/leader/mesos/foo/bar?key=value&var=num
+          - /system/v1/leader/marathon/foo/bar?key=value&var=num
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: skip
@@ -385,6 +412,10 @@ endpoint_tests:
     type:
       - master
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/v1/logs/foo/bar
       is_upstream_correct:
         test_paths:
           - /system/v1/logs/foo/bar
@@ -407,6 +438,10 @@ endpoint_tests:
 
 ######### /cosmos/service
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /cosmos/service/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -429,6 +464,10 @@ endpoint_tests:
 
 ######### /capabilities
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /capabilities
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -471,6 +510,10 @@ endpoint_tests:
 
 ######### /package
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /package/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -492,6 +535,10 @@ endpoint_tests:
 
 ######### /navstar/lashup/key
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /navstar/lashup/key
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: skip
@@ -511,6 +558,10 @@ endpoint_tests:
 
 ######### /dcos-history-service/foo/bar
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /dcos-history-service/foo/bar
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: skip
@@ -530,6 +581,10 @@ endpoint_tests:
 
 ######### /mesos_dns
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /mesos_dns/v1/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: false
@@ -553,6 +608,10 @@ endpoint_tests:
 
 ######### /mesos
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /mesos/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -576,6 +635,10 @@ endpoint_tests:
 
 ######### /pkgpanda
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /pkgpanda/foo/bar
       is_upstream_correct:
         test_paths:
           - /pkgpanda/foo/bar
@@ -626,6 +689,10 @@ endpoint_tests:
     type:
       - master
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /dcos-metadata/dcos-version.json
       is_unauthed_access_permitted:
         locations:
           - /dcos-metadata/dcos-version.json
@@ -635,6 +702,10 @@ endpoint_tests:
 
 ######### /system/v1/metrics endpoint
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/v1/metrics/foo/bar
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.0
         test_paths:
@@ -677,6 +748,10 @@ endpoint_tests:
       - master
 ######### /marathon
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /marathon/v2/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true
@@ -704,6 +779,10 @@ endpoint_tests:
 ######### This is a special case of a service behind /service endpoint:
 ######### /service/metronome
   - tests:
+      are_response_headers_ok:
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /service/metronome/v2/reflect/me
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
         auth_token_is_forwarded: true


### PR DESCRIPTION
## High-level description

This PR minimizes the software version information disclosed by Nginx. It does that by:
* minimizes software version information in the `Server:` header of the HTTP reply,
* prevents agent Admin Router from serving Nginx default homepage - it should serve 404 instead
* minimizes software version information in the error pages served by Admin Router:

Please look below to see how the error pages changed. Previously it was:
```
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>openresty/1.13.6.1</center>
</body>
</html>
```
 with `server_tokens` set to `off`: 
```
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>openresty</center>
</body>
</html>
```

**dcos-docker tests will be failing until https://github.com/dcos/dcos-docker/pull/65 is merged**

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-19534 `Agent Admin Router: do not serve root location (respond 404)`

## Related PRs

DC/OS EE: https://github.com/mesosphere/dcos-enterprise/pull/1806
DC/OS Docker: https://github.com/dcos/dcos-docker/pull/65
  