### PR TITLE
Bumping marathon version to 1.6.392-f9d087d2f

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.352-044939181/marathon-1.6.352-044939181.tgz",
-    "sha1": "2c9e0136a3bc59c8f243230efc96c2c653500d0b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.391-294dce5ce/marathon-1.6.391-294dce5ce.tgz",
+    "sha1": "aa2a3d564803f17b570a21da3458f8664ee92c4b"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.391-294dce5ce/marathon-1.6.391-294dce5ce.tgz",
-    "sha1": "aa2a3d564803f17b570a21da3458f8664ee92c4b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.392-f9d087d2f/marathon-1.6.392-f9d087d2f.tgz",
+    "sha1": "07431c89334b59ded6eb375f0f86bdc7a2edafa7"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Lots of clean-ups, removal of dead code, fixing tests and missing Preferential GPU Scheduling features and tests.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8092](https://jira.mesosphere.com/browse/MARATHON-8092) Integration tests for Preferential GPU Scheduling in Marathon
  - [MARATHON-8091](https://jira.mesosphere.com/browse/MARATHON-8091) GPU preferential scheduling Marathon documentation
  - [MARATHON-8124](https://jira.mesosphere.com/browse/MARATHON-8124) Always unreserve resources for non-existing instances
  - [MARATHON-8125](https://jira.mesosphere.com/browse/MARATHON-8125) Removing Akka Controllers
  - [MARATHON-8091](https://jira.mesosphere.com/browse/MARATHON-8091) Document GPU_scheduling_behavior
  - [MARATHON-8126](https://jira.mesosphere.com/browse/MARATHON-8126) Forward docs port from 1.5 to master
  - [MARATHON-8131](https://jira.mesosphere.com/browse/MARATHON-8131) Add support for symlinks for `--plugin_dir` and `--plugin_conf` parameters
  - [MARATHON-8104](https://jira.mesosphere.com/browse/MARATHON-8104) Use sliding average window on the metrics endpoint
  - [MARATHON-7940](https://jira.mesosphere.com/browse/MARATHON-7940) Disable Connection Pooling for HTTP Health Checks
  - [MARATHON-8129](https://jira.mesosphere.com/browse/MARATHON-8129) Fix native package tests
  - [MARATHON-8136](https://jira.mesosphere.com/browse/MARATHON-8136) Fix of http marathon healthchecks
  - [MARATHON_EE-1884](https://jira.mesosphere.com/browse/MARATHON_EE-1884) marathon-dcos-plugins don't evaluate SystemMetrics Auth
  - [MARATHON-8083](https://jira.mesosphere.com/browse/MARATHON-8083) Fixing datadog and statsd reporter configuration
  - [MARATHON-8141](https://jira.mesosphere.com/browse/MARATHON-8141) Test Marathon upgrades 1.4.9 thru 1.6.322
  - [MARATHON-8143](https://jira.mesosphere.com/browse/MARATHON-8143) Fix the failing integration tests on master
  - [MARATHON-8110](https://jira.mesosphere.com/browse/MARATHON-8110) Use given matched resources when building Mesos protobufs for pods

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-21901](https://jira.mesosphere.com/browse/DCOS-21901) Bump the marathon version on 1.6.391.


## Checklist for all PRs

  - [x] ~Included a test which will fail if code is reverted but test is not. If there is no test please explain here:~
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [X] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/773/
  - [X] Code Coverage (not available)
