### PR TITLE
dcos-checks: bump for register of subcommands

### DIFF
--- a/packages/dcos-checks/build
+++ b/packages/dcos-checks/build
@@ -11,7 +11,7 @@ cd /pkg/src/github.com/dcos/dcos-checks
 go install -v
 cp -r /pkg/bin/ "$PKG_PATH"
 
-# Create the service file for all roles 
+# Create the service file for all roles
 service="$PKG_PATH/dcos.target.wants/dcos-checks-poststart.service"
 mkdir -p "$(dirname "$service")"
 cp /pkg/extra/dcos-checks-poststart.service "$service"

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -1,9 +1,9 @@
 {
   "single_source": {
     "kind": "git",
-    "git": "https://github.com/dcos/dcos-checks.git",
-    "ref": "498298f4ff133bd6873f1007a92fa19de5053791",
-    "ref_origin": "master"
+    "git": "https://github.com/gpaul/dcos-checks.git",
+    "ref": "35e68e17a7e42fc534f11d7b74db3017e2fc11b8",
+    "ref_origin": "gpaul/DCOS-21728_crdb-underreplicated-ranges"
   },
   "state_directory": true,
   "username": "dcos_diagnostics",

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -1,9 +1,9 @@
 {
   "single_source": {
     "kind": "git",
-    "git": "https://github.com/gpaul/dcos-checks.git",
-    "ref": "35e68e17a7e42fc534f11d7b74db3017e2fc11b8",
-    "ref_origin": "gpaul/DCOS-21728_crdb-underreplicated-ranges"
+    "git": "https://github.com/dcos/dcos-checks.git",
+    "ref": "c5a667cd20713af21c618df48b0ab2b3fc5ed0a6",
+    "ref_origin": "master"
   },
   "state_directory": true,
   "username": "dcos_diagnostics",


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR bumps dcos-checks for some internal refactoring.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-21728](https://jira.mesosphere.com/browse/DCOS-21728) dcos-checks: add check for cockroachdb 'underreplicated ranges'

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a non-userfacing change because it bumps a component to benefit from internal refactoring with no external changes.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There is no behaviour change so I expect the existing tests to catch any errors.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-checks/compare/498298f4ff133bd6873f1007a92fa19de5053791...35e68e17a7e42fc534f11d7b74db3017e2fc11b8)
  - [x] Test Results: [dcos-checks](https://jenkins.mesosphere.com/service/jenkins/job/dcos-cluster-ops/job/public-dcos-checks-pulls-pipeline/12/)
  - [ ] Code Coverage (if available): [link to code coverage report]
___
