### PR TITLE
Bump dcos-test-utils

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "caf020d4c247bd0286fdfee8f361b7569dd92947",
+    "ref": "47825add34311ce12bebe6b6ff0993b6bee8295c",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This bump will introduce more verbose logging for metronome tests.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-20444](https://jira.mesosphere.com/browse/DCOS-20444) Investigate EE-Integration-Test/E2E CI run error in dcos-enterprise/pull/2092. Failure in _wait_for_metronome


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-test-utils/compare/caf020d4c247bd0286fdfee8f361b7569dd92947...47825add34311ce12bebe6b6ff0993b6bee8295c
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=948134&tab=buildResultsDiv&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils