### PR TITLE
Metronome 0.3.3 bump on DCOS 1.10

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.2/metronome-0.3.2.tgz",
-    "sha1": "c3d5f610ce4f2b3e63934652bfca2f48ac101c75"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.3/metronome-0.3.3.tgz",
+    "sha1": "a6bda71edd71e396720756617276843439d55722"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2026](https://jira.mesosphere.com/browse/DCOS_OSS-2026) Bump Metronome v0.3.3 Release on DCOS 1.10


## Related tickets (optional)

Other tickets related to this change:

- [METRONOME-188](https://jira.mesosphere.com/browse/METRONOME-188) Updated to Protocol Buffers v.3.3.0
- [METRONOME-196](https://jira.mesosphere.com/browse/METRONOME-196) ForcePullImage should not be required


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/metronome/compare/v0.3.2...v0.3.3
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/23/
  - [ ] Code Coverage (if available): N/A
