### PR TITLE
Downgrade REX-Ray 0.11.2 -> 0.9.0

### DIFF
--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,12 +9,5 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/rexray/rexray
-mkdir -p $(dirname $srcdir)
-ln -s /pkg/src/rexray $srcdir
-cd $srcdir
-
-DGOOS=linux make
-
 mkdir -p $PKG_PATH/bin
-mv rexray $PKG_PATH/bin
+tar -C $PKG_PATH/bin/ -xf /pkg/src/$PKG_NAME/*

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,9 +1,7 @@
 {
-  "docker": "golang:1.9",
-  "single_source" : {
-    "kind": "git",
-    "git": "https://github.com/rexray/rexray.git",
-    "ref": "fc8bfbd2d02c2690fc3a755a9560dd12c88e0852",
-    "ref_origin": "v0.11.2"
+  "single_source": {
+    "kind": "url",
+    "url": "https://downloads.dcos.io/packages/rexray/rexray-Linux-x86_64-0.9.0.tar.gz",
+    "sha1": "be07ec9a41e5dc287fbe62006025de8a64392afb"
   }
 }


### PR DESCRIPTION
## High-level description

This reverses https://github.com/dcos/dcos/pull/2593 due to a regression in test stability. Because REX-Ray v0.9.0 can no longer be built from source, we're pulling in a [prebuilt binary from DC/OS 1.11.0](https://downloads.dcos.io/dcos/stable/packages/rexray/rexray--da7f17f8a4b772c0bac3f8d289a08abd4ff272b4.tar.xz).

REX-Ray integration test history:
* [master](https://teamcity.mesosphere.io/project.html?tab=testDetails&testNameId=-4317366092774327&projectId=DcOs_Open_Test_IntegrationTest&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsCloudFormationSimple&branch_DcOs_Open_Test_IntegrationTest=%3Cdefault%3E)
* [This PR](https://teamcity.mesosphere.io/project.html?tab=testDetails&testNameId=-4317366092774327&projectId=DcOs_Open_Test_IntegrationTest&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsCloudFormationSimple&branch_DcOs_Open_Test_IntegrationTest=pull%2F2705)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2310](https://jira.mesosphere.com/browse/DCOS_OSS-2310) REX-Ray integration test is flaky after version bump

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Covered by an existing integration test that should now pass reliably.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]