### PR TITLE
[master] Bumped Mesos to nightly master

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "2f8c3d17691df767bb0fac1274077bbc8b6da0f0",
+    "ref": "0c503b01d3a9428ec9db35d09da5e237d737c570",
     "ref_origin": "1.8.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "2f8c3d17691df767bb0fac1274077bbc8b6da0f0",
+    "ref": "0c503b01d3a9428ec9db35d09da5e237d737c570",
     "ref_origin": "1.8.x"
   },
   "environment": {


### PR DESCRIPTION
This is a permanent PR, not to be merged.

This PR is updated nightly by the tooling and serves for testing the bleeding edge DC/OS.

Corresponding EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2781.