### PR TITLE
SRE-222: Builds AMIs with support for fifth gen EC2 instances

### DIFF
--- a/cloud_images/CHANGELOG.md
+++ b/cloud_images/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## Changelog
 
+### 2018-03-12
+
+#### dcos-centos7-201803121129
+
+* Adding support for fifth generation EC2 instances (i.e. m5 and c5):
+* Support for AWS ENA network adapters.
+* Enhancing DC/OS volume setup script to work with different block device names.
+
+Base (source) AMI:
+* ami-bd48b3c0 (us-east-1)
+
+DC/OS AMI's:
+ap-northeast-1: ami-f1aee697
+ap-northeast-2: ami-74a8041a
+ap-south-1: ami-866e37e9
+ap-southeast-1: ami-a55504d9
+ap-southeast-2: ami-5ba66539
+ca-central-1: ami-8478ffe0
+eu-central-1: ami-6a610905
+eu-west-1: ami-c51a54bc
+eu-west-2: ami-891ef9ee
+eu-west-3: ami-c55fe9b8
+sa-east-1: ami-f8f2b894
+us-east-1: ami-27e5235a
+us-east-2: ami-8f0234ea
+us-west-1: ami-03bbae63
+us-west-2: ami-845acbfc
+
 ### 2017-10-20
 
 #### cloud_images

--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -5,10 +5,10 @@ set -o errexit -o nounset -o pipefail
 export AWS_PROFILE=${AWS_PROFILE:-"development"}
 
 # Base CentOS 7 AMI and region
-export SOURCE_AMI=${SOURCE_AMI:-"ami-a9b24bd1"}
-export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
+export SOURCE_AMI=${SOURCE_AMI:-"ami-bd48b3c0"}
+export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-east-1"}
 # Version upgraded to in install_prereqs.sh
-export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
+export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-east-1"}
 
 # Useful options include -debug and -machine-readable
 PACKER_BUILD_OPTIONS=${PACKER_BUILD_OPTIONS:-""}

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -12,12 +12,14 @@
     "ssh_pty": true,
     "region": "{{user `source_ami_region`}}",
     "source_ami": "{{user `source_ami`}}",
-    "instance_type": "m4.xlarge",
+    "instance_type": "m4.large",
     "ssh_username": "centos",
     "ami_name": "dcos-centos7-{{isotime \"200601021504\"}}",
     "ami_description": "DC/OS Cloud Image for CentOS 7",
     "ami_regions": "{{user `deploy_regions`}}",
     "ebs_optimized": true,
