### PR TITLE
Increase executor reregistration timeout to 10 seconds.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -489,6 +489,7 @@ package:
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
+      MESOS_EXECUTOR_REREGISTRATION_TIMEOUT=10secs
       MESOS_RECONFIGURATION_POLICY=additive
       MESOS_RECOVERY_TIMEOUT={{ mesos_recovery_timeout }}
       MESOS_CGROUPS_ENABLE_CFS=true


### PR DESCRIPTION
In cases where the agent node is under heavy load, it can take more than
2 seconds (default executor reregistation timeout) for all executors
to reregister with an agent that just failed over. After the timeout,
the executors are explicitly removed and the tasks are marked as
TASK_GONE.

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2335](https://jira.mesosphere.com/browse/DCOS_OSS-2335) Increase executor reregistration timeout.

## Related tickets (optional)

Other tickets related to this change:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
    Manually tested with the app definition provided in the DC/OS ticket.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): 
  - [ ] Test Results: 
  - [ ] Code Coverage (if available):
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
