### PR TITLE
marathon 1.5.5 bump

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.4/marathon-1.5.4.tgz",
-    "sha1" : "3333f1641b0d366e0b7831376bdfb0c2c73c75a7"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.5/marathon-1.5.5.tgz",
+    "sha1" : "b616a9487f37799ace92c9299273ed9d446cac9d"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [MARATHON-7974](https://jira.mesosphere.com/browse/MARATHON-7974) Fixes a security concern for a non super user.  It was discovered that permissions for GroupResources was not honored and is now resolved.
- [MARATHON-7919](https://jira.mesosphere.com/browse/MARATHON-7919) Fix byte stream blocking on proxy of non-leader buffers 


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/compare/v1.5.4...v1.5.5
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/9/
  - [ ] Code Coverage (if available): N/A