+    "ena_support": true,
+    "sriov_support": true,
     "ami_block_device_mappings": [
       {
         "device_name": "/dev/sde",

--- a/cloud_images/lib/el7/configure_grub.sh
+++ b/cloud_images/lib/el7/configure_grub.sh
@@ -13,7 +13,7 @@ GRUB_DEFAULT=saved
 GRUB_DISABLE_SUBMENU=true
 GRUB_TERMINAL="serial console"
 GRUB_SERIAL_COMMAND="serial --speed=115200"
-GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200 net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y dm_mod.use_blk_mq=y"
 GRUB_DISABLE_RECOVERY="true"
 END
 

--- a/cloud_images/lib/el7/create_and_mount_rootfs.sh
+++ b/cloud_images/lib/el7/create_and_mount_rootfs.sh
@@ -6,7 +6,7 @@ set -o errexit -o nounset -o pipefail
 : ${DEVICE:?"ERROR: DEVICE must be set"}
 : ${ROOTFS:?"ERROR: ROOTFS must be set"}
 
-PARTITION=${DEVICE}1
+PARTITION="${DEVICE}1"
 
 parted -s "${DEVICE}" -- \
   mklabel msdos \

--- a/cloud_images/lib/el7/install_base_packages.sh
+++ b/cloud_images/lib/el7/install_base_packages.sh
@@ -7,8 +7,11 @@ set -o errexit -o nounset -o pipefail
 
 cp -r /etc/yum.repos.d "${ROOTFS}/etc"
 
-yum --installroot="${ROOTFS}" --nogpgcheck -t -y groupinstall core
-yum --installroot="${ROOTFS}" --nogpgcheck -t -y install openssh-server grub2 tuned kernel chrony
-yum --installroot="${ROOTFS}" --nogpgcheck -t -y install cloud-init cloud-utils-growpart
+yum --installroot="${ROOTFS}" -t -y groupinstall core
+yum --installroot="${ROOTFS}" -t -y install openssh-server grub2 tuned kernel chrony dracut-config-generic
+yum --installroot="${ROOTFS}" -t -y install cloud-init cloud-utils-growpart
 
 yum --installroot="${ROOTFS}" -C -t -y remove NetworkManager firewalld --setopt="clean_requirements_on_remove=1"
+
+echo ">>> Compatibility fixes for newer AWS instances like C5 and M5, see https://bugs.centos.org/view.php?id=14107&nbn=5"
+chroot "${ROOTFS}" dracut -f

--- a/cloud_images/lib/el7/install_dcos_required_packages.sh
+++ b/cloud_images/lib/el7/install_dcos_required_packages.sh
@@ -11,17 +11,17 @@ if [ ! -d "${ROOTFS}/etc/yum.repos.d" ]; then
     cp -r /etc/yum.repos.d "${ROOTFS}/etc"
 fi
 
-yum --installroot="${ROOTFS}" --nogpgcheck -t -y install \
-	perl \
-	tar \
-	xz \
-	unzip \
-	curl \
-	bind-utils \
-	net-tools \
-	ipset \
-	libtool-ltdl \
-	rsync \
-	nfs-utils \
-    wget \
-    git
+yum --installroot="${ROOTFS}" -t -y install \
+  perl \
+  tar \
+  xz \
+  unzip \
+  curl \
+  bind-utils \
+  net-tools \
+  ipset \
+  libtool-ltdl \
+  rsync \
+  nfs-utils \
+  wget \
+  git

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -131,49 +131,49 @@ region_to_ami_map = {
         'coreos': 'ami-93f2baf4',
         'stable': 'ami-93f2baf4',
         'el7': 'ami-965345f8',
-        'el7prereq': 'ami-72f93314',
+        'el7prereq': 'ami-f1aee697',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
         'coreos': 'ami-aacc7dc9',
         'stable': 'ami-aacc7dc9',
         'el7': 'ami-8af586e9',
-        'el7prereq': 'ami-cac2b2a9',
+        'el7prereq': 'ami-a55504d9',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
         'coreos': 'ami-9db0b0fe',
         'stable': 'ami-9db0b0fe',
         'el7': 'ami-427d9c20',
-        'el7prereq': 'ami-a0d736c2',
+        'el7prereq': 'ami-5ba66539',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
         'coreos': 'ami-903df7ff',
         'stable': 'ami-903df7ff',
         'el7': 'ami-2d0cbc42',
-        'el7prereq': 'ami-b371c1dc',
+        'el7prereq': 'ami-6a610905',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
         'coreos': 'ami-abcde0cd',
         'stable': 'ami-abcde0cd',
         'el7': 'ami-e46ea69d',
-        'el7prereq': 'ami-4d4f8634',
+        'el7prereq': 'ami-c51a54bc',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
         'coreos': 'ami-c11573ad',
         'stable': 'ami-c11573ad',
         'el7': 'ami-a5acd0c9',
-        'el7prereq': 'ami-1264187e',
+        'el7prereq': 'ami-f8f2b894',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
         'coreos': 'ami-1ad0000c',
         'stable': 'ami-1ad0000c',
         'el7': 'ami-771beb0d',
-        'el7prereq': 'ami-b05aadca',
+        'el7prereq': 'ami-27e5235a',
         'natami': 'ami-4c9e4b24'
     },
     'us-gov-west-1': {
@@ -187,14 +187,14 @@ region_to_ami_map = {
         'coreos': 'ami-b31d43d3',
         'stable': 'ami-b31d43d3',
         'el7': 'ami-866151e6',
-        'el7prereq': 'ami-63cafb03',
+        'el7prereq': 'ami-03bbae63',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
         'coreos': 'ami-444dcd24',
         'stable': 'ami-444dcd24',
         'el7': 'ami-a9b24bd1',
-        'el7prereq': 'ami-1de01e65',
+        'el7prereq': 'ami-845acbfc',
         'natami': 'ami-bb69128b'
     }
 }


### PR DESCRIPTION
## High-level description
These changes provide a new set of AWS EC2 AMIs that support both fourth generation (i.e. `m4.*`) as well as fifth generation (i.e. `m5.*` and `c5.*`) instances types.

There are also some minor changes to the AMI build process, mainly the change of AWS region to us-east-1 and the used instance type to a somewhat smaller but sufficient one.

## Corresponding DC/OS tickets (obligatory)

This Mesosphere internal JIRA ticket must be updated (ideally closed) in the moment this PR lands:

  - [SRE-222](https://jira.mesosphere.com/browse/SRE-222)

