### PR TITLE
marathon bump to 1.6.352

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.322-2bf46b341/marathon-1.6.348-e45e6e08d.tgz",
-    "sha1": "78a6f09d17662e5f20a043f5c480b04db0275294"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.352-044939181/marathon-1.6.352-044939181.tgz",
+    "sha1": "2c9e0136a3bc59c8f243230efc96c2c653500d0b"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8088](https://jira.mesosphere.com/browse/MARATHON-8088) Implement gpu_scheduling_behavior parameter and basic functionality.
  - [MARATHON-8089](https://jira.mesosphere.com/browse/MARATHON-8089) Application specific override for GPU scheduling behavior
  - [MARATHON-8112](https://jira.mesosphere.com/browse/MARATHON-8112) Open the persistence store before taking a backup using CLI


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review):  [changelog](https://github.com/mesosphere/marathon/compare/315f7a9365a9393335c3dae224900937c4c3d8cd...0449391819f28173833b5618b31b91d62ee1bbeb)
  - [x] Test Results: [CI Build](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/734/consoleFull)
  - [ ] Code Coverage (if available): [link to code coverage report]