### PR TITLE
Admin Router: /service endpoint url rewriting is now configurable using the Marathon label

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -479,6 +479,48 @@ as `.js` and `.css` files. This is due to the fact that the linked resources wil
 be reachable only in their relative location
 `<dcos-cluster>/services/<application ID><link>`.
 
+### Disabling URL path rewriting for selected applications
+Some applications like Jenkins or Artifactory, permit specifying a context path (e.g. `/service/jenkins`) that is used while generating application URLs (both relative and absolute). However, normally Admin Router strips these, and this can lead to breakages, esp. for assets like JavaScript files and images.
+
+It is possible to workaround it by using another another HTTP reverse proxy in the application container which rewrites URLs from / to /service/jenkins. This isn't ideal though, so an extra Marathon label is recognized by Admin Router. If a task has `DCOS_SERVICE_REWRITE_REQUEST_URLS` label set to `false`(string) or `false`(boolean), Admin Router will not strip the context path and the upstream request will be made with the same the URL path as the client request has been made. Please see below for an example of how to enable it in an application definition:
+
+```json
+{
+  "labels": {
+    "DCOS_SERVICE_REWRITE_REQUEST_URLS": "false",
+    "DCOS_SERVICE_NAME": "myapp",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "id": "/myapp",
+  "cmd": "echo \"It works!\" > index.html; /usr/local/bin/python -m http.server $PORT0",
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "python:3.6.5-stretch"
+    }
+  },
+  "cpus": 0.1,
+  "instances": 1,
+  "mem": 128,
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "name": "www",
+      "protocol": "tcp",
+      "port": 10000
+    }
+  ]
+}
+```
+
+This feature is available only for the tasks launched by the root Marathon.
+
 ## Authorization and authentication
 
 DC/OS uses DC/OS authentication token at the core of its authentication and

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -234,8 +234,24 @@ local function fetch_and_store_marathon_apps(auth_token)
           goto continue
        end
 
+       local do_rewrite_requrl = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
+       if do_rewrite_requrl == false or do_rewrite_requrl == 'false' then
+          ngx.log(ngx.INFO, "DCOS_SERVICE_REWRITE_REQUEST_URLS for app '" .. appId .. "' set to 'false'")
+          do_rewrite_requrl = false
+       else
+          -- Treat everything else as true, i.e.:
+          -- * label is absent
+          -- * label is set to "true" (string) or true (bool)
+          -- * label is set to some random string
+          do_rewrite_requrl = true
+       end
+
        local url = scheme .. "://" .. host_or_ip .. ":" .. port
-       svcApps[svcId] = {scheme=scheme, url=url}
+       svcApps[svcId] = {
+         scheme=scheme,
+         url=url,
+         do_rewrite_requrl=do_rewrite_requrl,
+         }
 
        ::continue::
     end


### PR DESCRIPTION
## High-level description

This PR makes it possible to configure `/service` endpoint upstream request URL rewriting basing on the `DCOS_SERVICE_REWRITE_REQUEST_URLS` label. See the Jira issue for details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-9032 `Adminrouter option to not rewrite URLs`

## Related PRs

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2570