### PR TITLE
Bumped Mesos SHA to the latest 1.4.x.

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8bfe874c68cdf6b9d7e4b7ab0dd81c45b26bc79",
-    "ref_origin" : "dcos-mesos-1.4.x-92d988c"
+    "ref": "178a8addd30f5f4e72c5aa3d61bc07e15e75fe87",
+    "ref_origin" : "dcos-mesos-1.4.x-24d3886"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description

This PR incorporates Mesos bug fixes and improvements.


## Related tickets

Other tickets related to this change:

  - [DCOS_OSS-2315](https://jira.mesosphere.com/browse/DCOS_OSS-2315) Bump Mesos SHA for DC/OS 1.10.6.
  - [MESOS-8488](https://issues.apache.org/jira/browse/MESOS-8488) Docker bug can cause unkillable tasks.
  - [MESOS-8574](https://issues.apache.org/jira/browse/MESOS-8574) Docker executor makes no progress when 'docker inspect' hangs.
  - [MESOS-8575](https://issues.apache.org/jira/browse/MESOS-8575) Improve discard handling for 'Docker::stop' and 'Docker::pull'.
  - [MESOS-8576](https://issues.apache.org/jira/browse/MESOS-8576) Improve discard handling of 'Docker::inspect()'.
  - [MESOS-8605](https://issues.apache.org/jira/browse/MESOS-8605) Terminal task status update will not send if 'docker inspect' is hung.


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Mesos integration tests validate these changes
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Mesos diff](https://github.com/mesosphere/mesos/compare/c8bfe874c68cdf6b9d7e4b7ab0dd81c45b26bc79...178a8addd30f5f4e72c5aa3d61bc07e15e75fe87)
  - [x] Test Results: [Mesos CI results](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/3018/)
  - [ ] Code Coverage (if available): [link to code coverage report]