### PR TITLE
Dump the JSON when waiting for /v2/apps/id

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -61,10 +61,11 @@ class MarathonApp:
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        _endpoint = 'v2/apps/{}'.format(self.id)
+        r = dcos_api_session.marathon.get(_endpoint)
         r.raise_for_status()
         self._info = r.json()
-        log.info("Response for /v2/apps/{id}".format(id=self.id))
+        log.info("Response for GET {endpoint}".format(endpoint=_endpoint))
         log.info(json.dumps(self._info, indent=4, separators=(',', ': ')))
         return self._info['app']['tasksHealthy'] == self.app['instances']
 
@@ -152,9 +153,12 @@ class MarathonPod:
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        _endpoint = "/v2/pods/{id}::status".format(id=self.id)
+        r = dcos_api_session.marathon.get(_endpoint)
         r.raise_for_status()
         self._info = r.json()
+        log.info("Response for GET {endpoint}".format(endpoint=_endpoint))
+        log.info(json.dumps(self._info, indent=4, separators=(',', ': ')))
         return self._info['status'] == 'STABLE'
 
     def info(self, dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -64,6 +64,8 @@ class MarathonApp:
         r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
         r.raise_for_status()
         self._info = r.json()
+        log.info("Response for /v2/apps/{id}".format(id=self.id))
+        log.info(json.dumps(self._info, indent=4, separators=(',', ': ')))
         return self._info['app']['tasksHealthy'] == self.app['instances']
 
     def info(self, dcos_api_session):


### PR DESCRIPTION
## High-level description

https://jira.mesosphere.com/browse/DCOS_OSS-2115 - The error message is mis-leading. We should give some debugging/ or related information whenever RetryError happens.

While we try to provide more generic solution, I think, for the specific networking issue and log on wait could be helpful.