### PR TITLE
[1.11] Avoid python dependency break for python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         'release.storage',
         'ssh'],
     install_requires=[
+        # DCOS-21656 - `botocore`` requires less than 2.7.0 while
+        # `analytics-python` package installs 2.7.0 version
+        'python-dateutil>=2.1,<2.7.0',
         'aiohttp==0.22.5',
         'analytics-python',
         'coloredlogs',
@@ -48,8 +51,8 @@ setup(
         'azure-storage==0.32.0',
         'azure-mgmt-network==0.30.0rc4',
         'azure-mgmt-resource==0.30.0rc4',
-        'boto3',
         'botocore',
+        'boto3',
         'checksumdir',
         'coloredlogs',
         'docopt',


### PR DESCRIPTION
python dateutil was updated to 2.7.0
botocore was updated to 1.8.9 and it breaks against
dateutil 2.7.0

## High-level description

1. sometime on march 11th, python-dateutil was bumped from 2.6.1 to 2.7.0 (https://pypi.python.org/pypi/python-dateutil/2.7.0)
2. on march 13th, someone at botocore decided to do this: https://github.com/boto/botocore/commit/90d7692702be1a423af15e0f49b58365f2a400f2

## Corresponding DC/OS tickets (obligatory)

 https://jira.mesosphere.com/browse/DCOS_OSS-2261

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
