### PR TITLE
Fixed broken link for Azure & AWS documentation.

### DIFF
--- a/gen/aws/templates/aws.html
+++ b/gen/aws/templates/aws.html
@@ -6,7 +6,7 @@
 <body>
 <h1>DC/OS {{ build_name }} AWS CloudFormation</h1>
 <ul>
-  <li>For more information on creating a DC/OS cluster, see the <a href='https://dcos.io/docs/latest/administration/installing/cloud/aws/'>DC/OS AWS documentation</a>.</li>
+  <li>For more information on creating a DC/OS cluster, see the <a href='https://docs.mesosphere.com/1.11/installing/oss/cloud/aws/'>DC/OS AWS documentation</a>.</li>
 </ul>
 <table>
 <tr><th>Region Name</th><th>Region Code</th>

--- a/gen/azure/templates/azure.html
+++ b/gen/azure/templates/azure.html
@@ -7,7 +7,7 @@
 
   <h1>DC/OS {{ build_name }} ARM Templates</h1>
 <ul>
-  <li>For more information on creating a DC/OS cluster, see the <a href='https://docs.mesosphere.com/1.10/installing/oss/cloud/azure/'>DC/OS Azure documentation</a>.</li>
+  <li>For more information on creating a DC/OS cluster, see the <a href='https://docs.mesosphere.com/1.11/installing/oss/cloud/azure/'>DC/OS Azure documentation</a>.</li>
 </ul>
 
   <h2>DC/OS for Azure Container Service</h2>

--- a/gen/azure/templates/azure.html
+++ b/gen/azure/templates/azure.html
@@ -7,7 +7,7 @@
 
   <h1>DC/OS {{ build_name }} ARM Templates</h1>
 <ul>
-  <li>For more information on creating a DC/OS cluster, see the <a href='https://dcos.io/docs/latest/administration/installing/cloud/azure/'>DC/OS Azure documentation</a>.</li>
+  <li>For more information on creating a DC/OS cluster, see the <a href='https://docs.mesosphere.com/1.10/installing/oss/cloud/azure/'>DC/OS Azure documentation</a>.</li>
 </ul>
 
   <h2>DC/OS for Azure Container Service</h2>


### PR DESCRIPTION
## High-level description

Fixing the Azure documentation link as the documentation site has been reorganized recently.