### PR TITLE
Node Rate Limiter considered HARMFUL

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -448,7 +448,7 @@ package:
       MESOS_REGISTRY_STORE_TIMEOUT=60secs
       MESOS_REGISTRY_FETCH_TIMEOUT=60secs
       MESOS_REGISTRY_STRICT=false
-      MESOS_SLAVE_REMOVAL_RATE_LIMIT=1/20mins
+      MESOS_SLAVE_REMOVAL_RATE_LIMIT=100/1mins
       MESOS_OFFER_TIMEOUT=2mins
       MESOS_WORK_DIR={{ mesos_master_work_dir }}
       MESOS_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

Mesos Core considers this a bug via:

  - [MESOS-7721](https://issues.apache.org/jira/browse/MESOS-7721) Master's agent removal rate limit also applies to agent unreachability.
- [MESOS-5948](https://issues.apache.org/jira/browse/MESOS-5948) Remove rate-limiting for agent removal

A major reason this is not already removed is the PM for the project left the project.   This should have been removed already.   It has likely caused more harm than good.  With companies changing it by our recommendation [under certain situations](https://jira.mesosphere.com/browse/COPS-719)

Mesos is a 2-level scheduler.  It makes NO sense for Mesos to keep and hold information from the "intelligent" scheduler.   `MESOS_SLAVE_REMOVAL_RATE_LIMIT` must die!!  for now `100/1mins` might be ok.
