### PR TITLE
Add Windows integration support

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -7,6 +7,19 @@ from dcos_test_utils import logger
 logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 
 
+def pytest_addoption(parser):
+    parser.addoption("--windows-only", action="store_true",
+        help="run only Windows tests")
+
+
+def pytest_runtest_setup(item):
+    if pytest.config.getoption('--windows-only'):
+        if item.get_marker('supportedwindows') is None:
+            pytest.skip("skipping not supported windows test")
+    elif item.get_marker('supportedwindowsonly') is not None:
+        pytest.skip("skipping windows only test")
+
+
 def pytest_configure(config):
     config.addinivalue_line('markers', 'first: run test before all not marked first')
     config.addinivalue_line('markers', 'last: run test after all not marked last')

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -40,6 +40,7 @@ def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_ses
     assert r.status_code == 200
 
 
+@pytest.mark.supportedwindows
 def test_logout(dcos_api_session):
     """Test logout endpoint. It's a soft logout, instructing
     the user agent to delete the authentication cookie, i.e. this test

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -14,6 +14,7 @@ from test_helpers import expanded_config
 
 
 @pytest.mark.first
+@pytest.mark.supportedwindows
 def test_dcos_cluster_is_up(dcos_api_session):
     def _docker_info(component):
         # sudo is required for non-coreOS installs
@@ -30,6 +31,7 @@ def test_dcos_cluster_is_up(dcos_api_session):
     logging.info(json.dumps(cluster_environment, sort_keys=True, indent=4))
 
 
+@pytest.mark.supportedwindows
 def test_leader_election(dcos_api_session):
     mesos_resolver = dns.resolver.Resolver()
     mesos_resolver.nameservers = dcos_api_session.masters
@@ -40,6 +42,7 @@ def test_leader_election(dcos_api_session):
         assert False, "Cannot resolve leader.mesos"
 
 
+@pytest.mark.supportedwindows
 def test_if_all_mesos_masters_have_registered(dcos_api_session):
     # Currently it is not possible to extract this information through Mesos'es
     # API, let's query zookeeper directly.
@@ -58,6 +61,7 @@ def test_if_all_mesos_masters_have_registered(dcos_api_session):
     assert sorted(master_ips) == dcos_api_session.masters
 
 
+@pytest.mark.supportedwindows
 def test_if_all_exhibitors_are_in_sync(dcos_api_session):
     r = dcos_api_session.get('/exhibitor/exhibitor/v1/cluster/status')
     assert r.status_code == 200
@@ -84,6 +88,7 @@ def test_mesos_agent_role_assignment(dcos_api_session):
         assert r.json()['flags']['default_role'] == '*'
 
 
+@pytest.mark.supportedwindows
 def test_signal_service(dcos_api_session):
     """
     signal-service runs on an hourly timer, this test runs it as a one-off

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -239,6 +239,7 @@ def test_dcos_diagnostics_units(dcos_api_session):
                                                 'puller, missing: {}'.format(diff))
 
 
+@pytest.mark.supportedwindows
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_systemd_units_health(dcos_api_session):
     """
@@ -270,6 +271,7 @@ def test_systemd_units_health(dcos_api_session):
         raise AssertionError('\n'.join(unhealthy_output))
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_units_unit(dcos_api_session):
     """
     test a unit response in a right format, endpoint: /system/health/v1/units/<unit>
@@ -342,6 +344,7 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
         assert len(agent_nodes) == len(dcos_api_session.slaves), '{} != {}'.format(agent_nodes, dcos_api_session.slaves)
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
     """
     test a specific node for a specific unit, endpoint /system/health/v1/units/<unit>/nodes/<node>
@@ -372,6 +375,7 @@ def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
                 assert node_response['help'], 'help field cannot be empty'
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_selftest(dcos_api_session):
     """
     test invokes dcos-diagnostics `self test` functionality
