### PR TITLE
(1.11) Use prebuilt REX-Ray binary

### DIFF
--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,12 +9,5 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/codedellemc/rexray
-mkdir -p $(dirname $srcdir)
-ln -s /pkg/src/rexray $srcdir
-cd $srcdir
-
-DGOOS=linux make
-
 mkdir -p $PKG_PATH/bin
-mv $GOPATH/bin/rexray $PKG_PATH/bin
+tar -C $PKG_PATH/bin/ -xf /pkg/src/$PKG_NAME/*

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,9 +1,7 @@
 {
-  "docker": "golang:1.7",
-  "single_source" : {
-    "kind": "git",
-    "git": "https://github.com/codedellemc/rexray.git",
-    "ref": "2a7458dd90a79c673463e14094377baf9fc8695e",
-    "ref_origin": "v0.9.0"
+  "single_source": {
+    "kind": "url",
+    "url": "https://downloads.dcos.io/packages/rexray/rexray-Linux-x86_64-0.9.0.tar.gz",
+    "sha1": "be07ec9a41e5dc287fbe62006025de8a64392afb"
   }
 }


### PR DESCRIPTION
## High-level description

REX-Ray v0.9.0 can no longer be built from source, so we need to reuse [a previously built v0.9.0 binary](https://downloads.dcos.io/dcos/stable/packages/rexray/rexray--da7f17f8a4b772c0bac3f8d289a08abd4ff272b4.tar.xz). See https://github.com/rexray/rexray/pull/995.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2310](https://jira.mesosphere.com/browse/DCOS_OSS-2310) REX-Ray integration test is flaky after version bump


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a change to the build process that should have no visible effect in DC/OS.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: A build of DC/OS without using cached packages will now work.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A, same version.
  - [x] Test Results: N/A, same version.
  - [x] Code Coverage (if available): N/A, same version.