### PR TITLE
Pin pytest to 3.2.2 and pytest-catchlog to 1.2.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,8 @@ passenv =
   AWS_DEFAULT_REGION
 deps =
   dnspython
-  pytest
+  pytest==3.3.2
+  pytest-catchlog==1.2.2
   PyYAML
   webtest
   webtest-aiohttp==1.1.0
@@ -67,7 +68,7 @@ passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
 deps =
-  pytest
+  pytest==3.3.2
   schema
 changedir=pkgpanda/build/tests
 commands=
@@ -77,7 +78,7 @@ commands=
 passenv =
   TEAMCITY_VERSION
 deps=
-  pytest
+  pytest==3.3.2
 changedir=packages/bootstrap/extra
 commands=
   pip install .


### PR DESCRIPTION
## High-level description

The default pytest version moved to 3.4.0 and apparently in this version catchlog (AKA the `caplog` fixture in pytest) stopped working and so the test that checks the log stream failed.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS_OSS-2124


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A this fixes the test
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)