### PR TITLE
bump dcos-log sha

### DIFF
--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "033a56494636bb7bc0539aded082c3cb5130e1dd",
+    "ref": "2ff6a6d031be86b4e444c84e1ae3d445a0655d78",
     "ref_origin": "master"
   },
   "username": "dcos_log",


### PR DESCRIPTION
## High-level description

bump dcos-log sha

this PR fixes an issue where dcos-log would not release journald file descriptors


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [SOAK-52](https://jira.mesosphere.com/browse/SOAK-52)


## Related tickets (optional)

Other tickets related to this change:

  - N/A


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
this fix was tested manually, unfortunately there is no easy way to test this with CI.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-log](https://github.com/dcos/dcos-log/compare/033a56494636bb7bc0539aded082c3cb5130e1dd...2ff6a6d031be86b4e444c84e1ae3d445a0655d78)
  - [X] Test Results: [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-log-pulls/198/console)
  - [X] Code Coverage (if available): [jenkins](https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-log-pulls/198/console)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
