### PR TITLE
Adminrouter master agent: Fix Vulnerable SSL/TLS cipher suites

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -995,7 +995,7 @@ package:
       # Modulo ChaCha20 cipher.
 {% switch adminrouter_tls_cipher_override %}
 {% case "false" %}
-      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA;
 {% case "true" %}
       ssl_ciphers {{ adminrouter_tls_cipher_suite }};
 {% endswitch %}

--- a/gen/tests/test_adminrouter_tls_conf.py
+++ b/gen/tests/test_adminrouter_tls_conf.py
@@ -30,7 +30,7 @@ class TestAdminRouterTLSConfig:
             # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
             # Modulo ChaCha20 cipher.
 
-            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA;
 
             ssl_prefer_server_ciphers on;
             # To manually test which TLS versions are enabled on a node, use
@@ -115,7 +115,7 @@ class TestSetCipherOverride:
             config_path: str) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -142,7 +142,7 @@ class TestSetCipherOverride:
             new_config_arguments: Dict[str, str]) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -194,7 +194,7 @@ class TestSetCipherOverride:
         ciphers = self.supported_ssl_ciphers_master(
             new_config_arguments=new_arguments,
         )
-        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5']
+        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA']
 
     def test_cipher_master_custom(self):
         """

--- a/packages/adminrouter/docker/adminrouter-tls-master.conf
+++ b/packages/adminrouter/docker/adminrouter-tls-master.conf
@@ -1,6 +1,6 @@
 # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
 # Modulo ChaCha20 cipher.
-ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5:!DES-CBC3-SHA:!ECDHE-RSA-DES-CBC3-SHA;
 ssl_prefer_server_ciphers on;
 
 ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
## Adminrouter master agent: Fix Vulnerable SSL/TLS cipher suites

What features does this change enable? What bugs does this change fix?

**Fix OpenVAS/Greenbone security risk**

Medium (CVSS: 5.0)
NVT: SSL/TLS: Report Vulnerable Cipher Suites for HTTPS

### Summary

This routine reports all SSL/TLS cipher suites accepted by a service where attack vectors exists
only on HTTPS services.
Vulnerability Detection Result
'Vulnerable' cipher suites accepted by this service via the TLSv1.1 protocol:
TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA (SWEET32)
'Vulnerable' cipher suites accepted by this service via the TLSv1.2 protocol:
TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA (SWEET32)

### Solution

Solution type: Mitigation
The configuration of this services should be changed so that it does not accept the listed cipher
suites anymore.
Please see the references for more resources supporting you with this task.

### Affected Software/OS

Services accepting vulnerable SSL/TLS cipher suites via HTTPS.

### Vulnerability Insight

These rules are applied for the evaluation of the vulnerable cipher suites:
- 64-bit block cipher 3DES vulnerable to the SWEET32 attack (CVE-2016-2183).

### Vulnerability Detection Method

Details:SSL/TLS: Report Vulnerable Cipher Suites for HTTPS
OID:1.3.6.1.4.1.25623.1.0.108031
Version used: $Revision: 5232 $

### References

CVE: CVE-2016-2183, CVE-2016-6329
Other:
URL:https://bettercrypto.org/
URL:https://mozilla.github.io/server-side-tls/ssl-config-generator/
URL:https://sweet32.info/ 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
