### PR TITLE
Assigning maintainers against tests.

### DIFF
--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -7,6 +7,9 @@ import requests
 import test_helpers
 from dcos_test_utils import marathon
 
+__maintainer__ = 'kensipe'
+__contact__ = 'marathon-team@mesosphere.io'
+
 log = logging.getLogger(__name__)
 
 

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -2,6 +2,9 @@ import subprocess
 
 import pytest
 
+__maintainer__ = 'vespian'
+__contact__ = 'dcos-security@mesosphere.io'
+
 
 def auth_enabled():
     out = subprocess.check_output([

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -12,6 +12,9 @@ import requests
 
 from test_helpers import expanded_config
 
+__maintainer__ = 'mnaboka'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
+
 
 @pytest.mark.first
 def test_dcos_cluster_is_up(dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -11,6 +11,9 @@ import pytest
 
 import retrying
 
+__maintainer__ = 'mnaboka'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
+
 # Expected latency for all dcos-diagnostics units to refresh after postflight plus
 # another minute to allow for check-time to settle. See: DCOS_OSS-988
 LATENCY = 120

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -7,6 +7,9 @@ import pytest
 import requests
 import retrying
 
+__maintainer__ = 'mnaboka'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
+
 log = logging.getLogger(__name__)
 
 

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -6,6 +6,9 @@ import pytest
 from requests.exceptions import ConnectionError
 from retrying import retry
 
+__maintainer__ = 'vespian'
+__contact__ = 'dcos-security@mesosphere.io'
+
 
 def test_if_dcos_ui_is_up(dcos_api_session):
     r = dcos_api_session.get('/')

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -4,6 +4,9 @@ import uuid
 
 from dcos_test_utils import marathon
 
+__maintainer__ = 'mellenburg'
+__contact__ = 'tools-infra-team@mesosphere.io'
+
 TEST_APP_NAME_FMT = 'integration-test-{}'
 
 

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -9,6 +9,9 @@ import retrying
 import test_helpers
 from dcos_test_utils import marathon, recordio
 
+__maintainer__ = 'Gilbert88'
+__contact__ = 'core-team@mesosphere.io'
+
 
 # Creates and yields the initial ATTACH_CONTAINER_INPUT message, then a data message,
 # then an empty data chunk to indicate end-of-stream.

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,5 +1,8 @@
 import retrying
 
+__maintainer__ = 'mnaboka'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
+
 
 LATENCY = 60
 

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -1,3 +1,7 @@
+__maintainer__ = 'ichernetsky'
+__contact__ = 'marathon-team@mesosphere.io'
+
+
 def test_metronome(dcos_api_session):
     job = {
         'description': 'Test Metronome API regressions',

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,9 +1,13 @@
 # Various tests that don't fit into the other categories and don't make their own really.
+
 import os
 
 import yaml
 
 from test_helpers import expanded_config
+
+__maintainer__ = 'branden'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
 # Test that user config is loadable

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -1,3 +1,4 @@
+
 import contextlib
 import enum
 import json
@@ -13,6 +14,9 @@ import retrying
 
 import test_helpers
 from dcos_test_utils import marathon
+
+__maintainer__ = 'urbanserj'
+__contact__ = 'dcos-networking@mesosphere.io'
 
 log = logging.getLogger(__name__)
 

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -1,7 +1,11 @@
+
 import logging
 
 import pytest
 from test_helpers import expanded_config
+
+__maintainer__ = 'branden'
+__contact__ = 'marathon-team@mesosphere.io'
 
 log = logging.getLogger(__name__)
 

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -6,6 +6,9 @@ import pytest
 
 from test_helpers import expanded_config
 
+__maintainer__ = 'gpaul'
+__contact__ = 'dcos-security@mesosphere.io'
+
 
 @pytest.mark.skipif(
     not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),

--- a/packages/dcos-integration-test/extra/test_rlimit.py
+++ b/packages/dcos-integration-test/extra/test_rlimit.py
@@ -1,6 +1,9 @@
 import subprocess
 import uuid
 
+__maintainer__ = 'bbannier'
+__contact__ = 'core-team@mesosphere.io'
+
 
 def test_if_rlimits_can_be_used(dcos_api_session):
     """This test verifies that rlimits can be used.

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -9,6 +9,9 @@ import retrying
 import test_helpers
 from dcos_test_utils import marathon
 
+__maintainer__ = 'urbanserj'
+__contact__ = 'dcos-networking@mesosphere.io'
+
 DNS_ENTRY_UPDATE_TIMEOUT = 60  # in seconds
 
 

--- a/packages/dcos-integration-test/extra/test_sysctl.py
+++ b/packages/dcos-integration-test/extra/test_sysctl.py
@@ -1,6 +1,9 @@
 import subprocess
 import uuid
 
+__maintainer__ = 'orsenthil'
+__contact__ = 'tools-infra-team@mesosphere.io'
+
 
 def test_if_default_systctls_are_set(dcos_api_session):
     """This test verifies that default sysctls are set for tasks.

--- a/packages/dcos-integration-test/extra/test_ucr.py
+++ b/packages/dcos-integration-test/extra/test_ucr.py
@@ -1,5 +1,8 @@
 import uuid
 
+__maintainer__ = 'Gilbert88'
+__contact__ = 'core-team@mesosphere.io'
+
 
 def test_if_ucr_app_can_be_deployed_with_image_whiteout(dcos_api_session):
     """Marathon app deployment integration test using the Mesos Containerizer.

--- a/packages/dcos-integration-test/extra/test_units.py
+++ b/packages/dcos-integration-test/extra/test_units.py
@@ -7,6 +7,9 @@ import subprocess
 
 import pytest
 
+__maintainer__ = 'gpaul'
+__contact__ = 'dcos-security@mesosphere.io'
+
 
 def test_verify_units():
     """Test that all systemd units are valid."""


### PR DESCRIPTION
## High-level description

### Define a Concept of Test Owners for Tests in DCOS/DCOS

https://jira.mesosphere.com/browse/DCOS-20355 

When a status check fails, we should make it easy for a developer to be self-sufficient, by helping the developer in identifying the purpose of the test, and provide information on the maintainer for the test.

Along those lines, we'd like to give [information about the various pull request statuses](https://github.com/dcos/dcos/pull/2320) and also give a `_maintainer_` information for the module. These could be useful when reviewing, assigning reviewers, or assisting with test failures.

####  Please Review

**Please review this PR** and share your feedback.

* I have assigned members from teams who, I thought, have worked on that piece of code.
* If a different maintainer is desired, please comment on this.
* Similar exercise will be done for the dcos-enterprise as well. 