### PR TITLE
Ensure that cache timestamps are well-formed

### DIFF
--- a/packages/dcos-history/extra/history/statebuffer.py
+++ b/packages/dcos-history/extra/history/statebuffer.py
@@ -12,6 +12,7 @@ logging.getLogger('requests.packages.urllib3').setLevel(logging.WARN)
 
 FETCH_PERIOD = 2
 FILE_EXT = '.state-summary.json'
+FILENAME_TS_FMT = '%Y-%m-%dT%H:%M:%S.%f{}'.format(FILE_EXT)
 
 STATE_SUMMARY_URI = os.getenv('STATE_SUMMARY_URI', 'http://leader.mesos:5050/state-summary')
 
@@ -28,7 +29,7 @@ if 'TLS_VERIFY' in os.environ:
 
 
 def parse_log_time(fname):
-    return datetime.strptime(fname, '%Y-%m-%dT%H:%M:%S.%f{}'.format(FILE_EXT))
+    return datetime.strptime(fname, FILENAME_TS_FMT)
 
 
 def fetch_state(headers_cb):
@@ -107,7 +108,7 @@ class HistoryBuffer():
 
     def _get_datafile_name(self, timestamp: datetime):
         assert timestamp.tzinfo is None
-        return '{}/{}{}'.format(self.path, timestamp.isoformat(), FILE_EXT)
+        return '{}/{}'.format(self.path, timestamp.strftime(FILENAME_TS_FMT))
 
     def _clean_excess_disk_files(self):
         while len(self.disk_files) > self.disk_count:

--- a/packages/dcos-history/extra/test_history_service.py
+++ b/packages/dcos-history/extra/test_history_service.py
@@ -147,3 +147,14 @@ def test_add_headers(history_service):
     assert resp.headers['Authorization'] == 'test'
     # check that original headers are still there
     assert resp.headers['Access-Control-Max-Age'] == '86400'
+
+
+# Tests for malformed filenames, ref DCOS_OSS-2210
+def test_file_timestamp(monkeypatch, tmpdir):
+    round_ts = datetime(2018, 2, 28, 20, 17, 14, 0)
+    b = history.statebuffer.HistoryBuffer(60, 2, path=tmpdir.strpath)
+    qname = b._get_datafile_name(round_ts)
+    fname = qname.split('/')[-1]
+    parsed_time = datetime.strptime(fname, '%Y-%m-%dT%H:%M:%S.%f.state-summary.json')
+    assert parsed_time == round_ts
+

--- a/packages/dcos-history/extra/test_history_service.py
+++ b/packages/dcos-history/extra/test_history_service.py
@@ -157,4 +157,3 @@ def test_file_timestamp(monkeypatch, tmpdir):
     fname = qname.split('/')[-1]
     parsed_time = datetime.strptime(fname, '%Y-%m-%dT%H:%M:%S.%f.state-summary.json')
     assert parsed_time == round_ts
-


### PR DESCRIPTION
## High-level description

When the history service writes data to file, it adds a timestamp. At
exactly zero microseconds past the second, this timestamp was
malformed, and as a result the history service could not load it.

This PR ensures that in such cases the timestamp contains the
microsecond field.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2210](https://jira.mesosphere.com/browse/DCOS_OSS-2210) Incomplete timestamp can cause a crash-loop in the history service

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
