### PR TITLE
Update CoreOS AMI images

### DIFF
--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -190,8 +190,8 @@ region_to_ami_map = {
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
-        'coreos': 'ami-dc4ce6a4',
-        'stable': 'ami-dc4ce6a4',
+        'coreos': 'ami-65269d1d',
+        'stable': 'ami-65269d1d',
         'el7': 'ami-a9b24bd1',
         'el7prereq': 'ami-1de01e65',
         'natami': 'ami-bb69128b'

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -127,71 +127,71 @@ aws_region_names = [
 
 region_to_ami_map = {
     'ap-northeast-1': {
-        'coreos': 'ami-93f2baf4',
-        'stable': 'ami-93f2baf4',
+        'coreos': 'ami-44a03c22',
+        'stable': 'ami-44a03c22',
         'el7': 'ami-965345f8',
         'el7prereq': 'ami-72f93314',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
-        'coreos': 'ami-aacc7dc9',
-        'stable': 'ami-aacc7dc9',
+        'coreos': 'ami-d085f3ac',
+        'stable': 'ami-d085f3ac',
         'el7': 'ami-8af586e9',
         'el7prereq': 'ami-cac2b2a9',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
-        'coreos': 'ami-9db0b0fe',
-        'stable': 'ami-9db0b0fe',
+        'coreos': 'ami-21ce3c43',
+        'stable': 'ami-21ce3c43',
         'el7': 'ami-427d9c20',
         'el7prereq': 'ami-a0d736c2',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
-        'coreos': 'ami-903df7ff',
-        'stable': 'ami-903df7ff',
+        'coreos': 'ami-90c152ff',
+        'stable': 'ami-90c152ff',
         'el7': 'ami-2d0cbc42',
         'el7prereq': 'ami-b371c1dc',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
-        'coreos': 'ami-abcde0cd',
-        'stable': 'ami-abcde0cd',
+        'coreos': 'ami-32d1474b',
+        'stable': 'ami-32d1474b',
         'el7': 'ami-e46ea69d',
         'el7prereq': 'ami-4d4f8634',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
-        'coreos': 'ami-c11573ad',
-        'stable': 'ami-c11573ad',
+        'coreos': 'ami-78befd14',
+        'stable': 'ami-78befd14',
         'el7': 'ami-a5acd0c9',
         'el7prereq': 'ami-1264187e',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
-        'coreos': 'ami-1ad0000c',
-        'stable': 'ami-1ad0000c',
+        'coreos': 'ami-e582d29f',
+        'stable': 'ami-e582d29f',
         'el7': 'ami-771beb0d',
         'el7prereq': 'ami-b05aadca',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
-        'coreos': 'ami-e441fb85',
-        'stable': 'ami-e441fb85',
+        'coreos': 'ami-9579f7f4',
+        'stable': 'ami-9579f7f4',
         'el7': 'ami-9923a1f8',
         'el7prereq': 'ami-9923a1f8',
         'natami': 'ami-fe991b9f'
     },
     'us-west-1': {
-        'coreos': 'ami-b31d43d3',
-        'stable': 'ami-b31d43d3',
+        'coreos': 'ami-e0696980',
+        'stable': 'ami-e0696980',
         'el7': 'ami-866151e6',
         'el7prereq': 'ami-63cafb03',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
-        'coreos': 'ami-444dcd24',
-        'stable': 'ami-444dcd24',
+        'coreos': 'ami-dc4ce6a4',
+        'stable': 'ami-dc4ce6a4',
         'el7': 'ami-a9b24bd1',
         'el7prereq': 'ami-1de01e65',
         'natami': 'ami-bb69128b'

--- a/gen/coreos/cloud-config.yaml
+++ b/gen/coreos/cloud-config.yaml
@@ -11,5 +11,3 @@ coreos:
     - name: locksmithd.service
       mask: true
       command: stop
-    - name: systemd-resolved.service
-      command: stop

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -12,12 +12,12 @@ fi
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
- [Match]
-  Type=bridge
-  Name=docker* m-* d-* vtep*
+[Match]
+Type=bridge
+Name=docker* m-* d-* vtep*
 
- [Link]
-  Unmanaged=yes
+[Link]
+Unmanaged=yes
 EOF
 }
 
@@ -27,7 +27,7 @@ if [[ "${distro}" == 'coreos' ]]; then
        coreos_networkd_config
        echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
 
-       if systemctl is-enabled systemd-networkd > /dev/null; then
+       if systemctl is-active systemd-networkd > /dev/null; then
           sudo systemctl restart systemd-networkd
        fi
     fi


### PR DESCRIPTION
## High-level description
Updates CoreOS to 1632.2.1 in the AWS CloudFormation Templates, which also includes a bump to docker 17

AMIs lifted from https://coreos.com/os/docs/latest/booting-on-ec2.html

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS_OSS-2130

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A update to cloud-provided underlying operating system
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)