### PR TITLE
Update DC/OS configuration to remove marathon GPU defaults on installation

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -927,12 +927,6 @@ package:
       MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}
 {% case "false" %}
 {% endswitch %}
-{% switch gpus_are_scarce %}
-{% case "true" %}
-      MARATHON_GPU_SCHEDULING_BEHAVIOR=restricted
-{% case "false" %}
-      MARATHON_GPU_SCHEDULING_BEHAVIOR=unrestricted
-{% endswitch %}
   - path: /etc/proxy.env
 {% switch use_proxy %}
 {% case "true" %}


### PR DESCRIPTION
## High-level description

Update of the DC/OS config generator to remove the default value for gpu_scheduling_behavior for marathon

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8090](https://jira.mesosphere.com/browse/MARATHON-8090) Update DC/OS configuration to set appropriate marathon defaults on installation.


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): 
  - [x] Test Results: 
  - [x] Code Coverage (if available): 
