### PR TITLE
Move Prometheus producer to port 61091

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -7,7 +7,6 @@ The following is a list of ports used by internal DC/OS services, and their corr
 ### TCP
 
  - 53: dcos-net (dns)
- - 9273: dcos-metrics
  - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)

--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -7,6 +7,7 @@ The following is a list of ports used by internal DC/OS services, and their corr
 ### TCP
 
  - 53: dcos-net (dns)
+ - 61091: dcos-metrics
  - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -461,7 +461,6 @@ function check_all() {
             "8123 mesos-dns" \
             "8181 exhibitor" \
             "9000 metronome" \
-            "9273 dcos-metrics" \
             "9942 metronome" \
             "9990 cosmos" \
             "15055 dcos-history" \

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -468,6 +468,7 @@ function check_all() {
             "41281 zookeeper" \
             "46839 metronome" \
             "61053 mesos-dns" \
+            "61091 dcos-metrics" \
             "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
@@ -480,6 +481,7 @@ function check_all() {
             "53 dcos-net" \
             "5051 mesos-agent" \
             "61001 agent-adminrouter" \
+            "61091 dcos-metrics" \
             "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -523,7 +523,7 @@ package:
 {% endswitch %}
   - path: /etc/mesos-slave
     content: |
-      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
+        MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1,6 +1,9 @@
 package:
   - path: /etc/dcos-metrics-config.yaml
     content: |
+      producers:
+        prometheus:
+          port: 61091
   - path: /etc/dcos-metrics.env
     content: |
       DCOS_METRICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-metrics-config.yaml

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -523,7 +523,7 @@ package:
 {% endswitch %}
   - path: /etc/mesos-slave
     content: |
-        MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
+      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -31,13 +31,13 @@ def test_metrics_masters_ping(dcos_api_session):
 
 def test_metrics_agents_prom(dcos_api_session):
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.session.request('GET', 'http://' + agent + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + agent + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
 def test_metrics_masters_prom(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.session.request('GET', 'http://' + master + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + master + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 


### PR DESCRIPTION
## High-level description

This PR moves the dcos-metrics Prometheus producer from port 9273 to port 61091. This avoids the need to update Mesos' reserved ports configuration. Altering Mesos resources in such a way causes various problems, one of which is the possibility of a port collision. 

Using a port which is not available to Mesos (any unoccupied port > 61000) avoids the need to update anything. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - [DCOS-21549](https://jira.mesosphere.com/browse/DCOS-21594) Unreserve port 9273 (prometheus metrics)
  - [DCOS-20072](https://jira.mesosphere.com/browse/DCOS-20072) Add explicit configuration for Prometheus producer in dcos-metrics

## Related tickets (optional)

Other tickets related to this change:

 - [DCOS-21545](https://jira.mesosphere.com/browse/DCOS-21545) Port 9273 is not reserved on public agents

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
