### PR TITLE
Add basic integration test for Metronome

### DIFF
--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -7,6 +7,7 @@ def test_metronome(dcos_api_session):
             'docker': {'image': 'busybox:latest'},
             'cpus': 1,
             'mem': 512,
+            'disk' 0,
             'user': 'nobody',
             'restart': {'policy': 'ON_FAILURE'}
         }

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -7,7 +7,7 @@ def test_metronome(dcos_api_session):
             'docker': {'image': 'busybox:latest'},
             'cpus': 1,
             'mem': 512,
-            'disk' 0,
+            'disk': 0,
             'user': 'nobody',
             'restart': {'policy': 'ON_FAILURE'}
         }

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -1,0 +1,14 @@
+def test_metronome(dcos_api_session):
+    job = {
+        'description': 'Test Metronome API regressions',
+        'id': 'test.metronome',
+        'run': {
+            'cmd': 'ls',
+            'docker': {'image': 'busybox:latest'},
+            'cpus': 1,
+            'mem': 512,
+            'user': 'nobody',
+            'restart': {'policy': 'ON_FAILURE'}
+        }
+    }
+    dcos_api_session.metronome_one_off(job)


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2036](https://jira.mesosphere.com/browse/DCOS_OSS-2036) Bump Metronome v0.3.3 Release on DCOS 1.11

## Related tickets (optional)

Other tickets related to this change:

  - [METRONOME-188](https://jira.mesosphere.com/browse/METRONOME-188) Updated to Protocol Buffers v.3.3.0
  - [METRONOME-196](https://jira.mesosphere.com/browse/METRONOME-196) ForcePullImage should not be required

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos/metronome@v0.3.2...v0.3.3](https://github.com/dcos/metronome/compare/v0.3.2...v0.3.3)
  - [x] Test Results: [CI job](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/23/)
  - [ ] Code Coverage (if available): [link to code coverage report]

  