### PR TITLE
Add MTU configuration for vtep1024

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -317,6 +317,9 @@ def validate_dcos_overlay_network(dcos_overlay_network):
         assert 'vtep_mac_oui' in overlay_network.keys(), (
             'Missing "vtep_mac_oui" in overlay configuration {}'.format(overlay_network))
 
+        vtep_mtu = overlay_network.get('vtep_mtu', 1500)
+        validate_int_in_range(vtep_mtu, 552, None)
+
         if 'subnet' in overlay:
             # Check the VTEP IP is present in the overlay configuration
             assert 'vtep_subnet' in overlay_network, (

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "56db2d021378db6f4aa9a6d2b7d1b06bcc809753",
+      "ref": "73fe6d28a38dfcc58347615493958be37ce97bf9",
       "ref_origin": "master"
     }
   },

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "683d3c137ed66d6e9a7e5da622f62a7ce962d4d1",
+      "ref": "2ff1ec94524c1fbca550a6063612b1226f233236",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
## High-level description

Add MTU configuration for vtep1024.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1529](https://jira.mesosphere.com/browse/DCOS_OSS-1529) Missing MTU configuration for VTEP1024

## Related tickets (optional)

 - [DCOS_OSS-728](https://jira.mesosphere.com/browse/DCOS_OSS-728) Create testcase for Mesos master failover with DC/OS overlay modules
 - [DCOS_OSS-695](https://jira.mesosphere.com/browse/DCOS_OSS-695) Introduce timeouts for calls to docker deamon in DC/OS overlay module
 - [DCOS-21919](https://jira.mesosphere.com/browse/DCOS-21919) dcos-mesos-modules build is broken

Other tickets related to this change:

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: that's a minor change
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/dcos/dcos-mesos-modules/compare/683d3c137ed66d6e9a7e5da622f62a7ce962d4d1...2ff1ec94524c1fbca550a6063612b1226f233236
https://github.com/dcos/dcos-mesos-modules/pull/37
https://github.com/dcos/dcos-mesos-modules/pull/38
https://github.com/dcos/dcos-mesos-modules/pull/39
https://github.com/dcos/dcos-net/compare/56db2d021378db6f4aa9a6d2b7d1b06bcc809753...73fe6d28a38dfcc58347615493958be37ce97bf9
https://github.com/dcos/dcos-net/pull/46

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).