### PR TITLE
changed shebang to bash instead of sh for ubuntu

### DIFF
--- a/gen/fault-domain-detect/cloud.sh
+++ b/gen/fault-domain-detect/cloud.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 AWS_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 


### PR DESCRIPTION
When running in ubuntu, the dash runs instead of sh which causes a failure:

```
azureuser@dcos-master-01234567-2:~$ sh /opt/mesosphere/bin/detect_fault_domain
/opt/mesosphere/bin/detect_fault_domain: 11: /opt/mesosphere/bin/detect_fault_domain: Syntax error: "(" unexpected
```
This change fixes it.

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-20064](https://jira.mesosphere.com/browse/DCOS-20064) Verify azure and aws advanced templates work with the licensing parameter


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
Manually tested that this worked on both Ubuntu and CoreOS

  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

@mnaboka @amitaekbote 