### PR TITLE
[1.11.0-GA] Don't bind dcos-dns on k8s cluster dns ip address

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -609,6 +609,12 @@ def validate_dns_bind_ip_blacklist(dns_bind_ip_blacklist):
     return validate_ip_list(dns_bind_ip_blacklist)
 
 
+def calculate_dns_bind_ip_blacklist_json(dns_bind_ip_blacklist, dns_bind_ip_reserved):
+    ips = validate_json_list(dns_bind_ip_blacklist)
+    reserved_ips = validate_json_list(dns_bind_ip_reserved)
+    return json.dumps(reserved_ips + ips)
+
+
 def validate_dns_forward_zones(dns_forward_zones):
     """
      "forward_zones": {"a.contoso.com": ["1.1.1.1:53", "2.2.2.2"],
@@ -971,6 +977,7 @@ entry = {
     'default': {
         'bootstrap_tmp_dir': 'tmp',
         'bootstrap_variant': lambda: calculate_environment_variable('BOOTSTRAP_VARIANT'),
+        'dns_bind_ip_reserved': '["198.51.100.4"]',
         'dns_bind_ip_blacklist': '[]',
         'dns_forward_zones': '{}',
         'use_proxy': 'false',
@@ -1076,6 +1083,7 @@ entry = {
         'fault_domain_enabled': 'false',
         'custom_auth': 'false',
         'master_quorum': lambda num_masters: str(floor(int(num_masters) / 2) + 1),
+        'dns_bind_ip_blacklist_json': calculate_dns_bind_ip_blacklist_json,
         'resolvers_str': calculate_resolvers_str,
         'dcos_image_commit': calulate_dcos_image_commit,
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -52,7 +52,7 @@ package:
         "bind_interface": "spartan",
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc_slave_public/dcos-dns.json
@@ -62,7 +62,7 @@ package:
         "bind_interface": "spartan",
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc_master/dcos-dns.json
@@ -76,7 +76,7 @@ package:
         "upstream_resolvers": {{ resolvers }},
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc/mesos-dns.env


### PR DESCRIPTION
## High-level description

dcos-net binds dns servers on all ip addresses on start. It works fine on clean node, but once k8s start coredns on 198.51.100.4, dcos-net tries to bind on this ip as well and crashes with eaddrinuse error. To fix it we have to add 198.51.100.4 ip address to the blacklist.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-21486](https://jira.mesosphere.com/browse/DCOS-21486) Don't bind dcos-dns on k8s cluster dns ip address

## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

https://github.com/mesosphere/dcos-kubernetes/pull/386/files#diff-965e73ab742e8a42e6874e28e5edda57R358

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).