### PR TITLE
gen: Generate config packages with new IDs after editing files under genconf/

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,1 +1,2 @@
 ## DC/OS 1.12.0
+* A cluster's IP detect script may be changed with a config upgrade.

--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -134,10 +134,6 @@ def validate_aws_bucket_access(aws_template_storage_region_name,
                 aws_template_storage_bucket_path, aws_template_storage_bucket, ex)) from ex
 
 
-def calculate_reproducible_artifact_path(config_id):
-    return 'config_id/{}'.format(config_id)
-
-
 def calculate_base_repository_url(
         aws_template_storage_region_name,
         aws_template_storage_bucket,
@@ -146,16 +142,6 @@ def calculate_base_repository_url(
         domain=region_to_endpoint[aws_template_storage_region_name],
         bucket=aws_template_storage_bucket,
         path=aws_template_storage_bucket_path)
-
-
-# Figure out the s3 bucket url from region + bucket + path
-def calculate_cloudformation_s3_url(bootstrap_url, config_id):
-    return '{}/config_id/{}'.format(bootstrap_url, config_id)
-
-
-# Figure out the s3 bucket url from region + bucket + path
-def calculate_cloudformation_s3_url_full(cloudformation_s3_url):
-    return '{}/cloudformation'.format(cloudformation_s3_url)
 
 
 def calculate_aws_template_storage_region_name(
@@ -209,10 +195,7 @@ aws_advanced_source = gen.internals.Source({
         'package_ids': lambda bootstrap_variant: json.dumps(
             config_util.installer_latest_complete_artifact(bootstrap_variant)['packages']
         ),
-        'cloudformation_s3_url': calculate_cloudformation_s3_url,
-        'cloudformation_s3_url_full': calculate_cloudformation_s3_url_full,
         'bootstrap_url': calculate_base_repository_url,
-        'reproducible_artifact_path': calculate_reproducible_artifact_path,
     },
     'secret': [
         'aws_template_storage_access_key_id',
@@ -239,12 +222,9 @@ def get_aws_advanced_target():
             'aws_template_storage_bucket_path',
             'aws_template_upload',
             'aws_template_storage_bucket_path_autocreate',
-            'cloudformation_s3_url',
-            'cloudformation_s3_url_full',
             'provider',
             'bootstrap_url',
             'bootstrap_variant',
-            'reproducible_artifact_path',
             'package_ids'},
         sub_scopes={
             'aws_template_upload': gen.internals.Scope(
@@ -308,12 +288,18 @@ def do_aws_cf_configure():
     # done a validation run.
     full_config = {k: v.value for k, v in resolver.arguments.items()}
 
+    # Calculate the config ID and values that depend on it.
+    config_id = gen.get_config_id(full_config)
+    reproducible_artifact_path = 'config_id/{}'.format(config_id)
+    cloudformation_s3_url = '{}/config_id/{}'.format(full_config['bootstrap_url'], config_id)
+    cloudformation_s3_url_full = '{}/cloudformation'.format(cloudformation_s3_url)
+
     # TODO(cmaloney): Switch to using the targets
     gen_config['bootstrap_url'] = full_config['bootstrap_url']
     gen_config['provider'] = full_config['provider']
     gen_config['bootstrap_id'] = full_config['bootstrap_id']
     gen_config['package_ids'] = full_config['package_ids']
-    gen_config['cloudformation_s3_url_full'] = full_config['cloudformation_s3_url_full']
+    gen_config['cloudformation_s3_url_full'] = cloudformation_s3_url_full
 
     # Convert the bootstrap_Variant string we have back to a bootstrap_id as used internally by all
     # the tooling (never has empty string, uses None to say "no variant")
@@ -323,7 +309,7 @@ def do_aws_cf_configure():
     for built_resource in list(gen.build_deploy.aws.do_create(
             tag='dcos_generate_config.sh --aws-cloudformation',
             build_name='Custom',
-            reproducible_artifact_path=full_config['reproducible_artifact_path'],
+            reproducible_artifact_path=reproducible_artifact_path,
             variant_arguments={bootstrap_variant: gen_config},
             commit=full_config['dcos_image_commit'],
             all_completes=None)):
@@ -349,7 +335,7 @@ def do_aws_cf_configure():
     repository = release.Repository(
         full_config['aws_template_storage_bucket_path'],
         None,
-        'config_id/' + full_config['config_id'])
+        'config_id/' + config_id)
 
     storage_commands = repository.make_commands({'core_artifacts': [], 'channel_artifacts': artifacts})
 
@@ -360,7 +346,7 @@ def do_aws_cf_configure():
 
     log.warning(
         "Generated templates locally available at %s",
-        cf_dir + "/" + full_config["reproducible_artifact_path"])
+        cf_dir + "/" + reproducible_artifact_path)
     # TODO(cmaloney): Print where the user can find the files locally
 
     if full_config['aws_template_upload'] == 'false':
@@ -369,15 +355,14 @@ def do_aws_cf_configure():
     storage_provider = release.storage.aws.S3StorageProvider(
         bucket=full_config['aws_template_storage_bucket'],
         object_prefix=None,
-        download_url=full_config['cloudformation_s3_url'],
+        download_url=cloudformation_s3_url,
         region_name=full_config['aws_template_storage_region_name'],
         access_key_id=full_config['aws_template_storage_access_key_id'],
         secret_access_key=full_config['aws_template_storage_secret_access_key'])
 
     log.warning("Uploading to AWS")
     release.apply_storage_commands({'aws': storage_provider}, storage_commands)
-    log.warning("AWS CloudFormation templates now available at: {}".format(
-        full_config['cloudformation_s3_url']))
+    log.warning("AWS CloudFormation templates now available at: {}".format(cloudformation_s3_url))
 
     # TODO(cmaloney): Print where the user can find the files in AWS
     # TODO(cmaloney): Dump out a JSON with machine paths to make scripting easier.

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -35,9 +35,6 @@ import schema
 import yaml
 
 import gen.internals
-import pkgpanda.exceptions
-from pkgpanda import PackageId
-from pkgpanda.util import hash_checkout, hash_str
 
 
 DCOS_VERSION = '1.12-dev'
@@ -413,39 +410,6 @@ def validate_mesos_dns_ip_sources(mesos_dns_ip_sources):
 
 def calc_num_masters(master_list):
     return str(len(json.loads(master_list)))
-
-
-def calculate_config_id(dcos_image_commit, template_filenames, sources_id):
-    return hash_checkout({
-        "commit": dcos_image_commit,
-        "template_filenames": json.loads(template_filenames),
-        "sources_id": sources_id})
-
-
-def calculate_config_package_ids(config_package_names, config_id):
-    def get_config_package_id(config_package_name):
-        pkg_id_str = "{}--setup_{}".format(config_package_name, config_id)
-        # validate the pkg_id_str generated is a valid PackageId
-        return pkg_id_str
-
-    return json.dumps(list(sorted(map(get_config_package_id, json.loads(config_package_names)))))
-
-
-def calculate_cluster_packages(config_package_ids, package_ids):
-    return json.dumps(sorted(json.loads(config_package_ids) + json.loads(package_ids)))
-
-
-def calculate_cluster_package_list_id(cluster_packages):
-    return hash_str(cluster_packages)
-
-
-def validate_cluster_packages(cluster_packages):
-    pkg_id_list = json.loads(cluster_packages)
-    for pkg_id in pkg_id_list:
-        try:
-            PackageId(pkg_id)
-        except pkgpanda.exceptions.ValidationError as ex:
-            raise AssertionError(str(ex)) from ex
 
 
 def calculate_no_proxy(no_proxy):
@@ -957,7 +921,6 @@ entry = {
         validate_dns_forward_zones,
         validate_zk_hosts,
         validate_zk_path,
-        validate_cluster_packages,
         lambda oauth_enabled: validate_true_false(oauth_enabled),
         lambda oauth_available: validate_true_false(oauth_available),
         validate_mesos_dns_ip_sources,
@@ -1131,10 +1094,6 @@ entry = {
         'dcos_variant': 'open',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
-        'config_package_ids': calculate_config_package_ids,
-        'cluster_packages': calculate_cluster_packages,
-        'cluster_package_list_id': calculate_cluster_package_list_id,
-        'config_id': calculate_config_id,
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,
         'exhibitor_admin_password_enabled': calculate_exhibitor_admin_password_enabled,
         'ui_branding': 'false',


### PR DESCRIPTION
## High-level description

This PR fixes genconf to allow changing config values that are provided as files under `genconf/` as part of an upgrade. Without this PR, editing `genconf/detect_ip` and re-running genconf will create a new config package with an updated IP detect script, but with the same ID as the prior config package. Because the ID hasn't changed, Pkgpanda will assume it has the same contents as the config package currently present on cluster nodes, and reuse it instead of downloading the updated package. With this PR, the new config package will have a different ID, causing Pkgpanda to recognize that it is different and use it.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2389](https://jira.mesosphere.com/browse/DCOS_OSS-2389) Upgrades Fails to Update the agents ip-detect script

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]