### PR TITLE
Bump Marathon to 11.6.0-pre-270-g3872d5e

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-250-g12d57af.tgz",
-    "sha1": "adae62336c6250abcd028a48f6d74a587b634d4d"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-269-g1fd0fd3.tgz",
+    "sha1": "c08e364147d4dfb89ea3bedb2d6500823c3d03cb"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-269-g1fd0fd3.tgz",
-    "sha1": "c08e364147d4dfb89ea3bedb2d6500823c3d03cb"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-270-g3872d5e.tgz",
+    "sha1": "69e4a3977c4def332cab1e34222dbfd5b476659a"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

  - Expose volume information for pod instances
  - It fixes a race condition in status updates handling in case of pods with two or more containers.
  - Persistent volumes for pods ZK data migration.
  - Important fixes.
  - Minor features.

## Tickets

  - [COPS-2072](https://jira.mesosphere.com/browse/COPS-2072) - Expose containerPort as $PORT_NAME env vars
  - [MARATHON-7839](https://jira.mesosphere.com/browse/MARATHON-7839) - Introducing missing deployment types
  - [MARATHON_EE-1673](https://jira.mesosphere.com/browse/MARATHON_EE-1673) - Introduce lightweight SSE flag
  - [MARATHON_EE-1785](https://jira.mesosphere.com/browse/MARATHON_EE-1785) - ZK data migration for persistent volumes for pods
  - [MARATHON-8005](https://jira.mesosphere.com/browse/MARATHON-8005) - Fix datetime serialization for the API endpoints.
  - [MARATHON-8032](https://jira.mesosphere.com/browse/MARATHON-8032) - Make reservation ID generation backward-compatible with Marathon versions < 1.6
  - [MARATHON-8008](https://jira.mesosphere.com/browse/MARATHON-8008) - Expose volume information for pod instances

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Github compare](https://github.com/mesosphere/marathon/compare/e40d2f458b8bb4a38809f61dbcd62804189c3499...3872d5e74ed4d826412245c22a0851efcf25fcd6)
  - [x] Test Results: [CI job](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/642/)
  - [ ] Code Coverage (if available): N/A