### PR TITLE
(1.11) Add deprecation message to web installer

### DIFF
--- a/dcos_installer/async_server.py
+++ b/dcos_installer/async_server.py
@@ -358,6 +358,8 @@ def start(cli_options):
     global options
     options = cli_options
 
+    log.warning('WARNING: The DC/OS web installer (--web) is deprecated and will be removed in 1.12.')
+
     log.debug('DC/OS Installer')
     make_default_config_if_needed(CONFIG_PATH)
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
## High-level description

This prints a deprecation warning to the console when `dcos_generate_config.sh --web` is executed. We'll be removing the web installer in 1.12.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2129](https://jira.mesosphere.com/browse/DCOS_OSS-2129) Add deprecation message to web installer


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]