### PR TITLE
Random task selection for adminrouter

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -166,9 +166,11 @@ local function fetch_and_store_marathon_apps(auth_token)
           end
        end
 
-       -- next() returns nil if table is empty.
-       local i, task = next(tasks)
-       if i == nil then
+       -- Randomly select the task.
+       local i = math.random(1,#tasks)
+       local task = tasks[i]
+
+       if task == nil then
           ngx.log(ngx.NOTICE, "No task in state TASK_RUNNING for app '" .. appId .. "'")
           goto continue
        end
@@ -553,6 +555,9 @@ local function periodically_refresh_cache(auth_token)
     -- This function is invoked from within init_worker_by_lua code.
     -- ngx.timer.at() can be called here, whereas most of the other ngx.*
     -- API is not available.
+
+    -- Seeding the PRNG
+    math.randomseed(os.time())
 
     timerhandler = function(premature)
         -- Handler for recursive timer invocation.


### PR DESCRIPTION
## High-level description

Web requests to an scaled Marathon App  through adminrouter go always to the same task (the first one). This PR allows to randomly select the task so the load is more "balanced" between them.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2007](https://jira.mesosphere.com/browse/DCOS_OSS-2007) Adminrouter: Randomly select task.

## Related tickets (optional)

Other tickets related to this change:

  - NONE

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___

