### PR TITLE
Move networkd setup to mesos unit

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -413,39 +413,11 @@ set -o errexit -o nounset -o pipefail
 # For setenforce & xfs_info
 PATH=$PATH:/usr/sbin:/sbin
 
-# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
-function coreos_networkd_config() {
-
-network_config="/etc/systemd/network/dcos.network"
-sudo tee $network_config > /dev/null<<'EOF'
-[Match]
-Type=bridge
-Name=docker* m-* d-* vtep*
-
-[Link]
-Unmanaged=yes
-EOF
-
-}
-
 echo "Validating distro..."
 distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
   echo "Distro: CoreOS"
-
-  if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
-    echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
-    coreos_networkd_config
-
-    if systemctl is-enabled systemd-networkd > /dev/null; then
-        echo "Restarting systemd-networkd...."
-        sudo systemctl restart systemd-networkd
-    fi
-
-    echo "CoreOS network setup complete."
-  else
-    echo "All prerequisites already installed"
-  fi
+  echo "All prerequisites already installed"
   exit 0
 elif [[ "${distro}" == 'rhel' ]]; then
   echo "Distro: RHEL"

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -8,4 +8,27 @@ if [ -x $FAULT_DOMAIN_SCRIPT ]; then
   export MESOS_DOMAIN="$($FAULT_DOMAIN_SCRIPT)"
 fi
 
+function coreos_networkd_config() {
+ network_config="/etc/systemd/network/dcos.network"
+ sudo tee $network_config > /dev/null<<'EOF'
+ [Match]
+  Type=bridge
+  Name=docker* m-* d-* vtep*
+ 
+ [Link]
+  Unmanaged=yes
+EOF
+}
+
+distro="$(source /etc/os-release && echo "${ID}")"
+if [[ "${distro}" == 'coreos' ]]; then
+     if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       coreos_networkd_config
+ 
+       if systemctl is-enabled systemd-networkd > /dev/null; then
+          sudo systemctl restart systemd-networkd
+       fi
+    fi
+fi  
+
 exec "$@"

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -8,13 +8,14 @@ if [ -x $FAULT_DOMAIN_SCRIPT ]; then
   export MESOS_DOMAIN="$($FAULT_DOMAIN_SCRIPT)"
 fi
 
+# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
  [Match]
   Type=bridge
   Name=docker* m-* d-* vtep*
- 
+
  [Link]
   Unmanaged=yes
 EOF
@@ -24,11 +25,12 @@ distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
      if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
        coreos_networkd_config
- 
+       echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
+
        if systemctl is-enabled systemd-networkd > /dev/null; then
           sudo systemctl restart systemd-networkd
        fi
     fi
-fi  
+fi
 
 exec "$@"


### PR DESCRIPTION
## High-level description
Fix for networkd overlay network in coreOS. Previous fix only worked when the 'install-prereqs' feature of the dcos_installer was used, which is not a guaranteed setup step.


## Corresponding DC/OS tickets (obligatory)
https://jira.mesosphere.com/browse/DCOS_OSS-2003

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Updating service unit file
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
