### PR TITLE
Bumps mesos modules enabling file based ZK configuration

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
+      "ref": "683d3c137ed66d6e9a7e5da622f62a7ce962d4d1",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
## High-level description

ZooKeeper configuration is passed to the Mesos modules as the environment variables `MESOS_ZK` and `MESOS_MASTER` for masters and agents respectively. This variables expect ZooKeeper configuration to be stored in the environment variable following the pattern `zk://user:password@zk1:port,zk2:port`. However, mesos has always allowed this configuration to be stored in files.

With [MESOS-8413](https://issues.apache.org/jira/browse/MESOS-8413) an issue was resolved in which the contents of the files were shown instead of the path of the file, thus preventing accidental leak of ZooKeeper credentials.

While the issue of Mesos is fixed, using ZooKeeper file based configuration cannot yet be used since the mesos-modules do not yet support this feature. This PR addresses this problem.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2162](https://jira.mesosphere.com/browse/DCOS_OSS-2162) Enable Mesos Modules to accept ZooKeeper configuration stored in  files.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-19073](https://jira.mesosphere.com/browse/DCOS-19073) ZK credentials for Mesos master show up in diagnostics bundles.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: _Tested in the EE PR_
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-mesos-modules/compare/6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8...683d3c137ed66d6e9a7e5da622f62a7ce962d4d1)
  - [ ] Test Results: _Mesos modules don't seem to run a CI job_
  - [ ] Code Coverage (if available):
