### PR TITLE
Update the default of the cento-os AMI - ami-a9b24bd1

### DIFF
--- a/cloud_images/centos7/create_dcos_ami.sh
+++ b/cloud_images/centos7/create_dcos_ami.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o pipefail
 export AWS_PROFILE=${AWS_PROFILE:-"development"}
 
 # Base CentOS 7 AMI and region
-export SOURCE_AMI=${SOURCE_AMI:-"ami-31a8ca51"}
+export SOURCE_AMI=${SOURCE_AMI:-"ami-a9b24bd1"}
 export SOURCE_AMI_REGION=${SOURCE_AMI_REGION:-"us-west-2"}
 # Version upgraded to in install_prereqs.sh
 export DEPLOY_REGIONS=${DEPLOY_REGIONS:-"us-west-2"}


### PR DESCRIPTION
## High-level description

We had updated the version https://github.com/dcos/dcos/pull/2040/files
but missed updating the default when we want to use `create_dcos_ami.sh`

## Corresponding DC/OS tickets (obligatory)

  - https://jira.mesosphere.com/browse/INFINITY-2715

### Testing Done.

```
Build 'builder-generic' finished.
==> builder-gpu: Creating the AMI: skumaran-7-dcos-centos7-gpu-nvidia-384.130-201804070135
    builder-gpu: AMI: ami-d54a2cad
==> builder-gpu: Waiting for AMI to become ready...
==> builder-gpu: Modifying attributes on AMI (ami-d54a2cad)...
    builder-gpu: Modifying: description
    builder-gpu: Modifying: groups
==> builder-gpu: Modifying attributes on snapshot (snap-0f0086d6df757893b)...
==> builder-gpu: Modifying attributes on snapshot (snap-05452755050872ff0)...
==> builder-gpu: Modifying attributes on snapshot (snap-0ded2cae5b9b8dc72)...
==> builder-gpu: Modifying attributes on snapshot (snap-07af74f2036c6ac53)...
==> builder-gpu: Modifying attributes on snapshot (snap-0151fd2d994bb9115)...
==> builder-gpu: Adding tags to AMI (ami-d54a2cad)...
==> builder-gpu: Tagging snapshot: snap-0f0086d6df757893b
==> builder-gpu: Tagging snapshot: snap-05452755050872ff0
==> builder-gpu: Tagging snapshot: snap-0ded2cae5b9b8dc72
==> builder-gpu: Tagging snapshot: snap-07af74f2036c6ac53
==> builder-gpu: Tagging snapshot: snap-0151fd2d994bb9115
==> builder-gpu: Creating AMI tags
    builder-gpu: Adding tag: "nvidia_version": "384.130"
    builder-gpu: Adding tag: "cloud_builder_version": "0.1"
==> builder-gpu: Creating snapshot tags
==> builder-gpu: Terminating the source AWS instance...
==> builder-gpu: Cleaning up any extra volumes...
==> builder-gpu: No volumes to clean up, skipping
==> builder-gpu: Deleting temporary security group...
==> builder-gpu: Deleting temporary keypair...
Build 'builder-gpu' finished.

==> Builds finished. The artifacts of successful builds are:
--> builder-generic: AMIs were created:
us-west-2: ami-0c4c2a74

--> builder-gpu: AMIs were created:
us-west-2: ami-d54a2cad
```