### PR TITLE
Marathon 1.5.6 bump

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.5/marathon-1.5.5.tgz",
-    "sha1" : "b616a9487f37799ace92c9299273ed9d446cac9d"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/v1.5.6/marathon-1.5.6.tgz",
+    "sha1" : "6ec578d9ff9ed7d4b1866bfb487967756cc35a59"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

- [MARATHON-7990](https://jira.mesosphere.com/browse/MARATHON-7990) Ease up on the `toString` for Group and log clashing ids.
- [COPS-2072](https://jira.mesosphere.com/browse/COPS-2072) Expose `containerPort` as `$PORT_NAME` in environment variables.
- [MARATHON-7914](https://jira.mesosphere.com/browse/MARATHON-7914) Migration from joda-time to java.time.
- [MARATHON-8005](https://jira.mesosphere.com/browse/MARATHON-8005) Fixing OffsetDateTime json serialization that was different form Timestamp serialization.
- [MARATHON-8015](https://jira.mesosphere.com/browse/MARATHON-8015) Fixes v1.5 migration issue with args only apps
- [MARATHON-8011](https://jira.mesosphere.com/browse/MARATHON-8011) Scaling to zero takes too much time in case of non-scaling related runspec changes


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/compare/v1.5.5...v1.5.6
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/28/
  - [ ] Code Coverage (if available): N/A

