### PR TITLE
Change a test setup requirement assertion to a skip.

### DIFF
--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -72,7 +72,8 @@ def _service_discovery_test(dcos_api_session, docker_network_bridge):
 
     app_definition['instances'] = 2
 
-    assert len(dcos_api_session.slaves) >= 2, "Test requires a minimum of two agents"
+    if len(dcos_api_session.slaves) < 2:
+        pytest.skip("Service Discovery Tests require a minimum of two agents.")
 
     app_definition["constraints"] = [["hostname", "UNIQUE"], ]
 


### PR DESCRIPTION
## High-level description

Encountered this when I was playing with integration tests. 

```
>       assert len(dcos_api_session.slaves) >= 2, "Test requires a minimum of two agents"
E       AssertionError: Test requires a minimum of two agents
E       assert 1 >= 2
E        +  where 1 = len(['172.17.0.3'])
E        +    where ['172.17.0.3'] = <dcos_test_utils.enterprise.EnterpriseApiSession object at 0x7fa73c858128>.slaves

open_source_tests/test_service_discovery.py:72: AssertionError
```

