### PR TITLE
Revert "Copy systemd unit files instead of symlinking"

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -455,28 +455,6 @@ def symlink_tree(src, dest):
                 raise ConflictingFile(src_path, dest_path, ex) from ex
 
 
-def copy_tree(src, dest):
-    """Copy the contents of directory src to directory dest.
-
-    The targets of any symlinks in src are copied into dest.
-
-    """
-    for name in os.listdir(src):
-        src_path = os.path.join(src, name)
-        dest_path = os.path.join(dest, name)
-
-        if os.path.exists(dest_path):
-            raise ConflictingFile(src_path, dest_path, 'Destination path {} already exists'.format(dest_path))
-
-        if os.path.isdir(src_path):
-            # Copy the directory recursively. Individual files are copied with shutil.copy() and symlinks' targets are
-            # copied into the destination.
-            shutil.copytree(src_path, dest_path, copy_function=shutil.copy, symlinks=False)
-        else:
-            # Copy the file and its permissions. If src_path is a symlink, copy its target.
-            shutil.copy(src_path, dest_path, follow_symlinks=True)
-
-
 # Manages a systemd-sysusers user set.
 # Can have users
 class UserManagement:
@@ -732,12 +710,6 @@ class Install:
 
             symlink_tree(src, dest)
 
-        def copy_all(src, dest):
-            if not os.path.isdir(src):
-                return
-
-            copy_tree(src, dest)
-
         # Set the new LD_LIBRARY_PATH, PATH.
         env_contents = env_header.format("/opt/mesosphere" if self.__fake_path else self.__root)
         env_export_contents = env_export_header.format("/opt/mesosphere" if self.__fake_path else self.__root)
@@ -773,25 +745,19 @@ class Install:
             # Do the basename since some well known dirs are full paths (dcos.target.wants)
             # while inside the packages they are always top level directories.
             for new, dir_name in zip(new_dirs, self.__well_known_dirs):
-                base_dir_name = os.path.basename(dir_name)
-                pkg_dir = os.path.join(package.path, base_dir_name)
+                dir_name = os.path.basename(dir_name)
+                pkg_dir = os.path.join(package.path, dir_name)
 
                 assert os.path.isabs(new)
                 assert os.path.isabs(pkg_dir)
 
-                add_dir = symlink_all
-                # Copy systemd unit files instead of symlinking them from the original files in package directories.
-                # This allows systemd to start DC/OS after booting when it's installed to a systemd-managed mount.
-                if not self.__skip_systemd_dirs and dir_name == self.__systemd_dir:
-                    add_dir = copy_all
-
                 try:
-                    add_dir(pkg_dir, new)
+                    symlink_all(pkg_dir, new)
 
                     # Symlink all applicable role-based config
                     for role in self.__roles:
-                        role_dir = os.path.join(package.path, "{0}_{1}".format(base_dir_name, role))
-                        add_dir(role_dir, new)
+                        role_dir = os.path.join(package.path, "{0}_{1}".format(dir_name, role))
+                        symlink_all(role_dir, new)
 
                 except ConflictingFile as ex:
                     raise ValidationError("Two packages are trying to install the same file {0} or "

--- a/pkgpanda/test_setup.py
+++ b/pkgpanda/test_setup.py
@@ -256,26 +256,3 @@ def test_activate(tmpdir):
 
     # TODO(cmaloney): expect_fs
     # TODO(cmaloney): Test a full OS setup using http://0pointer.de/blog/projects/changing-roots.html
-
-
-def test_copy_systemd_dir(tmpdir):
-    repo_path = tmp_repository(tmpdir)
-    tmpdir.join("root", "bootstrap").write("", ensure=True)
-
-    check_call(["pkgpanda",
-                "setup",
-                "--root={0}/root".format(tmpdir),
-                "--rooted-systemd",
-                "--repository={}".format(repo_path),
-                "--config-dir={}".format(resources_test_dir("etc-active")),
-                "--no-systemd"
-                ])
-
-    unit_file = 'dcos-mesos-master.service'
-    base_path = '{}/root/{}'.format(tmpdir, unit_file)
-    wants_path = '{}/root/dcos.target.wants/{}'.format(tmpdir, unit_file)
-
-    # Unit file is copied to dcos.target.wants and then symlinked into the base dir.
-    assert os.path.isfile(wants_path) and not os.path.islink(wants_path)
-    assert os.path.islink(base_path)
-    assert os.path.realpath(base_path) == os.path.realpath(wants_path)


### PR DESCRIPTION

## High-level description

This reverts commit ec32f171777fee18fd0a808e4c86576fe311819c, which fails on CoreOS 1465.6.0. See https://jira.mesosphere.com/browse/DCOS-20428.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-20428](https://jira.mesosphere.com/browse/DCOS-20428) Unable to spin-up up 1.11-dev cluster on GCP


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]