### PR TITLE
Bumped Mesos to 1.5.0-rc1 (af64bcb38).

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "8a7340f7ccd06261e17b80a04c3e60a4dd1480e5",
-    "ref_origin" : "dcos-mesos-master-63f116a"
+    "ref": "457f26c359e124c6cfb6a1a3059737d682db5843",
+    "ref_origin" : "dcos-mesos-1.5.x-af64bcb38"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description

Bumped Mesos to 1.5.0-rc1.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2083](https://jira.mesosphere.com/browse/DCOS_OSS-2083) Bump Mesos to 1.5.0-rc1.


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [CHANGELOG](https://github.com/mesosphere/mesos/compare/8a7340f7ccd06261e17b80a04c3e60a4dd1480e5...457f26c359e124c6cfb6a1a3059737d682db5843)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/2618/)
  - [ ] Code Coverage (if available): [link to code coverage report]
___
