### PR TITLE
[1.12/master] Disable the 3DES and TLS 1.1 for Master Admin Router by default in 1.12/master

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -982,7 +982,7 @@ entry = {
         'weights': '',
         'adminrouter_auth_enabled': calculate_adminrouter_auth_enabled,
         'adminrouter_tls_1_0_enabled': 'false',
-        'adminrouter_tls_1_1_enabled': 'true',
+        'adminrouter_tls_1_1_enabled': 'false',
         'adminrouter_tls_1_2_enabled': 'true',
         'adminrouter_tls_cipher_suite': '',
         'oauth_enabled': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -992,10 +992,11 @@ package:
   - path: /etc/adminrouter-tls-master.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-      # Modulo ChaCha20 cipher.
+      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+      # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 {% switch adminrouter_tls_cipher_override %}
 {% case "false" %}
-      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 {% case "true" %}
       ssl_ciphers {{ adminrouter_tls_cipher_suite }};
 {% endswitch %}

--- a/gen/tests/test_adminrouter_tls_conf.py
+++ b/gen/tests/test_adminrouter_tls_conf.py
@@ -30,9 +30,10 @@ class TestAdminRouterTLSConfig:
         expected_configuration = dedent(
             """\
             # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-            # Modulo ChaCha20 cipher.
+            # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+            # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 
-            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 
             ssl_prefer_server_ciphers on;
             # To manually test which TLS versions are enabled on a node, use
@@ -40,7 +41,7 @@ class TestAdminRouterTLSConfig:
             #
             # See comments on https://jira.mesosphere.com/browse/DCOS-13437 for more
             # details.
-            ssl_protocols TLSv1.1 TLSv1.2;
+            ssl_protocols TLSv1.2;
             """
         )
         assert config['content'] == expected_configuration
@@ -119,7 +120,7 @@ class TestSetCipherOverride:
             config_path: str) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -146,7 +147,7 @@ class TestSetCipherOverride:
             new_config_arguments: Dict[str, str]) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -201,7 +202,7 @@ class TestSetCipherOverride:
         ciphers = self.supported_ssl_ciphers_master(
             new_config_arguments=new_arguments,
         )
-        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5']
+        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES']
 
     @pytest.mark.skipif(pkgpanda.util.is_windows, reason="test fails on Windows reason unknown")
     def test_cipher_master_custom(self):
@@ -280,9 +281,10 @@ class TestToggleTLSVersions:
             new_config_arguments={},
         )
         disable_tls1_protocols = self.supported_tls_protocols_ar_master(
-            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false'},
+            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false',
+                                  'adminrouter_tls_1_1_enabled': 'false'},
         )
-        assert default_protocols == ['TLSv1.1', 'TLSv1.2']
+        assert default_protocols == ['TLSv1.2']
         assert default_protocols == disable_tls1_protocols
 
     @pytest.mark.parametrize(

--- a/packages/adminrouter/docker/adminrouter-tls-master.conf
+++ b/packages/adminrouter/docker/adminrouter-tls-master.conf
@@ -1,6 +1,8 @@
 # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-# Modulo ChaCha20 cipher.
-ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+# Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+# For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
+
+ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 ssl_prefer_server_ciphers on;
 
 ssl_protocols TLSv1.1 TLSv1.2;


### PR DESCRIPTION
## High-level description

This PR disables the 3DES bulk encryption algorithm and TLS 1.1 for Master Admin Router by default in DC/OS 1.12/master.

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS-21958

## Checklist for all PRs
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
