### PR TITLE
[master] Bump Mesos to nightly master a1c6a7a

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "683d3c137ed66d6e9a7e5da622f62a7ce962d4d1",
-      "ref_origin": "master"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "b0ecfa4466f0b377cc419b583f90c8c926aebc12",
+    "ref_origin": "master"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "97de6eea9ad70f700082f70cd8d2584e199186df",
-    "ref_origin" : "dcos-mesos-master-e91ce42ed"
+    "ref": "7659c405f51c1771fd341c9fad34085982774014",
+    "ref_origin": "dcos-mesos-master-nightly-a1c6a7a"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -3,19 +3,19 @@
   "git": "https://github.com/mesosphere/mesos",
   "patches": [
     {
-      "ref": "23dda3f685fbc552646ca5e4a560b1256640eda4",
-      "description": "Set LIBPROCESS_IP into docker container"
+      "ref": "0f762c15455900083f7a3f72c6cdc60a418ec12f",
+      "description": "Set LIBPROCESS_IP into docker container."
     },
     {
-      "ref": "d523dba4ca02ad15c0ce2fb9a93a7a1d7ec0eedf",
-      "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy"
+      "ref": "b6d7b1f3ca61a536132b3e973c32dd695e181005",
+      "description": "Mesos UI: updated the URL generation to make it work with adminrouter."
     },
     {
-      "ref": "c9c5537b229fa55b5d5034b5fc40ae450fbbd08b",
+      "ref": "9796bf3d889397aa6ee707c937af4e8c757c9f2a",
       "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
     },
     {
-      "ref": "a9f5ddb8614ef057537994f389eb7e19f0c85652",
+      "ref": "7659c405f51c1771fd341c9fad34085982774014",
       "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
     }
   ]


### PR DESCRIPTION
## High-level description

This is a routine bump to the latest master branch of Mesos.

It also changes 2 DC/OS specific cherry-picks.

1. Following [the recent change in UCR code](https://reviews.apache.org/r/62472/) an update of the cherry-pick related to the GPU isolator failure is required.
`a9f5ddb8614ef057537994f389eb7e19f0c85652` -> `7659c405f51c1771fd341c9fad34085982774014` 

2. Following [an update of the Web controllers in Apache Mesos](https://reviews.apache.org/r/65246/), an update of the cherry-pick affecting those controllers is also required.
`d523dba4ca02ad15c0ce2fb9a93a7a1d7ec0eedf` -> `b6d7b1f3ca61a536132b3e973c32dd695e181005`

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/97de6eea9ad70f700082f70cd8d2584e199186df...7659c405f51c1771fd341c9fad34085982774014)
    [dcos/dcos-mesos-modules diff](https://github.com/dcos/dcos-mesos-modules/compare/683d3c137ed66d6e9a7e5da622f62a7ce962d4d1...b0ecfa4466f0b377cc419b583f90c8c926aebc12)
    [mesosphere/dcos-ee-mesos-modules diff](https://github.com/mesosphere/dcos-ee-mesos-modules/compare/21afe5d01f2ecf2f4f742fd40692c79d3f33c19b...6e0f4d149906f9cb00f958e2b0c81d4943dc5d6c)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
