### PR TITLE
Makes overlay IPv6 validation checks optional

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -293,48 +293,54 @@ def validate_dcos_overlay_network(dcos_overlay_network):
     except ValueError as ex:
         raise AssertionError("Provided input was not valid JSON: {}".format(dcos_overlay_network)) from ex
 
-    # Check the VTEP IP, VTEP MAC keys are present in the overlay
-    # configuration
-    assert 'vtep_subnet' in overlay_network.keys(), (
-        'Missing "vtep_subnet" in overlay configuration {}'.format(overlay_network))
-
-    try:
-        ipaddress.ip_network(overlay_network['vtep_subnet'])
-    except ValueError as ex:
-        raise AssertionError(
-            "Incorrect value for vtep_subnet: {}."
-            " Only IPv4 values are allowed".format(overlay_network['vtep_subnet'])) from ex
-
-    assert 'vtep_subnet6' in overlay_network.keys(), (
-        'Missing "vtep_subnet6" in overlay configuration {}'.format(overlay_network))
-
-    try:
-        ipaddress.ip_network(overlay_network['vtep_subnet6'])
-    except ValueError as ex:
-        raise AssertionError(
-            "Incorrect value for vtep_subnet6: {}."
-            " Only IPv6 values are allowed".format(overlay_network['vtep_subnet6'])) from ex
-
-    assert 'vtep_mac_oui' in overlay_network.keys(), (
-        'Missing "vtep_mac_oui" in overlay configuration {}'.format(overlay_network))
-
-    assert 'overlays' in overlay_network.keys(), (
+    assert 'overlays' in overlay_network, (
         'Missing "overlays" in overlay configuration {}'.format(overlay_network))
+
     assert len(overlay_network['overlays']) > 0, (
-        'We need at least one overlay network configuration {}'.format(overlay_network))
+        '"Overlays" network configuration is empty: {}'.format(overlay_network))
 
     for overlay in overlay_network['overlays']:
+        assert 'name' in overlay, (
+            'Missing "name" in overlay configuration: {}'.format(overlay))
+
         assert (len(overlay['name']) <= 13), (
             "Overlay name cannot exceed 13 characters:{}".format(overlay['name']))
 
-        if overlay['name'] == 'dcos':
+        assert ('subnet' in overlay or 'subnet6' in overlay), (
+            'Missing "subnet" or "subnet6" in overlay configuration:{}'.format(overlay))
+
+        assert 'vtep_mac_oui' in overlay_network.keys(), (
+            'Missing "vtep_mac_oui" in overlay configuration {}'.format(overlay_network))
+
+        if 'subnet' in overlay:
+            # Check the VTEP IP is present in the overlay configuration
+            assert 'vtep_subnet' in overlay_network, (
+                'Missing "vtep_subnet" in overlay configuration {}'.format(overlay_network))
+
+            try:
+                ipaddress.ip_network(overlay_network['vtep_subnet'])
+            except ValueError as ex:
+                raise AssertionError(
+                    "Incorrect value for vtep_subnet: {}."
+                    " Only IPv4 values are allowed".format(overlay_network['vtep_subnet'])) from ex
             try:
                 ipaddress.ip_network(overlay['subnet'])
             except ValueError as ex:
                 raise AssertionError(
                     "Incorrect value for overlay subnet {}."
                     " Only IPv4 values are allowed".format(overlay['subnet'])) from ex
-        elif overlay['name'] == 'dcos6':
+
+        if 'subnet6' in overlay:
+            # Check the VTEP IP6 is present in the overlay configuration
+            assert 'vtep_subnet6' in overlay_network, (
+                'Missing "vtep_subnet6" in overlay configuration {}'.format(overlay_network))
+
+            try:
+                ipaddress.ip_network(overlay_network['vtep_subnet6'])
+            except ValueError as ex:
+                raise AssertionError(
+                    "Incorrect value for vtep_subnet6: {}."
+                    " Only IPv6 values are allowed".format(overlay_network['vtep_subnet6'])) from ex
             try:
                 ipaddress.ip_network(overlay['subnet6'])
             except ValueError as ex:


### PR DESCRIPTION
As of DC/OS 1.11, IPv6 overlay network is optional. Hence, the
validation check shouldn't assert on the presence of IPv6 overlay.
This patch makes modifies the validation checks such that IPv6
overlay could be optional

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

   - [DCOS-21095](https://jira.mesosphere.com/browse/DCOS-21095) Turn IPv6 Overlay Off in IPv4 Environment


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
