### PR TITLE
Admin Router: Prevent reusing tcp sockets by AR's cache code [1.11]

### DIFF
--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -11,6 +11,7 @@ pylint==1.6.5
 pyroute2==0.4.21
 pytest-mccabe==0.1
 pytest-pythonpath==0.7.1
+pytest-repeat==0.4.1
 pytest-timeout==1.2.0
 pytest==3.2.1
 requests==2.18.4

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -59,7 +59,15 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {["User-Agent"] = "Master Admin Router"}
+    -- We need to make sure that Nginx does not reuse the TCP connection here,
+    -- as i.e. during failover it could result in fetching data from e.g. Mesos
+    -- master which already abdicated. On top of that we also need to force
+    -- re-resolving leader.mesos address which happens during the setup of the
+    -- new connection.
+    local headers = {
+        ["User-Agent"] = "Master Admin Router",
+        ["Connection"] = "close",
+        }
     if auth_token ~= nil then
         headers["Authorization"] = "token=" .. auth_token
     end

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
@@ -227,6 +227,8 @@ INITIAL_STATEJSON = {
 
 # pylint: disable=R0903
 class MesosHTTPRequestHandler(RecordingHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
     """A request hander class mimicking Mesos master daemon.
     """
     def _calculate_response(self, base_path, url_args, body_args=None):

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
@@ -44,7 +44,7 @@ class RecordingHTTPRequestHandler(BaseHTTPRequestHandler):
         msg_fmt = "[Endpoint `%s`] Request recorded: `%s`"
         log.debug(msg_fmt, ctx.data['endpoint_id'], res)
 
-    def _process_commands(self, blob):
+    def _process_commands(self, content_type, blob):
         """Process all the endpoint configuration and execute things that
            user requested.
 
@@ -66,7 +66,7 @@ class RecordingHTTPRequestHandler(BaseHTTPRequestHandler):
                 200, 'text/plain; charset=utf-8', ctx.data["encoded_response"])
             return True
 
-        return super()._process_commands(blob)
+        return super()._process_commands(content_type, blob)
 
 
 # pylint: disable=C0103


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/2511 to 1.11. Check it for more details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - DCOS-21451 `debug and fix for SOAK-68`

## Related PRs:
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2360
DC/OS Open, master branch PR: https://github.com/dcos/dcos/pull/2511
DC/OS EE, master branch PR: https://github.com/mesosphere/dcos-enterprise/pull/2331