### PR TITLE
Admin Router: Conditional request buffering for /service endpoint

### DIFF
--- a/packages/adminrouter/extra/src/README.md
+++ b/packages/adminrouter/extra/src/README.md
@@ -521,6 +521,48 @@ It is possible to workaround it by using another another HTTP reverse proxy in t
 
 This feature is available only for the tasks launched by the root Marathon.
 
+### Disabling request buffering for selected applications
+Some applications can not tolerate request buffering while there are others that require it in order to function properly. To support both groups, support for `DCOS_SERVICE_REQUEST_BUFFERING` label was introduced.
+
+If a task has `DCOS_SERVICE_REQUEST_BUFFERING` label set to `false` (string) or `false` (boolean), Admin Router will not perform request buffering for this application. Please see below for an example of how to enable it in an application definition:
+
+```json
+{
+  "labels": {
+    "DCOS_SERVICE_REQUEST_BUFFERING": false,
+    "DCOS_SERVICE_NAME": "myapp2",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "id": "/myapp2",
+  "cmd": "echo \"It works!\" > index.html; /usr/local/bin/python -m http.server $PORT0",
+  "container": {
+    "type": "DOCKER",
+    "volumes": [],
+    "docker": {
+      "image": "python:3.6.5-stretch"
+    }
+  },
+  "cpus": 0.1,
+  "instances": 1,
+  "mem": 128,
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "name": "www",
+      "protocol": "tcp",
+      "port": 10000
+    }
+  ]
+}
+```
+
+This feature is available only for the tasks launched by the root Marathon.
+
 ## Authorization and authentication
 
 DC/OS uses DC/OS authentication token at the core of its authentication and

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -172,32 +172,61 @@ location ~ ^/service/(?<serviceid>[0-9a-zA-Z-.]+)$ {
 # Group: Service
 # Description: Proxy to services running on DC/OS
 location ~ ^/service/(?<service_path>.+) {
+    # These vars are set internally, by service.recursive_resolve() and passed
+    # over to internal `@service_*` blocks.
     set $upstream_url '';
     set $upstream_scheme '';
     set $service_realpath '';
 
-    more_clear_input_headers Accept-Encoding;
     rewrite_by_lua_block {
+        local service_name
+
+        -- Acquire cache data:
+        -- On one hand we want to fetch cache only once no matter the number of
+        -- resolving attempts, on the other hand - we want to treat each cache
+        -- entry independently. If i.e. Root Marathon is fine but Mesos Master
+        -- is not, and the resolving given /service request requires only Root
+        -- Marathon data, we should still route the request. This is the reason
+        -- why error checking is done in a different place than actually
+        -- fetching the cache data. The case when Root Marathon is broken but
+        -- Mesos is fine is different - here the request must not be handled as
+        -- AR can't be sure if the request could have been handled using Root
+        -- Marathon data or not (i.e. there are strict priorities).
+        local marathon_cache = cache.get_cache_entry("svcapps")
+        local mesos_cache = cache.get_cache_entry("mesosstate")
+
         -- Auth is done during recursive_resolve stage, here we only
-        -- pass the module.
+        -- pass the module. Also see the comment about ngx vars at the begining
+        -- of this location block.
         -- TODO (prozlach): not sure if passing auth during init wouldn't
         -- be cleaner. On the other hand passing it here is more explicit.
-        service.recursive_resolve(auth, ngx.var.service_path);
+        service_name = service.recursive_resolve(auth, ngx.var.service_path, marathon_cache, mesos_cache);
+
         util.clear_dcos_cookies();
+
+        -- A hack to enable the control of proxy_request_buffering via Marathon
+        -- labels. The proxy_request_buffering directive by itself is unable to
+        -- parse lua variables directly.
+        if service.request_buffering_required(service_name, marathon_cache) == false then
+            -- Do an internal redirect; proceed handling this request in the
+            -- @service_requnbuffered location block below.
+            return ngx.exec("@service_requnbuffered");
+        end
+
+            -- Do an internal redirect; proceed handling this request in the
+            -- @service_default location block below.
+        return ngx.exec("@service_default");
     }
+}
 
-    include includes/proxy-headers.conf;
-    include includes/websockets.conf;
+location @service_requnbuffered {
+    proxy_request_buffering off;
 
-    # Disable response buffering for SSE support.
-    # Also see https://serverfault.com/a/801629/121951
-    proxy_buffering off;
+    include includes/service-location.common.conf;
+}
 
-    proxy_redirect $upstream_scheme://$host/service/$service_realpath/ /service/$service_realpath/;
-    proxy_redirect $upstream_scheme://$host/ /service/$service_realpath/;
-    proxy_redirect / /service/$service_realpath/;
-
-    proxy_pass $upstream_url;
+location @service_default {
+    include includes/service-location.common.conf;
 }
 
 # Group: Agent

--- a/packages/adminrouter/extra/src/includes/service-location.common.conf
+++ b/packages/adminrouter/extra/src/includes/service-location.common.conf
@@ -1,0 +1,14 @@
+    more_clear_input_headers Accept-Encoding;
+
+    include includes/proxy-headers.conf;
+    include includes/websockets.conf;
+
+    # Disable response buffering for SSE support.
+    # Also see https://serverfault.com/a/801629/121951
+    proxy_buffering off;
+
+    proxy_redirect $upstream_scheme://$host/service/$service_realpath/ /service/$service_realpath/;
+    proxy_redirect $upstream_scheme://$host/ /service/$service_realpath/;
+    proxy_redirect / /service/$service_realpath/;
+
+    proxy_pass $upstream_url;

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -234,23 +234,36 @@ local function fetch_and_store_marathon_apps(auth_token)
           goto continue
        end
 
-       local do_rewrite_requrl = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
-       if do_rewrite_requrl == false or do_rewrite_requrl == 'false' then
+       local do_rewrite_req_url = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
+       if do_rewrite_req_url == false or do_rewrite_req_url == 'false' then
           ngx.log(ngx.INFO, "DCOS_SERVICE_REWRITE_REQUEST_URLS for app '" .. appId .. "' set to 'false'")
-          do_rewrite_requrl = false
+          do_rewrite_req_url = false
        else
           -- Treat everything else as true, i.e.:
           -- * label is absent
           -- * label is set to "true" (string) or true (bool)
           -- * label is set to some random string
-          do_rewrite_requrl = true
+          do_rewrite_req_url = true
+       end
+
+       local do_request_buffering = labels["DCOS_SERVICE_REQUEST_BUFFERING"]
+       if do_request_buffering == false or do_request_buffering == 'false' then
+          ngx.log(ngx.INFO, "DCOS_SERVICE_REQUEST_BUFFERING for app '" .. appId .. "' set to 'false'")
+          do_request_buffering = false
+       else
+          -- Treat everything else as true, i.e.:
+          -- * label is absent
+          -- * label is set to "true" (string) or true (bool)
+          -- * label is set to some random string
+          do_request_buffering = true
        end
 
        local url = scheme .. "://" .. host_or_ip .. ":" .. port
        svcApps[svcId] = {
          scheme=scheme,
          url=url,
-         do_rewrite_requrl=do_rewrite_requrl,
+         do_rewrite_req_url=do_rewrite_req_url,
+         do_request_buffering=do_request_buffering,
          }
 
        ::continue::

--- a/packages/adminrouter/extra/src/test-harness/tests/test_service.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_service.py
@@ -26,7 +26,7 @@ from mocker.endpoints.mesos_dns import (
     EMPTY_SRV,
     SCHEDULER_SRV_ALWAYSTHERE_DIFFERENTPORT,
 )
-from util import GuardedSubprocess
+from util import GuardedSubprocess, LineBufferFilter, SearchCriteria
 
 
 class TestServiceStateful:
@@ -856,7 +856,7 @@ class TestServiceStateful:
          ('false', False),
          (False, False),
          ],)
