### PR TITLE
change git protocol from SSH to HTTPS for pip

### DIFF
--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -22,7 +22,7 @@
     },
     "pip": {
       "kind": "git",
-      "git": "git@github.com:pypa/pip.git",
+      "git": "https://github.com/pypa/pip.git",
       "ref": "8ed4ac1fe6e2a05db41585c10a7b46f16bc60666",
       "ref_origin": "master"
     }


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This resolves the issue where a user requires to have his machines SSH keys registered to github. This is not required for DC/OS Open.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2082](https://jira.mesosphere.com/browse/DCOS_OSS-2082) Build process requires SSH GitHub access when HTTPS access would do.


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Testing this manually to confirm that this will resolve issue for the user. `git clone https://github.com/pypa/pip.git`
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


PTAL @branden @amitaekbote 
