### PR TITLE
Bump dcos-test-utils: strict URL path handling

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -81,7 +81,7 @@ def _dump_diagnostics(request, dcos_api_session):
     make_diagnostics_report = os.environ.get('DIAGNOSTICS_DIRECTORY') is not None
     if make_diagnostics_report:
         log.info('Create diagnostics report for all nodes')
-        check_json(dcos_api_session.health.post('report/diagnostics/create', json={"nodes": ["all"]}))
+        check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
 
         last_datapoint = {
             'time': None,
@@ -98,7 +98,7 @@ def _dump_diagnostics(request, dcos_api_session):
         bundles = _get_bundle_list(dcos_api_session)
         for bundle in bundles:
             for master_node in dcos_api_session.masters:
-                r = dcos_api_session.health.get(os.path.join('report/diagnostics/serve', bundle), stream=True,
+                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
                                                 node=master_node)
                 bundle_path = os.path.join(os.path.expanduser('~'), bundle)
                 with open(bundle_path, 'wb') as f:

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -48,7 +48,7 @@ def check_response_ok(response: requests.models.Response, headers: dict):
 
 def test_log_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=10', node=node)
+        response = dcos_api_session.logs.get('/v1/range/?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 lines
@@ -58,21 +58,21 @@ def test_log_text(dcos_api_session):
 
 def test_log_json(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
         check_response_ok(response, {'Content-Type': 'application/json'})
         validate_json_entry(response.json())
 
 
 def test_log_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         validate_sse_entry(response.text)
 
 
 def test_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/stream/?skip_prev=1', node=node, stream=True,
+        response = dcos_api_session.logs.get('/v1/stream/?skip_prev=1', node=node, stream=True,
                                              headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
@@ -253,7 +253,7 @@ def validate_journald_cursor(c: str, cursor_regexp=None):
 
 def test_log_v2_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?limit=10', node=node)
+        response = dcos_api_session.logs.get('/v2/component?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 lines
@@ -263,8 +263,8 @@ def test_log_v2_text(dcos_api_session):
 
 def test_log_v2_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?limit=1', node=node, headers={'Accept': 'text/event-stream'},
-                                             stream=True)
+        response = dcos_api_session.logs.get(
+            '/v2/component?limit=1', node=node, headers={'Accept': 'text/event-stream'}, stream=True)
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
         sse_id = next(lines)
@@ -275,7 +275,7 @@ def test_log_v2_server_sent_events(dcos_api_session):
 
 def test_log_v2_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?skip=-1', node=node, stream=True,
+        response = dcos_api_session.logs.get('/v2/component?skip=-1', node=node, stream=True,
                                              headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
@@ -321,11 +321,11 @@ def test_log_v2_task_logs(dcos_api_session):
     }
 
     with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
-        response = dcos_api_session.logs.get('v2/task/{}/file/stdout'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/stdout'.format(task_id))
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
 
-        response = dcos_api_session.logs.get('v2/task/{}/file/stderr'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/stderr'.format(task_id))
         check_response_ok(response, {})
         assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
 
@@ -354,11 +354,11 @@ def test_log_v2_pod_logs(dcos_api_session):
     }
 
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
-        response = dcos_api_session.logs.get('v2/task/sleep1')
+        response = dcos_api_session.logs.get('/v2/task/sleep1')
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
 
-        response = dcos_api_session.logs.get('v2/task/sleep1/file/stderr')
+        response = dcos_api_session.logs.get('/v2/task/sleep1/file/stderr')
         check_response_ok(response, {})
         assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
 
@@ -389,38 +389,38 @@ def test_log_v2_api(dcos_api_session):
 
     with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         # skip 2 entries from the beggining
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=2'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=2'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "three\nfour\nfive\n"
 
         # move to the end of file and read 2 last LINE_SIZE
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # move three lines from the top and limit to one entry
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=3&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=3&limit=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\n"
 
         # set cursor to 7 (bytes) which the second word and skip 1 lines
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=7&skip=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # set cursor to 7 (bytes) which the second word and skip -1 lines and limit 1
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "two\n"
 
         # validate the bug is fixed https://jira.mesosphere.com/browse/DCOS_OSS-1995
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "one\ntwo\nthree\nfour\nfive\n"
 
 
 def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
-    response = dcos_api_session.logs.get('v2/task/{}/browse'.format(task))
+    response = dcos_api_session.logs.get('/v2/task/{}/browse'.format(task))
     check_response_ok(response, {})
 
     expected_fields = ['gid', 'mode', 'mtime', 'nlink', 'path', 'size', 'uid']
@@ -438,7 +438,7 @@ def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
 
 def _assert_can_download_files(dcos_api_session, task, expected_files):
     for expected_file in expected_files:
-        response = dcos_api_session.logs.get('v2/task/{}/file/{}/download'.format(task, expected_file))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/{}/download'.format(task, expected_file))
         check_response_ok(response, {
             'Content-Type': 'application/octet-stream',
             'Content-Disposition': 'attachment; filename={}'.format(expected_file)})

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -11,20 +11,20 @@ def test_metrics_agents_ping(dcos_api_session):
     """ Test that the metrics service is up on masters.
     """
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
         'agent.'
 
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
 def test_metrics_masters_ping(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('ping', node=master)
+        response = dcos_api_session.metrics.get('/ping', node=master)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
@@ -80,7 +80,7 @@ def test_metrics_node(dcos_api_session):
 
     # private agents
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -89,7 +89,7 @@ def test_metrics_node(dcos_api_session):
 
     # public agents
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -98,7 +98,7 @@ def test_metrics_node(dcos_api_session):
 
     # masters
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('node', node=master)
+        response = dcos_api_session.metrics.get('/node', node=master)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -134,16 +134,16 @@ def test_metrics_containers(dcos_api_session):
             # state every 2 minutes to propogate containers to the API
             @retrying.retry(wait_fixed=2000, stop_max_delay=150000)
             def wait_for_container_propogation():
-                response = dcos_api_session.metrics.get('containers', node=agent.host)
+                response = dcos_api_session.metrics.get('/containers', node=agent.host)
                 assert response.status_code == 200
                 assert len(response.json()) > 0, 'must have at least 1 container'
 
             wait_for_container_propogation()
 
-            response = dcos_api_session.metrics.get('containers', node=agent.host)
+            response = dcos_api_session.metrics.get('/containers', node=agent.host)
             for c in response.json():
                 # Test that /containers/<id> responds with expected data
-                container_id_path = 'containers/{}'.format(c)
+                container_id_path = '/containers/{}'.format(c)
                 container_response = dcos_api_session.metrics.get(container_id_path, node=agent.host)
 
                 # /containers/<container_id> should always respond succesfully
@@ -176,7 +176,7 @@ def test_metrics_containers(dcos_api_session):
                 # looking for "statsd-emitter.<some_uuid>"
                 if 'statsd-emitter' in container_response.json()['dimensions']['executor_id'].split('.'):
                     # Test that /app response is responding with expected data
-                    app_response = dcos_api_session.metrics.get('containers/{}/app'.format(c), node=agent.host)
+                    app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(c), node=agent.host)
                     assert app_response.status_code == 200
                     'got {}'.format(app_response.status_code)
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -59,13 +59,13 @@ class MarathonApp:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/apps', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/apps', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/apps/{}'.format(self.id))
         assert_response_ok(r)
 
         self._info = r.json()
@@ -75,7 +75,7 @@ class MarathonApp:
         try:
             if self._info['app']['tasksHealthy'] != self.app['instances']:
                 raise Exception("Number of Healthy Tasks not equal to number of instances.")
-        except:
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -95,7 +95,7 @@ class MarathonApp:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/apps/{}'.format(self.id))
 
 
 class MarathonPod:
@@ -148,14 +148,14 @@ class MarathonPod:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/pods', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/pods', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/pods/{}::status'.format(self.id))
         assert_response_ok(r)
 
         self._info = r.json()
@@ -166,7 +166,7 @@ class MarathonPod:
         try:
             if self._info['status'] != 'STABLE':
                 raise Exception("The status information is not Stable!")
-        except:
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -181,7 +181,7 @@ class MarathonPod:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/pods/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/pods/{}'.format(self.id))
 
 
 def unused_port():
@@ -365,7 +365,7 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, nam
                 retry_on_exception=lambda x: True)
 def test_if_overlay_ok(dcos_api_session):
     def _check_overlay(hostname, port):
-        overlays = dcos_api_session.get('overlay-agent/overlay', host=hostname, port=port).json()['overlays']
+        overlays = dcos_api_session.get('/overlay-agent/overlay', host=hostname, port=port).json()['overlays']
         assert len(overlays) > 0
         for overlay in overlays:
             assert overlay['state']['status'] == 'STATUS_OK'

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -45,8 +45,8 @@ def test_pkgpanda_api(dcos_api_session):
                 assert package == buildinfo_package
 
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        package_ids = get_and_validate_package_ids('pkgpanda/repository/', node)
-        active_package_ids = get_and_validate_package_ids('pkgpanda/active/', node)
+        package_ids = get_and_validate_package_ids('/pkgpanda/repository/', node)
+        active_package_ids = get_and_validate_package_ids('/pkgpanda/active/', node)
 
         assert set(active_package_ids) <= set(package_ids)
         assert_packages_match_active_buildinfo(active_package_ids)
@@ -74,7 +74,7 @@ KAFKA_PACKAGE_REQUIREMENTS = {
 def _get_cluster_resources(dcos_api_session):
     """Return the mesos state summary
     """
-    r = dcos_api_session.get('mesos/state-summary')
+    r = dcos_api_session.get('/mesos/state-summary')
     return r.json()
 
 

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "9a2489e1d622de1bcbb5163e8b860d5408edad81",
+    "ref": "c7eaecd8c0502e854d4fb1818947fb9d17cbac79",
     "ref_origin": "master"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "a4cd8815fde6624a645c83eef85abde88b73a38f",
+    "ref": "9a2489e1d622de1bcbb5163e8b860d5408edad81",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This update to dcos-test-utils removed magic URL path handling which enabled the following to requests to be identical:
```
# old, confusing behavior
api.get('/v1/foo/bar') ==> http://dcos.com/v1/foo/bar
api.get('v1/foo/bar')  ==> http://dcos.com/v1/foo/bar
```
Now, paths must be intentionally prefaced with `/` if they are to work in most cases. This is useful for ensuring that test's which may want to push the slash-handling are transparent at the test-harness level.
E.G.
```
# new, simple behavior
api.get('/v1/foo/bar') ==> http://dcos.com/v1/foo/bar
api.get('v1/foo/bar')  ==> http://dcos.comv1/foo/bar
```

## Corresponding DC/OS tickets

https://jira.mesosphere.com/browse/DCOS-13496

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A touches many tests which themselves are the check
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
