### PR TITLE
[1.10] Disable the 3DES bulk encryption algorithm by default

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -956,8 +956,9 @@ package:
   - path: /etc/adminrouter-tls.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-      # Modulo ChaCha20 cipher.
-      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm. 
+      # For 3DES see https://jira.mesosphere.com/browse/DCOS-21957
+      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
       ssl_prefer_server_ciphers on;
       # To manually test which TLS versions are enabled on a node, use
       # `openssl` commands.

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -956,7 +956,7 @@ package:
   - path: /etc/adminrouter-tls.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm. 
+      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
       # For 3DES see https://jira.mesosphere.com/browse/DCOS-21957
       ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
       ssl_prefer_server_ciphers on;

--- a/gen/tests/test_adminrouter_tls_conf.py
+++ b/gen/tests/test_adminrouter_tls_conf.py
@@ -28,8 +28,9 @@ class TestAdminRouterTLSConfig:
         expected_configuration = dedent(
             """\
             # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-            # Modulo ChaCha20 cipher.
-            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+            # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+            # For 3DES see https://jira.mesosphere.com/browse/DCOS-21957
+            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
             ssl_prefer_server_ciphers on;
             # To manually test which TLS versions are enabled on a node, use
             # `openssl` commands.

--- a/packages/adminrouter/docker/adminrouter-tls.conf
+++ b/packages/adminrouter/docker/adminrouter-tls.conf
@@ -1,6 +1,7 @@
 # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-# Modulo ChaCha20 cipher.
-ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+# Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+# For 3DES see https://jira.mesosphere.com/browse/DCOS-21957
+ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 ssl_prefer_server_ciphers on;
 
 ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
## High-level description

This PR disables the 3DES bulk encryption algorithm by default.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  https://jira.mesosphere.com/browse/DCOS-21957

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
