### PR TITLE
[Ready for Review] Backport Adminrouter DNS entry TTL override of 5 seconds to 1.9 OSS

### DIFF
--- a/packages/adminrouter/extra/src/nginx.agent.conf
+++ b/packages/adminrouter/extra/src/nginx.agent.conf
@@ -2,7 +2,7 @@ include common/main.conf;
 
 
 http {
-    resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=60s;
+    resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 
     client_max_body_size 1024M;
 

--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -4,7 +4,7 @@ include common/main.conf;
 http {
     # Without this, cosocket-based code in worker
     # initialization cannot resolve leader.mesos.
-    resolver 127.0.0.1:61053 ipv6=off;
+    resolver 127.0.0.1:61053 valid=5s ipv6=off;
 
     include common/http.conf;
 


### PR DESCRIPTION
This PR is a backport from 1.10/1.11/master.
It aims to reduce the upper bound of Adminrouter Mesos state cache refresh to 25 + 5 seconds.
Before the TTL was 60 seconds (explicit) for agents and 60 seconds (implicit) for masters.
The resolver used here then caches DNS entries for at most 5 seconds.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS-2388](https://jira.mesosphere.com/browse/DCOS_OSS-2388) Adminrouter DNS entry TTL override of 5 seconds OSS.

## Checklist for all PRs

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)

___
