### PR TITLE
[1.9] Bump Mesos to nightly mesosphere/1.2.x 563f24c

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
-      "ref_origin": "1.9.x"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
+    "ref_origin": "1.9"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
-    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
+    "ref": "1ef04cb3653ad2645a44f81dd94d3b75e37c56c4",
+    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-563f24c"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -1,0 +1,26 @@
+{
+  "kind": "git",
+  "git": "https://github.com/mesosphere/mesos",
+  "patches": [
+    {
+      "ref": "3c5804c6a2d417de53c1827efcb55f8ea16201a8",
+      "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy."
+    },
+    {
+      "ref": "87d2eed40d5ca8b2bb53ad61b8010932738bde09",
+      "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
+    },
+    {
+      "ref": "b8a4501fb520fb2082927b190dec6cee2db08c4b",
+      "description": "Set LIBPROCESS_IP into docker container."
+    },
+    {
+      "ref": "4f76d1817384b100e609343f31ec28396736d05c",
+      "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
+    },
+    {
+      "ref": "1ef04cb3653ad2645a44f81dd94d3b75e37c56c4",
+      "description": "Added '--filter_gpu_resources' flag to the mesos master."
+    }
+  ]
+}


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest mesosphere/1.2.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/05ba66b1ea2d00f3d784ac732f95f237dff652a8...1ef04cb3653ad2645a44f81dd94d3b75e37c56c4)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
