### PR TITLE
[DCOS_OSS-2372][1.11] Use `pip download` to prepare TeamCity rather than the removed `pip i…

### DIFF
--- a/prep_teamcity
+++ b/prep_teamcity
@@ -33,7 +33,7 @@ pip install -U pip
 pip install wheel
 
 # Download distro independent artifacts
-pip install --download wheelhouse $DIR/ext/dcos-image
+pip download -d wheelhouse $DIR/ext/dcos-image
 
 # Make the wheels, they will be output into the folder `wheelhouse` by default.
 pip wheel --wheel-dir=wheelhouse --no-index --find-links=wheelhouse $DIR/ext/dcos-image


### PR DESCRIPTION
…nstall --download`

## High-level description

This fixes a build error with `teamcity/dcos/build/dcos`.

This is a backport of https://github.com/dcos/dcos/pull/2747.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2372](https://jira.mesosphere.com/browse/DCOS_OSS-2372) DC/OS builds - no such option: --download (pip 10)

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is just a build step change
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The build is already failing
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)