### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 9840ae1

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
-      "ref_origin": "master"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "6ffea4242dd39e7f84a39bf40855ae11a9d2d0a8",
+    "ref_origin": "1.11"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "8436b76224c48a1a90aa7940fd52399ca7e8a9e7",
-    "ref_origin" : "dcos-mesos-1.5.0-rc1"
+    "ref": "de6c7c6131f46064f6d9eff56b392f8e381b06d4",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-9840ae1"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }


### PR DESCRIPTION
## High-level description

This is a routine bump to the latest 1.5.x branch of Mesos.

## Related JIRA Issues

* [MESOS-8480](https://issues.apache.org/jira/browse/MESOS-8480) Mesos returns high resource usage when killing a Docker task.
* [MESOS-8413](https://issues.apache.org/jira/browse/MESOS-8413) Zookeeper configuration passwords are shown in clear text
* [MESOS-8413](https://issues.apache.org/jira/browse/MESOS-8481) Agent reboot during checkpointing may result in empty checkpoints.
* [MESOS-7742](https://issues.apache.org/jira/browse/MESOS-7742) Race conditions in IOSwitchboard: listening on unix socket and premature closing of the connection.
* [MESOS-7742](https://issues.apache.org/jira/browse/MESOS-7742) CGROUPS_ROOT_PidNamespaceForward and CGROUPS_ROOT_PidNamespaceBackward tests fail
* [MESOS-8510](https://issues.apache.org/jira/browse/MESOS-8510) URI disk profile adaptor does not consider plugin type for a profile.
* [MESOS-8577](https://issues.apache.org/jira/browse/MESOS-8577) Destroy nested container if `LAUNCH_NESTED_CONTAINER_SESSION` fails
* [MESOS-1720](https://issues.apache.org/jira/browse/MESOS-1720) Slave should send exited executor message when the executor is never launched.
* [MESOS-8468](https://issues.apache.org/jira/browse/MESOS-8468) `LAUNCH_GROUP` failure tears down the default executor.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/8436b76224c48a1a90aa7940fd52399ca7e8a9e7... de6c7c6131f46064f6d9eff56b392f8e381b06d4)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]