### PR TITLE
[1.9] Bump Mesos to nightly mesosphere/1.2.x 563f24c

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
-      "ref_origin": "1.9.x"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
+    "ref_origin": "1.9"
+  }
 }

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,6 +1,27 @@
 <H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 All commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>.
 
+<h3>Critical backports that are not in Mesos 1.2.3</h3>
+<li>[8594503910fc35a8cbf33d4c270d6d0e33276b03] Promoted log level to warning for disconnected events in exec.cpp.
+<li>[e0889bf81890202cc3c55ce36c5f0e037f720761] Ensured command executor always honors shutdown request.
+<li>[59d17c833bd464e2e16d1cd685193f4f3277a925] Ensured executor adapter propagates error and shutdown messages.
+<li>[13a07821db91c8e2787421a63abcb422aaa171f4] Terminated driver-based executors if kill arrives before launch task.
+<li>[d566462f8af1739d718a994885334ad7063dce86] Reaped the container process directly in Docker executor.
+<li>[f03e2a1545ef1e70269c33245503c3efb215b7c5] Windows: Fixed flaky Docker command health check test.
+<li>[c5479b6e1a140728e60390ae77f5430dcacc014c] Prevented Docker library from terminating incorrect processes.
+<li>[2d17e0b9098c3f455eac5ceb82ac5021b23e55ce] Updated discard handling for Docker 'stop' and 'pull' commands.
+<li>[e7c9c1da92be006c161ccfba6e3ae6bfc5b46276] Ensured that Docker containerizer returns a failed Future in one case.
+<li>[721dee01bce444b06f71b68a68eb741dd331ed9f] Updated discard handling in `Docker::inspect()`.
+<li>[088498968dadef1b98e0d98d02044b7172dc1a56] Avoided orphan subprocess in the Docker library.
+<li>[a28a0daacb20b9acd68c0bd1ed86cb51afc66ff1] Handled hanging docker `stop`, `inspect` commands in docker executor.
+<li>[fa7106d947300d9eebe0dbeea3bed84dac187419] Added overload of process::await that takes and returns single future.
+<li>[314a117446f9f7f6e05d319a53c1eb9235cbe247] Fixed compile issue for backporting by removing 'AwaitSingleAbandon'.
+<li>[89a430b525c4612606af419ab88f7383217464ab] Added inspect retries to the Docker executor.
+<li>[abfa0229c5017e1644c301192c877e36ba7fe177] Added inspect retries to the docker containerizer in `update` method.
+<li>[1d104c8584dbcc398d709ced6271971593471991] Fixed an issue with the scheduler driver subscribe backoff time.
+<li>[4a0d0de518b71330667a186f0c01846a82922135] Libprocess: Fixed a crash in the presence of request/response trailers.
+<li>[563f24caba5c3dd07350bd8f6f1aef2dbfb87bb5] Stout: Ensured exceptions are caught for `picojson::parse()`.
+
 <h3>WebUI magic for DC/OS' reverse proxy</h3>
 <li>[9659ca424cbc9bd7c3942e6f48dc1bbd1b2f27cc] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[0e61b936bf383572d2613b5ff8af045339f8c633] Revert "Fixed the broken metrics information of master in WebUI."
@@ -11,9 +32,3 @@ All commits can be found in the repository at <a href="https://github.com/mesosp
 <h3>GPU-related workarounds</h3>
 <li>[cdec8ecded25db8c8d8ac0a4838b9f7e3d9285d1] Updated mesos containerizer to ignore GPU isolator creation failure.
 <li>[bd983e54c7d941db4a67c1d5659a60014b3fec71] Added '--filter_gpu_resources' flag to the mesos master.
-
-<h3>Critical backports that are not in Mesos 1.2.3</h3>
-<li>[13a07821db91c8e2787421a63abcb422aaa171f4] Terminated driver-based executors if kill arrives before launch task.
-<li>[59d17c833bd464e2e16d1cd685193f4f3277a925] Ensured executor adapter propagates error and shutdown messages.
-<li>[e0889bf81890202cc3c55ce36c5f0e037f720761] Ensured command executor always honors shutdown request.
-<li>[8594503910fc35a8cbf33d4c270d6d0e33276b03] Promoted log level to warning for disconnected events in exec.cpp.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
-    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
+    "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
+    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-563f24c"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -1,0 +1,26 @@
+{
+  "kind": "git",
+  "git": "https://github.com/mesosphere/mesos",
+  "patches": [
+    {
+      "ref": "d4b525e4ee76ebd3518e651ad3bad00e4d6fc3f6",
+      "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy."
+    },
+    {
+      "ref": "56483bfa58fac720ac9cf7df96dc9bb4cf4df0c0",
+      "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
+    },
+    {
+      "ref": "8aed90470dd250ab6ca3bc67923c152cd4419eb2",
+      "description": "Set LIBPROCESS_IP into docker container."
+    },
+    {
+      "ref": "da39a5a3ad05c7cc277a7f7602c29f40c57cef39",
+      "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
+    },
+    {
+      "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
+      "description": "Added '--filter_gpu_resources' flag to the mesos master."
+    }
+  ]
+}


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest mesosphere/1.2.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/05ba66b1ea2d00f3d784ac732f95f237dff652a8...bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
