### PR TITLE
Bump dcos-metrics to prometheus branch

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "5bbbb585d8e600073f6dc8946a3c0b4476ab7fff",
+    "ref": "12c6f2b31e8074a792132c8146917939f2afe57e",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "12c6f2b31e8074a792132c8146917939f2afe57e",
+    "ref": "e484e553bb56de85cdb403c4c8eb594ca92cbdc0",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This PR introduces the metrics prometheus producer. 

NB the changelog shows the diff between #2206 (open, has shipit) and this PR, not the current master and this PR.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-19849](https://jira.mesosphere.com/browse/DCOS_OSS-19849) Add a Prometheus endpoint to dcos-metrics

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [change log](https://github.com/dcos/dcos-metrics/compare/d08d02d048b4a2997b5f2a2836ee08c4197482c4...e484e553bb56de85cdb403c4c8eb594ca92cbdc0)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/155/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/155/cobertura/)
