### PR TITLE
Admin router Marathon 1.5 container networking support

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -97,7 +97,9 @@ end
 
 local function is_container_network(app)
     local container = app["container"]
-    return container and app["networks"][1]["mode"] == "container"
+    local network = app["networks"][1]
+
+    return container and network and network["mode"] == "container"
 end
 
 local function fetch_and_store_marathon_apps(auth_token)

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -199,7 +199,7 @@ local function fetch_and_store_marathon_apps(auth_token)
             -- override with ports from the container's portMappings
             ports = {}
 
-            local port_mappings = app["container"]["portMappings"] or app["portDefinitions"] or {}
+            local port_mappings = app["container"]["portMappings"] or {}
             local port_attr = app["container"]["portMappings"] and "containerPort" or "port"
 
             for _, port_mapping in ipairs(port_mappings) do

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -179,7 +179,7 @@ local function fetch_and_store_marathon_apps(auth_token)
        local host_or_ip = task["host"] --take host  by default
 
        if is_container_network(app) then
-          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is in container network")
+          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is in a container network")
           -- override with the ip of the task
           local task_ip_addresses = task["ipAddresses"]
           if task_ip_addresses then

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -200,10 +200,9 @@ local function fetch_and_store_marathon_apps(auth_token)
             ports = {}
 
             local port_mappings = app["container"]["portMappings"] or {}
-            local port_attr = app["container"]["portMappings"] and "containerPort" or "port"
 
             for _, port_mapping in ipairs(port_mappings) do
-               table.insert(ports, port_mapping[port_attr])
+               table.insert(ports, port_mapping["containerPort"])
             end
        end
 

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -97,7 +97,7 @@ end
 
 local function is_container_network(app)
     local container = app["container"]
-    return container and container["type"] == "DOCKER" and app["networks"][1]["mode"] == "container"
+    return container and app["networks"][1]["mode"] == "container"
 end
 
 local function fetch_and_store_marathon_apps(auth_token)

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -929,41 +929,6 @@ class TestCacheMarathon:
             req_data = resp.json()
             assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
 
-    def test_app_with_container_networking_and_portdefinitions(
-            self, nginx_class, mocker, valid_user_header):
-
-        app = self._scheduler_alwaysthere_app()
-
-        app['networks'][0]['mode'] = 'container'
-        app['networks'][0]['name'] = 'samplenet'
-
-        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
-
-        app['portDefinitions'] = [
-            {
-                "port": 80,
-                "protocol": "tcp",
-                "labels": {}
-            },
-        ]
-
-        ar = nginx_class()
-
-        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
-                            func_name='set_apps_response',
-                            aux_data={"apps": [app]})
-
-        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
-        with GuardedSubprocess(ar):
-            # Trigger cache update by issuing request:
-            resp = requests.get(url,
-                                allow_redirects=False,
-                                headers=valid_user_header)
-
-            assert resp.status_code == 200
-            req_data = resp.json()
-            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
-
     def test_ip_per_task_app_with_unspecified_ip_address_DCOS_OSS_1366(
             self, nginx_class, mocker, valid_user_header):
         """

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -904,10 +904,12 @@ class TestCacheMarathon:
 
         app = self._scheduler_alwaysthere_app()
 
-        app['networks'][0]['mode'] = 'container'
-        app['networks'][0]['name'] = 'samplenet'
+        app['networks'] = [{
+            'mode': 'container',
+            'name': 'samplenet'
+        }]
 
-        app['container']['portMappings'][0]['containerPort'] = '80'
+        app['container']['portMappings'] = [{ 'containerPort': 80 }]
         app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
 
         ar = nginx_class()


### PR DESCRIPTION
## High-level description

With the transition to Marathon 1.5 in DC/OS 1.10.x, this code was not updated to reflect the changes in Marathon task/app API (no more `container.docker.network`, `networks` being at the root of the app definition, etc.).

The IP-per-task concept is now also marked as deprecated in the Marathon documentation, so that's been removed except for one test (`test_ip_per_task_app_with_unspecified_ip_address_DCOS_OSS_1366`) that I didn't want to touch. 

`is_ip_per_task` and `is_user_network` were condensed into one simple check, `is_container_network()`. `container.type` does no longer need to be `DOCKER`, since I assume the container networking concept will carry over to other containerizers, too. (probably the whole reason for this change)

`test_ip_per_task_app_without_user_networking` was removed, since I don't think this is a possible scenario anymore? (correct me if I'm wrong)

## Corresponding DC/OS tickets (obligatory)

This work is a spontaneous bug fix introducing a minor change, only concerning the admin UI.

## Related tickets (optional)

Other tickets related to this change:

  - Not a JIRA ticket, but: https://github.com/dcos/dcos/pull/1628

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]