### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 0a1a345

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "b2eeb11ede805a7830cd6fb796d0b21a647aba04",
-    "ref_origin": "dcos-mesos-1.5.x-b0a33cb"
+    "ref": "160a68e59ff7a8cdc6983473ebcbd298f5bdd901",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-0a1a345"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest 1.5.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/b2eeb11ede805a7830cd6fb796d0b21a647aba04...160a68e59ff7a8cdc6983473ebcbd298f5bdd901)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
