### PR TITLE
Upgrade REX-Ray to v0.11.2

### DIFF
--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,7 +9,7 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/codedellemc/rexray
+srcdir=$GOPATH/src/github.com/rexray/rexray
 mkdir -p $(dirname $srcdir)
 ln -s /pkg/src/rexray $srcdir
 cd $srcdir

--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -17,4 +17,4 @@ cd $srcdir
 DGOOS=linux make
 
 mkdir -p $PKG_PATH/bin
-mv $GOPATH/bin/rexray $PKG_PATH/bin
+mv rexray $PKG_PATH/bin

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,9 +1,9 @@
 {
-  "docker": "golang:1.7",
+  "docker": "golang:1.9",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/rexray/rexray.git",
-    "ref": "2a7458dd90a79c673463e14094377baf9fc8695e",
-    "ref_origin": "v0.9.0"
+    "ref": "fc8bfbd2d02c2690fc3a755a9560dd12c88e0852",
+    "ref_origin": "v0.11.2"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -2,7 +2,7 @@
   "docker": "golang:1.7",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/codedellemc/rexray.git",
+    "git": "https://github.com/rexray/rexray.git",
     "ref": "2a7458dd90a79c673463e14094377baf9fc8695e",
     "ref_origin": "v0.9.0"
   }

--- a/packages/rexray/extra/dcos-rexray.service
+++ b/packages/rexray/extra/dcos-rexray.service
@@ -13,4 +13,6 @@ Environment=REXRAY_HOME=/
 ExecStartPre=/bin/rm -f /var/run/libstorage/lsx.lock
 # Allow REX-Ray configuration to be changed during upgrade.
 ExecStartPre=/bin/cp /opt/mesosphere/etc/rexray.conf /etc/rexray/config.yml
+# Prevent startup error: "open /run/docker/plugins/rexray.sock: no such file or directory"
+ExecStartPre=/bin/mkdir -p /run/docker/plugins
 ExecStart=__PKG_PATH__/bin/rexray start -f


### PR DESCRIPTION
## High-level description

This upgrades REX-Ray from v0.9.0 to v0.11.2. The current package can't be built due to the issue fixed by https://github.com/rexray/rexray/pull/995, and v0.11.2 is the latest available release.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2245](https://jira.mesosphere.com/browse/DCOS_OSS-2245) Rexray does not build in 1.11 and master


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Building without cache should now succeed. REX-Ray is covered by an existing integration test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/rexray/rexray/compare/2a7458dd90a79c673463e14094377baf9fc8695e...fc8bfbd2d02c2690fc3a755a9560dd12c88e0852
  - [x] Test Results: Official release of an externally managed project.
  - [x] Code Coverage (if available): Official release of an externally managed project.