### PR TITLE
Fixed bug in `calculate_ip_detect_public_contents()`.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -204,7 +204,7 @@ def calculate_ip_detect_contents(ip_detect_filename):
 
 def calculate_ip_detect_public_contents(ip_detect_contents, ip_detect_public_filename):
     if ip_detect_public_filename != '':
-        calculate_ip_detect_contents(ip_detect_public_filename)
+        return calculate_ip_detect_contents(ip_detect_public_filename)
     return ip_detect_contents
 
 


### PR DESCRIPTION
## High Level Description

Previously, the calculate_ip_detect_public_contents() function would
throw away the value of calculate_ip_detect_contents() in the case where
ip_detect_public_filename is passed in. Now it doesn't.

## Related Issues

  - [DCOS_OSS-847](https://jira.mesosphere.com/browse/DCOS_OSS-847) Cannot customize ip_detect_public_filename in config.yaml as expected.

## Checklist for all PR's

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: It's unclear how best to write a test for this at the moment. If someone gives me some guidance, I am happy to add one.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]