### PR TITLE
Pkgpanda: Update docs to cover systemd unit files

### DIFF
--- a/pkgpanda/docs/package_concepts.md
+++ b/pkgpanda/docs/package_concepts.md
@@ -52,7 +52,7 @@ Package directory    | Files are symlinked from:
 `etc/`               | `/opt/mesosphere/etc/`
 `lib/`               | `/opt/mesosphere/lib/`
 `include/`           | `/opt/mesosphere/include/`
-`dcos.target.wants/` | `/etc/systemd/system/dcos.target.wants/`
+`dcos.target.wants/` | `/etc/systemd/system/dcos.target.wants/` (See **dcos.target.wants** below.)
 
 If the config package writes its Mesos config file to `etc/mesos`, it'll be symlinked from `/opt/mesosphere/etc/mesos`,
 where the Mesos package can find it. Because the Mesos package is looking for its config at this fixed location, a new
@@ -61,6 +61,17 @@ config package can be built and distributed without rebuilding the Mesos package
 Each of these special package directories can be appended with an underscore and a role name, which will cause the
 files to only be linked on nodes of that role. E.g. files under the package directory `etc_master/` will only be linked
 from `/opt/mesosphere/etc/` on a master node.
+
+### dcos.target.wants
+
+The package directory `dcos.target.wants/` is a well-known directory that's intended for systemd unit files, and the
+files within are made available at `/etc/systemd/system/dcos.target.wants/`. However this well-known directory is
+handled differently from the others due to requirements imposed by systemd: each symlink under
+`/etc/systemd/system/dcos.target.wants/` must have a corresponding unit file at `/etc/systemd/system/`, and unit files
+and their symlinks must be readable when systemd starts, potentially before it mounts the volume that contains the
+package files. So when a package containing a `dcos.target.wants/` is activated on a cluster node, the files within are
+copied to `/etc/systemd/system/`, and the symlinks under `/etc/systemd/system/dcos.target.wants/` point to those
+copies. This allows systemd to start DC/OS units before it mounts the DC/OS installation.
 
 ## Special install files and directories
 


### PR DESCRIPTION
## High-level description

This is a followup to https://github.com/dcos/dcos/pull/2404 that updates documentation accordingly.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2178](https://jira.mesosphere.com/browse/DCOS_OSS-2178) Update pkgpanda docs to cover systemd unit files

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: No new tests, only touching docs.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]