### PR TITLE
metronome 0.4.0 bump for DCOS 1.10.5+

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -1,10 +1,11 @@
 {
-  "requires": ["java", "exhibitor"],
-  "single_source": {
-    "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.4/metronome-0.3.4.tgz",
-    "sha1": "fe498617a5e0a6b78582527ef133ccc7e50577f8"
-  },
-  "username": "dcos_metronome",
-  "state_directory": true
+    "requires": ["java", "exhibitor"],
+    "single_source": {
+        "kind": "url_extract",
+        "url":
+            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.0/metronome-0.4.0.tgz",
+        "sha1": "b21f7d9e30d240954509b712128f89d468655e7c"
+    },
+    "username": "dcos_metronome",
+    "state_directory": true
 }


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-21523](https://jira.mesosphere.com/browse/DCOS-21523) Bump Metronome 0.4.0


## Related tickets (optional)

Other tickets related to this change:

- [METRONOME-190](https://jira.mesosphere.com/browse/METRONOME-190) Added authorized launch queue
- [METRONOME-194](https://jira.mesosphere.com/browse/METRONOME-194) Support FORBID Concurrency Policy

- [METRONOME-100](https://jira.mesosphere.com/browse/METRONOME-100) Metronome Restarts causes duplication of jobruns
- [METRONOME-191](https://jira.mesosphere.com/browse/METRONOME-191) Implement Start Deadline Timeout



## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [change log](https://github.com/dcos/metronome/compare/releases/0.3...1457e6)
  - [x] Test Results: [CI tests](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/35/consoleFull)
  - [ ] Code Coverage (if available): N/A
