### PR TITLE
Bump dcos-metrics sha

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -139,7 +139,8 @@ def test_metrics_containers(dcos_api_session):
                 cid_registry = []
                 for dp in container_response.json()['datapoints']:
                     assert 'tags' in dp, 'got {}'.format(dp)
-                    assert len(dp['tags']) == 5, 'got {}'.format(
+                    # blkio stats have 'device' tags as well
+                    assert len(dp['tags']) >= 5, 'got {}'.format(
                         len(dp['tags']))
 
                     # Ensure all container ID's in the container/<id> endpoint are

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "5bbbb585d8e600073f6dc8946a3c0b4476ab7fff",
+    "ref": "d08d02d048b4a2997b5f2a2836ee08c4197482c4",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?
This PR brings the version of dcos-metrics in DC/OS up to date with the current dcos-metrics master. The two significant changes here both add new metrics to the </containers/container-id> endpoint in dcos-metrics. 

Note that there is a lot of activity in the changelog linked below, all related to plugins and documentation. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - [DCOS_OSS-1607](https://jira.mesosphere.com/browse/DCOS_OSS-1607) Add container resource utilisation metrics
 - [DCOS_OSS-1489](https://jira.mesosphere.com/browse/DCOS_OSS-1489) Support cgroup blkio statistics in dcos-metrics.

 - [DCOS-19920](https://jira.mesosphere.com/browse/DCOS-19920) Update vendored dcos-go in dcos-metrics
 - [DCOS-19984](https://jira.mesosphere.com/browse/DCOS-19984) Mesos module for dcos-metrics fails during dcos build


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [change log](https://github.com/dcos/dcos-metrics/compare/5bbbb585d8e600073f6dc8946a3c0b4476ab7fff...d08d02d048b4a2997b5f2a2836ee08c4197482c4)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/153/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/153/cobertura/)

