### PR TITLE
Admin Router: Support for custom 'Host' header and response status for generic tests

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -779,8 +779,9 @@ was developed.
 Tests shared by most of the endpoints are as follows:
 * `generic_no_slash_redirect_test` - test that a location without a trailing
   slash is redirected to one that ends with `/`.
-* `generic_response_headers_verify_test` - test that the response sent by AR is
-  correct, this mostly involves checking response headers.
+* `generic_verify_response_test` - test that the response sent by AR is
+  correct, this mostly involves checking response headers and the response
+  status code.
 * `generic_upstream_headers_verify_test` - test that the headers of the request
   sent by NGINX to the upstream is correct.
 * `generic_upstream_cookies_verify_test` - check if the cookies set in the
@@ -900,7 +901,7 @@ The syntax is as follows:
   subtest entry.
 * At the time of writing this text, the following subtests are supported:
   * `are_response_headers_ok`
-    * Calls `generic_response_headers_verify_test` generic test underneath.
+    * Calls `generic_verify_response_test` generic test underneath.
     * Tests if:
       * Response code is 200.
       * Depending on the value of `nocaching_headers_are_sent` parameter:

--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -842,7 +842,7 @@ Let's analyse a very simplified YAML configuration that covers only
 ```
 endpoint_tests:
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /exhibitor/foo/bar
@@ -900,7 +900,7 @@ The syntax is as follows:
 * Each subtest entry is a dictionary itself. There has to be at least one
   subtest entry.
 * At the time of writing this text, the following subtests are supported:
-  * `are_response_headers_ok`
+  * `is_response_correct`
     * Calls `generic_verify_response_test` generic test underneath.
     * Tests if:
       * Response code is 200.
@@ -1368,7 +1368,7 @@ Steps are as follows:
   are not cached. Test:
   ```
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /schmetterlingdb/stats/foo/bar
@@ -1517,7 +1517,7 @@ To sum up, our test configuration should look as follows:
     type:
       - master
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /schmetterlingdb/stats/foo/bar
@@ -1575,7 +1575,7 @@ which can be simplified into:
         test_paths:
           - /schmetterlingdb/stats/foo/bar
           - /schmetterlingdb/foo/bar
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /schmetterlingdb/stats/foo/bar

--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -903,7 +903,7 @@ The syntax is as follows:
   * `is_response_correct`
     * Calls `generic_verify_response_test` generic test underneath.
     * Tests if:
-      * Response code is 200.
+      * HTTP response code is equal to `expect_http_status`.
       * Depending on the value of `nocaching_headers_are_sent` parameter:
         * `true` - caching headers are present (`Cache-Control`, `Pragma`,
           `Expires`) and set to disable all caching.

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -67,7 +67,12 @@ def generic_no_slash_redirect_test(ar, path, code=301):
 
 
 def generic_verify_response_test(
-        ar, auth_header, path, assert_headers=None, assert_headers_absent=None):
+        ar,
+        auth_header,
+        path,
+        assert_headers=None,
+        assert_headers_absent=None,
+        assert_status=200):
     """Test if response sent by AR is correct
 
     Helper function meant to simplify writing multiple tests testing the
@@ -83,13 +88,14 @@ def generic_verify_response_test(
             asserted header name and value is expected value
         assert_headers_absent (dict): headers that *MUST NOT* be present in the
             upstream request
+        assert_status (int): http status of the response that is expected
     """
     url = ar.make_url_from_path(path)
     resp = requests.get(url,
                         allow_redirects=False,
                         headers=auth_header)
 
-    assert resp.status_code == 200
+    assert resp.status_code == assert_status
 
     if assert_headers is not None:
         for name, value in assert_headers.items():

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/common.py
@@ -66,7 +66,7 @@ def generic_no_slash_redirect_test(ar, path, code=301):
     assert r.headers['Location'] == url + '/'
 
 
