### PR TITLE
1.9 train march7

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -80,7 +80,7 @@ Hashicorp's Vault
 - https://github.com/hashicorp/vault/blob/master/LICENSE
 
 java
-- http://www.oracle.com/technetwork/java/javase/downloads/jre-6u21-license-159054.txt
+- http://www.oracle.com/technetwork/java/javase/terms/license/index.html
 
 libevent
 - Libvent License

--- a/packages/adminrouter/extra/src/master/cache.lua
+++ b/packages/adminrouter/extra/src/master/cache.lua
@@ -59,7 +59,14 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    -- We need to make sure that Nginx does not reuse the TCP connection here,
+    -- as i.e. during failover it could result in fetching data from e.g. Mesos
+    -- master which already abdicated. On top of that we also need to force
+    -- re-resolving leader.mesos address which happens during the setup of the
+    -- new connection.
+    local headers = {
+        ["Connection"] = "close",
+    }
     if auth_token ~= nil then
         headers = {["Authorization"] = "token=" .. auth_token}
     end

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "ed715d747c1362bac545f6b4047484bd822027e1",
-    "ref_origin": "v1.9.3"
+    "ref": "8bda9b7098a795ab39293215e873792645192712",
+    "ref_origin": "v1.9.4"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "bd983e54c7d941db4a67c1d5659a60014b3fec71",
-    "ref_origin" : "dcos-mesos-post-1.2.3"
+    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
+    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -1,10 +1,11 @@
 {
-  "requires": ["java", "exhibitor"],
-  "single_source": {
-    "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.2/metronome-0.3.2.tgz",
-    "sha1": "c3d5f610ce4f2b3e63934652bfca2f48ac101c75"
-  },
-  "username": "dcos_metronome",
-  "state_directory": true
+    "requires": ["java", "exhibitor"],
+    "single_source": {
+        "kind": "url_extract",
+        "url":
+            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.5/metronome-0.3.5.tgz",
+        "sha1": "2ff7c41ff969e3c552194b7338f9e0ca14a3deb5"
+    },
+    "username": "dcos_metronome",
+    "state_directory": true
 }


### PR DESCRIPTION
## High-level description

* Update DCOS-UI to 1.9.4 #2326 
* Update JDK License link.  #2441
* Admin Router: Prevent reusing tcp sockets by AR's cache code [1.9]  #2539 
* bumping metronome to 0.3.5 #2562 
* Bumped mesos SHA to include the fix for docker daemon hanging issue. #2582 