### PR TITLE
Train 307

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -217,6 +217,7 @@ late_services = """- name: dcos-cfn-signal.service
     EnvironmentFile=/opt/mesosphere/etc/cfn_signal_metadata
     Environment="AWS_CFN_SIGNAL_THIS_RESOURCE={{ report_name }}"
     ExecStartPre=/bin/ping -c1 leader.mesos
+    ExecStartPre=/opt/mesosphere/bin/dcos-diagnostics check node-poststart
     ExecStartPre=/opt/mesosphere/bin/cfn-signal
     ExecStart=/usr/bin/touch /var/lib/dcos-cfn-signal"""
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-245-g40b89a2.tgz",
-    "sha1": "0afda31385597a7e12b2388e972b1d87fedbae2a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-250-g12d57af.tgz",
+    "sha1": "adae62336c6250abcd028a48f6d74a587b634d4d"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "8a7340f7ccd06261e17b80a04c3e60a4dd1480e5",
-    "ref_origin" : "dcos-mesos-master-63f116a"
+    "ref": "337413f1ec1fda69ca888bc250853695b542bdcc",
+    "ref_origin" : "dcos-mesos-1.5.x-1d9b5de7d"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Train 307 (master)
Includes
#2298 gen/tests: Improve TLS configuration parameters tests 
#2304 Bump Marathon on 1.11 to Version 1.6.0-pre-250 
#2314 adding dcos-diag check for aws cf templates
#2316 Bumped Mesos to 1.5.0-rc1 (1d9b5de7d)
