### PR TITLE
(1.10 backport) Update EL7 AMI IDs

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -126,61 +126,61 @@ region_to_ami_map = {
     'ap-northeast-1': {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
-        'el7': 'ami-965345f8',
+        'el7': 'ami-e21fd884',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
-        'el7': 'ami-8af586e9',
+        'el7': 'ami-3b8ee058',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
-        'el7': 'ami-427d9c20',
+        'el7': 'ami-c2e501a0',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
-        'el7': 'ami-2d0cbc42',
+        'el7': 'ami-868531e9',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
-        'el7': 'ami-e46ea69d',
+        'el7': 'ami-5f03c426',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
-        'el7': 'ami-a5acd0c9',
+        'el7': 'ami-5d2f5d31',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
-        'el7': 'ami-771beb0d',
+        'el7': 'ami-abb1a2d0',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
         'coreos': 'ami-e441fb85',
         'stable': 'ami-e441fb85',
-        'el7': 'ami-9923a1f8',
-        'natami': 'ami-fe991b9f'
+        'el7': 'ami-e58c0f84',
+        'natami': ''
     },
     'us-west-1': {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
-        'el7': 'ami-866151e6',
+        'el7': 'ami-f6427596',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
-        'el7': 'ami-a9b24bd1',
+        'el7': 'ami-6eed1a16',
         'natami': 'ami-bb69128b'
     }
 }


### PR DESCRIPTION
This PR is a cherry-picked commit backport to update AMI IDs which include a fix to a `dcos_vol_setup` bug which is sometimes breaking `cronyd` and `navstar`.  Related JIRA is [DCOS_OSS-1043](https://jira.mesosphere.com/browse/DCOS_OSS-1043).