### PR TITLE
[1.10] Bumped Mesos to latest nightly.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "11b2e62489dd3efe98046d06ef9fa43fb51e8d47",
-      "ref_origin": "1.10"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "11b2e62489dd3efe98046d06ef9fa43fb51e8d47",
+    "ref_origin": "1.10"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "732c49e6e98ac720df3418d9d868a6dfe1b2c6b5",
-    "ref_origin" : "dcos-mesos-1.4.x-6199905"
+    "ref": "c781879a04db523e3bfb9e4ea84e454587f908af",
+    "ref_origin": "dcos-mesos-1.4.x-nightly-3cc631fca"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c781879a04db523e3bfb9e4ea84e454587f908af",
-    "ref_origin": "dcos-mesos-1.4.x-nightly-3cc631fca"
+    "ref": "a16cc41e3499f8bc367f85f558c683b58589fecf",
+    "ref_origin": "dcos-mesos-1.4.x-nightly-5746f98ff"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8bfe874c68cdf6b9d7e4b7ab0dd81c45b26bc79",
-    "ref_origin" : "dcos-mesos-1.4.x-92d988c"
+    "ref": "a16cc41e3499f8bc367f85f558c683b58589fecf",
+    "ref_origin": "dcos-mesos-1.4.x-nightly-5746f98ff"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
Permanent PR to update Mesos+modules SHAs.

Corresponding DC/OS Enterprise PR: https://github.com/mesosphere/dcos-enterprise/pull/2192