### PR TITLE
dcos-integration-test: Fix SAML integration tests [1.11]

### DIFF
--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -10,7 +10,7 @@ for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 
-for package in aiohttp checksumdir coloredlogs docker-py humanfriendly multidict \
+for package in aiohttp checksumdir coloredlogs humanfriendly multidict \
     oauthlib waitress websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -86,11 +86,6 @@
       "url": "https://pypi.python.org/packages/source/c/coloredlogs/coloredlogs-3.5.tar.gz",
       "sha1": "251c88bd48ee3e23a12b416f7297202e544d0cd2"
     },
-    "docker-py": {
-      "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/d/docker-py/docker-py-1.7.2.tar.gz",
-      "sha1": "bc4f33cac9d6ad13c41ac7ff3e76de30fef8c4cf"
-    },
     "docutils": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/3.4/d/docutils/docutils-0.12-py3-none-any.whl",


### PR DESCRIPTION
## High-level description

This is a partial work that is required to re-enable SAML integration tests. The change in DC/OS Open is removing `docker-py` package that is unused, outdated and unsupported. The package is replaced with new `docker` library in EE PR.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
  - [DCOS-21531](https://jira.mesosphere.com/browse/DCOS-21531) dcos-integration-test: enable SAML tests again (PhantomJS doesn't support ES2015 anymore)


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]