### PR TITLE
[1.8] Move networkd setup to mesos unit

### DIFF
--- a/dcos_installer/async_server.py
+++ b/dcos_installer/async_server.py
@@ -227,7 +227,7 @@ def action_action_name(request):
             try:
                 log.warning("GENERATING CONFIGURATION")
                 backend.do_configure()
-            except:
+            except Exception:
                 genconf_failure = {
                     "errors": "Configuration generation failed, please see command line for details"
                 }

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -399,7 +399,7 @@ class DFSArgumentCalculator():
         except CalculatorError as ex:
             self._arguments[name] = None
             raise CalculatorError(ex.message, ex.chain + ['while calculating {}'.format(name)]) from ex
-        except:
+        except Exception:
             self._arguments[name] = None
             raise
         finally:

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -47,34 +47,34 @@
   "Mappings": {
     "RegionToAmi": {
       "ap-northeast-1": {
-        "stable": "ami-965899f7"
+        "stable": "ami-44a03c22"
       },
       "ap-southeast-1": {
-        "stable": "ami-3120fe52"
+        "stable": "ami-d085f3ac"
       },
       "ap-southeast-2": {
-        "stable": "ami-b1291dd2"
+        "stable": "ami-21ce3c43"
       },
       "eu-central-1": {
-        "stable": "ami-3ae31555"
+        "stable": "ami-90c152ff"
       },
       "eu-west-1": {
-        "stable": "ami-b7cba3c4"
+        "stable": "ami-32d1474b"
       },
       "sa-east-1": {
-        "stable": "ami-61e3750d"
+        "stable": "ami-78befd14"
       },
       "us-east-1": {
-        "stable": "ami-6d138f7a"
+        "stable": "ami-e582d29f"
       },
       "us-gov-west-1": {
-        "stable": "ami-b712acd6"
+        "stable": "ami-9579f7f4"
       },
       "us-west-1": {
-        "stable": "ami-ee57148e"
+        "stable": "ami-e0696980"
       },
       "us-west-2": {
-        "stable": "ami-dc6ba3bc"
+        "stable": "ami-65269d1d"
       }
     },
     "NATAmi" : {

--- a/gen/coreos/cloud-config.yaml
+++ b/gen/coreos/cloud-config.yaml
@@ -11,5 +11,3 @@ coreos:
     - name: locksmithd.service
       mask: true
       command: stop
-    - name: systemd-resolved.service
-      command: stop

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -70,3 +70,7 @@ chmod +x "$tee_stderr_script"
 # Install slave modules.
 mkdir -p "$PKG_PATH/etc/mesos-slave-modules"
 cp /pkg/extra/slave_logrotate_module.json "$PKG_PATH/etc/mesos-slave-modules/"
+
+mesos_start_wrapper="$PKG_PATH/bin/start_mesos.sh"
+cp /pkg/extra/start_mesos.sh "$mesos_start_wrapper"
+chmod +x "$mesos_start_wrapper"

--- a/packages/mesos/extra/dcos-mesos-master.service
+++ b/packages/mesos/extra/dcos-mesos-master.service
@@ -17,4 +17,4 @@ EnvironmentFile=-/run/dcos/etc/mesos-master
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-master
-ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/mesos-master /var/lib/dcos/mesos/log/mesos-master.log
+ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-master /var/lib/dcos/mesos/log/mesos-master.log

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/mesos-agent /var/log/mesos/mesos-agent.log
+ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent /var/log/mesos/mesos-agent.log

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -22,4 +22,4 @@ ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
-ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/mesos-agent /var/log/mesos/mesos-agent.log
+ExecStart=$PKG_PATH/bin/tee_stderr $PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent /var/log/mesos/mesos-agent.log

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -5,12 +5,12 @@ set -e
 function coreos_networkd_config() {
  network_config="/etc/systemd/network/dcos.network"
  sudo tee $network_config > /dev/null<<'EOF'
- [Match]
-  Type=bridge
-  Name=docker* m-* d-* vtep*
+[Match]
+Type=bridge
+Name=docker* m-* d-* vtep*
 
- [Link]
-  Unmanaged=yes
+[Link]
+Unmanaged=yes
 EOF
 }
 
@@ -19,7 +19,7 @@ if [[ "${distro}" == 'coreos' ]]; then
      if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
        coreos_networkd_config
 
-       if systemctl is-enabled systemd-networkd > /dev/null; then
+       if systemctl is-active systemd-networkd > /dev/null; then
           sudo systemctl restart systemd-networkd
        fi
     fi

--- a/packages/mesos/extra/start_mesos.sh
+++ b/packages/mesos/extra/start_mesos.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+function coreos_networkd_config() {
+ network_config="/etc/systemd/network/dcos.network"
+ sudo tee $network_config > /dev/null<<'EOF'
+ [Match]
+  Type=bridge
+  Name=docker* m-* d-* vtep*
+
+ [Link]
+  Unmanaged=yes
+EOF
+}
+
+distro="$(source /etc/os-release && echo "${ID}")"
+if [[ "${distro}" == 'coreos' ]]; then
+     if systemctl list-unit-files | grep systemd-networkd.service > /dev/null; then
+       coreos_networkd_config
+
+       if systemctl is-enabled systemd-networkd > /dev/null; then
+          sudo systemctl restart systemd-networkd
+       fi
+    fi
+fi
+
+exec "$@"

--- a/packages/mesos/extra/tee_stderr
+++ b/packages/mesos/extra/tee_stderr
@@ -3,9 +3,9 @@
 #  <program>: The command to run.
 #  <output file>: Where to `tee` the stderr of the <program>.
 
-if [ $# -ne 2 ]; then
-    echo "usage: $0 <program> <output file>"
+if [ $# -ne 3 ]; then
+    echo "usage: $0 <wrapper script> <program> <output file>"
     exit 1
 fi
 
-$1 2>&1 | tee -a "$2"
+$1 $2 2>&1 | tee -a "$3"

--- a/packages/spartan/extra/gen_resolvconf.py
+++ b/packages/spartan/extra/gen_resolvconf.py
@@ -37,7 +37,7 @@ def check_server(addr):
     except dns.exception.Timeout:
         print('Skipping DNS server {}: no response'.format(
             addr), file=sys.stderr)
-    except:
+    except Exception:
         print("Unexpected error querying DNS for server \"{}\" exception: {}".format(
             addr, sys.exc_info()[1]))
 

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -83,7 +83,7 @@ def download_atomic(out_filename, url, work_dir):
     except FetchError:
         try:
             os.remove(tmp_filename)
-        except:
+        except Exception:
             pass
         raise
 
@@ -100,7 +100,7 @@ def extract_tarball(path, target):
         assert os.path.exists(path), "Path doesn't exist but should: {}".format(path)
         check_call(['mkdir', '-p', target])
         check_call(['tar', '-xf', path, '-C', target])
-    except:
+    except Exception:
         # If there are errors, we can't really cope since we are already in an error state.
         rmtree(target, ignore_errors=True)
         raise

--- a/release/storage/http.py
+++ b/release/storage/http.py
@@ -38,7 +38,7 @@ class HttpStorageProvider(AbstractStorageProvider):
                 for chunk in r.iter_content(chunk_size=4096):
                     f.write(chunk)
                 os.rename(local_path_tmp, local_path)
-        except:
+        except Exception:
             # Delete the temp file, re-raise.
             try:
                 os.remove(local_path_tmp)

--- a/test_util/azure_test_driver.py
+++ b/test_util/azure_test_driver.py
@@ -122,7 +122,7 @@ def run():
         print("Waiting for template to deploy ...")
         try:
             poll_deploy()
-        except:
+        except Exception:
             print("Current deploy status:\n{}".format(deploy_poller.result(0)))
             raise
         print("Template deployed successfully")


### PR DESCRIPTION
## High-level description
Fix for networkd overlay network in coreOS. Previous fix only worked when the 'install-prereqs' feature of the dcos_installer was used, which is not a guaranteed setup step.


## Corresponding DC/OS tickets (obligatory)
https://jira.mesosphere.com/browse/DCOS_OSS-2003

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Updating service unit file
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
