### PR TITLE
Update JDK License link. 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -80,7 +80,7 @@ Hashicorp's Vault
 - https://github.com/hashicorp/vault/blob/master/LICENSE
 
 java
-- http://www.oracle.com/technetwork/java/javase/downloads/jre-6u21-license-159054.txt
+- http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 
 libevent
 - Libvent License


### PR DESCRIPTION
## High-level description

We ship JDK 8 and were pointing to Java 6 License.