### PR TITLE
marathon bump 1.5.8

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.7/marathon-1.5.7.tgz",
-    "sha1" : "d6b93e1eae76c9aeb90a4201d453aaf120ddd9cb"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.8/marathon-1.5.8.tgz",
+    "sha1" : "359fabb498652b2b06077331b2dca9036f1a1b4c"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Marathon bump 1.5.8


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2352](https://jira.mesosphere.com/browse/DCOS_OSS-2352) Bump Marathon to 1.5.8
- [MARATHON-7609](https://jira.mesosphere.com/browse/MARATHON-7609) Send Instance health changed event when the overall status changed
- [MARATHON-8104](https://jira.mesosphere.com/browse/MARATHON-8104) SlidingAverageSnapshot fix for metrics
- [MARATHON_EE-1884](https://jira.mesosphere.com/browse/MARATHON_EE-1884) SystemConfig is the Correct Security Constraint

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/compare/v1.5.7...v1.5.8
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/57/console
  - [x] Code Coverage (if available): N/A

