### PR TITLE
Bump Marathon to 1.6.322

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/marathon-1.6.0-pre-270-g3872d5e.tgz",
-    "sha1": "69e4a3977c4def332cab1e34222dbfd5b476659a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.322-2bf46b341/marathon-1.6.322-2bf46b341.tgz",
+    "sha1": "3eb9a0d89bc328aa289dd748cad6521e0cb7b4eb"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
The same as #2473, but into `master` branch.