### PR TITLE
Admin Router: Prevent reusing tcp sockets by AR's cache code [1.9]

### DIFF
--- a/packages/adminrouter/extra/src/master/cache.lua
+++ b/packages/adminrouter/extra/src/master/cache.lua
@@ -59,7 +59,14 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    -- We need to make sure that Nginx does not reuse the TCP connection here,
+    -- as i.e. during failover it could result in fetching data from e.g. Mesos
+    -- master which already abdicated. On top of that we also need to force
+    -- re-resolving leader.mesos address which happens during the setup of the
+    -- new connection.
+    local headers = {
+        ["Connection"] = "close",
+    }
     if auth_token ~= nil then
         headers = {["Authorization"] = "token=" .. auth_token}
     end


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/2511 to 1.9. Due to the fact that 1.9 is very old and it is impossible to port the test, I am making here only the functional change.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - DCOS-21451 `debug and fix for SOAK-68`

## Related PRs:
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2362
DC/OS Open, master branch PR: https://github.com/dcos/dcos/pull/2511
DC/OS EE, master branch PR: https://github.com/mesosphere/dcos-enterprise/pull/2331