### PR TITLE
Integration Train for 1.11.0-GA - 2018-03-05

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -7,6 +7,7 @@ The following is a list of ports used by internal DC/OS services, and their corr
 ### TCP
 
  - 53: dcos-net (dns)
+ - 61091: dcos-metrics
  - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -460,7 +460,6 @@ function check_all() {
             "8123 mesos-dns" \
             "8181 exhibitor" \
             "9000 metronome" \
-            "9273 dcos-metrics" \
             "9942 metronome" \
             "9990 cosmos" \
             "15055 dcos-history" \
@@ -468,6 +467,7 @@ function check_all() {
             "41281 zookeeper" \
             "46839 metronome" \
             "61053 mesos-dns" \
+            "61091 dcos-metrics" \
             "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
@@ -480,6 +480,7 @@ function check_all() {
             "53 dcos-net" \
             "5051 mesos-agent" \
             "61001 agent-adminrouter" \
+            "61091 dcos-metrics" \
             "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -349,6 +349,24 @@ def validate_dcos_overlay_network(dcos_overlay_network):
                     " Only IPv6 values are allowed".format(overlay_network['subnet6'])) from ex
 
 
+def calculate_dcos_overlay_network_json(dcos_overlay_network, enable_ipv6):
+    if enable_ipv6 == 'true':
+        return dcos_overlay_network
+    if dcos_overlay_network == entry['default']['dcos_overlay_network']:
+        # Remove ipv6 overlays from default overlay networks
+        overlay_network = json.loads(dcos_overlay_network)
+        del overlay_network['vtep_subnet6']
+        overlay_network['overlays'] = \
+            [o for o in overlay_network['overlays'] if 'subnet' in o]
+        return json.dumps(overlay_network)
+    else:
+        overlay_network = json.loads(dcos_overlay_network)
+        overlays = overlay_network['overlays']
+        assert [o['name'] for o in overlays if 'subnet6' in o] == [], \
+            "ipv6 is disabled, only ipv4 networks are allowed"
+        return dcos_overlay_network
+
+
 def validate_num_masters(num_masters):
     assert int(num_masters) in [1, 3, 5, 7, 9], "Must have 1, 3, 5, 7, or 9 masters. Found {}".format(num_masters)
 
@@ -513,6 +531,13 @@ def validate_dcos_l4lb_min_named_ip6(dcos_l4lb_min_named_ip6):
 
 def validate_dcos_l4lb_max_named_ip6(dcos_l4lb_max_named_ip6):
     validate_ipv6_addresses([dcos_l4lb_max_named_ip6])
+
+
+def validate_dcos_l4lb_enable_ipv6(dcos_l4lb_enable_ipv6, enable_ipv6):
+    validate_true_false(dcos_l4lb_enable_ipv6)
+    if enable_ipv6 == 'false':
+        assert dcos_l4lb_enable_ipv6 == 'false', "When enable_ipv6 is false, " \
+            "dcos_l4lb_enable_ipv6 must be false as well"
 
 
 def calculate_docker_credentials_dcos_owned(cluster_docker_credentials):
@@ -944,7 +969,7 @@ entry = {
         validate_dcos_l4lb_max_named_ip,
         validate_dcos_l4lb_min_named_ip6,
         validate_dcos_l4lb_max_named_ip6,
-        lambda dcos_l4lb_enable_ipv6: validate_true_false(dcos_l4lb_enable_ipv6),
+        validate_dcos_l4lb_enable_ipv6,
         lambda cluster_docker_credentials_dcos_owned: validate_true_false(cluster_docker_credentials_dcos_owned),
         lambda cluster_docker_credentials_enabled: validate_true_false(cluster_docker_credentials_enabled),
         lambda cluster_docker_credentials_write_to_etc: validate_true_false(cluster_docker_credentials_write_to_etc),
@@ -953,6 +978,7 @@ entry = {
         validate_exhibitor_storage_master_discovery,
         lambda exhibitor_admin_password_enabled: validate_true_false(exhibitor_admin_password_enabled),
         lambda enable_lb: validate_true_false(enable_lb),
+        lambda enable_ipv6: validate_true_false(enable_ipv6),
         lambda adminrouter_tls_1_0_enabled: validate_true_false(adminrouter_tls_1_0_enabled),
         lambda adminrouter_tls_1_1_enabled: validate_true_false(adminrouter_tls_1_1_enabled),
         lambda adminrouter_tls_1_2_enabled: validate_true_false(adminrouter_tls_1_2_enabled),
@@ -985,6 +1011,7 @@ entry = {
         'telemetry_enabled': 'true',
         'check_time': 'true',
         'enable_lb': 'true',
+        'enable_ipv6': 'true',
         'docker_remove_delay': '1hrs',
         'docker_stop_timeout': '20secs',
         'gc_delay': '2days',
@@ -1100,6 +1127,7 @@ entry = {
         'dcos_l4lb_max_named_ip_erltuple': calculate_dcos_l4lb_max_named_ip_erltuple,
         'dcos_l4lb_min_named_ip6_erltuple': calculate_dcos_l4lb_min_named_ip6_erltuple,
         'dcos_l4lb_max_named_ip6_erltuple': calculate_dcos_l4lb_max_named_ip6_erltuple,
+        'dcos_overlay_network_json': calculate_dcos_overlay_network_json,
         'mesos_isolation': calculate_mesos_isolation,
         'has_mesos_max_completed_tasks_per_framework': calculate_has_mesos_max_completed_tasks_per_framework,
         'mesos_hooks': calculate_mesos_hooks,

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -634,6 +634,12 @@ def validate_dns_bind_ip_blacklist(dns_bind_ip_blacklist):
     return validate_ip_list(dns_bind_ip_blacklist)
 
 
+def calculate_dns_bind_ip_blacklist_json(dns_bind_ip_blacklist, dns_bind_ip_reserved):
+    ips = validate_json_list(dns_bind_ip_blacklist)
+    reserved_ips = validate_json_list(dns_bind_ip_reserved)
+    return json.dumps(reserved_ips + ips)
+
+
 def validate_dns_forward_zones(dns_forward_zones):
     """
      "forward_zones": {"a.contoso.com": ["1.1.1.1:53", "2.2.2.2"],
@@ -997,6 +1003,7 @@ entry = {
     'default': {
         'bootstrap_tmp_dir': 'tmp',
         'bootstrap_variant': lambda: calculate_environment_variable('BOOTSTRAP_VARIANT'),
+        'dns_bind_ip_reserved': '["198.51.100.4"]',
         'dns_bind_ip_blacklist': '[]',
         'dns_forward_zones': '{}',
         'use_proxy': 'false',
@@ -1103,6 +1110,7 @@ entry = {
         'fault_domain_enabled': 'false',
         'custom_auth': 'false',
         'master_quorum': lambda num_masters: str(floor(int(num_masters) / 2) + 1),
+        'dns_bind_ip_blacklist_json': calculate_dns_bind_ip_blacklist_json,
         'resolvers_str': calculate_resolvers_str,
         'dcos_image_commit': calulate_dcos_image_commit,
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -52,7 +52,7 @@ package:
         "bind_interface": "spartan",
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc_slave_public/dcos-dns.json
@@ -62,7 +62,7 @@ package:
         "bind_interface": "spartan",
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc_master/dcos-dns.json
@@ -76,7 +76,7 @@ package:
         "upstream_resolvers": {{ resolvers }},
         "udp_port": 53,
         "tcp_port": 53,
-        "bind_ip_blacklist": {{ dns_bind_ip_blacklist }},
+        "bind_ip_blacklist": {{ dns_bind_ip_blacklist_json }},
         "forward_zones": {{ dns_forward_zones }}
       }
   - path: /etc/mesos-dns.env

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -97,9 +97,10 @@ package:
         "IPSources": {{ mesos_dns_ip_sources }},
         "SetTruncateBit": {{ mesos_dns_set_truncate_bit }}
       }
-  - path: /etc/dcos-net-watchdog
+  - path: /etc/dcos_net
     content: |
       DCOS_NET_WATCHDOG={{ dcos_net_watchdog }}
+      DCOS_NET_IPV6={{ enable_ipv6 }}
   - path: /etc_master/dcos-net.config.d/master.config
     content: |
       [
@@ -153,7 +154,7 @@ package:
     content: |
       {
         "replicated_log_dir":"/var/lib/dcos/mesos/master/",
-        "network": {{ dcos_overlay_network }}
+        "network": {{ dcos_overlay_network_json }}
        }
   - path: /etc/dcos/network/cni/ucr-default-bridge.conf
     content: |
@@ -384,8 +385,13 @@ package:
               "network_mode": "USER",
               "dns": {
                 "nameservers": [
+{% switch enable_ipv6 %}
+{% case "true" %}
                                 "198.51.100.1",
                                 "fd01:d::c633:6401"
+{% case "false" %}
+                                "198.51.100.1"
+{% endswitch %}
                 ]
               }
             }

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1,6 +1,9 @@
 package:
   - path: /etc/dcos-metrics-config.yaml
     content: |
+      producers:
+        prometheus:
+          port: 61091
   - path: /etc/dcos-metrics.env
     content: |
       DCOS_METRICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-metrics-config.yaml
@@ -521,7 +524,7 @@ package:
 {% endswitch %}
   - path: /etc/mesos-slave
     content: |
-      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 9272},{"begin": 9274, "end": 32000}]}}]
+      MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1025, "end": 2180},{"begin": 2182, "end": 3887},{"begin": 3889, "end": 5049},{"begin": 5052, "end": 8079},{"begin": 8082, "end": 8180},{"begin": 8182, "end": 32000}]}}]
   - path: /etc/mesos-slave-public
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -28,13 +28,13 @@ def test_metrics_masters_ping(dcos_api_session):
 
 def test_metrics_agents_prom(dcos_api_session):
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.session.request('GET', 'http://' + agent + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + agent + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
 def test_metrics_masters_prom(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.session.request('GET', 'http://' + master + ':9273/metrics')
+        response = dcos_api_session.session.request('GET', 'http://' + master + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 

--- a/packages/dcos-net/extra/dcos-net-setup.py
+++ b/packages/dcos-net/extra/dcos-net-setup.py
@@ -13,6 +13,7 @@ Also the script prevents from duplicating iptables rules [3]
 [3] ExecStartPre=/path/dcos-net-setup.py iptables --wait -A FORWARD -j ACCEPT
 """
 
+import os
 import subprocess
 import sys
 
@@ -30,6 +31,12 @@ def main():
         if result.returncode != 0:
             # if it doesn't exist append or insert that rules
             result = subprocess.run(sys.argv[1:])
+    elif sys.argv[1] == '--ipv6':
+        if os.getenv('DCOS_NET_IPV6', 'true') == 'false':
+            sys.exit(0)
+        else:
+            del sys.argv[1]
+            result = subprocess.run(sys.argv)
     else:
         result = subprocess.run(sys.argv[1:])
     sys.exit(result.returncode)

--- a/packages/dcos-net/extra/dcos-net-watchdog.service
+++ b/packages/dcos-net/extra/dcos-net-watchdog.service
@@ -6,6 +6,6 @@ Restart=always
 StartLimitInterval=0
 RestartSec=15
 EnvironmentFile=/opt/mesosphere/environment
-EnvironmentFile=/opt/mesosphere/etc/dcos-net-watchdog
+EnvironmentFile=/opt/mesosphere/etc/dcos_net
 Environment=HOME=/opt/mesosphere
 ExecStart=/opt/mesosphere/active/dcos-net/bin/dcos-net-watchdog.py

--- a/packages/dcos-net/extra/dcos-net.service
+++ b/packages/dcos-net/extra/dcos-net.service
@@ -10,6 +10,7 @@ LimitNOFILE=16384
 WorkingDirectory=${PKG_PATH}/dcos-net
 EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=/opt/mesosphere/etc/dcos_net
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=-/opt/mesosphere/etc/dns_config_master
 Environment=HOME=/opt/mesosphere
@@ -24,10 +25,10 @@ ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip l
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link set minuteman up
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link add spartan type dummy
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link set spartan up
-ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py sysctl -w net.ipv6.conf.spartan.disable_ipv6=0
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip addr add 198.51.100.1/32 dev spartan
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip addr add 198.51.100.2/32 dev spartan
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip addr add 198.51.100.3/32 dev spartan
-ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip -6 addr add fd01:d::c633:6401/128 dev spartan
+ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py --ipv6 sysctl -w net.ipv6.conf.spartan.disable_ipv6=0
+ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py --ipv6 ip -6 addr add fd01:d::c633:6401/128 dev spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-net
 ExecStart=/opt/mesosphere/bin/dcos-net-env foreground


### PR DESCRIPTION
## High-level description

* [1.11.0-GA] dcos-net not starting if IPv6 is disabled  #2530 
* [1.11.0-GA] Don't bind dcos-dns on k8s cluster dns ip address #2533
* [1.11.0-GA] Move Prometheus producer to port 61091  #2567
