### PR TITLE
Fix l4lb VIP from local agent using UCR bridge mode

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -307,13 +307,8 @@ def test_vip(dcos_api_session,
 
 def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net, ipv6):
     same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
-    if marathon.Network.BRIDGE in [vip_net, proxy_net]:
-        if container == marathon.Container.DOCKER:
-            pass
-        elif container == marathon.Container.NONE:
-            same_hosts = []
-        else:
-            same_hosts.remove(True)
+    if marathon.Network.BRIDGE in [vip_net, proxy_net] and container == marathon.Container.NONE:
+        same_hosts = []
     tests = [vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, named_vip, same_host)
              for named_vip in [True, False]
              for same_host in same_hosts]

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "57b94928f6858294f18a32bf7c6fce5917ceee60",
+      "ref": "feed9c8606a479333a46ea3ac869090451e3176b",
       "ref_origin": "master"
     }
   },


### PR DESCRIPTION
## High-level description

Once IPVS picks up the packet for load balancing it goes directly to routing layer instead of traversing the IPtables again. However, to reach to the container in bridge mode the packet has to go through the IPtables for DNAT. Hence this issue. The only solution possible is to have actual container IP address as the backend in IPVS configuration. This way container would be accessible through routing instead of port mapping. However, this has to be done only for the agent where the container is running. Other agents would still have to go through the port mapping as container IP, in case of bridge mode, is non-routable.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2070](https://jira.mesosphere.com/browse/DCOS_OSS-2070) Service is not accessible via l4lb VIP from local agent using UCR bridge mode


## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

https://github.com/dcos/dcos-net/pull/34

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).