### PR TITLE
Admin Router: Bump openresty to 1.13.6 [1.10]

### DIFF
--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 
 # Let's try to limit the number of layers to minimum:
-ENV OPENRESTY_VERSION=1.9.15.1 \
-    OPENRESTY_DOWNLOAD_SHASUM=491a84d70ed10b79abb9d1a7496ee57a9244350b \
+ENV OPENRESTY_VERSION=1.13.6.1 \
+    OPENRESTY_DOWNLOAD_SHASUM=775b89cfadf3dbfa13864f3ad4dee4f67dac6604 \
     OPENRESTY_DIR=/usr/local/src/openresty \
     OPENRESTY_COMPILE_SCRIPT=/usr/local/src/build-resty.sh \
     OPENRESTY_COMPILE_OPTS="" \
@@ -56,6 +56,7 @@ RUN set -ex \
         libpcre++-dev \
         libssl-dev \
         make \
+        patch \
         python3 \
         python3-dev \
         python3-pip \
@@ -93,12 +94,14 @@ RUN curl -fsSL "$VEGETA_DOWNLOAD_URL" -o vegeta.tar.gz \
 
 # Prepare Openresty. Compilation is done in Makefile itself so that
 # this container can be reused during DC/OS build.
+COPY openresty-1.13.6.1-no_sse42.patch /usr/local/src/
 RUN set -ex \
     && curl -fsSL "$OPENRESTY_DOWNLOAD_URL" -o openresty.tar.gz \
     && echo "$OPENRESTY_DOWNLOAD_SHASUM  openresty.tar.gz" | shasum -c - \
     && mkdir -pv $OPENRESTY_DIR \
     && tar --strip-components=1 -C $OPENRESTY_DIR -xzf openresty.tar.gz \
-    && rm openresty.tar.gz
+    && rm openresty.tar.gz \
+    && patch -p1 openresty/configure openresty-1.13.6.1-no_sse42.patch
 
 COPY build-resty.sh $OPENRESTY_COMPILE_SCRIPT
 

--- a/packages/adminrouter/docker/build-resty.sh
+++ b/packages/adminrouter/docker/build-resty.sh
@@ -7,7 +7,6 @@ set -u  # Undefined variables
 cd $OPENRESTY_DIR
 ./configure \
     "--prefix=$AR_BIN_DIR" \
-    --with-ipv6 \
     --with-file-aio \
     --with-http_gunzip_module \
     --with-http_gzip_static_module \

--- a/packages/adminrouter/docker/openresty-1.13.6.1-no_sse42.patch
+++ b/packages/adminrouter/docker/openresty-1.13.6.1-no_sse42.patch
@@ -1,0 +1,51 @@
+diff -Nwrup openresty-1.13.6.1.orig/configure openresty-1.13.6.1/configure
+--- openresty-1.13.6.1.orig/configure	2017-11-17 19:08:37.076470575 +0100
++++ openresty-1.13.6.1/configure	2017-11-17 19:09:21.473377394 +0100
+@@ -638,47 +638,6 @@ _END_
+             $luajit_xcflags .= " -DLUAJIT_ENABLE_LUA52COMPAT";
+         }
+ 
+-        if (!$user_luajit_xcflags
+-            || $user_luajit_xcflags !~ /-msse4\.2\b/)
+-        {
+-            # check -msse4.2
+-            my ($out, $cfile) = tempfile("resty-config-XXXXXX",
+-                                         SUFFIX => '.c', TMPDIR => 1,
+-                                         UNLINK => 1);
+-
+-            print $out "
+-int main(void) {
+-#ifndef __SSE4_2__
+-#   error SSE 4.2 not found
+-#endif
+-    return 0;
+-}
+-";
+-            close $out;
+-
+-            my $ofile = tmpnam();
+-            my $comp = ($cc || 'cc');
+-            my $found;
+-
+-            if (system("$comp -o $ofile -msse4.2 -c $cfile") == 0 && -s $ofile) {
+-                unlink $ofile;
+-
+-                if (system("$comp -o $ofile -march=native -c $cfile") == 0 && -s $ofile) {
+-                    print "INFO: found -msse4.2 in $comp.\n";
+-                    $found = 1;
+-                    $luajit_xcflags .= " -msse4.2";
+-                }
+-            }
+-
+-            if (-f $ofile) {
+-                unlink $ofile;
+-            }
+-
+-            if (!$found) {
+-                print "WARNING: -msse4.2 not supported in $comp.\n";
+-            }
+-        }
+-
+         if ($opts->{debug}) {
+             $luajit_xcflags .= " -DLUA_USE_APICHECK -DLUA_USE_ASSERT";
+ 


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/2114/files


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS_OSS-2181 `Admin Router: bump to OpenResty 1.13.x [1.10]`


## Related tickets (optional)

Other tickets related to this change:

  - https://jira.mesosphere.com/browse/DCOS_OSS-1859 `Admin Router: bump to OpenResty 1.13.x`


## Related PRs

* original PR: https://github.com/dcos/dcos/pull/2114
* DC/OS EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2313
