### PR TITLE
bump dcos-log sha

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -418,6 +418,14 @@ def test_log_v2_api(dcos_api_session):
         check_response_ok(response, {})
         assert response.text == "one\ntwo\nthree\nfour\nfive\n"
 
+        # make sure if 'Last-Event-ID' header is passed, other get parameters are ignored
+        # https://jira.mesosphere.com/browse/DCOS_OSS-2292
+        # number 7 used in 'Last-Event-ID' header points to a second word.
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-1'.format(task_id),
+                                             headers={'Last-Event-ID': '7'})
+        check_response_ok(response, {})
+        assert response.text == "three\nfour\nfive\n"
+
 
 def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
     response = dcos_api_session.logs.get('/v2/task/{}/browse'.format(task))

--- a/packages/dcos-log/build
+++ b/packages/dcos-log/build
@@ -2,9 +2,9 @@
 mkdir -p /pkg/src/github.com/dcos
 # Create the GOPATH for the go tool to work properly
 mv /pkg/src/dcos-log /pkg/src/github.com/dcos/
-cd /pkg/src/github.com/dcos/dcos-log
+cd /pkg/src/github.com/dcos/dcos-log/dcos-log
 
-make install
+go install
 # Copy the build from the bin to the correct place
 cp -r /pkg/bin/ "$PKG_PATH"
 

--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "2ff6a6d031be86b4e444c84e1ae3d445a0655d78",
+    "ref": "7ce9b88c2f9854ec75e49fd720ab78dc2d04b57b",
     "ref_origin": "master"
   },
   "username": "dcos_log",


### PR DESCRIPTION
## High-level description

bump dcos-log sha
this PR includes:
 - fix for task logs Server-Sent-Event
 - make dcos-log respect journald files rotation


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2292](https://jira.mesosphere.com/browse/DCOS_OSS-2292) - fir for server sent events
  - [DCOS_OSS-2132](https://jira.mesosphere.com/browse/DCOS_OSS-2132) - respect systemd files rotation


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-2984](https://jira.mesosphere.com/browse/COPS-2984)


## Checklist for all PRs

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-log/compare/2ff6a6d031be86b4e444c84e1ae3d445a0655d78...7ce9b88c2f9854ec75e49fd720ab78dc2d04b57b)
  - [X] Test Results:[jenkins#291]( https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-log-pulls/291/)
  - [X] Code Coverage (if available): [jenkins#291]( https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-log-pulls/291/)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
