### PR TITLE
Marathon with a race condition fix

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-245-g40b89a2.tgz",
-    "sha1": "0afda31385597a7e12b2388e972b1d87fedbae2a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-250-g12d57af.tgz",
+    "sha1": "adae62336c6250abcd028a48f6d74a587b634d4d"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

  - It fixes a race condition in status updates handling in case of pods with two or more containers.
  - Optimization of group validation.

## Tickets

  - [MARATHON_EE-1817](https://jira.mesosphere.com/browse/MARATHON_EE-1817) - Race condition when handling pod task status updates
  - [MARATHON_EE-883](https://jira.mesosphere.com/browse/MARATHON_EE-883) - Investigate whether validation in Marathon is indeed a performance bottleneck.

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Github compare](https://github.com/mesosphere/marathon/compare/e40d2f458b8bb4a38809f61dbcd62804189c3499...12d57af5facd852fa80d32a2be2c3ed4ae3817db)
  - [x] Test Results: [CI job](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/622/)
  - [ ] Code Coverage (if available): N/A