### PR TITLE
Bump dcos-test-utils to point at master

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "aa22cf1e6ffcf0a375e7e424a02669f51b0adbee",
+    "ref": "fae6ca9fa1abafe5f70215f7508f3d078f5f4e64",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description
* CLI binary is now configurable
* users must opt-in to having the test fixture assume the cluster composition

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS-17702

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-test-utils/compare/aa22cf1e6ffcf0a375e7e424a02669f51b0adbee...master
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=905247&tab=buildResultsDiv&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
