### PR TITLE
Admin Router: Prevent reusing tcp sockets by AR's cache code [1.10]

### DIFF
--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -11,6 +11,7 @@ pylint==1.6.5
 pyroute2==0.4.11
 pytest-mccabe==0.1
 pytest-pythonpath==0.7.1
+pytest-repeat==0.4.1
 pytest-timeout==1.2.0
 pytest==3.0.4
 requests==2.13.0

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -59,9 +59,16 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    -- We need to make sure that Nginx does not reuse the TCP connection here,
+    -- as i.e. during failover it could result in fetching data from e.g. Mesos
+    -- master which already abdicated. On top of that we also need to force
+    -- re-resolving leader.mesos address which happens during the setup of the
+    -- new connection.
+    local headers = {
+        ["Connection"] = "close",
+        }
     if auth_token ~= nil then
-        headers = {["Authorization"] = "token=" .. auth_token}
+        headers["Authorization"] = "token=" .. auth_token
     end
 
     -- Use cosocket-based HTTP library, as ngx subrequests are not available

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/mesos.py
@@ -221,6 +221,8 @@ INITIAL_STATEJSON = {
 
 # pylint: disable=R0903
 class MesosHTTPRequestHandler(RecordingHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
     """A request hander class mimicking Mesos master daemon.
     """
     def _calculate_response(self, base_path, url_args, body_args=None):

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/recording.py
@@ -44,7 +44,7 @@ class RecordingHTTPRequestHandler(BaseHTTPRequestHandler):
         msg_fmt = "[Endpoint `%s`] Request recorded: `%s`"
         log.debug(msg_fmt, ctx.data['endpoint_id'], res)
 
-    def _process_commands(self, blob):
+    def _process_commands(self, content_type, blob):
         """Process all the endpoint configuration and execute things that
            user requested.
 
@@ -66,7 +66,7 @@ class RecordingHTTPRequestHandler(BaseHTTPRequestHandler):
                 200, 'text/plain; charset=utf-8', ctx.data["encoded_response"])
             return True
 
-        return super()._process_commands(blob)
+        return super()._process_commands(content_type, blob)
 
 
 # pylint: disable=C0103

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import time
 
+import pytest
 import requests
 
 from generic_test_code.common import ping_mesos_agent
@@ -755,6 +756,54 @@ class TestCache:
                 assert resp.status_code == 200
 
             assert lbf.extra_matches == {}
+
+    # This test can succed 40-50% number of times if we remove the fix. Hence
+    # we re-run it here 5 times.
+    @pytest.mark.parametrize('execution_number', range(5))
+    def test_if_mesos_leader_failover_is_followed_by_cache_http(
+            self,
+            nginx_class,
+            valid_user_header,
+            mocker,
+            dns_server_mock,
+            execution_number):
+        # Nginx resolver enforces 5s (grep for `resolver ... valid=Xs`), so it
+        # is VERY important to use cache pool period of >5s.
+        cache_poll_period = 6
+        ar = nginx_class(
+            cache_poll_period=cache_poll_period,
+            cache_expiration=cache_poll_period - 1,
+            upstream_mesos="http://leader.mesos:5050",
+            )
+
+        # Enable recording for Mesos mocks:
+        mocker.send_command(endpoint_id='http://127.0.0.2:5050',
+                            func_name='record_requests')
+        mocker.send_command(endpoint_id='http://127.0.0.3:5050',
+                            func_name='record_requests')
+        dns_server_mock.set_dns_entry('leader.mesos.', ip="127.0.0.2", ttl=2)
+        with GuardedSubprocess(ar):
+            # Force cache refresh early, so that we do not have to wait too
+            # long
+            ping_mesos_agent(ar,
+                             valid_user_header,
+                             agent_id=EXTRA_AGENT_DICT['id'],
+                             expect_status=404)
+
+            dns_server_mock.set_dns_entry('leader.mesos.', ip="127.0.0.3", ttl=2)
+
+            # First poll (2s) + normal poll interval(4s) < 2 * normal poll
+            # interval(4s)
+            time.sleep(cache_poll_period * 2)
+
+        mesosmock_pre_reqs = mocker.send_command(
+            endpoint_id='http://127.0.0.2:5050',
+            func_name='get_recorded_requests')
+        mesosmock_post_reqs = mocker.send_command(
+            endpoint_id='http://127.0.0.3:5050',
+            func_name='get_recorded_requests')
+        assert len(mesosmock_pre_reqs) == 1
+        assert len(mesosmock_post_reqs) == 1
 
 
 class TestCacheMesosLeader:


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/2511 to 1.10. Check it for more details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - DCOS-21451 `debug and fix for SOAK-68`

## Related PRs:
EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2361
DC/OS Open, master branch PR: https://github.com/dcos/dcos/pull/2511
DC/OS EE, master branch PR: https://github.com/mesosphere/dcos-enterprise/pull/2331