### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x aedbcfd

### DIFF
--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,8 +1,3 @@
 <h2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 
-These commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>:
-
-<li>[20e5654a294f599b637efadf32206e7b15398081] Set LIBPROCESS_IP into docker container.
-<li>[77ae0475cc692acb359afad6a26f4566460af2ec] Mesos UI: updated the URL generation to make it work with adminrouter.
-<li>[f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6] Revert "Fixed the broken metrics information of master in WebUI."
-<li>[1adcbaf630abe383fc3b7b28f8fdbf0bfa212d1b] Updated mesos containerizer to ignore GPU isolator creation failure.
+See [patches.json](patches.json) for the list of patches.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "b2eeb11ede805a7830cd6fb796d0b21a647aba04",
-    "ref_origin": "dcos-mesos-1.5.x-b0a33cb"
+    "ref": "27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-aedbcfd"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -1,0 +1,26 @@
+{
+  "kind": "git",
+  "git": "https://github.com/mesosphere/mesos",
+  "patches": [
+    {
+      "ref": "439b92bdd91c6a83a6d5bffb8f2abefdfa824211",
+      "description": "Set LIBPROCESS_IP into docker container."
+    },
+    {
+      "ref": "6d478a33ec85904482bae974e43beff8d21f8ce9",
+      "description": "Mesos UI: updated the URL generation to make it work with adminrouter."
+    },
+    {
+      "ref": "27b9f7aad8221ffdf3f7af33e291051b94874771",
+      "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
+    },
+    {
+      "ref": "e45fc008bef25373b8f9849e20976d9894f331fc",
+      "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
+    },
+    {
+      "ref": "27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8",
+      "description": "Displayed resource provider resources in GET_RESOURCE_PROVIDER response."
+    }
+  ]
+}

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -3,23 +3,23 @@
   "git": "https://github.com/mesosphere/mesos",
   "patches": [
     {
-      "ref": "439b92bdd91c6a83a6d5bffb8f2abefdfa824211",
+      "ref": "20e5654a294f599b637efadf32206e7b15398081",
       "description": "Set LIBPROCESS_IP into docker container."
     },
     {
-      "ref": "6d478a33ec85904482bae974e43beff8d21f8ce9",
+      "ref": "77ae0475cc692acb359afad6a26f4566460af2ec",
       "description": "Mesos UI: updated the URL generation to make it work with adminrouter."
     },
     {
-      "ref": "27b9f7aad8221ffdf3f7af33e291051b94874771",
+      "ref": "f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6",
       "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
     },
     {
-      "ref": "e45fc008bef25373b8f9849e20976d9894f331fc",
+      "ref": "1adcbaf630abe383fc3b7b28f8fdbf0bfa212d1b",
       "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
     },
     {
-      "ref": "27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8",
+      "ref": "09b92d822658b9563103d86ad45a9a7fdf85f271",
       "description": "Displayed resource provider resources in GET_RESOURCE_PROVIDER response."
     }
   ]


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest 1.5.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/b2eeb11ede805a7830cd6fb796d0b21a647aba04...0e3da451d379b7dd58b25bfb9ec3569a9b8eac87)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