-def generic_response_headers_verify_test(
+def generic_verify_response_test(
         ar, auth_header, path, assert_headers=None, assert_headers_absent=None):
     """Test if response sent by AR is correct
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -12,7 +12,7 @@ from generic_test_code.common import (
     generic_correct_upstream_request_test,
     generic_location_header_during_redirect_is_adjusted_test,
     generic_no_slash_redirect_test,
-    generic_response_headers_verify_test,
+    generic_verify_response_test,
     generic_upstream_cookies_verify_test,
     generic_upstream_headers_verify_test,
 )
@@ -525,7 +525,7 @@ class GenericTestMasterClass:
             headers_absent.append("Expires")
         # caching_headers_test == "skip", do nothing
 
-        generic_response_headers_verify_test(
+        generic_verify_response_test(
             master_ar_process_perclass,
             valid_user_header,
             path,
@@ -638,7 +638,7 @@ class GenericTestAgentClass:
             headers_absent.append("Expires")
         # caching_headers_test == "skip", do nothing
 
-        generic_response_headers_verify_test(
+        generic_verify_response_test(
             agent_ar_process_perclass,
             valid_user_header,
             path,

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -157,6 +157,9 @@ def _verify_is_response_correct(t_config):
     assert 'nocaching_headers_are_sent' in t_config
     assert t_config['nocaching_headers_are_sent'] in [True, False, 'skip']
 
+    assert 'expect_http_status' in t_config
+    assert 99 < t_config['expect_http_status'] < 600
+
     assert 'test_paths' in t_config
     for p in t_config['test_paths']:
         assert p.startswith('/')
@@ -288,7 +291,11 @@ def _testdata_to_is_response_correct(tests_config, node_type):
 
         h = x['tests']['is_response_correct']
 
-        res.extend([(x, h['nocaching_headers_are_sent']) for x in h['test_paths']])
+        res.extend([
+            (x,
+             h['nocaching_headers_are_sent'],
+             h['expect_http_status'],
+             ) for x in h['test_paths']])
 
     return res
 
@@ -417,7 +424,7 @@ def create_tests(metafunc, path):
 
     if 'caching_headers_test' in metafunc.fixturenames:
         args = _testdata_to_is_response_correct(tests_config, ar_type)
-        metafunc.parametrize("path,caching_headers_test", args)
+        metafunc.parametrize("path,caching_headers_test,expect_http_status", args)
         return
 
 
@@ -508,6 +515,7 @@ class GenericTestMasterClass:
             valid_user_header,
             path,
             caching_headers_test,
+            expect_http_status,
             ):
 
         headers_present = {}
@@ -531,6 +539,7 @@ class GenericTestMasterClass:
             path,
             assert_headers=headers_present,
             assert_headers_absent=headers_absent,
+            assert_status=expect_http_status,
             )
 
 
@@ -621,6 +630,7 @@ class GenericTestAgentClass:
             valid_user_header,
             path,
             caching_headers_test,
+            expect_http_status,
             ):
 
         headers_present = {}
@@ -644,4 +654,5 @@ class GenericTestAgentClass:
             path,
             assert_headers=headers_present,
             assert_headers_absent=headers_absent,
+            assert_status=expect_http_status,
             )

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -79,9 +79,9 @@ def _verify_endpoint_tests_conf(endpoint_tests):
         if 'are_upstream_req_headers_ok' in t['tests']:
             _verify_are_upstream_req_headers_ok(
                 t['tests']['are_upstream_req_headers_ok'])
-        if 'are_response_headers_ok' in t['tests']:
-            _verify_are_response_headers_ok(
-                t['tests']['are_response_headers_ok'])
+        if 'is_response_correct' in t['tests']:
+            _verify_is_response_correct(
+                t['tests']['is_response_correct'])
         if 'is_unauthed_access_permitted' in t['tests']:
             _verify_is_unauthed_access_permitted(
                 t['tests']['is_unauthed_access_permitted'])
@@ -153,7 +153,7 @@ def _verify_are_upstream_req_headers_ok(t_config):
         assert p.startswith('/')
 
 
-def _verify_are_response_headers_ok(t_config):
+def _verify_is_response_correct(t_config):
     assert 'nocaching_headers_are_sent' in t_config
     assert t_config['nocaching_headers_are_sent'] in [True, False, 'skip']
 
@@ -276,17 +276,17 @@ def _testdata_to_is_unauthed_access_permitted(tests_config, node_type):
     return res
 
 
-def _testdata_to_are_response_headers_ok(tests_config, node_type):
+def _testdata_to_is_response_correct(tests_config, node_type):
     res = []
 
     for x in tests_config['endpoint_tests']:
         if node_type not in x['type']:
             continue
 
-        if 'are_response_headers_ok' not in x['tests']:
+        if 'is_response_correct' not in x['tests']:
             continue
 
-        h = x['tests']['are_response_headers_ok']
+        h = x['tests']['is_response_correct']
 
         res.extend([(x, h['nocaching_headers_are_sent']) for x in h['test_paths']])
 
@@ -416,7 +416,7 @@ def create_tests(metafunc, path):
         return
 
     if 'caching_headers_test' in metafunc.fixturenames:
-        args = _testdata_to_are_response_headers_ok(tests_config, ar_type)
+        args = _testdata_to_is_response_correct(tests_config, ar_type)
         metafunc.parametrize("path,caching_headers_test", args)
         return
 

--- a/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/generic_test_code/generalised_tests.py
@@ -12,9 +12,9 @@ from generic_test_code.common import (
     generic_correct_upstream_request_test,
     generic_location_header_during_redirect_is_adjusted_test,
     generic_no_slash_redirect_test,
-    generic_verify_response_test,
     generic_upstream_cookies_verify_test,
     generic_upstream_headers_verify_test,
+    generic_verify_response_test,
 )
 
 log = logging.getLogger(__name__)
@@ -193,7 +193,7 @@ def _testdata_to_is_upstream_correct_testdata(tests_config, node_type):
         h = x['tests']['is_upstream_correct']
 
         for p in h['test_paths']:
-            e = (p, h['upstream'])
+            e = (p, h['upstream'], h.get("vhost", None))
             res.append(e)
 
     return res
@@ -212,7 +212,10 @@ def _testdata_to_is_upstream_req_ok_testdata(tests_config, node_type):
         h = x['tests']['is_upstream_req_ok']
 
         for p in h['test_paths']:
-            e = (p['sent'], p['expected'], h['expected_http_ver'])
+            e = (p['sent'],
+                 p['expected'],
+                 h['expected_http_ver'],
+                 h.get("vhost", None))
             res.append(e)
 
     return res
@@ -233,7 +236,8 @@ def _testdata_to_are_upstream_req_headers_ok_testdata(tests_config, node_type):
         for p in h['test_paths']:
             e = (p,
                  h['auth_token_is_forwarded'],
-                 h['skip_authcookie_filtering_test'])
+                 h['skip_authcookie_filtering_test'],
+                 h.get("vhost", None))
             res.append(e)
 
     return res
@@ -256,7 +260,8 @@ def _testdata_to_location_header_rewrite_testdata(tests_config, node_type):
                 (h['endpoint_id'],
                  h['basepath'],
                  l['location_set'],
-                 l['location_expected']),
+                 l['location_expected'],
+                 h.get("vhost", None)),
             )
 
     return res
@@ -274,7 +279,8 @@ def _testdata_to_is_unauthed_access_permitted(tests_config, node_type):
 
         h = x['tests']['is_unauthed_access_permitted']
 
-        res.extend(h['locations'])
+        for p in h['locations']:
+            res.append((p, h.get("vhost", None)))
 
     return res
 
@@ -295,7 +301,7 @@ def _testdata_to_is_response_correct(tests_config, node_type):
             (x,
              h['nocaching_headers_are_sent'],
              h['expect_http_status'],
-             ) for x in h['test_paths']])
+             h.get("vhost", None)) for x in h['test_paths']])
 
     return res
 
@@ -313,7 +319,7 @@ def _testdata_to_redirect_testdata(tests_config, node_type):
         h = x['tests']['is_endpoint_redirecting_properly']
 
         for l in h['locations']:
-            res.append((l['path'], l['code']))
+            res.append((l['path'], l['code'], h.get("vhost", None)))
 
     return res
 
@@ -321,7 +327,7 @@ def _testdata_to_redirect_testdata(tests_config, node_type):
 def _universal_test_if_upstream_headers_are_correct(
         self,
         ar_process,
-        valid_user_header,
+        req_headers,
         path,
         jwt_forwarded_test,
         skip_authcookie_filtering_test,
@@ -331,14 +337,14 @@ def _universal_test_if_upstream_headers_are_correct(
     headers_absent = []
 
     if jwt_forwarded_test is True:
-        headers_present.update(valid_user_header)
+        headers_present['Authorization'] = req_headers['Authorization']
     elif jwt_forwarded_test is False:
         headers_absent.append("Authorization")
     # jwt_forwarded_test == "skip", do nothing
 
     generic_upstream_headers_verify_test(
         ar_process,
-        valid_user_header,
+        req_headers,
         path,
         assert_headers=headers_present,
         assert_headers_absent=headers_absent,
@@ -351,7 +357,7 @@ def _universal_test_if_upstream_headers_are_correct(
     jar = {}
     # both dcos-* cookies should be removed by AR
     # the dcos-acs-auth-cookie cookie is simply the DC/OS authentication token:
-    jar['dcos-acs-auth-cookie'] = valid_user_header['Authorization']
+    jar['dcos-acs-auth-cookie'] = req_headers['Authorization']
     # the dcos-acs-info-cookie is a base64-encoded JSON-encoded dictionary
     # which contains `uid`, `descrption` and `is_remote` fields which relate to
     # the DC/OS authentication token from the `dcos-acs-auth-cookie` cookie.
@@ -364,7 +370,7 @@ def _universal_test_if_upstream_headers_are_correct(
     # should not be sent
     generic_upstream_cookies_verify_test(
         ar_process,
-        valid_user_header,
+        req_headers,
         path,
         cookies_to_send=jar,
         assert_cookies_absent=filtered_cookies,
@@ -376,7 +382,7 @@ def _universal_test_if_upstream_headers_are_correct(
     jar.update(cookies_present)
     generic_upstream_cookies_verify_test(
         ar_process,
-        valid_user_header,
+        req_headers,
         path,
         cookies_to_send=jar,
         assert_cookies_absent=filtered_cookies,
@@ -393,20 +399,23 @@ def create_tests(metafunc, path):
 
     if set(['path', 'expected_upstream']) <= set(metafunc.fixturenames):
         args = _testdata_to_is_upstream_correct_testdata(tests_config, ar_type)
-        metafunc.parametrize("path,expected_upstream", args)
+        metafunc.parametrize("path,expected_upstream,vhost", args)
         return
 
     if set(['path', 'jwt_forwarded_test']) <= set(metafunc.fixturenames):
         args = _testdata_to_are_upstream_req_headers_ok_testdata(tests_config, ar_type)
-        metafunc.parametrize("path,jwt_forwarded_test,skip_authcookie_filtering_test", args)
+        metafunc.parametrize(
+            "path,jwt_forwarded_test,skip_authcookie_filtering_test,vhost",
+            args)
         return
 
     if set(['path', 'upstream_path', 'http_ver']) <= set(metafunc.fixturenames):
         args = _testdata_to_is_upstream_req_ok_testdata(tests_config, ar_type)
-        metafunc.parametrize("path,upstream_path,http_ver", args)
+        metafunc.parametrize("path,upstream_path,http_ver,vhost", args)
         return
 
-    f_names = ['endpoint_id', 'basepath', 'location_set', 'location_expected']
+    f_names = [
+        'endpoint_id', 'basepath', 'location_set', 'location_expected', 'vhost']
     if set(f_names) <= set(metafunc.fixturenames):
         args = _testdata_to_location_header_rewrite_testdata(tests_config, ar_type)
         metafunc.parametrize(','.join(f_names), args)
@@ -414,17 +423,18 @@ def create_tests(metafunc, path):
 
     if 'redirect_path' in metafunc.fixturenames:
         args = _testdata_to_redirect_testdata(tests_config, ar_type)
-        metafunc.parametrize("redirect_path, code", args)
+        metafunc.parametrize("redirect_path,code,vhost", args)
         return
 
     if 'unauthed_path' in metafunc.fixturenames:
         args = _testdata_to_is_unauthed_access_permitted(tests_config, ar_type)
-        metafunc.parametrize("unauthed_path", args)
+        metafunc.parametrize("unauthed_path,vhost", args)
         return
 
     if 'caching_headers_test' in metafunc.fixturenames:
         args = _testdata_to_is_response_correct(tests_config, ar_type)
-        metafunc.parametrize("path,caching_headers_test,expect_http_status", args)
+        metafunc.parametrize(
+            "path,caching_headers_test,expect_http_status,vhost", args)
         return
 
 
@@ -434,11 +444,16 @@ class GenericTestMasterClass:
             master_ar_process_perclass,
             valid_user_header,
             path,
-            expected_upstream):
+            expected_upstream,
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_correct_upstream_dest_test(
             master_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             expected_upstream,
             )
@@ -450,12 +465,16 @@ class GenericTestMasterClass:
             path,
             jwt_forwarded_test,
             skip_authcookie_filtering_test,
-            ):
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         _universal_test_if_upstream_headers_are_correct(
             self,
             master_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             jwt_forwarded_test,
             skip_authcookie_filtering_test,
@@ -467,11 +486,16 @@ class GenericTestMasterClass:
             valid_user_header,
             path,
             upstream_path,
-            http_ver):
+            http_ver,
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_correct_upstream_request_test(
             master_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             upstream_path,
             http_ver,
@@ -486,12 +510,16 @@ class GenericTestMasterClass:
             basepath,
             location_set,
             location_expected,
-            ):
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_location_header_during_redirect_is_adjusted_test(
             master_ar_process_perclass,
             mocker,
-            valid_user_header,
+            req_headers,
             endpoint_id,
             basepath,
             location_set,
@@ -499,15 +527,33 @@ class GenericTestMasterClass:
             )
 
     def test_redirect_req_without_slash(
-            self, master_ar_process_perclass, redirect_path, code):
+            self, master_ar_process_perclass, redirect_path, code, vhost):
+
+        if vhost is not None:
+            req_headers = {"Host": vhost}
+        else:
+            req_headers = {}
+
         generic_no_slash_redirect_test(
             master_ar_process_perclass,
             redirect_path,
-            code)
+            code,
+            headers=req_headers,
+            )
 
     def test_if_unauthn_user_is_granted_access(
-            self, master_ar_process_perclass, unauthed_path):
-        assert_endpoint_response(master_ar_process_perclass, unauthed_path, 200)
+            self, master_ar_process_perclass, unauthed_path, vhost):
+
+        if vhost is not None:
+            req_headers = {"Host": vhost}
+        else:
+            req_headers = {}
+
+        assert_endpoint_response(
+            master_ar_process_perclass,
+            unauthed_path,
+            200,
+            headers=req_headers)
 
     def test_if_resp_headers_are_correct(
             self,
@@ -516,7 +562,7 @@ class GenericTestMasterClass:
             path,
             caching_headers_test,
             expect_http_status,
-            ):
+            vhost):
 
         headers_present = {}
         headers_absent = []
@@ -533,9 +579,13 @@ class GenericTestMasterClass:
             headers_absent.append("Expires")
         # caching_headers_test == "skip", do nothing
 
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
+
         generic_verify_response_test(
             master_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             assert_headers=headers_present,
             assert_headers_absent=headers_absent,
@@ -549,11 +599,16 @@ class GenericTestAgentClass:
             agent_ar_process_perclass,
             valid_user_header,
             path,
-            expected_upstream):
+            expected_upstream,
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_correct_upstream_dest_test(
             agent_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             expected_upstream,
             )
@@ -565,12 +620,16 @@ class GenericTestAgentClass:
             path,
             jwt_forwarded_test,
             skip_authcookie_filtering_test,
-            ):
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         _universal_test_if_upstream_headers_are_correct(
             self,
             agent_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             jwt_forwarded_test,
             skip_authcookie_filtering_test=skip_authcookie_filtering_test,
@@ -582,11 +641,16 @@ class GenericTestAgentClass:
             valid_user_header,
             path,
             upstream_path,
-            http_ver):
+            http_ver,
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_correct_upstream_request_test(
             agent_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             upstream_path,
             http_ver,
@@ -601,12 +665,16 @@ class GenericTestAgentClass:
             basepath,
             location_set,
             location_expected,
-            ):
+            vhost):
+
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
 
         generic_location_header_during_redirect_is_adjusted_test(
             agent_ar_process_perclass,
             mocker,
-            valid_user_header,
+            req_headers,
             endpoint_id,
             basepath,
             location_set,
@@ -614,15 +682,32 @@ class GenericTestAgentClass:
             )
 
     def test_redirect_req_without_slash(
-            self, agent_ar_process_perclass, redirect_path, code):
+            self, agent_ar_process_perclass, redirect_path, code, vhost):
+
+        if vhost is not None:
+            req_headers = {"Host": vhost}
+        else:
+            req_headers = {}
+
         generic_no_slash_redirect_test(
             agent_ar_process_perclass,
             redirect_path,
-            code)
+            code,
+            headers=req_headers)
 
     def test_if_unauthn_user_is_granted_access(
-            self, agent_ar_process_perclass, unauthed_path):
-        assert_endpoint_response(agent_ar_process_perclass, unauthed_path, 200)
+            self, agent_ar_process_perclass, unauthed_path, vhost):
+
+        if vhost is not None:
+            req_headers = {"Host": vhost}
+        else:
+            req_headers = {}
+
+        assert_endpoint_response(
+            agent_ar_process_perclass,
+            unauthed_path,
+            200,
+            headers=req_headers)
 
     def test_if_resp_headers_are_correct(
             self,
@@ -631,7 +716,7 @@ class GenericTestAgentClass:
             path,
             caching_headers_test,
             expect_http_status,
-            ):
+            vhost):
 
         headers_present = {}
         headers_absent = []
@@ -648,9 +733,13 @@ class GenericTestAgentClass:
             headers_absent.append("Expires")
         # caching_headers_test == "skip", do nothing
 
+        req_headers = copy.deepcopy(valid_user_header)
+        if vhost is not None:
+            req_headers["Host"] = vhost
+
         generic_verify_response_test(
             agent_ar_process_perclass,
-            valid_user_header,
+            req_headers,
             path,
             assert_headers=headers_present,
             assert_headers_absent=headers_absent,

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -42,7 +42,7 @@ endpoint_tests:
       - master
 ######### /dcos-metadata/ui-config.json
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-metadata/ui-config.json

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_generic.config.yml
@@ -43,6 +43,7 @@ endpoint_tests:
 ######### /dcos-metadata/ui-config.json
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-metadata/ui-config.json

--- a/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_agent.py
@@ -3,7 +3,7 @@
 import pytest
 import requests
 
-from generic_test_code.common import generic_response_headers_verify_test
+from generic_test_code.common import generic_verify_response_test
 
 
 class TestLogsEndpoint:
@@ -21,7 +21,7 @@ class TestLogsEndpoint:
             aux_data=accel_buff_header,
         )
 
-        generic_response_headers_verify_test(
+        generic_verify_response_test(
             agent_ar_process,
             valid_user_header,
             '/system/v1/logs/foo/bar',

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -2,6 +2,7 @@ endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /exhibitor/foo/bar
@@ -42,6 +43,7 @@ endpoint_tests:
 ######### /service endpoint
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
@@ -202,6 +204,7 @@ endpoint_tests:
 ######### /agent endpoint
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
@@ -258,6 +261,7 @@ endpoint_tests:
       - master
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/health/v1/foo/bar
@@ -279,6 +283,7 @@ endpoint_tests:
 # Agent A
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
@@ -357,6 +362,7 @@ endpoint_tests:
 ######### /system/v1/leader endpoint
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
@@ -413,6 +419,7 @@ endpoint_tests:
       - master
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/logs/foo/bar
@@ -439,6 +446,7 @@ endpoint_tests:
 ######### /cosmos/service
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /cosmos/service/foo/bar
@@ -465,6 +473,7 @@ endpoint_tests:
 ######### /capabilities
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /capabilities
@@ -488,6 +497,7 @@ endpoint_tests:
 ######### /acs/api/v1/
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: true
         test_paths:
           - /acs/api/v1/reflect/me
@@ -511,6 +521,7 @@ endpoint_tests:
 ######### /package
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /package/foo/bar
@@ -536,6 +547,7 @@ endpoint_tests:
 ######### /navstar/lashup/key
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /navstar/lashup/key
@@ -559,6 +571,7 @@ endpoint_tests:
 ######### /dcos-history-service/foo/bar
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-history-service/foo/bar
@@ -582,6 +595,7 @@ endpoint_tests:
 ######### /mesos_dns
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /mesos_dns/v1/reflect/me
@@ -609,6 +623,7 @@ endpoint_tests:
 ######### /mesos
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /mesos/reflect/me
@@ -636,6 +651,7 @@ endpoint_tests:
 ######### /pkgpanda
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /pkgpanda/foo/bar
@@ -683,6 +699,7 @@ endpoint_tests:
 ######### /pkgpanda/active.buildinfo.full.json
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: true
         test_paths:
           - /pkgpanda/active.buildinfo.full.json
@@ -690,6 +707,7 @@ endpoint_tests:
       - master
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-metadata/dcos-version.json
@@ -703,6 +721,7 @@ endpoint_tests:
 ######### /system/v1/metrics endpoint
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/metrics/foo/bar
@@ -749,6 +768,7 @@ endpoint_tests:
 ######### /marathon
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /marathon/v2/reflect/me
@@ -780,6 +800,7 @@ endpoint_tests:
 ######### /service/metronome
   - tests:
       is_response_correct:
+        expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
           - /service/metronome/v2/reflect/me

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -1,7 +1,7 @@
 endpoint_tests:
 ######### /exhibitor endpoint
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /exhibitor/foo/bar
@@ -41,7 +41,7 @@ endpoint_tests:
 
 ######### /service endpoint
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /service/scheduler-alwaysthere/foo/bar
@@ -201,7 +201,7 @@ endpoint_tests:
 
 ######### /agent endpoint
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/foo/bar
@@ -257,7 +257,7 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/health/v1/foo/bar
@@ -278,7 +278,7 @@ endpoint_tests:
 ######### /system/v1/agent/ endpoint
 # Agent A
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs/foo/bar?key=value&var=num
@@ -356,7 +356,7 @@ endpoint_tests:
 
 ######### /system/v1/leader endpoint
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/leader/mesos/foo/bar?key=value&var=num
@@ -412,7 +412,7 @@ endpoint_tests:
     type:
       - master
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/logs/foo/bar
@@ -438,7 +438,7 @@ endpoint_tests:
 
 ######### /cosmos/service
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /cosmos/service/foo/bar
@@ -464,7 +464,7 @@ endpoint_tests:
 
 ######### /capabilities
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /capabilities
@@ -487,7 +487,7 @@ endpoint_tests:
 
 ######### /acs/api/v1/
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /acs/api/v1/reflect/me
@@ -510,7 +510,7 @@ endpoint_tests:
 
 ######### /package
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /package/foo/bar
@@ -535,7 +535,7 @@ endpoint_tests:
 
 ######### /navstar/lashup/key
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /navstar/lashup/key
@@ -558,7 +558,7 @@ endpoint_tests:
 
 ######### /dcos-history-service/foo/bar
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-history-service/foo/bar
@@ -581,7 +581,7 @@ endpoint_tests:
 
 ######### /mesos_dns
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /mesos_dns/v1/reflect/me
@@ -608,7 +608,7 @@ endpoint_tests:
 
 ######### /mesos
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /mesos/reflect/me
@@ -635,7 +635,7 @@ endpoint_tests:
 
 ######### /pkgpanda
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /pkgpanda/foo/bar
@@ -682,14 +682,14 @@ endpoint_tests:
 
 ######### /pkgpanda/active.buildinfo.full.json
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: true
         test_paths:
           - /pkgpanda/active.buildinfo.full.json
     type:
       - master
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /dcos-metadata/dcos-version.json
@@ -702,7 +702,7 @@ endpoint_tests:
 
 ######### /system/v1/metrics endpoint
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /system/v1/metrics/foo/bar
@@ -748,7 +748,7 @@ endpoint_tests:
       - master
 ######### /marathon
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /marathon/v2/reflect/me
@@ -779,7 +779,7 @@ endpoint_tests:
 ######### This is a special case of a service behind /service endpoint:
 ######### /service/metronome
   - tests:
-      are_response_headers_ok:
+      is_response_correct:
         nocaching_headers_are_sent: skip
         test_paths:
           - /service/metronome/v2/reflect/me

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -11,7 +11,7 @@ import requests
 from generic_test_code.common import (
     generic_correct_upstream_dest_test,
     generic_correct_upstream_request_test,
-    generic_response_headers_verify_test,
+    generic_verify_response_test,
     generic_upstream_headers_verify_test,
     overridden_file_content,
     verify_header,
@@ -360,7 +360,7 @@ class TestMisc:
             aux_data=accel_buff_header,
         )
 
-        generic_response_headers_verify_test(master_ar_process_perclass,
+        generic_verify_response_test(master_ar_process_perclass,
                                              valid_user_header,
                                              '/system/v1/logs/foo/bar',
                                              assert_headers=accel_buff_header,

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -11,8 +11,8 @@ import requests
 from generic_test_code.common import (
     generic_correct_upstream_dest_test,
     generic_correct_upstream_request_test,
-    generic_verify_response_test,
     generic_upstream_headers_verify_test,
+    generic_verify_response_test,
     overridden_file_content,
     verify_header,
 )
@@ -360,8 +360,8 @@ class TestMisc:
             aux_data=accel_buff_header,
         )
 
-        generic_verify_response_test(master_ar_process_perclass,
-                                             valid_user_header,
-                                             '/system/v1/logs/foo/bar',
-                                             assert_headers=accel_buff_header,
-                                             )
+        generic_verify_response_test(
+            master_ar_process_perclass,
+            valid_user_header,
+            '/system/v1/logs/foo/bar',
+            assert_headers=accel_buff_header)


### PR DESCRIPTION
## High-level description

This PR prepares AR test harness for tests needed by the private registry feature [1][2].  This includes:
* some naming changes for response tests, now that they are also capable of testing custom HTTP response status
* make is_response_correct generic test customizable wrt. response status
* make all generic tests accept a parameter defining the "Host" header that is to be sent to the tested AR

[1] https://github.com/mesosphere/dcos-enterprise/pull/1807
[2] https://jira.mesosphere.com/browse/DCOS-2799

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - DCOS-21456 `Admin Router: Add missing AR tests for the registry service`

## Related tickets (optional)

Other tickets related to this change:

  - DCOS-2799 `Package Registry` - linking to the epic, as there are lots of issues there that this PR relates to

## Related PRs
DC/OS EE: https://github.com/mesosphere/dcos-enterprise/pull/2398
registry PR: https://github.com/mesosphere/dcos-enterprise/pull/1807
registry PR tests: 