### PR TITLE
Enabled UCR auto image gc for DC/OS.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -367,7 +367,7 @@ package:
       }
 {% case "false" %}
 {% endswitch %}
-  - path: /etc/mesos-slave-dns.json 
+  - path: /etc/mesos-slave-dns.json
     content: |
       {
         "docker":
@@ -375,7 +375,7 @@ package:
             {
               "network_mode": "USER",
               "dns": {
-                "nameservers": [ 
+                "nameservers": [
                                 "198.51.100.1",
                                 "fd01:d::c633:6401"
                 ]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -383,6 +383,15 @@ package:
             }
         ]
       }
+  - path: /etc/mesos-slave-image-gc-config.json
+    content: |
+      {
+        "image_disk_headroom": 0.1,
+        "image_disk_watch_interval": {
+          "nanoseconds": 300000000000
+        },
+        "excluded_images": []
+      }
   - path: /etc/logrotate_master.config
     content: |
       compress
@@ -469,6 +478,7 @@ package:
       MESOS_GC_DELAY={{ gc_delay }}
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_DEFAULT_CONTAINER_DNS=file:///opt/mesosphere/etc/mesos-slave-dns.json
+      MESOS_IMAGE_GC_CONFIG=file:///opt/mesosphere/etc/mesos-slave-image-gc-config.json
       GLOG_drop_log_memory=false
 {% switch use_mesos_hooks %}
 {% case "true" %}


### PR DESCRIPTION
## High-level description

 - Enabled UCR auto image gc for dc/os.
 - This PR builds on top of [pull/2165](https://github.com/dcos/dcos/pull/2165)([DCOS_OSS-1945](https://jira.mesosphere.com/browse/DCOS_OSS-1945)).


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1933](https://jira.mesosphere.com/browse/DCOS_OSS-1933) Enable UCR basic auto image GC for DC/OS.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-1945](https://jira.mesosphere.com/browse/DCOS_OSS-1945) Bump mesos just before Beta freeze.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]