### PR TITLE
Reserve port 9273 for prometheus metrics

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -460,6 +460,7 @@ function check_all() {
             "8123 mesos-dns" \
             "8181 exhibitor" \
             "9000 metronome" \
+            "9273 dcos-metrics" \
             "9942 metronome" \
             "9990 cosmos" \
             "15055 dcos-history" \

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -515,7 +515,7 @@ package:
 {% endswitch %}
   - path: /etc/mesos-slave
     content: |
-      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]
+        MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -515,7 +515,7 @@ package:
 {% endswitch %}
   - path: /etc/mesos-slave
     content: |
-        MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
+      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]


### PR DESCRIPTION
## High-level description

This PR reserves the port 9273 for dcos-metrics' Prometheus producer. Additionally, a check is added to ensure that this port is available on the node. 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - [DCOS-20073](https://jira.mesosphere.com/browse/DCOS-20073) Reserve port 9273 for dcos-metrics


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-2046](https://jira.mesosphere.com/browse/DCOS_OSS-2046) Add Prometheus Producer for Metrics

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates (*not applicable*):

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