@@ -384,6 +388,7 @@ def test_dcos_diagnostics_selftest(dcos_api_session):
             assert attrs['Success'], '{} failed, error message {}'.format(test_name, attrs['ErrorMessage'])
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_report(dcos_api_session):
     """
     test dcos-diagnostics report endpoint /system/health/v1/report
@@ -407,6 +412,7 @@ def _get_bundle_list(dcos_api_session):
     return bundles
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_bundle_create(dcos_api_session):
     """
     test bundle create functionality
@@ -484,6 +490,7 @@ def test_dcos_diagnostics_bundle_download_and_extract(dcos_api_session):
     _download_bundle_from_master(dcos_api_session, 0)
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_bundle_download_and_extract_from_another_master(dcos_api_session):
     """
     test bundle download and validate zip file
@@ -630,6 +637,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                     assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
 
 
+@pytest.mark.supportedwindows
 def test_bundle_delete(dcos_api_session):
     bundles = _get_bundle_list(dcos_api_session)
     assert bundles, 'no bundles found'
@@ -640,6 +648,7 @@ def test_bundle_delete(dcos_api_session):
     assert len(bundles) == 0, 'Could not remove bundles {}'.format(bundles)
 
 
+@pytest.mark.supportedwindows
 def test_diagnostics_bundle_status(dcos_api_session):
     # validate diagnostics job status response
     diagnostics_bundle_status = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -7,6 +7,7 @@ from requests.exceptions import ConnectionError
 from retrying import retry
 
 
+@pytest.mark.supportedwindows
 def test_if_dcos_ui_is_up(dcos_api_session):
     r = dcos_api_session.get('/')
 
@@ -26,6 +27,7 @@ def test_if_dcos_ui_is_up(dcos_api_session):
         assert link_response.status_code == 200
 
 
+@pytest.mark.supportedwindows
 def test_if_mesos_is_up(dcos_api_session):
     r = dcos_api_session.get('/mesos')
 
@@ -34,6 +36,7 @@ def test_if_mesos_is_up(dcos_api_session):
     assert '<title>Mesos</title>' in r.text
 
 
+@pytest.mark.supportedwindows
 def test_if_all_mesos_slaves_have_registered(dcos_api_session):
     r = dcos_api_session.get('/mesos/master/slaves')
     assert r.status_code == 200
@@ -44,6 +47,7 @@ def test_if_all_mesos_slaves_have_registered(dcos_api_session):
     assert slaves_ips == dcos_api_session.all_slaves
 
 
+@pytest.mark.supportedwindows
 def test_if_exhibitor_api_is_up(dcos_api_session):
     r = dcos_api_session.exhibitor.get('/exhibitor/v1/cluster/list')
     assert r.status_code == 200
@@ -52,12 +56,14 @@ def test_if_exhibitor_api_is_up(dcos_api_session):
     assert data["port"] > 0
 
 
+@pytest.mark.supportedwindows
 def test_if_exhibitor_ui_is_up(dcos_api_session):
     r = dcos_api_session.exhibitor.get('/')
     assert r.status_code == 200
     assert 'Exhibitor for ZooKeeper' in r.text
 
 
+@pytest.mark.supportedwindows
 def test_if_zookeeper_cluster_is_up(dcos_api_session):
     r = dcos_api_session.get('/exhibitor/exhibitor/v1/cluster/status')
     assert r.status_code == 200
@@ -72,6 +78,7 @@ def test_if_zookeeper_cluster_is_up(dcos_api_session):
     assert zks_leaders == 1
 
 
+@pytest.mark.supportedwindows
 def test_if_uiconfig_is_available(dcos_api_session):
     r = dcos_api_session.get('/dcos-metadata/ui-config.json')
 
@@ -79,6 +86,7 @@ def test_if_uiconfig_is_available(dcos_api_session):
     assert 'uiConfiguration' in r.json()
 
 
+@pytest.mark.supportedwindows
 def test_if_dcos_history_service_is_up(dcos_api_session):
     r = dcos_api_session.get('/dcos-history-service/ping')
 
@@ -86,6 +94,7 @@ def test_if_dcos_history_service_is_up(dcos_api_session):
     assert 'pong' == r.text
 
 
+@pytest.mark.supportedwindows
 def test_if_marathon_is_up(dcos_api_session):
     r = dcos_api_session.get('/marathon/v2/info')
 
@@ -95,12 +104,14 @@ def test_if_marathon_is_up(dcos_api_session):
     assert "marathon" == response_json["name"]
 
 
+@pytest.mark.supportedwindows
 def test_if_marathon_ui_redir_works(dcos_api_session):
     r = dcos_api_session.get('/marathon')
     assert r.status_code == 200
     assert '<title>Marathon</title>' in r.text
 
 
+@pytest.mark.supportedwindows
 def test_if_srouter_service_endpoint_works(dcos_api_session):
     r = dcos_api_session.get('/service/marathon/v2/info')
 
@@ -112,6 +123,7 @@ def test_if_srouter_service_endpoint_works(dcos_api_session):
     assert "version" in response_json
 
 
+@pytest.mark.supportedwindows
 def test_if_mesos_api_is_up(dcos_api_session):
     r = dcos_api_session.get('/mesos_dns/v1/version')
     assert r.status_code == 200
@@ -120,6 +132,7 @@ def test_if_mesos_api_is_up(dcos_api_session):
     assert data["Service"] == 'Mesos-DNS'
 
 
+@pytest.mark.supportedwindows
 def test_if_pkgpanda_metadata_is_available(dcos_api_session):
     r = dcos_api_session.get('/pkgpanda/active.buildinfo.full.json')
     assert r.status_code == 200
@@ -129,6 +142,7 @@ def test_if_pkgpanda_metadata_is_available(dcos_api_session):
     assert len(data) > 5  # (prozlach) We can try to put minimal number of pacakages required
 
 
+@pytest.mark.supportedwindows
 def test_if_dcos_history_service_is_getting_data(dcos_api_session):
     @retry(stop_max_delay=20000, wait_fixed=500)
     def check_up():
@@ -143,6 +157,7 @@ def test_if_dcos_history_service_is_getting_data(dcos_api_session):
     check_up()
 
 
+@pytest.mark.supportedwindows
 def test_if_we_have_capabilities(dcos_api_session):
     """Indirectly test that Cosmos is up since this call is handled by Cosmos.
     """
@@ -317,6 +332,7 @@ def _validate_overlay_backend(overlay_name, backend):
         raise AssertionError("Could not find key :" + str(ex)) from ex
 
 
+@pytest.mark.supportedwindows
 def test_if_cosmos_is_only_available_locally(dcos_api_session):
     # One should not be able to connect to the cosmos HTTP and admin ports
     # over non-lo interfaces

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import sys
 import uuid
 
 from dcos_test_utils import marathon
@@ -30,7 +31,7 @@ with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
     expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
 
 
-def marathon_test_app(
+def marathon_test_app_linux(
         host_port: int=0,
         container_port: int=None,
         container_type: marathon.Container=marathon.Container.NONE,
@@ -160,3 +161,64 @@ def marathon_test_app(
     if host_constraint is not None:
         app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
     return app, test_uuid
+
+
+def marathon_test_app_windows(
+        host_constraint: str=None,
+        network_name: str='nat_network'):
+    """ Creates an app definition for the microsoft/iis container
+
+    Args:
+        host_constraint: string representing a hostname for an agent that this
+            app should run on
+
+    Return:
+        (dict, str): 2-Tuple of app definition (dict) and app ID (string)
+    """
+    # `BRIDGE` mode will be translated to `NAT` on Windows.
+    network = "BRIDGE"
+    # Container type can be only DOCKER
+    container_type = marathon.Container.DOCKER
+
+    test_uuid = uuid.uuid4().hex
+    app = copy.deepcopy({
+        'id': TEST_APP_NAME_FMT.format(test_uuid),
+        'cpus': 1,
+        'mem': 512,
+        'disk': 0,
+        'instances': 1,
+        'cmd': None,
+        'healthChecks': [
+            {
+                'protocol': 'HTTP',
+                'path': '/',
+                'gracePeriodSeconds': 300,
+                'intervalSeconds': 60,
+                'timeoutSeconds': 20,
+                'maxConsecutiveFailures': 3,
+                'port': 80,
+                'ignoreHttp1xx': False
+            }
+        ],
+    })
+
+    app['container'] = {
+        'type': container_type.value,
+        'docker': {'image': 'microsoft/iis:windowsservercore-1709'},
+        'volumes': []}
+    app['container']['docker']['parameters'] = [
+        {'key': 'network', 'value': network_name},
+        {'key': 'publish', 'value': '80:80'}]
+    app['container']['docker']['forcePullImage'] = False
+    app['container']['docker']['network'] = network
+
+    if host_constraint is not None:
+        app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
+    # Add Windows constraint
+    app['constraints'] = app.get('constraints', []) + [['os', 'LIKE', 'Windows']]
+    app['acceptedResourceRoles'] = ["slave_public"]
+
+    return app, test_uuid
+
+
+marathon_test_app = marathon_test_app_linux

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -283,6 +283,7 @@ def get_region_zone(domain):
     return region, zone
 
 
+@pytest.mark.supportedwindows
 @pytest.mark.skipif(
     test_helpers.expanded_config['fault_domain_enabled'] == 'false',
     reason='fault domain is not set')

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,3 +1,5 @@
+import pytest
+
 import retrying
 
 
@@ -19,6 +21,7 @@ def test_metrics_agents_ping(dcos_api_session):
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
+@pytest.mark.supportedwindows
 def test_metrics_masters_ping(dcos_api_session):
     for master in dcos_api_session.masters:
         response = dcos_api_session.metrics.get('ping', node=master)

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,6 +1,7 @@
 # Various tests that don't fit into the other categories and don't make their own really.
 import os
 
+import pytest
 import yaml
 
 from test_helpers import expanded_config
@@ -8,6 +9,7 @@ from test_helpers import expanded_config
 
 # Test that user config is loadable
 # TODO(cmaloney): Validate it contains some settings we expact.
+@pytest.mark.supportedwindows
 def test_load_user_config():
     with open('/opt/mesosphere/etc/user.config.yaml', 'r') as f:
         user_config = yaml.load(f)
@@ -19,6 +21,7 @@ def test_load_user_config():
     # platforms have different sets...
 
 
+@pytest.mark.supportedwindows
 def test_expanded_config():
     # Caluclated parameters should be present
     assert 'master_quorum' in expanded_config
@@ -27,6 +30,7 @@ def test_expanded_config():
     # platforms have different sets...
 
 
+@pytest.mark.supportedwindows
 def test_profile_symlink():
     """Assert the DC/OS profile script is symlinked from the correct source."""
     symlink_target = expanded_config['profile_symlink_target']

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -7,6 +7,7 @@ import pytest
 from test_helpers import expanded_config
 
 
+@pytest.mark.supportedwindows
 @pytest.mark.skipif(
     not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),
     reason='Must be run in an AWS environment!')

--- a/packages/dcos-integration-test/extra/test_units.py
+++ b/packages/dcos-integration-test/extra/test_units.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 
+@pytest.mark.supportedwindows
 def test_verify_units():
     """Test that all systemd units are valid."""
     def _check_units(path):
@@ -72,6 +73,7 @@ def test_verify_units():
     _check_units("/etc/systemd/system/dcos-*.socket")
 
 
+@pytest.mark.supportedwindows
 def test_socket_units():
     """Test that socket units configure socket files in /run/dcos
     that are owned by 'dcos_adminrouter'.
@@ -114,6 +116,7 @@ def test_socket_units():
         _check_unit(file)
 
 
+@pytest.mark.supportedwindows
 def test_socket_files():
     """Test that all socket files in /run/dcos are owned by 'dcos_adminrouter'."""
     for file in glob.glob("/run/dcos/*"):


### PR DESCRIPTION
Add Windows support for Python integration tests

This patch adds a new method in test_helpers.py which is
Windows specific. It will return the json needed to create
a marathon app on Windows.

The tests which are supported on Windows are now marked with
"supportedwindows".

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
