### PR TITLE
Fix error when custom check bins are provided during onprem install

### DIFF
--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -154,6 +154,7 @@ utils = Bunch({
     "role_names": role_names,
     "add_services": None,
     "add_stable_artifact": None,
+    "add_channel_artifact": None,
     "add_units": add_units,
     "render_cloudconfig": render_cloudconfig
 })
@@ -622,6 +623,7 @@ def generate(
             assert template.keys() <= PACKAGE_KEYS, template.keys()
 
     stable_artifacts = []
+    channel_artifacts = []
 
     # Find all files which contain late bind variables and turn them into a "late bind package"
     # TODO(cmaloney): check there are no late bound variables in cloud-config.yaml
@@ -718,15 +720,22 @@ def generate(
     utils.add_services = add_services
 
     def add_stable_artifact(filename):
-        assert filename not in stable_artifacts
+        assert filename not in stable_artifacts + channel_artifacts
         stable_artifacts.append(filename)
 
     utils.add_stable_artifact = add_stable_artifact
+
+    def add_channel_artifact(filename):
+        assert filename not in stable_artifacts + channel_artifacts
+        channel_artifacts.append(filename)
+
+    utils.add_channel_artifact = add_channel_artifact
 
     return Bunch({
         'arguments': argument_dict,
         'cluster_packages': cluster_package_info,
         'stable_artifacts': stable_artifacts,
+        'channel_artifacts': channel_artifacts,
         'templates': rendered_templates,
         'utils': utils
     })

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -153,6 +153,7 @@ utils = Bunch({
     "add_roles": add_roles,
     "role_names": role_names,
     "add_services": None,
+    "add_stable_artifact": None,
     "add_units": add_units,
     "render_cloudconfig": render_cloudconfig
 })
@@ -710,12 +711,17 @@ def generate(
         cc['write_files'].append(item)
     rendered_templates['cloud-config.yaml'] = cc
 
-    # Add in the add_services util. Done here instead of the initial
-    # map since we need to bind in parameters
+    # Add utils that need to be defined here so they can be bound to locals.
     def add_services(cloudconfig, cloud_init_implementation):
         return add_units(cloudconfig, rendered_templates['dcos-services.yaml'], cloud_init_implementation)
 
     utils.add_services = add_services
+
+    def add_stable_artifact(filename):
+        assert filename not in stable_artifacts
+        stable_artifacts.append(filename)
+
+    utils.add_stable_artifact = add_stable_artifact
 
     return Bunch({
         'arguments': argument_dict,

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -598,7 +598,7 @@ def make_bash(gen_out) -> List[str]:
             gen_out.arguments['custom_check_bins_package_id'],
         )
         make_custom_check_bins_package(gen_out.arguments['custom_check_bins_dir'], package_filename)
-        artifacts.append(package_filename)
+        gen_out.utils.add_stable_artifact(package_filename)
 
     setup_flags = ""
     cloud_config = gen_out.templates['cloud-config.yaml']

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -6,7 +6,6 @@ import os.path
 import shutil
 import subprocess
 import tempfile
-from typing import List
 
 import checksumdir
 import pkg_resources
@@ -583,14 +582,12 @@ fi
 
 def generate(gen_out, output_dir):
     print("Generating Bash configuration files for DC/OS")
-    extra_files = make_bash(gen_out)
-    util.do_bundle_onprem(extra_files, gen_out, output_dir)
+    make_bash(gen_out)
+    util.do_bundle_onprem(gen_out, output_dir)
 
 
-def make_bash(gen_out) -> List[str]:
+def make_bash(gen_out) -> None:
     """Build bash deployment artifacts and return a list of their filenames."""
-    artifacts = []
-
     # Build custom check bins package
     if gen_out.arguments['custom_check_bins_provided'] == 'true':
         package_filename = 'packages/{}/{}.tar.xz'.format(
@@ -655,9 +652,7 @@ def make_bash(gen_out) -> List[str]:
     # Output the dcos install script
     install_script_filename = 'dcos_install.sh'
     pkgpanda.util.write_string(install_script_filename, bash_script)
-    artifacts.append(install_script_filename)
-
-    return artifacts
+    gen_out.utils.add_channel_artifact(install_script_filename)
 
 
 def make_custom_check_bins_package(source_dir, package_filename):

--- a/gen/build_deploy/util.py
+++ b/gen/build_deploy/util.py
@@ -29,7 +29,7 @@ def copy_makedirs(src, dest):
     shutil.copy(src, dest)
 
 
-def do_bundle_onprem(extra_files, gen_out, output_dir):
+def do_bundle_onprem(gen_out, output_dir):
     # We are only being called via dcos_generate_config.sh with an output_dir
     assert output_dir is not None
     assert output_dir
@@ -37,7 +37,7 @@ def do_bundle_onprem(extra_files, gen_out, output_dir):
     output_dir = output_dir + '/'
 
     # Copy generated artifacts
-    for filename in extra_files + gen_out.stable_artifacts:
+    for filename in gen_out.channel_artifacts + gen_out.stable_artifacts:
         copy_makedirs(filename, output_dir + filename)
 
     # Write an index of the cluster packages


### PR DESCRIPTION
## High-level description

This fixes an error where, when custom check bins are provided, the installer will attempt to copy the custom check bins package from the Docker container's artifact cache, and fail with an error when it can't find it. This is accomplished by adding the package to the gen result's list of generated stable artifacts, which are skipped when copying artifacts. This error was introduced in bf2032fb4fdf5fc31fa0d79f860b9d0d45255a23.

This also includes a followup refactor, see commits.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1982](https://jira.mesosphere.com/browse/DCOS_OSS-1982) genconf fails when custom check bins are provided

## Related tickets (optional)

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually on CentOS 7.2. Ticket for getting this covered by CI here: https://jira.mesosphere.com/browse/QUALITY-1724
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]