### PR TITLE
[master] Bump dcos-ui to 1.13.0

### DIFF
--- a/packages/dcos-ui/build
+++ b/packages/dcos-ui/build
@@ -1,17 +1,3 @@
 #!/bin/bash
 
-cd "/pkg/src/dcos-ui"
-
-npm install -g npm@3.9.1
-
-# Run npm install with `unsafe-perm` flag to run install scripts with root
-# privileges. Without those privileges the installation will fail to write some
-# of the dependencies with the correct user/permissions.
-npm --unsafe-perm install
-
-echo "module.exports = {};" > ./src/js/config/Config.dev.js
-npm run scaffold
-
-npm run build
-
-cp -r dist/ "$PKG_PATH"/usr
+cp -r "/pkg/src/dcos-ui" "$PKG_PATH"/usr/

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -1,9 +1,7 @@
 {
-  "docker": "node:4.4.4",
   "single_source": {
-    "kind": "git",
-    "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "57553a6be1d9fc07a7153dc8df5c338f1c1e6890",
-    "ref_origin": "v1.12.0-rc.1"
+    "kind": "url_extract",
+    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-1.13.0.tar.gz",
+    "sha1": "78565b860a194423f3743a26e02990d21bb0e654"
   }
 }


### PR DESCRIPTION
## High-level description

This is our first (not yet) automated DC/OS UI bump PR, from now on, we will follow a `semver` compliant versioning system instead of using DC/OS versions. 

1.13 isnt referring to DC/OS 1.13, instead it is the next `semver` version our tooling bumped from the last `1.12.0-rc1` tag. 
In order to prevent version conflicts and document compatibility, we also added a `prefix` which defines the DC/OS target version. In this case its `master`, but it also could be `1.11` or any previous DC/OS release.
That said, at the time DC/OS 1.12 will be branched from `master`, the included dcos-ui bump could be something like `master+1.15.4` or even `master+2.1.7`. 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

[DCOS-21932](https://jira.mesosphere.com/browse/DCOS-21932): GPU services
[DCOS-21921](https://jira.mesosphere.com/browse/DCOS-21921): automatically create release with standard-version
[DCOS-21931](https://jira.mesosphere.com/browse/DCOS-21931): GPU dashboard
[DCOS-21574](https://jira.mesosphere.com/browse/DCOS-21574): remove comments about versions
[DCOS-21847](https://jira.mesosphere.com/browse/DCOS-21847): add webpack dashboard
[DCOS-21798](https://jira.mesosphere.com/browse/DCOS-21798): render empty modal if the service is not loaded
[DCOS-21846](https://jira.mesosphere.com/browse/DCOS-21846): stop browser from opened automatically
[DCOS-21845](https://jira.mesosphere.com/browse/DCOS-21845): inmprove bootstrap css script
[DCOS-21896](https://jira.mesosphere.com/browse/DCOS-21896): cypress 2.1.0
[DCOS_OSS-2190](https://jira.mesosphere.com/browse/DCOS_OSS-2190): remove unused dependencies
[DCOS-21640](https://jira.mesosphere.com/browse/DCOS-21640): wrap repository api with http-service
[DCOS_OSS-1564](https://jira.mesosphere.com/browse/DCOS_OSS-1564): Let's update webpack (2nd try)
[DCOS-21784](https://jira.mesosphere.com/browse/DCOS-21784): adjust stream data handling
[DCOS-20949](https://jira.mesosphere.com/browse/DCOS-20949): adjust getDefinition default
[DCOS-21571](https://jira.mesosphere.com/browse/DCOS-21571): update moment
[DCOS-21335](https://jira.mesosphere.com/browse/DCOS-21335): 
[DCOS_OSS-2244](https://jira.mesosphere.com/browse/DCOS_OSS-2244): display task's ip addresses
[DCOS-21440](https://jira.mesosphere.com/browse/DCOS-21440): keep VIP label
[DCOS-21614](https://jira.mesosphere.com/browse/DCOS-21614): show cosmos services in json-schema form
[DCOS-19740](https://jira.mesosphere.com/browse/DCOS-19740): improve schema errors
[DCOS-21190](https://jira.mesosphere.com/browse/DCOS-21190): hide text if the service status is N/A
[DCOS-21701](https://jira.mesosphere.com/browse/DCOS-21701): repeat the stream
[DCOS-20258](https://jira.mesosphere.com/browse/DCOS-20258): display DSS type and size
[DCOS_OSS-2233](https://jira.mesosphere.com/browse/DCOS_OSS-2233): switch from react-addons-test-util to enzyme
[DCOS_OSS-2206](https://jira.mesosphere.com/browse/DCOS_OSS-2206): switch from react-addons-test-utils to enzyme
[DCOS_OSS-2206](https://jira.mesosphere.com/browse/DCOS_OSS-2206): add enzyme for testing renders
[DCOS_OSS-1550](https://jira.mesosphere.com/browse/DCOS_OSS-1550): enable service endpoints on ucr
[DCOS_OSS-2243](https://jira.mesosphere.com/browse/DCOS_OSS-2243): remove misleading endpoints row from config table
[DCOS-21370](https://jira.mesosphere.com/browse/DCOS-21370): check if node exists before relying on it
[DCOS-21305](https://jira.mesosphere.com/browse/DCOS-21305): respect minDcosReleaseVersion
[DCOS-21369](https://jira.mesosphere.com/browse/DCOS-21369): fix undefined service in TasksView
[DCOS_OSS-2186](https://jira.mesosphere.com/browse/DCOS_OSS-2186): document new node versions
[DCOS_OSS-1563](https://jira.mesosphere.com/browse/DCOS_OSS-1563): update node in Dockerfile
[DCOS-21367](https://jira.mesosphere.com/browse/DCOS-21367): fix undefined or null object
[DCOS-21337](https://jira.mesosphere.com/browse/DCOS-21337): add linearBackoff retry to the stream
[DCOS-21359](https://jira.mesosphere.com/browse/DCOS-21359): checks and updates modalProps if needed
[DCOS-21366](https://jira.mesosphere.com/browse/DCOS-21366): 
[DCOS-21181](https://jira.mesosphere.com/browse/DCOS-21181): align status filters



## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
