### PR TITLE
Add checks for ftype=1 for docker and mesos directories if using XFS

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -279,6 +279,47 @@ EOM
     fi
 }
 
+function d_type_enabled_if_xfs()
+{
+    # Return 1 if $1 is a directory on XFS volume with ftype ! = 1
+    # otherwise return 0
+    DIRNAME="$1"
+
+    RC=0
+    # "df", the command being used to get the filesystem device and type,
+    # fails if the directory does not exist, hence we need to iterate up the
+    # directory chain to find a directory that exists before executing the command
+    while [[ ! -d "$DIRNAME" ]]; do
+        DIRNAME="$(dirname "$DIRNAME")"
+    done
+    read -r filesystem_device filesystem_type <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2}')"
+    if [[ "$filesystem_type" == "xfs" ]]; then
+        echo -n -e "Checking if $DIRNAME is mounted with \"fytpe=1\": "
+        ftype_value="$(xfs_info $filesystem_device | grep -oE ftype=[0-9])"
+        if [[ "$ftype_value" != "ftype=1" ]]; then
+            RC=1
+        fi
+        print_status $RC "${NORMAL}(${ftype_value})"
+    fi
+    return $RC
+}
+
+# check node storage has d_type (ftype=1) support enabled if using XFS
+function check_xfs_ftype() {
+    RC=0
+
+    mesos_agent_dir="{{ mesos_agent_work_dir }}"
+    # Check if ftype=1 on the volume, for $mesos_agent_dir, if its on XFS filesystem
+    ( d_type_enabled_if_xfs "$mesos_agent_dir" ) || RC=1
+
+    # Check if ftype=1 on the volume, for docker root dir, if its on XFS filesystem
+    docker_root_dir="$(docker info | grep 'Docker Root Dir' | cut -d ':' -f 2  | tr -d '[[:space:]]')"
+    ( d_type_enabled_if_xfs "$docker_root_dir" ) || RC=1
+
+    (( OVERALL_RC += $RC ))
+    return $RC
+}
+
 function check_all() {
     # Disable errexit because we want the preflight checks to run all the way
     # through and not bail in the middle, which will happen as it relies on
@@ -416,6 +457,7 @@ function check_all() {
         do
             check_service $service
         done
+        check_xfs_ftype
     fi
 
     # Check we're not in docker on devicemapper loopback as storage driver.
@@ -571,7 +613,8 @@ def make_bash(gen_out):
         'dcos_image_commit': util.dcos_image_commit,
         'generation_date': util.template_generation_date,
         'setup_flags': setup_flags,
-        'setup_services': setup_services})
+        'setup_services': setup_services,
+        'mesos_agent_work_dir': gen_out.arguments['mesos_agent_work_dir']})
 
     # Output the dcos install script
     pkgpanda.util.write_string('dcos_install.sh', bash_script)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -308,7 +308,7 @@ function d_type_enabled_if_xfs()
 function check_xfs_ftype() {
     RC=0
 
-    mesos_agent_dir="{{ mesos_agent_work_dir }}"
+    mesos_agent_dir="/var/lib/mesos/slave"
     # Check if ftype=1 on the volume, for $mesos_agent_dir, if its on XFS filesystem
     ( d_type_enabled_if_xfs "$mesos_agent_dir" ) || RC=1
 
@@ -613,8 +613,7 @@ def make_bash(gen_out):
         'dcos_image_commit': util.dcos_image_commit,
         'generation_date': util.template_generation_date,
         'setup_flags': setup_flags,
-        'setup_services': setup_services,
-        'mesos_agent_work_dir': gen_out.arguments['mesos_agent_work_dir']})
+        'setup_services': setup_services})
 
     # Output the dcos install script
     pkgpanda.util.write_string('dcos_install.sh', bash_script)


### PR DESCRIPTION
## High-level description

This is backport of #2768 
When using XFS (only supported filesystem for lower level filesystems for Centos) the volumes must be mounted d_type support enabled (ftype=1). This requirement is documented here https://docs.mesosphere.com/1.10/installing/ent/custom/system-requirements/install-docker-centos/#requirements-and-recommendations. DC/OS installer currently does not enforce this and can lead to a lot of pain for users and customers if they discover this requirement after setting installing the cluster and having it operational for some time. Reformatting the volumes is not a trivial task. So If we short circuit the install of DC/OS if the requirement is not met we can save a lot of pain to the users and customers 

What features does this change enable? What bugs does this change fix?
Enforce the system requirement of ftype=1 for XFS volumes

## Corresponding DC/OS tickets (obligatory)

[COPS-3158](https://jira.mesosphere.com/browse/COPS-3158) Block DC/OS install if mesos work dir or docker root dir is XFS but not mounted with ftype=1 

## Related tickets (optional)

None

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
