### PR TITLE
Metronome Back Bump to 0.4.2 to fix Metrics 

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -3,8 +3,8 @@
     "single_source": {
         "kind": "url_extract",
         "url":
-            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.1/metronome-0.4.1.tgz",
-        "sha1": "098aff34f8d4b58f63e7168a60222a8d08c7f75e"
+            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.2/metronome-0.4.2.tgz",
+        "sha1": "61652afa0f1209635dcf9839f985ae5ee64486ba"
     },
     "username": "dcos_metronome",
     "state_directory": true


### PR DESCRIPTION
## High-level description

Metronome bump 0.4.2 on DCOS 1.10.6

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [METRONOME-248](https://jira.mesosphere.com/browse/METRONOME-248)Metronome metrics breaking change


## Related tickets (optional)


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff 0.4.1...0.4.2](https://github.com/dcos/metronome/compare/b4a9cc18c4c14df29d1cf1f3b543910bbfdcc22f...0659f671431d32e17ec034231f62eb1015b8c15d)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/67/
  - [ ] Code Coverage (if available): N/A
