### PR TITLE
Bump curl from 7.48 to 7.59 in dcos 1.9

### DIFF
--- a/packages/curl/buildinfo.json
+++ b/packages/curl/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["openssl", "python-requests"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://curl.haxx.se/download/curl-7.48.0.tar.gz",
-    "sha1": "eac95625b849408362cf6edb0bc9489da317ba30"
+    "url": "https://curl.haxx.se/download/curl-7.58.0.tar.gz",
+    "sha1": "089f17884d672aca7a661a65d847135f2f0ccbbf"
   }
 }


### PR DESCRIPTION
## High-level description

This PR bumps curl from 17.48 to 7.59.0 in 1.9

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS-21557

## Checklist for all PRs

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)