### PR TITLE
Train 291 (master)

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c0db2357c53c79058cc6ef1cc94bdcc5aa66c91c",
-    "ref_origin" : "dcos-mesos-master-37a393c"
+    "ref": "5b9c94ee9875fce54386d45aacb976ae1ad17a93",
+    "ref_origin" : "dcos-mesos-master-a4b1134"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
This is Train 291, against the `master` branch. It contains the following pull requests:

- #2058 (Fixed detection of CoreOS and overlay issues with `systemd-networkd`)
- #2046 (Bump dcos-mesos to latest master a4b1134)