### PR TITLE
When generating advanced templates, only append prereq to os_name for el7

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -241,7 +241,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}prereq"
+                "{{ os_type }}"
               ]
             }
           ]

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -16,7 +16,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}prereq"
+                "{{ os_type }}"
               ]
             }
           ]

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -78,7 +78,7 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "{{ os_type }}prereq"
+                "{{ os_type }}"
               ]
             }
           ]


### PR DESCRIPTION
## High-level description

This is a fix for the open and ee "AWS CloudFormation Zen CoreOS" jobs on TeamCity. The problem was that `prereqs` was being appended to the AMI name being put into the template, but the `<os>prereq` AMIs are only applicable to el7 ones, and cloudformation was looking for nonexistant `coreosprereqs` images. This adds some logic to only append prereqs to el7 clusters. 

The EE job also needed a build step added to get it to work, see https://github.com/mesosphere/dcos-enterprise/pull/2094#issuecomment-366081215

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS-20266

## Related tickets (optional)

https://jira.mesosphere.com/browse/DCOS-20026

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
