### PR TITLE
[DCOS-14199][1.11.1] Write strings to files atomically in pkgpanda.util

### DIFF
--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -6,7 +6,9 @@ import os
 import re
 import shutil
 import socketserver
+import stat
 import subprocess
+import tempfile
 from contextlib import contextmanager, ExitStack
 from itertools import chain
 from multiprocessing import Process
@@ -20,13 +22,6 @@ import yaml
 from teamcity.messages import TeamcityServiceMessages
 
 from pkgpanda.exceptions import FetchError, ValidationError
-
-
-json_prettyprint_args = {
-    "sort_keys": True,
-    "indent": 2,
-    "separators": (',', ':')
-}
 
 
 def variant_str(variant):
@@ -159,8 +154,8 @@ def load_yaml(filename):
 
 
 def write_yaml(filename, data, **kwargs):
-    with open(filename, "w+") as f:
-        return yaml.safe_dump(data, f, **kwargs)
+    dumped_yaml = yaml.safe_dump(data, **kwargs)
+    write_string(filename, dumped_yaml)
 
 
 def make_file(name):
@@ -169,13 +164,45 @@ def make_file(name):
 
 
 def write_json(filename, data):
-    with open(filename, "w+") as f:
-        return json.dump(data, f, **json_prettyprint_args)
+    dumped_json = json_prettyprint(data=data)
+    write_string(filename, dumped_json)
 
 
 def write_string(filename, data):
-    with open(filename, "w+") as f:
-        return f.write(data)
+    """
+    Write a string to a file.
+    Overwrite any data in that file.
+
+    We use an atomic write practice of creating a temporary file and then
+    moving that temporary file to the given ``filename``. This prevents race
+    conditions such as the file being read by another process after it is
+    opened here but not yet written to.
+
+    It also prevents us from creating or truncating a file before we fail to
+    write data to it because of low disk space.
+
+    If no file already exists at ``filename``, the new file is created with
+    permissions 0o644.
+    """
+    prefix = os.path.basename(filename)
+    tmp_file_dir = os.path.dirname(os.path.realpath(filename))
+    fd, temporary_filename = tempfile.mkstemp(prefix=prefix, dir=tmp_file_dir)
+
+    try:
+        permissions = os.stat(filename).st_mode
+    except FileNotFoundError:
+        permissions = 0o644
+
+    try:
+        try:
+            os.write(fd, data.encode())
+        finally:
+            os.close(fd)
+        os.chmod(temporary_filename, stat.S_IMODE(permissions))
+        os.replace(temporary_filename, filename)
+    except Exception:
+        os.remove(temporary_filename)
+        raise
 
 
 def load_string(filename):
@@ -184,7 +211,12 @@ def load_string(filename):
 
 
 def json_prettyprint(data):
-    return json.dumps(data, **json_prettyprint_args)
+    return json.dumps(
+        data,
+        sort_keys=True,
+        indent=2,
+        separators=(',', ':'),
+    )
 
 
 def if_exists(fn, *args, **kwargs):


### PR DESCRIPTION
## High-level description

**This is a backport of https://github.com/dcos/dcos/pull/2730 which has a Ship It label**

This changes `pkgpanda.util.write_string` to avoid a race condition as described in [DCOS-14199](https://jira.mesosphere.com/browse/DCOS-14199).
I have also applied this change to some related functions as a precaution.
I have stopped returning data from the functions as it appears that those return values are never used.

This also adds a test for `write_string` to enshrine the permission requirements and basic functionality of `write_string` (thanks @mhrabovcin for help). That test passes on `master` *and* with the changes here.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-14199](https://jira.mesosphere.com/browse/DCOS-14199) exhibitor.py try_shortcut() failed due to an empty file

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: See https://github.com/dcos/dcos/pull/2730#issuecomment-380506106.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This code is already called by the test suite. We could test the race condition with something like the following with a timeout but I'd rather not. I'm happy to discuss this with a reviewer:

```python
# This will trigger the error from the issue if run by two processes in parallel.
# Calling the new function in the loop will not.
filename = 'foo.txt'
while True:
    with open(filename, 'w+') as f:
        f.write('hello')

    with open(filename) as f:
        stripped = f.read().strip()
        assert stripped != ''
```

  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)