### PR TITLE
add nvidia support to create_dcos_ami.sh

### DIFF
--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -10,6 +10,10 @@ export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
 # Version upgraded to in install_prereqs.sh
 export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}
 
+# The version component of the dcos-nvidia-drivers/ bucket to use
+# for fetching the nVidia drivers
+export NVIDIA_VERSION=${NVIDIA_VERSION:-"384.130"}
+
 # Useful options include -debug and -machine-readable
 PACKER_BUILD_OPTIONS=${PACKER_BUILD_OPTIONS:-""}
 

--- a/cloud_images/centos7/install_nvidia.sh
+++ b/cloud_images/centos7/install_nvidia.sh
@@ -1,0 +1,170 @@
+set -o errexit -o nounset -o pipefail
+unset HISTFILE
+
+# Root directories for source and target (Default to same machine)
+TARGETROOT=""
+SRCROOT=""
+
+# Prepare target directory configuration
+DST_USERSPACE_DIR="${TARGETROOT}/usr"
+DST_BOOT_DIR="${TARGETROOT}/boot"
+DST_ETC_DIR="${TARGETROOT}/etc"
+TEMP_DIR="/tmp"
+
+# If we only need to prepare, do clean-ups and reboot
+if [ "$1" == "prepare" ]; then
+
+  # Disable nouveau from kernel cmdline
+  echo ">>> Blacklisting nouveau driver through GRUB"
+  sed -r -i 's/^(GRUB_CMDLINE_LINUX=.*)"$/\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' \
+    /etc/default/grub
+
+  # Update GRUB
+  grub2-mkconfig -o /boot/grub2/grub.cfg
+
+  # Shutdown
+  echo ">>> Rebooting instance"
+  sync
+  nohup sh -c 'kill $(pidof sshd); reboot' </dev/null >/dev/null 2>&1 &
+  sleep 60
+  exit 0
+fi
+
+# Get cuda bucket to use from command-line
+NVIDIA_VERSION=$1
+
+# The nVidia driver files to download and install
+NVIDIA_KERNEL_DRIVER_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/NVIDIA-Linux-x86_64-${NVIDIA_VERSION}.run"
+
+# The header and devel URLs for our strange version of Centos
+KERNEL_DEVEL_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/kernel-devel-3.10.0-514.21.1.el7.x86_64.rpm"
+KERNEL_HEADER_URL="https://s3-us-west-2.amazonaws.com/dcos-nvidia-drivers/kernel-headers-3.10.0-514.21.1.el7.x86_64.rpm"
+
+#
+# WARNING: Some nVidia's hard-links will require authorization, making
+#          the link impossible to use. On production, please downoad all
+#          these files to a separate directory first.
+
+echo ">>> Removing nouveau module from kernel..."
+rmmod nouveau
+
+# Get the kernel to install packages for
+KERNEL=$(uname -r)
+
+# Download and install kernel development RPMs
+echo ""
+echo ">>> Downloading kernel development RPMs..."
+curl -s ${KERNEL_DEVEL_URL} > ${TEMP_DIR}/kernel-devel.rpm
+curl -s ${KERNEL_HEADER_URL} > ${TEMP_DIR}/kernel-headers.rpm
+yum install -y ${TEMP_DIR}/kernel-devel.rpm ${TEMP_DIR}/kernel-headers.rpm
+
+# Install missing dependencies
+echo ">>> Installing required packages to build for kernel ${KERNEL}..."
+yum install -y gcc make pciutils
+
+# Prepare kernel-specific directories
+DST_KERNEL_DIR="${TARGETROOT}/lib/modules/${KERNEL}/kernel/drivers/video"
+SRC_KERNEL_DIR="${SRCROOT}/lib/modules/${KERNEL}/build"
+
+# Crawl latest URL from here: http://www.nvidia.com/object/linux-amd64-display-archive.html
+echo ""
+echo ">>> Downloading nvidia kernel modules..."
+curl -s ${NVIDIA_KERNEL_DRIVER_URL} > ${TEMP_DIR}/NVIDIA-kernel.run
+chmod +x ${TEMP_DIR}/NVIDIA-kernel.run
+
+echo ">>> Installing nvidia kernel modules..."
+${TEMP_DIR}/NVIDIA-kernel.run \
+  --accept-license \
+  --no-questions \
+  --ui=none \
+  --disable-nouveau \
+  --utility-prefix=${DST_USERSPACE_DIR} \
+  --documentation-prefix=${DST_USERSPACE_DIR} \
+  --application-profile-path=${DST_USERSPACE_DIR}/share/nvidia \
+  --kernel-source-path=${SRC_KERNEL_DIR} \
+  --kernel-install-path=${DST_KERNEL_DIR} \
+  --kernel-name=${KERNEL}
+
+echo ">>> Installing nVidia boot scripts..."
+cat <<"EOF" > /usr/local/sbin/start-nvidia-drivers.sh
+#!/bin/bash
+
+start() {
+  /sbin/modprobe nvidia
+  if [ "$?" -eq 0 ]; then
+    # Count the number of NVIDIA controllers found.
+    NVDEVS=`lspci | grep -i NVIDIA`
+    N3D=`echo "$NVDEVS" | grep "3D controller" | wc -l`
+    NVGA=`echo "$NVDEVS" | grep "VGA compatible controller" | wc -l`
+    N=`expr $N3D + $NVGA - 1`
+    for i in `seq 0 $N`; do
+      mknod -m 666 /dev/nvidia$i c 195 $i
+    done
+    mknod -m 666 /dev/nvidiactl c 195 255
+  else
+    exit 1
+  fi
+  /sbin/modprobe nvidia-uvm
+  if [ "$?" -eq 0 ]; then
+    # Find out the major device number used by the nvidia-uvm driver
+    D=`grep nvidia-uvm /proc/devices | awk '{print $1}'`
+    mknod -m 666 /dev/nvidia-uvm c $D 0
+  else
+    exit 1
+  fi
+}
+
+stop() {
+  /sbin/rmmod nvidia
+  /sbin/rmmod nvidia-uvm
+  rm -f /dev/nvidia*
+}
+
+case $1 in
+  start|stop) "$1" ;;
+esac
+EOF
+chmod 0755 /usr/local/sbin/start-nvidia-drivers.sh
+
+# Create service
+cat <<"EOF" > /etc/systemd/system/nvidia.service
+[Unit]
+Description=Load nVidia kernel drivers and populate devices
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/start-nvidia-drivers.sh start
+ExecStop=/usr/local/sbin/start-nvidia-drivers.sh stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Register service
+echo ">>> Enabling nVidia service"
+systemctl enable nvidia.service
+
+# Clean-up
+echo ">>> Remove temporary files"
+rm ${TEMP_DIR}/NVIDIA-kernel.run
+rm -rf /tmp/* /var/tmp/*
+rm /usr/local/sbin/install_nvidia.sh
+
+echo ">>> Cleaning up SSH host keys"
+shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
+
+echo ">>> Cleaning up accounting files"
+rm -f rm -f /var/run/utmp
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+echo ">>> Remove temporary files"
+rm -rf /tmp/* /var/tmp/*
+
+echo ">>> Remove ssh client directories"
+rm -rf /home/*/.ssh /root/.ssh
+
+echo ">>> Remove history"
+rm -rf /home/*/.*history /root/.*history

--- a/cloud_images/centos7/packer.json
+++ b/cloud_images/centos7/packer.json
@@ -2,11 +2,13 @@
   "min_packer_version": "0.10.1",
   "variables": {
     "cloud_builder_version": "0.1",
+    "nvidia_version": "{{env `NVIDIA_VERSION`}}",
     "deploy_regions": "{{env `DEPLOY_REGIONS`}}",
     "source_ami": "{{env `SOURCE_AMI`}}",
     "source_ami_region": "{{env `SOURCE_AMI_REGION`}}"
   },
   "builders": [{
+    "name": "builder-generic",
     "type": "amazon-ebs",
     "communicator": "ssh",
     "ssh_pty": true,
@@ -76,6 +78,89 @@
     "ami_groups": [
       "all"
     ]
+  }, {
+    "name": "builder-gpu",
+    "type": "amazon-ebs",
+    "communicator": "ssh",
+    "ssh_pty": true,
+    "region": "{{user `source_ami_region`}}",
+    "source_ami": "{{user `source_ami`}}",
+    "instance_type": "g3.4xlarge",
+    "ssh_username": "centos",
+    "ami_name": "dcos-centos7-gpu-nvidia-{{user `nvidia_version`}}-{{isotime \"200601021504\"}}",
+    "ami_description": "DC/OS Cloud Image for CentOS 7, with nVidia {{user `nvidia_version`}} GPU Drivers",
+    "ebs_optimized": true,
+    "ami_block_device_mappings": [
+      {
+        "device_name": "/dev/sda1",
+        "volume_size": 16,
+        "volume_type": "gp2",
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sde",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdf",
+        "volume_type": "gp2",
+        "volume_size": 100,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdh",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      }
+    ],
+    "launch_block_device_mappings": [
+      {
+        "device_name": "/dev/sda1",
+        "volume_size": 16,
+        "volume_type": "gp2",
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sde",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdf",
+        "volume_type": "gp2",
+        "volume_size": 100,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdg",
+        "volume_type": "gp2",
+        "volume_size": 50,
+        "delete_on_termination": true
+      },
+      {
+        "device_name": "/dev/sdh",
+        "volume_type": "gp2",
+        "volume_size": 20,
+        "delete_on_termination": true
+      }
+    ],
+    "tags": {
+      "cloud_builder_version": "{{user `cloud_builder_version`}}",
+      "nvidia_version": "{{user `nvidia_version`}}"
+    },
+    "ami_groups": [
+      "all"
+    ]
   }],
   "provisioners": [
     {
@@ -98,14 +183,43 @@
       "source": "../lib/el7/install_docker.sh",
       "destination": "/tmp/install_docker.sh"
 	},
+	{
+      "type": "file",
+      "source": "install_nvidia.sh",
+      "destination": "/tmp/install_nvidia.sh",
+      "only": [ "builder-gpu" ]
+    },
     {
       "type": "shell",
       "inline_shebang": "/bin/bash -e",
+      "override": {
+        "builder-generic": {
+          "inline": [
+            "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+            "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_dcos_required_packages.sh /tmp/configure_dcos_system.sh /tmp/install_docker.sh",
+            "sudo ROOTFS=/ /tmp/install_dcos_required_packages.sh",
+            "sudo /tmp/configure_dcos_system.sh"
+          ]
+        },
+        "builder-gpu": {
+          "expect_disconnect": true,
+          "inline": [
+            "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
+            "sudo mv /tmp/install_nvidia.sh /usr/local/sbin/",
+            "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /usr/local/sbin/install_nvidia.sh /tmp/install_dcos_required_packages.sh /tmp/configure_dcos_system.sh /tmp/install_docker.sh",
+            "sudo ROOTFS=/ /tmp/install_dcos_required_packages.sh",
+            "sudo /tmp/configure_dcos_system.sh no-cleanup",
+            "sudo /usr/local/sbin/install_nvidia.sh prepare"
+          ]
+        }
+      }
+    },
+    {
+      "type": "shell",
+      "inline_shebang": "/bin/bash -e",
+      "only": [ "builder-gpu" ],
       "inline": [
-        "sudo mv /tmp/dcos_vol_setup.sh /usr/local/sbin/",
-        "sudo chmod 0755 /usr/local/sbin/dcos_vol_setup.sh /tmp/install_dcos_required_packages.sh /tmp/configure_dcos_system.sh /tmp/install_docker.sh",
-		"sudo ROOTFS=/ /tmp/install_dcos_required_packages.sh",
-        "sudo /tmp/configure_dcos_system.sh"
+        "sudo /usr/local/sbin/install_nvidia.sh '{{user `nvidia_version`}}'"
       ]
     }
   ]

--- a/cloud_images/lib/el7/configure_dcos_system.sh
+++ b/cloud_images/lib/el7/configure_dcos_system.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
+MODE=${1:-}
 
 echo ">>> In configure_dcos_system.sh:"
 
@@ -50,6 +51,9 @@ sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 
 echo ">>> Adding group [nogroup]"
 /usr/sbin/groupadd -f nogroup
+
+# Skip cleanup if requested
+[ "$MODE" == "no-cleanup" ] && exit 0
 
 echo ">>> Cleaning up SSH host keys"
 shred -u /etc/ssh/*_key /etc/ssh/*_key.pub


### PR DESCRIPTION
add nvidia support to create_dcos_ami.sh (initially copy/paste from klues)

## High-level description

Builds AMI via create_dcos_ami.sh with NVIDIA drivers. Follow up to INFINITY-2715 where the AMI failed to build. I do not know how to prove that it does what is expected, but the build now succeeds.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [INFINITY-2715](https://jira.mesosphere.com/browse/INFINITY-2715) Test Spark on GPUs (with our distribution)
