### PR TITLE
bumping metronome to 0.3.1

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.0/metronome-0.3.0.tgz",
-    "sha1": "f1a85ee638bc5b31dcd5594da4e84ca3e7a36451"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.1/metronome-0.3.1.tgz",
+    "sha1": "f6fd3d48a889ea19cb13dfd908a82e53c03ffab1"
   },
   "username": "dcos_metronome",
   "state_directory": true

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/metronome/snapshots/metronome-0.2.4.tgz",
-    "sha1": "71bad732f85d03094f5fd2d92c7f3801bbb45f1a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.0/metronome-0.3.0.tgz",
+    "sha1": "f1a85ee638bc5b31dcd5594da4e84ca3e7a36451"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description


* Upgraded to a released version of Marathon Lib [v1.3.13](https://github.com/mesosphere/marathon/releases/tag/v1.3.13)
* Updates to dependencies (including an Akka update to fix [schedule time wrap around bug](https://github.com/akka/akka/issues/20424))
* Added `/info` end point for metronome version information


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:


* [PR150](https://github.com/dcos/metronome/pull/150) Added `/info` endpoint
* [MARATHON_EE-1717](https://jira.mesosphere.com/browse/MARATHON_EE-1717) 60s min between reschedules
* [MARATHON_EE-1725](https://jira.mesosphere.com/browse/MARATHON_EE-1725) 
* [MARATHON_EE-1726](https://jira.mesosphere.com/browse/MARATHON_EE-1726) Upgrade Marathon libraries and dependencies 


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/metronome/compare/v0.2.4...v0.3.0
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/19/
  - [x] Code Coverage (if available): N/A
