### PR TITLE
[1.10] Move networkd setup to mesos unit

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -415,39 +415,12 @@ def _add_prereqs_script(chain):
 # For setenforce
 PATH=$PATH:/sbin
 
-# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
-function coreos_networkd_config() {
-
-network_config="/etc/systemd/network/dcos.network"
-sudo tee $network_config > /dev/null<<'EOF'
-[Match]
-Type=bridge
-Name=docker* m-* d-* vtep*
-
-[Link]
-Unmanaged=yes
-EOF
-
-}
 
 echo "Validating distro..."
 distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
   echo "Distro: CoreOS"
-
-  if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
-    echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
-    coreos_networkd_config
-
-    if systemctl is-enabled systemd-networkd > /dev/null; then
-        echo "Restarting systemd-networkd...."
-        sudo systemctl restart systemd-networkd
-    fi
-
-    echo "CoreOS network setup complete."
-  else
-    echo "All prerequisites already installed"
-  fi
+  echo "All prerequisites already installed"
   exit 0
 fi
 

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -62,3 +62,7 @@ envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave-public.service > "$systemd_sl
 disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
+
+mesos_start_wrapper="$PKG_PATH/bin/start_mesos.sh"
+cp /pkg/extra/start_mesos.sh "$mesos_start_wrapper"
+chmod +x "$mesos_start_wrapper"

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -17,4 +17,4 @@ EnvironmentFile=-/run/dcos/etc/mesos-master
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-master
-ExecStart=$PKG_PATH/bin/mesos-master
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-master

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/mesos-agent
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/mesos-agent
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
@@ -17,6 +18,7 @@ EOF
 distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
      if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
        coreos_networkd_config
 
        if systemctl is-enabled systemd-networkd > /dev/null; then

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+function coreos_networkd_config() {
+ network_config="/etc/systemd/network/dcos.network"
+ sudo tee $network_config > /dev/null<<'EOF'
+ [Match]
+  Type=bridge
+  Name=docker* m-* d-* vtep*
+
+ [Link]
+  Unmanaged=yes
+EOF
+}
+
+distro="$(source /etc/os-release && echo "${ID}")"
+if [[ "${distro}" == 'coreos' ]]; then
+     if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       coreos_networkd_config
+
+       if systemctl is-enabled systemd-networkd > /dev/null; then
+          sudo systemctl restart systemd-networkd
+       fi
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
## High-level description
Fix for networkd overlay network in coreOS. Previous fix only worked when the 'install-prereqs' feature of the dcos_installer was used, which is not a guaranteed setup step.


## Corresponding DC/OS tickets (obligatory)
https://jira.mesosphere.com/browse/DCOS_OSS-2003

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Updating service unit file
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
