### PR TITLE
[1.9] Move networkd setup to mesos unit

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -357,39 +357,12 @@ def _add_prereqs_script(chain):
 # For setenforce
 PATH=$PATH:/sbin
 
-# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
-function coreos_networkd_config() {
-
-network_config="/etc/systemd/network/dcos.network"
-sudo tee $network_config > /dev/null<<'EOF'
-[Match]
-Type=bridge
-Name=docker* m-* d-* vtep*
-
-[Link]
-Unmanaged=yes
-EOF
-
-}
 
 echo "Validating distro..."
 distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
   echo "Distro: CoreOS"
-
-  if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
-    echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
-    coreos_networkd_config
-
-    if systemctl is-enabled systemd-networkd > /dev/null; then
-        echo "Restarting systemd-networkd...."
-        sudo systemctl restart systemd-networkd
-    fi
-
-    echo "CoreOS network setup complete."
-  else
-    echo "All prerequisites already installed"
-  fi
+  echo "All prerequisites already installed"
   exit 0
 fi
 

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -125,62 +125,62 @@ aws_region_names = [
 
 region_to_ami_map = {
     'ap-northeast-1': {
-        'coreos': 'ami-86f1b9e1',
-        'stable': 'ami-86f1b9e1',
+        'coreos': 'ami-44a03c22',
+        'stable': 'ami-44a03c22',
         'el7': 'ami-5942133e',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
-        'coreos': 'ami-27cc7d44',
-        'stable': 'ami-27cc7d44',
+        'coreos': 'ami-d085f3ac',
+        'stable': 'ami-d085f3ac',
         'el7': 'ami-83ea59e0',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
-        'coreos': 'ami-5baeae38',
-        'stable': 'ami-5baeae38',
+        'coreos': 'ami-21ce3c43',
+        'stable': 'ami-21ce3c43',
         'el7': 'ami-7f393b1c',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
-        'coreos': 'ami-4733f928',
-        'stable': 'ami-4733f928',
+        'coreos': 'ami-90c152ff',
+        'stable': 'ami-90c152ff',
         'el7': 'ami-9e13c7f1',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
-        'coreos': 'ami-89f6dbef',
-        'stable': 'ami-89f6dbef',
+        'coreos': 'ami-32d1474b',
+        'stable': 'ami-32d1474b',
         'el7': 'ami-41b89327',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
-        'coreos': 'ami-c51573a9',
-        'stable': 'ami-c51573a9',
+        'coreos': 'ami-78befd14',
+        'stable': 'ami-78befd14',
         'el7': 'ami-6d600101',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
-        'coreos': 'ami-42ad7d54',
-        'stable': 'ami-42ad7d54',
+        'coreos': 'ami-e582d29f',
+        'stable': 'ami-e582d29f',
         'el7': 'ami-84862092',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
-        'coreos': 'ami-a846fcc9',
-        'stable': 'ami-a846fcc9',
+        'coreos': 'ami-9579f7f4',
+        'stable': 'ami-9579f7f4',
         'el7': 'ami-8dce4bec',
         'natami': 'ami-e8ab1489'
     },
     'us-west-1': {
-        'coreos': 'ami-1a1b457a',
-        'stable': 'ami-1a1b457a',
+        'coreos': 'ami-e0696980',
+        'stable': 'ami-e0696980',
         'el7': 'ami-794f1619',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
-        'coreos': 'ami-2551d145',
-        'stable': 'ami-2551d145',
+        'coreos': 'ami-65269d1d',
+        'stable': 'ami-65269d1d',
         'el7': 'ami-4953df29',
         'natami': 'ami-bb69128b'
     }

--- a/gen/coreos/cloud-config.yaml
+++ b/gen/coreos/cloud-config.yaml
@@ -11,5 +11,3 @@ coreos:
     - name: locksmithd.service
       mask: true
       command: stop
-    - name: systemd-resolved.service
-      command: stop

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -62,3 +62,7 @@ envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave-public.service > "$systemd_sl
 disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
+
+mesos_start_wrapper="$PKG_PATH/bin/start_mesos.sh"
+cp /pkg/extra/start_mesos.sh "$mesos_start_wrapper"
+chmod +x "$mesos_start_wrapper"

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -17,4 +17,4 @@ EnvironmentFile=-/run/dcos/etc/mesos-master
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-master
-ExecStart=$PKG_PATH/bin/mesos-master
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-master

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/mesos-agent
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/mesos-agent
+ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -6,12 +6,12 @@ set -e
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
- [Match]
-  Type=bridge
-  Name=docker* m-* d-* vtep*
+[Match]
+Type=bridge
+Name=docker* m-* d-* vtep*
 
- [Link]
-  Unmanaged=yes
+[Link]
+Unmanaged=yes
 EOF
 }
 
@@ -21,7 +21,7 @@ if [[ "${distro}" == 'coreos' ]]; then
        echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
        coreos_networkd_config
 
-       if systemctl is-enabled systemd-networkd > /dev/null; then
+       if systemctl is-active systemd-networkd > /dev/null; then
           sudo systemctl restart systemd-networkd
        fi
     fi

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# Helper to configure `networkd` on CoreOS to ignore all DC/OS overlay interfaces.
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
@@ -17,6 +18,7 @@ EOF
 distro="$(source /etc/os-release && echo "${ID}")"
 if [[ "${distro}" == 'coreos' ]]; then
      if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       echo "Configuring systemd-networkd to ignore docker bridge and DC/OS overlay interfaces..."
        coreos_networkd_config
 
        if systemctl is-enabled systemd-networkd > /dev/null; then

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+function coreos_networkd_config() {
+ network_config="/etc/systemd/network/dcos.network"
+ sudo tee $network_config > /dev/null<<'EOF'
+ [Match]
+  Type=bridge
+  Name=docker* m-* d-* vtep*
+
+ [Link]
+  Unmanaged=yes
+EOF
+}
+
+distro="$(source /etc/os-release && echo "${ID}")"
+if [[ "${distro}" == 'coreos' ]]; then
+     if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       coreos_networkd_config
+
+       if systemctl is-enabled systemd-networkd > /dev/null; then
+          sudo systemctl restart systemd-networkd
+       fi
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
## High-level description
Fix for networkd overlay network in coreOS. Previous fix only worked when the 'install-prereqs' feature of the dcos_installer was used, which is not a guaranteed setup step.


## Corresponding DC/OS tickets (obligatory)
https://jira.mesosphere.com/browse/DCOS_OSS-2003

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Updating service unit file
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
