### PR TITLE
[1.11] Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "fe764a8d79fdb7a606406109f2293b86e10491cd",
-    "ref_origin": "master"
+    "ref": "4d63ddb74c9297b1f2b4328a238da4212b802546",
+    "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"
 }


### PR DESCRIPTION
## High-level description

This change fixes an issue where metrics labels offered by the Prometheus producer could be prefixed with numbers, which is illegal. Prometheus would ignore those metrics, dropping data. We now prefix such labels with an underscore. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2360](https://jira.mesosphere.com/browse/DCOS_OSS-2360) Metric names can begin with numbers in dcos-metrics Prometheus endpoint

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this is a bugfix. 
  - [x] Included a test which will fail if code is reverted but test is not. 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/fe764a8d79fdb7a606406109f2293b86e10491cd... 4d63ddb74c9297b1f2b4328a238da4212b802546)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/8/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/8/cobertura/)