### PR TITLE
openssl: bump to 1.0.2n

### DIFF
--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2k.tar.gz",
-    "sha1": "5f26a624479c51847ebd2f22bb9f84b3b44dcb44"
+    "url": "https://openssl.org/source/openssl-1.0.2n.tar.gz",
+    "sha1": "0ca2957869206de193603eca6d89f532f61680b1"
   }
 }


### PR DESCRIPTION
This bumps OpenSSL from 1.0.2k to 1.0.2n in 1.12_master.

The related PR for 1.11: https://github.com/dcos/dcos/pull/2611
The related PR for 1.10: #2548

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS_OSS-1903


## Checklist for all PRs

  - [x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)