### PR TITLE
[1.11] Bumped Mesos to latest nightly.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
-      "ref_origin": "master"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
+    "ref_origin": "master"
+  }
 }

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -7,6 +7,6 @@
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
     "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
-    "ref_origin": "master"
+    "ref_origin": "1.11"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "03174f99d3d2f79a2a4a3bf21bae78137d1268ad",
+    "ref": "108a6b8a6fa72c39d3ff810ece6eea0d402ae4bd",
     "ref_origin": "dcos-mesos-1.5.x-nightly-8a9f99e9f"
   },
   "environment": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "108a6b8a6fa72c39d3ff810ece6eea0d402ae4bd",
-    "ref_origin": "dcos-mesos-1.5.x-nightly-8a9f99e9f"
+    "ref": "1ff5dd10831ae7845285dc138a062f63fc8b1faf",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-df1ab5405"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "1ff5dd10831ae7845285dc138a062f63fc8b1faf",
-    "ref_origin": "dcos-mesos-1.5.x-nightly-df1ab5405"
+    "ref": "44bbd16550fda29b32cf4c5102be8783ac904bc2",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-2efd2b9ce"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "8436b76224c48a1a90aa7940fd52399ca7e8a9e7",
-    "ref_origin" : "dcos-mesos-1.5.0-rc1"
+    "ref": "03174f99d3d2f79a2a4a3bf21bae78137d1268ad",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-8a9f99e9f"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }


### PR DESCRIPTION
Permanent PR to update Mesos+modules SHAs.

Corresponding DC/OS Enterprise PR: https://github.com/mesosphere/dcos-enterprise/pull/2191