### PR TITLE
Pkgpanda: Copy systemd unit files instead of symlinking

### DIFF
--- a/pkgpanda/test_setup.py
+++ b/pkgpanda/test_setup.py
@@ -256,3 +256,26 @@ def test_activate(tmpdir):
 
     # TODO(cmaloney): expect_fs
     # TODO(cmaloney): Test a full OS setup using http://0pointer.de/blog/projects/changing-roots.html
+
+
+def test_copy_systemd_dir(tmpdir):
+    repo_path = tmp_repository(tmpdir)
+    tmpdir.join("root", "bootstrap").write("", ensure=True)
+
+    check_call(["pkgpanda",
+                "setup",
+                "--root={0}/root".format(tmpdir),
+                "--rooted-systemd",
+                "--repository={}".format(repo_path),
+                "--config-dir={}".format(resources_test_dir("etc-active")),
+                "--no-systemd"
+                ])
+
+    unit_file = 'dcos-mesos-master.service'
+    base_path = '{}/root/{}'.format(tmpdir, unit_file)
+    wants_path = '{}/root/dcos.target.wants/{}'.format(tmpdir, unit_file)
+
+    # Unit file is copied to dcos.target.wants and then symlinked into the base dir.
+    assert os.path.isfile(wants_path) and not os.path.islink(wants_path)
+    assert os.path.islink(base_path)
+    assert os.path.realpath(base_path) == os.path.realpath(wants_path)


### PR DESCRIPTION
## High-level description

Systemd requires that all unit files be readable when it boots. If DC/OS unit files are symlinked to a non-root volume mount that's managed by systemd, that mount won't be available when systemd starts, so systemd won't be able to read DC/OS unit files and will mark those units as failed without starting them. This PR changes the behavior of `pkgpanda setup` to copy unit files instead of symlinking, so that systemd can read DC/OS unit files before it mounts the volume that contains the rest of the installation.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1587](https://jira.mesosphere.com/browse/DCOS_OSS-1587) Support DC/OS install on non-root LVM volume

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually on CentOS 7.2, see https://github.com/dcos/dcos/pull/2293#issuecomment-358243915.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]