### PR TITLE
Check that ifconfig is available on cluster nodes

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -436,6 +436,7 @@ function check_all() {
     check unzip
     check ipset
     check systemd-notify
+    check ifconfig
 
     # $ systemctl --version ->
     # systemd nnn

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -764,6 +764,11 @@ def calculate_check_config(check_time):
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'unzip'],
                     'timeout': '1s'
                 },
+                'ifconfig': {
+                    'description': 'The ifconfig utility is available',
+                    'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'ifconfig'],
+                    'timeout': '1s'
+                },
                 'ip_detect_script': {
                     'description': 'The IP detect script produces valid output',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'ip'],
@@ -795,6 +800,7 @@ def calculate_check_config(check_time):
                 'tar',
                 'curl',
                 'unzip',
+                'ifconfig',
                 'ip_detect_script',
                 'mesos_master_replog_synchronized',
                 'mesos_agent_registered_with_masters',

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-checks.git",
-    "ref": "c5a667cd20713af21c618df48b0ab2b3fc5ed0a6",
+    "ref": "c34c5a76bd49bf5df224e0c8abca51a71dece475",
     "ref_origin": "master"
   },
   "state_directory": true,


### PR DESCRIPTION
## High-level description

DC/OS network components depend on `ifconfig`, and will fail if it's not installed. This PR adds a check to the advanced install script that causes it to fail if `ifconfig` is not available on the host. It also adds a poststart node check that will fail if `ifconfig` is not available. This should shorten the debug loop by preventing DC/OS from deploying to hosts without `ifconfig`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2395](https://jira.mesosphere.com/browse/DCOS_OSS-2395) Fail install if ifconfig isn't available

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Doesn't seem significant enough for a changelog entry.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually on a CentOS host with ifconfig made unavailable. Install fails as expected.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-checks/compare/c5a667cd20713af21c618df48b0ab2b3fc5ed0a6...c34c5a76bd49bf5df224e0c8abca51a71dece475)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-checks/job/dcos-checks-pulls-pipeline/14/
  - [x] Code Coverage (if available): https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-checks/job/dcos-checks-pulls-pipeline/14/