### PR TITLE
(1.11) gen: Generate config packages with new IDs after editing files under genconf/

### DIFF
--- a/dcos_installer/backend.py
+++ b/dcos_installer/backend.py
@@ -134,10 +134,6 @@ def validate_aws_bucket_access(aws_template_storage_region_name,
                 aws_template_storage_bucket_path, aws_template_storage_bucket, ex)) from ex
 
 
-def calculate_reproducible_artifact_path(config_id):
-    return 'config_id/{}'.format(config_id)
-
-
 def calculate_base_repository_url(
         aws_template_storage_region_name,
         aws_template_storage_bucket,
@@ -146,16 +142,6 @@ def calculate_base_repository_url(
         domain=region_to_endpoint[aws_template_storage_region_name],
         bucket=aws_template_storage_bucket,
         path=aws_template_storage_bucket_path)
-
-
-# Figure out the s3 bucket url from region + bucket + path
-def calculate_cloudformation_s3_url(bootstrap_url, config_id):
-    return '{}/config_id/{}'.format(bootstrap_url, config_id)
-
-
-# Figure out the s3 bucket url from region + bucket + path
-def calculate_cloudformation_s3_url_full(cloudformation_s3_url):
-    return '{}/cloudformation'.format(cloudformation_s3_url)
 
 
 def calculate_aws_template_storage_region_name(
@@ -209,10 +195,7 @@ aws_advanced_source = gen.internals.Source({
         'package_ids': lambda bootstrap_variant: json.dumps(
             config_util.installer_latest_complete_artifact(bootstrap_variant)['packages']
         ),
-        'cloudformation_s3_url': calculate_cloudformation_s3_url,
-        'cloudformation_s3_url_full': calculate_cloudformation_s3_url_full,
         'bootstrap_url': calculate_base_repository_url,
-        'reproducible_artifact_path': calculate_reproducible_artifact_path,
     },
     'secret': [
         'aws_template_storage_access_key_id',
@@ -239,12 +222,9 @@ def get_aws_advanced_target():
             'aws_template_storage_bucket_path',
             'aws_template_upload',
             'aws_template_storage_bucket_path_autocreate',
-            'cloudformation_s3_url',
-            'cloudformation_s3_url_full',
             'provider',
             'bootstrap_url',
             'bootstrap_variant',
-            'reproducible_artifact_path',
             'package_ids'},
         sub_scopes={
             'aws_template_upload': gen.internals.Scope(
@@ -308,12 +288,18 @@ def do_aws_cf_configure():
     # done a validation run.
     full_config = {k: v.value for k, v in resolver.arguments.items()}
 
+    # Calculate the config ID and values that depend on it.
+    config_id = gen.get_config_id(full_config)
+    reproducible_artifact_path = 'config_id/{}'.format(config_id)
+    cloudformation_s3_url = '{}/config_id/{}'.format(full_config['bootstrap_url'], config_id)
+    cloudformation_s3_url_full = '{}/cloudformation'.format(cloudformation_s3_url)
+
     # TODO(cmaloney): Switch to using the targets
     gen_config['bootstrap_url'] = full_config['bootstrap_url']
     gen_config['provider'] = full_config['provider']
     gen_config['bootstrap_id'] = full_config['bootstrap_id']
     gen_config['package_ids'] = full_config['package_ids']
-    gen_config['cloudformation_s3_url_full'] = full_config['cloudformation_s3_url_full']
+    gen_config['cloudformation_s3_url_full'] = cloudformation_s3_url_full
 
     # Convert the bootstrap_Variant string we have back to a bootstrap_id as used internally by all
     # the tooling (never has empty string, uses None to say "no variant")
@@ -323,7 +309,7 @@ def do_aws_cf_configure():
     for built_resource in list(gen.build_deploy.aws.do_create(
             tag='dcos_generate_config.sh --aws-cloudformation',
             build_name='Custom',
-            reproducible_artifact_path=full_config['reproducible_artifact_path'],
+            reproducible_artifact_path=reproducible_artifact_path,
             variant_arguments={bootstrap_variant: gen_config},
             commit=full_config['dcos_image_commit'],
             all_completes=None)):
@@ -349,7 +335,7 @@ def do_aws_cf_configure():
     repository = release.Repository(
         full_config['aws_template_storage_bucket_path'],
         None,
-        'config_id/' + full_config['config_id'])
+        'config_id/' + config_id)
 
     storage_commands = repository.make_commands({'core_artifacts': [], 'channel_artifacts': artifacts})
 
@@ -360,7 +346,7 @@ def do_aws_cf_configure():
 
     log.warning(
         "Generated templates locally available at %s",
-        cf_dir + "/" + full_config["reproducible_artifact_path"])
+        cf_dir + "/" + reproducible_artifact_path)
     # TODO(cmaloney): Print where the user can find the files locally
 
     if full_config['aws_template_upload'] == 'false':
@@ -369,15 +355,14 @@ def do_aws_cf_configure():
     storage_provider = release.storage.aws.S3StorageProvider(
         bucket=full_config['aws_template_storage_bucket'],
         object_prefix=None,
-        download_url=full_config['cloudformation_s3_url'],
+        download_url=cloudformation_s3_url,
         region_name=full_config['aws_template_storage_region_name'],
         access_key_id=full_config['aws_template_storage_access_key_id'],
         secret_access_key=full_config['aws_template_storage_secret_access_key'])
 
     log.warning("Uploading to AWS")
     release.apply_storage_commands({'aws': storage_provider}, storage_commands)
-    log.warning("AWS CloudFormation templates now available at: {}".format(
-        full_config['cloudformation_s3_url']))
+    log.warning("AWS CloudFormation templates now available at: {}".format(cloudformation_s3_url))
 
     # TODO(cmaloney): Print where the user can find the files in AWS
     # TODO(cmaloney): Dump out a JSON with machine paths to make scripting easier.

--- a/gen/__init__.py
+++ b/gen/__init__.py
@@ -27,6 +27,7 @@ import gen.calc
 import gen.internals
 import gen.template
 import gen.util
+import pkgpanda.exceptions
 from gen.exceptions import ValidationError
 from pkgpanda import PackageId
 from pkgpanda.util import (
@@ -450,7 +451,14 @@ def get_dcosconfig_source_target_and_templates(
                 "Internal Error: Only know how to merge YAML templates at this point in time. "
                 "Can't merge template {} in template_list {}".format(filename, templates[key]))
 
-    targets = target_from_templates(templates)
+    # Include a base target that references variables we need to calculate cluster_packages.
+    base_target = gen.internals.Target({
+        'config_package_names',
+        'dcos_image_commit',
+        'package_ids',
+        'template_filenames',
+    })
+    targets = [base_target] + target_from_templates(templates)
     base_source = gen.internals.Source(is_user=False)
     base_source.add_entry(gen.calc.entry, replace_existing=False)
 
@@ -472,16 +480,14 @@ def get_dcosconfig_source_target_and_templates(
     # unset argument errors. The placeholder value with be replaced with the actual value after all other variables are
     # calculated.
     temporary_str = 'DO NOT USE THIS AS AN ARGUMENT TO OTHER ARGUMENTS. IT IS TEMPORARY'
+    add_builtin('cluster_packages', temporary_str)
+    add_builtin('cluster_package_list_id', temporary_str)
     add_builtin('user_arguments_full', temporary_str)
     add_builtin('user_arguments', temporary_str)
     add_builtin('config_yaml_full', temporary_str)
     add_builtin('config_yaml', temporary_str)
     add_builtin('expanded_config', temporary_str)
     add_builtin('expanded_config_full', temporary_str)
-
-    # Note: must come last so the hash of the "base_source" this is beign added to contains all the
-    # variables but this.
-    add_builtin('sources_id', hash_checkout([hash_checkout(source.make_id()) for source in sources]))
 
     return sources, targets, templates
 
@@ -563,6 +569,25 @@ def user_arguments_to_yaml(user_arguments: dict):
     )
 
 
+def validate_cluster_packages(cluster_packages):
+    for pkg_id in cluster_packages:
+        try:
+            PackageId(pkg_id)
+        except pkgpanda.exceptions.ValidationError as ex:
+            raise Exception('Invalid cluster package ID: {}'.format(str(ex))) from ex
+
+
+def get_config_id(argument_dict: dict):
+    """Return a unique ID for the configuration represented by argument_dict."""
+    # dcos_image_commit and template_filenames should be included in argument_dict, but we reference them explicitly to
+    # ensure that the config ID reflects the current commit and config templates.
+    return hash_checkout({
+        'commit': argument_dict['dcos_image_commit'],
+        'template_filenames': argument_dict['template_filenames'],
+        'argument_dict': argument_dict,
+    })
+
+
 def generate(
         arguments,
         extra_templates=list(),
@@ -582,7 +607,20 @@ def generate(
     secret_variables = set(get_secret_variables(sources) + secret_builtins)
     masked_value = '**HIDDEN**'
 
+    # Calculate config ID after all variables are resolved, to make sure any change in config yields a new config ID.
+    config_id = get_config_id(argument_dict)
+
+    # Calculate values that depend on the config ID.
+    config_package_names = json.loads(argument_dict['config_package_names'])
+    package_ids = json.loads(argument_dict['package_ids'])
+    config_package_ids = ['{}--setup_{}'.format(name, config_id) for name in config_package_names]
+    cluster_packages = sorted(config_package_ids + package_ids)
+    validate_cluster_packages(cluster_packages)
+    cluster_package_list_id = hash_checkout(cluster_packages)
+
     # Calculate values for builtin variables.
+    argument_dict['cluster_packages'] = json.dumps(cluster_packages)
+    argument_dict['cluster_package_list_id'] = cluster_package_list_id
     user_arguments_masked = {k: (masked_value if k in secret_variables else v) for k, v in user_arguments.items()}
     argument_dict['user_arguments_full'] = json_prettyprint(user_arguments)
     argument_dict['user_arguments'] = json_prettyprint(user_arguments_masked)
@@ -637,9 +675,7 @@ def generate(
     rendered_templates['dcos-config.yaml'] = {'package': regular_files}
 
     # Render cluster package list artifact.
-    cluster_package_list_filename = 'package_lists/{}.package_list.json'.format(
-        argument_dict['cluster_package_list_id']
-    )
+    cluster_package_list_filename = 'package_lists/{}.package_list.json'.format(cluster_package_list_id)
     os.makedirs(os.path.dirname(cluster_package_list_filename), mode=0o755, exist_ok=True)
     write_string(cluster_package_list_filename, argument_dict['cluster_packages'])
     log.info('Cluster package list: {}'.format(cluster_package_list_filename))
@@ -655,7 +691,7 @@ def generate(
     cluster_package_info = {}
 
     # Prepare late binding config, if any.
-    late_package = build_late_package(late_files, argument_dict['config_id'], argument_dict['provider'])
+    late_package = build_late_package(late_files, config_id, argument_dict['provider'])
     if late_variables:
         # Render the late binding package. This package will be downloaded onto
         # each cluster node during bootstrap and rendered into the final config
@@ -684,7 +720,7 @@ def generate(
             })})
 
     # Collect metadata for cluster packages.
-    for package_id_str in json.loads(argument_dict['cluster_packages']):
+    for package_id_str in cluster_packages:
         package_id = PackageId(package_id_str)
         package_filename = make_package_filename(package_id, '.tar.xz')
 
@@ -694,7 +730,6 @@ def generate(
         }
 
     # Render config packages.
-    config_package_ids = json.loads(argument_dict['config_package_ids'])
     for package_id_str in config_package_ids:
         package_id = PackageId(package_id_str)
         package_filename = cluster_package_info[package_id.name]['filename']

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -35,9 +35,6 @@ import schema
 import yaml
 
 import gen.internals
-import pkgpanda.exceptions
-from pkgpanda import PackageId
-from pkgpanda.util import hash_checkout, hash_str
 
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
@@ -405,39 +402,6 @@ def validate_mesos_dns_ip_sources(mesos_dns_ip_sources):
 
 def calc_num_masters(master_list):
     return str(len(json.loads(master_list)))
-
-
-def calculate_config_id(dcos_image_commit, template_filenames, sources_id):
-    return hash_checkout({
-        "commit": dcos_image_commit,
-        "template_filenames": json.loads(template_filenames),
-        "sources_id": sources_id})
-
-
-def calculate_config_package_ids(config_package_names, config_id):
-    def get_config_package_id(config_package_name):
-        pkg_id_str = "{}--setup_{}".format(config_package_name, config_id)
-        # validate the pkg_id_str generated is a valid PackageId
-        return pkg_id_str
-
-    return json.dumps(list(sorted(map(get_config_package_id, json.loads(config_package_names)))))
-
-
-def calculate_cluster_packages(config_package_ids, package_ids):
-    return json.dumps(sorted(json.loads(config_package_ids) + json.loads(package_ids)))
-
-
-def calculate_cluster_package_list_id(cluster_packages):
-    return hash_str(cluster_packages)
-
-
-def validate_cluster_packages(cluster_packages):
-    pkg_id_list = json.loads(cluster_packages)
-    for pkg_id in pkg_id_list:
-        try:
-            PackageId(pkg_id)
-        except pkgpanda.exceptions.ValidationError as ex:
-            raise AssertionError(str(ex)) from ex
 
 
 def calculate_no_proxy(no_proxy):
@@ -949,7 +913,6 @@ entry = {
         validate_dns_forward_zones,
         validate_zk_hosts,
         validate_zk_path,
-        validate_cluster_packages,
         lambda oauth_enabled: validate_true_false(oauth_enabled),
         lambda oauth_available: validate_true_false(oauth_available),
         validate_mesos_dns_ip_sources,
@@ -1119,10 +1082,6 @@ entry = {
         'dcos_version': '1.11.1',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
-        'config_package_ids': calculate_config_package_ids,
-        'cluster_packages': calculate_cluster_packages,
-        'cluster_package_list_id': calculate_cluster_package_list_id,
-        'config_id': calculate_config_id,
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,
         'exhibitor_admin_password_enabled': calculate_exhibitor_admin_password_enabled,
         'ui_branding': 'false',

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 
 import pkg_resources
 import yaml
@@ -790,3 +791,25 @@ def test_exhibitor_admin_password_obscured():
 
     assert yaml.load(generated.arguments['config_yaml'])[var_name] == '**HIDDEN**'
     assert yaml.load(generated.arguments['config_yaml_full'])[var_name] == var_value
+
+
+def test_edited_ip_detect_script_yields_new_packages():
+    with tempfile.NamedTemporaryFile() as f:
+        arguments = make_arguments(new_arguments={'ip_detect_filename': f.name})
+
+        f.write('initial script contents\n'.encode('utf-8'))
+        f.flush()
+        initial_cluster_packages = gen.generate(arguments).cluster_packages
+
+        # Running genconf with the same config yields the same set of packages.
+        initial_cluster_packages_rerun = gen.generate(arguments).cluster_packages
+        assert initial_cluster_packages == initial_cluster_packages_rerun
+
+        f.seek(0)
+        f.truncate()
+        f.write('edited script contents\n'.encode('utf-8'))
+        f.flush()
+        edited_cluster_packages = gen.generate(arguments).cluster_packages
+
+        # Running genconf with an edited IP detect script yields a new set of packages.
+        assert initial_cluster_packages != edited_cluster_packages


### PR DESCRIPTION
## High-level description

This is a 1.11 backport of #2724.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-21611](https://jira.mesosphere.com/browse/DCOS-21611) DC/OS Upgrades Fails to Update the agents fault-domain-detect script


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A, there's no changelog on the 1.11 branch.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]