### PR TITLE
Bumped `mesos-dns`.

### DIFF
--- a/packages/mesos-dns/buildinfo.json
+++ b/packages/mesos-dns/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos-dns.git",
-    "ref": "be539256550ae317c5f3ba440256f04c44d68320",
-    "ref_origin": "master"
+    "ref": "114915e5ce05376be2b237b5016d6832d273ea6f",
+    "ref_origin": "dcos/1.11"
   },
   "username": "dcos_mesos_dns"
 }


### PR DESCRIPTION
Added capability in `mesos-dns` of providing DC/OS version it was
validated against.

## High-level description
Currently the `mesos-dns` that comes with DC/OS only returns the version as `dev` when users invoke the `mesos-dns --version` command. This is confusing to users. To fix this we are now going to maintain DC/OS version specific branches in `mesos-dns` and the `mesos-dns` binaries of these branches is going to return the DC/OS version number as its version. 

What features does this change enable? What bugs does this change fix?
https://jira.mesosphere.com/browse/DCOS_OSS-1990

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1990](https://jira.mesosphere.com/browse/DCOS_OSS-1990) 


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [*] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [*] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [*] Change log from the last version integrated (this should be a link to commits for easy verification and review): [master-dcos 1.11](https://github.com/mesosphere/mesos-dns/compare/master...dcos/1.11)
  - [*] Test Results: [https://jenkins.mesosphere.com/service/jenkins/view/Mesos%20DNS/job/public-mesos-dns-pulls/202/]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos/2223)
<!-- Reviewable:end -->
