### PR TITLE
metronome 0.3.2 bump for dcos 1.11

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.1/metronome-0.3.1.tgz",
-    "sha1": "f6fd3d48a889ea19cb13dfd908a82e53c03ffab1"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.2/metronome-0.3.2.tgz",
+    "sha1": "c3d5f610ce4f2b3e63934652bfca2f48ac101c75"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

- taskKillGracePeriod - [METRONOME-151](https://jira.mesosphere.com/browse/METRONOME-151)  Allow for a configurable number of seconds for a task to die before a SIGKILL is sent.
- forcePullImage for Docker images - [METRONOME-148](https://jira.mesosphere.com/browse/METRONOME-148)  Ensures that an image is pulled regardless if it exists locally

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

-  Security issue - [METRONOME-185](https://jira.mesosphere.com/browse/METRONOME-185) non superuser was not able to retrieve a job run based on runid


## Related tickets (optional)

Other tickets related to this change:

-  Security issue - [METRONOME-185](https://jira.mesosphere.com/browse/METRONOME-185) non superuser was not able to retrieve a job run based on runid

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/metronome/compare/v0.3.1...v0.3.2
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/21/
  - [ ] Code Coverage (if available): N/A
