### PR TITLE
Update Python in tox environments 3.5 -> 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,14 +26,14 @@ testpaths =
   ssh
   test_util
 
-[testenv:py35-syntax]
+[testenv:py36-syntax]
 passenv =
     TEAMCITY_VERSION
 commands =
   pip install -e flake8_dcos_lint
   flake8 --verbose
 
-[testenv:py35-unittests]
+[testenv:py36-unittests]
 # See the following link for AWS_* environment variables:
 # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
 passenv =
@@ -63,7 +63,7 @@ commands=
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a
 # specific working directory (something that should be fixed).
-[testenv:py35-pkgpanda-build]
+[testenv:py36-pkgpanda-build]
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
@@ -74,7 +74,7 @@ changedir=pkgpanda/build/tests
 commands=
   pytest --basetemp={envtmpdir} {posargs} build_integration_test.py
 
-[testenv:py35-bootstrap]
+[testenv:py36-bootstrap]
 passenv =
   TEAMCITY_VERSION
 deps=


### PR DESCRIPTION
## High-level description

This updates the Python version we use when we run `tox` to 3.6, to bring it in line with the Python that we install on clusters.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2209](https://jira.mesosphere.com/browse/DCOS_OSS-2209) Run unit tests on Python3.6

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Updating test environments.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]