### PR TITLE
Bump DC/OS metrics sha (introduces Prometheus endpoint)

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -26,6 +26,18 @@ def test_metrics_masters_ping(dcos_api_session):
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
+def test_metrics_agents_prom(dcos_api_session):
+    for agent in dcos_api_session.slaves:
+        response = dcos_api_session.session.request('http://' + agent + ':9273/metrics')
+        assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
+
+
+def test_metrics_masters_prom(dcos_api_session):
+    for master in dcos_api_session.masters:
+        response = dcos_api_session.session.request('http://' + master + ':9273/metrics')
+        assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
+
+
 def test_metrics_node(dcos_api_session):
     """Test that the '/system/v1/metrics/v0/node' endpoint returns the expected
     metrics and metric metadata.

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -28,13 +28,13 @@ def test_metrics_masters_ping(dcos_api_session):
 
 def test_metrics_agents_prom(dcos_api_session):
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.session.request('http://' + agent + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + agent + ':9273/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
 def test_metrics_masters_prom(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.session.request('http://' + master + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + master + ':9273/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "d08d02d048b4a2997b5f2a2836ee08c4197482c4",
+    "ref": "fe764a8d79fdb7a606406109f2293b86e10491cd",
     "ref_origin": "master"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This PR introduces a Prometheus producer on each node (successor to #2239). 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-19849](https://jira.mesosphere.com/browse/DCOS_OSS-19849) Add a Prometheus endpoint to dcos-metrics

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [change log](https://github.com/dcos/dcos-metrics/compare/d08d02d048b4a2997b5f2a2836ee08c4197482c4...e484e553bb56de85cdb403c4c8eb594ca92cbdc0)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/155/testReport/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-master/155/cobertura/)
