### PR TITLE
1.10 backport - Update dcos-test-utils

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "8825756e8aa465557d8de3f03116d6d80087b010",
+    "ref": "aa22cf1e6ffcf0a375e7e424a02669f51b0adbee",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

It should address this:

*test_composition.test_dcos_cluster_is_up seems to be instable* 

* https://jira.mesosphere.com/browse/DCOS-19925 

Backports this change:
https://github.com/dcos/dcos/pull/2109

Essentially brings dcos-test-utils up to date with the current `master`

https://github.com/dcos/dcos/blob/master/packages/dcos-test-utils/buildinfo.json
