### PR TITLE
Set interactivity to false for certain commands.

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -10,9 +10,13 @@
         "default": "Work In Progress",
         "pr-creator-can-apply": ["Ready For Review", "Work In Progress"]
     },
-    "pr-status-checks": true,
+    "pr-status-checks": {
+        "enabled": true,
+        "interactive": false
+    },
     "ship_it_label_status_check": {
         "enabled": true,
+        "interactive": false,
         "acceptable_labels": ["Ship It"],
         "labels_to_remove_when_applying_ship_it": ["Work In Progress", "Ready For Review", "Request For Comment"]
     }


### PR DESCRIPTION
## High-level description

* https://jira.mesosphere.com/browse/QUALITY-1958 - Suppress Non-Interactive Mergebot Commands from help

More discussion is here - https://github.com/mesosphere/mergebot/pull/121