### PR TITLE
Install to an existing install directory if it's empty

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -302,8 +302,11 @@ function empty_dir() {
 function check_preexisting_dcos() {
     echo -e -n 'Checking if DC/OS is already installed: '
     if (
+        # dcos.target exists and is a directory, OR
         [[ -d /etc/systemd/system/dcos.target ]] ||
+        # dcos.target.wants exists and is a directory, OR
         [[ -d /etc/systemd/system/dcos.target.wants ]] ||
+        # /opt/mesosphere exists and is not an empty directory
         ( [[ -a /opt/mesosphere ]] && ( ! empty_dir /opt/mesosphere ) )
     ); then
         # this will print: Checking if DC/OS is already installed: FAIL (Currently installed)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -288,11 +288,24 @@ function check_service() {
   (( OVERALL_RC += $RC ))
 }
 
+function empty_dir() {
+    # Return 0 if $1 is a directory containing no files.
+    DIRNAME=$1
+
+    RC=0
+    if [[ ( ! -d "$DIRNAME" ) || $(ls -A "$DIRNAME") ]]; then
+        RC=1
+    fi
+    return $RC
+}
+
 function check_preexisting_dcos() {
     echo -e -n 'Checking if DC/OS is already installed: '
-    if [[ ( -d /etc/systemd/system/dcos.target ) || \
-       ( -d /etc/systemd/system/dcos.target.wants ) || \
-       ( -d /opt/mesosphere ) ]]; then
+    if (
+        [[ -d /etc/systemd/system/dcos.target ]] ||
+        [[ -d /etc/systemd/system/dcos.target.wants ]] ||
+        ( [[ -a /opt/mesosphere ]] && ( ! empty_dir /opt/mesosphere ) )
+    ); then
         # this will print: Checking if DC/OS is already installed: FAIL (Currently installed)
         print_status 1 "${NORMAL}(Currently installed)"
         echo

--- a/gen/dcos-services.yaml
+++ b/gen/dcos-services.yaml
@@ -20,7 +20,7 @@
     Description=Pkgpanda: Download DC/OS to this host.
     After=network-online.target
     Wants=network-online.target
-    ConditionPathExists=!/opt/mesosphere/
+    ConditionPathExists=!/opt/mesosphere/active/
     [Service]
     Type=oneshot
     StandardOutput=journal+console


### PR DESCRIPTION
## High-level description

This allows onprem installations on hosts with a premade (and empty) `/opt/mesosphere/`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1587](https://jira.mesosphere.com/browse/DCOS_OSS-1587) Support DC/OS install on non-root LVM volume

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually on CentOS 7.2, with `/opt/mesosphere/` symlinked to `/var/dcos_install/` on all cluster nodes prior to install. Preflight and install succeeded when `/opt/mesosphere/` was existent but empty, and both preflight and install failed if `/opt/mesosphere/` existed with any files in it.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]