### PR TITLE
Train 298 for 1.10.4

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -106,7 +106,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.3',
+        'version': '1.10.4',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -976,7 +976,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.3',
+        'dcos_version': '1.10.4',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "aa22cf1e6ffcf0a375e7e424a02669f51b0adbee",
+    "ref": "fae6ca9fa1abafe5f70215f7508f3d078f5f4e64",
     "ref_origin": "master"
   }
 }

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.4/marathon-1.5.4.tgz",
-    "sha1" : "3333f1641b0d366e0b7831376bdfb0c2c73c75a7"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.5/marathon-1.5.5.tgz",
+    "sha1" : "b616a9487f37799ace92c9299273ed9d446cac9d"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c968b18baffd52c4f89f3968f73926fa5256fba8",
-    "ref_origin" : "dcos-mesos-1.4.x-60b8d41"
+    "ref": "732c49e6e98ac720df3418d9d868a6dfe1b2c6b5",
+    "ref_origin" : "dcos-mesos-1.4.x-6199905"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.1/metronome-0.3.1.tgz",
-    "sha1": "f6fd3d48a889ea19cb13dfd908a82e53c03ffab1"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.2/metronome-0.3.2.tgz",
+    "sha1": "c3d5f610ce4f2b3e63934652bfca2f48ac101c75"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
Includes:

#2212 - bootstrap: More robust handling of a zk.pid file while waiting for exhibitor 
#2229 - Bump dcos-test-utils to point at master
#2243 - metronome 0.3.2 bump for DCOS 1.10
#2246 - Update version to 1.10.4
#2250 - Bumped Mesos package to 1.4.x head 732c49e
#2253 - marathon 1.5.5 bump