-    def test_if_requrl_rewriting_can_be_configured(
+    def test_if_req_url_rewriting_can_be_configured(
             self,
             master_ar_process_pertest,
             mocker,
@@ -897,3 +897,81 @@ class TestServiceStateful:
             path_expected,
             http_ver='websockets'
             )
+
+    @pytest.mark.parametrize(
+        'label_val,should_buffer',
+        [('yes', True),
+         ('true', True),
+         ('1', True),
+         ('make it so', True),
+         ('whatever', True),
+         ('', True),  # the label contains empty string
+         (None, True),  # the label is absent
+         ('false', False),
+         (False, False),
+         ],)
+    def test_if_request_buffering_can_be_configured(
+            self,
+            mocker,
+            nginx_class,
+            valid_user_header,
+            label_val,
+            should_buffer):
+        # If `DCOS_SERVICE_REQUEST_BUFFERING` is set to `false` (string) or
+        # `false` (boolean), Admin Router will not buffer the client request before
+        # sending it to the upstream. In any other case it the request is going
+        # to be buffered.
+
+        # Remove the data from MesosDNS and Mesos mocks w.r.t. resolved service
+        mocker.send_command(endpoint_id='http://127.0.0.2:5050',
+                            func_name='set_frameworks_response',
+                            aux_data=[])
+        mocker.send_command(endpoint_id='http://127.0.0.1:8123',
+                            func_name='set_srv_response',
+                            aux_data=EMPTY_SRV)
+
+        # Set the DCOS_SERVICE_REQUEST_BUFFERING for the test mock:
+        srv = SCHEDULER_APP_ALWAYSTHERE_DIFFERENTPORT
+        if label_val is not None:
+            srv['labels']['DCOS_SERVICE_REQUEST_BUFFERING'] = label_val
+        new_apps = {"apps": [srv, ]}
+        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
+                            func_name='set_apps_response',
+                            aux_data=new_apps)
+
+        # In theory it is possible to write a test that really checks if the
+        # request was buffered or not. It would require talking to the mocked
+        # endpoint during the test and checking if it is receiving the data as
+        # it is being sent (there is no buffering) or only after the whole
+        # request has been uploaded (Nginx buffers the data). Such a feature
+        # would introduce some extra complexity into the test harness. Simply
+        # checking if AR is printing the warning to the error log seems to be
+        # good enough.
+        filter_regexp = {}
+        tmp = 'a client request body is buffered to a temporary file'
+        if label_val in ["false", False]:
+            filter_regexp[tmp] = SearchCriteria(0, True)
+        else:
+            filter_regexp[tmp] = SearchCriteria(1, True)
+
+        ar = nginx_class(role="master")
+        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
+        # In order to make Nginx print a warning to the errorlog, the request
+        # payload needs to be greater than client_body_buffer_size, which by
+        # default is set to 16k. We use here 2MB for safe measure.
+        # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+        payload = {"data": "x" * 1024 * 1024 * 2}
+
+        with GuardedSubprocess(ar):
+            lbf = LineBufferFilter(
+                filter_regexp,
+                line_buffer=ar.stderr_line_buffer)
+            resp = requests.post(
+                url,
+                allow_redirects=False,
+                headers=valid_user_header,
+                data=payload)
+            lbf.scan_log_buffer()
+
+        assert lbf.extra_matches == {}
+        assert resp.status_code == 200


### PR DESCRIPTION
## High-level description

This PR makes it possible to configure `/service` endpoint request buffering basing on the `DCOS_SERVICE_REQUEST_BUFFERING` label. See the Jira issue for details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-20269 `Request entity too large error`

## Related PRs

EE PR: https://github.com/mesosphere/dcos-enterprise/pull/2587