### PR TITLE
dcos-oauth: bump for increased zk connection timeout 1.9

### DIFF
--- a/packages/dcos-oauth/buildinfo.json
+++ b/packages/dcos-oauth/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-oauth.git",
-    "ref": "2b7b0a5aa3810b4f517a5b18516a4bbd30e28fee",
+    "ref": "67fe686cbca439a9e872a18e382a0eb51bf737c4",
     "ref_origin": "master"
   },
   "username": "dcos_oauth",


### PR DESCRIPTION
## High-level description

This is a backport to 1.10 of https://github.com/dcos/dcos/pull/2038. Description from that:

> This PR bumps dcos-oauth to increase the ZooKeeper connection timeout from 1s to 60s. It also includes a bump from Go 1.6 to Go 1.7.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2041](https://jira.mesosphere.com/browse/DCOS_OSS-2041) Integration Test Failure: test_applications.py::test_if_marathon_app_can_be_deployed_with_mesos_containerizer 


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This fixes a flaky test, so kinda 😄 
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)