### PR TITLE
Use `pip download` to prepare TeamCity rather than the removed `pip i…

### DIFF
--- a/prep_teamcity
+++ b/prep_teamcity
@@ -33,7 +33,7 @@ pip install -U pip
 pip install wheel
 
 # Download distro independent artifacts
-pip install --download wheelhouse $DIR/ext/dcos-image
+pip download -d wheelhouse $DIR/ext/dcos-image
 
 # Make the wheels, they will be output into the folder `wheelhouse` by default.
 pip wheel --wheel-dir=wheelhouse --no-index --find-links=wheelhouse $DIR/ext/dcos-image


### PR DESCRIPTION
…nstall --download`

## High-level description

Backport of https://github.com/dcos/dcos/pull/2747 
