### PR TITLE
Admin Router: Clarify why /exhibitor/v1/cluster/status needs to be unauthenticated

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -118,6 +118,11 @@ location /dcos-metadata/ui-config.json {
 
 # Group: Exhibitor
 # Description: Exhibitor cluster status (unauthenticated)
+## This endpoint needs to be unauthenticated so that bootstrap can do "exhibitor
+## wait" without connecting to exhibitor directly. It is a requirement for the
+## Exhibitor TLS. Please check Exhibitor TLS PR for more details:
+##
+## https://github.com/dcos/dcos/pull/2098
 location = /exhibitor/exhibitor/v1/cluster/status {
     proxy_pass http://exhibitor;
     rewrite ^/exhibitor/(.*) /$1 break;


### PR DESCRIPTION
## High-level description

Short clarification on why `/exhibitor/v1/cluster/status` needs to be unauthenticated.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS_OSS-1545 `Admin Router: Investigate whether `/exhibitor/v1/cluster/status` still needs to be unauthenticated`

## Related PRs:
DC/OS EE: https://github.com/mesosphere/dcos-enterprise/pull/2131