### PR TITLE
Bump pkgpanda pkgs kazoo and gunicorn

### DIFF
--- a/packages/python-gunicorn/buildinfo.json
+++ b/packages/python-gunicorn/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/84/ce/7ea5396efad1cef682bbc4068e72a0276341d9d9d0f501da609fab9fcb80/gunicorn-19.6.0.tar.gz",
-    "sha1": "ec049362953567e1acdc16e74c0c337301bc4867"
+    "url": "https://pypi.python.org/packages/30/3a/10bb213cede0cc4d13ac2263316c872a64bf4c819000c8ccd801f1d5f822/gunicorn-19.7.1.tar.gz",
+    "sha1": "e4d9f55744bf4198f71d29f61f9eeaf9d216ecac"
   }
 }

--- a/packages/python-kazoo/buildinfo.json
+++ b/packages/python-kazoo/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python", "six"],
   "single_source": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/k/kazoo/kazoo-2.2.1.tar.gz",
-      "sha1": "c7c2c9753d6e50e410784615883a6fa4af2d5847"
+      "url": "https://pypi.python.org/packages/9c/85/952b9e8e2415d4fb76e0be9e66469d7139f5c4d15d6eab263746b7aa37af/kazoo-2.4.0.tar.gz",
+      "sha1": "c6366c20e2fa4208e3d11b563178ea2c6198c371"
   }
 }


### PR DESCRIPTION
## High-level description

This bumps gunicorn (a WSGI server) and kazoo (a ZooKeeper client).

Both Python libraries are used by various DC/OS components. The new versions bring along quite a few patches for corner-case production issues. See JIRA tickets for details.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS_OSS-1896
https://jira.mesosphere.com/browse/DCOS_OSS-2001
