### PR TITLE
Increase nginx client body size limit for ar

### DIFF
--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -1,4 +1,4 @@
-client_max_body_size 1024M;
+client_max_body_size 4096M;
 access_log syslog:server=unix:/dev/log;
 include mime.types;
 default_type application/octet-stream;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -189,6 +189,9 @@ location ~ ^/service/(?<service_path>.+) {
     include includes/proxy-headers.conf;
     include includes/websockets.conf;
 
+    # Disable request buffering to support large files
+    # proxy_request_buffering off;
+
     # Disable response buffering for SSE support.
     # Also see https://serverfault.com/a/801629/121951
     proxy_buffering off;


### PR DESCRIPTION
## High-level description

Increase the value of `client_max_body_size ` nginx directive to support uploading of large files from `cli` to the `registry` task. Disable proxy buffering for the service. [Justification](https://jira.mesosphere.com/browse/DCOS-20269?focusedCommentId=138668&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138668)

There is an enterprise bump PR for this but it won't be merged as it was for testing only. However this PR would be used in https://github.com/mesosphere/dcos-enterprise/pull/1807

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-20269](https://jira.mesosphere.com/browse/DCOS-20269) AR responds with Request entity too large error when uploading large files.


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There is no whitelisted package that is of required size to check this in the tests. This is only tested locally.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
