### PR TITLE
[1.9] Bump Mesos to nightly mesosphere/1.2.x 563f24c

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
-      "ref_origin": "1.9.x"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
+    "ref_origin": "1.9"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
-    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
+    "ref": "810181537a652bf28c0dcdfd257a6d32b965d9a8",
+    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-563f24c"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -1,0 +1,26 @@
+{
+  "kind": "git",
+  "git": "https://github.com/mesosphere/mesos",
+  "patches": [
+    {
+      "ref": "6d3d64626a9c20eb0273fbe058d6b0d74aade2ec",
+      "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy."
+    },
+    {
+      "ref": "1fc3ed6ac182ae296f521b9220b0abd926a5b515",
+      "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
+    },
+    {
+      "ref": "273da3894ac92665cee8ed604270484a89ce598c",
+      "description": "Set LIBPROCESS_IP into docker container."
+    },
+    {
+      "ref": "44414bcbc2f79c6a5a2445512bdb3a4f57069119",
+      "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
+    },
+    {
+      "ref": "810181537a652bf28c0dcdfd257a6d32b965d9a8",
+      "description": "Added '--filter_gpu_resources' flag to the mesos master."
+    }
+  ]
+}


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest mesosphere/1.2.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/05ba66b1ea2d00f3d784ac732f95f237dff652a8...810181537a652bf28c0dcdfd257a6d32b965d9a8)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
