### PR TITLE
Bumped mesos SHA to include the fix for docker daemon hanging issue.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "bd983e54c7d941db4a67c1d5659a60014b3fec71",
-    "ref_origin" : "dcos-mesos-post-1.2.3"
+    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
+    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description

This PR incorporates Mesos bug fixes and improvements.


## Related tickets

Other tickets related to this change:

  - [MESOS-8488](https://issues.apache.org/jira/browse/MESOS-8488) Docker bug can cause unkillable tasks.
  - [MESOS-8574](https://issues.apache.org/jira/browse/MESOS-8574) Docker executor makes no progress when 'docker inspect' hangs.
  - [MESOS-8575](https://issues.apache.org/jira/browse/MESOS-8575) Improve discard handling for 'Docker::stop' and 'Docker::pull'.
  - [MESOS-8576](https://issues.apache.org/jira/browse/MESOS-8576) Improve discard handling of 'Docker::inspect()'.
  - [MESOS-8605](https://issues.apache.org/jira/browse/MESOS-8605) Terminal task status update will not send if 'docker inspect' is hung.


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Mesos integration tests validate these changes
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/bd983e54c7d941db4a67c1d5659a60014b3fec71...05ba66b1ea2d00f3d784ac732f95f237dff652a8)
  - [x] Test Results: [Mesos CI results](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/2972/)
  - [ ] Code Coverage (if available): [link to code coverage report]