### PR TITLE
[1.11] Disable the 3DES and TLS 1.1 for Master Admin Router by default.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1010,7 +1010,7 @@ entry = {
         'weights': '',
         'adminrouter_auth_enabled': calculate_adminrouter_auth_enabled,
         'adminrouter_tls_1_0_enabled': 'false',
-        'adminrouter_tls_1_1_enabled': 'true',
+        'adminrouter_tls_1_1_enabled': 'false',
         'adminrouter_tls_1_2_enabled': 'true',
         'adminrouter_tls_cipher_suite': '',
         'oauth_enabled': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -989,10 +989,11 @@ package:
   - path: /etc/adminrouter-tls-master.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-      # Modulo ChaCha20 cipher.
+      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+      # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 {% switch adminrouter_tls_cipher_override %}
 {% case "false" %}
-      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 {% case "true" %}
       ssl_ciphers {{ adminrouter_tls_cipher_suite }};
 {% endswitch %}

--- a/gen/tests/test_adminrouter_tls_conf.py
+++ b/gen/tests/test_adminrouter_tls_conf.py
@@ -28,9 +28,10 @@ class TestAdminRouterTLSConfig:
         expected_configuration = dedent(
             """\
             # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-            # Modulo ChaCha20 cipher.
+            # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+            # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 
-            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 
             ssl_prefer_server_ciphers on;
             # To manually test which TLS versions are enabled on a node, use
@@ -38,7 +39,7 @@ class TestAdminRouterTLSConfig:
             #
             # See comments on https://jira.mesosphere.com/browse/DCOS-13437 for more
             # details.
-            ssl_protocols TLSv1.1 TLSv1.2;
+            ssl_protocols TLSv1.2;
             """
         )
         assert config['content'] == expected_configuration
@@ -115,7 +116,7 @@ class TestSetCipherOverride:
             config_path: str) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -142,7 +143,7 @@ class TestSetCipherOverride:
             new_config_arguments: Dict[str, str]) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -194,7 +195,7 @@ class TestSetCipherOverride:
         ciphers = self.supported_ssl_ciphers_master(
             new_config_arguments=new_arguments,
         )
-        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5']
+        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES']
 
     def test_cipher_master_custom(self):
         """
@@ -270,9 +271,10 @@ class TestToggleTLSVersions:
             new_config_arguments={},
         )
         disable_tls1_protocols = self.supported_tls_protocols_ar_master(
-            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false'},
+            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false',
+                                  'adminrouter_tls_1_1_enabled': 'false'},
         )
-        assert default_protocols == ['TLSv1.1', 'TLSv1.2']
+        assert default_protocols == ['TLSv1.2']
         assert default_protocols == disable_tls1_protocols
 
     @pytest.mark.parametrize(

--- a/packages/adminrouter/docker/adminrouter-tls-master.conf
+++ b/packages/adminrouter/docker/adminrouter-tls-master.conf
@@ -1,6 +1,7 @@
 # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-# Modulo ChaCha20 cipher.
-ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+# Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+# For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
+ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 ssl_prefer_server_ciphers on;
 
 ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
## High-level description

This PR disables the 3DES bulk encryption algorithm and TLS 1.1 for Master Admin Router by default in DC/OS 1.11.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS-21958

## Checklist for all PRs

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)