### PR TITLE
Merge Train for DC/OS 1.9.9

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -104,7 +104,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.9.8',
+        'version': '1.9.9',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -719,7 +719,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.9.8',
+        'dcos_version': '1.9.9',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -204,7 +204,7 @@ def calculate_ip_detect_contents(ip_detect_filename):
 
 def calculate_ip_detect_public_contents(ip_detect_contents, ip_detect_public_filename):
     if ip_detect_public_filename != '':
-        calculate_ip_detect_contents(ip_detect_public_filename)
+        return calculate_ip_detect_contents(ip_detect_public_filename)
     return ip_detect_contents
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -407,6 +407,7 @@ package:
       MESOS_LAUNCHER_DIR=/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_EXECUTOR_ENVIRONMENT_VARIABLES=file:///opt/mesosphere/etc/mesos-executor-environment.json
       MESOS_EXECUTOR_REGISTRATION_TIMEOUT=10mins
+      MESOS_EXECUTOR_REREGISTRATION_TIMEOUT=10secs
       MESOS_CGROUPS_ENABLE_CFS=true
       MESOS_CGROUPS_LIMIT_SWAP=false
       MESOS_DOCKER_REMOVE_DELAY={{ docker_remove_delay }}

--- a/packages/adminrouter/extra/src/nginx.agent.conf
+++ b/packages/adminrouter/extra/src/nginx.agent.conf
@@ -2,7 +2,7 @@ include common/main.conf;
 
 
 http {
-    resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=60s;
+    resolver 198.51.100.1:53 198.51.100.2:53 198.51.100.3:53 valid=5s ipv6=off;
 
     client_max_body_size 1024M;
 

--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -4,7 +4,7 @@ include common/main.conf;
 http {
     # Without this, cosocket-based code in worker
     # initialization cannot resolve leader.mesos.
-    resolver 127.0.0.1:61053 ipv6=off;
+    resolver 127.0.0.1:61053 valid=5s ipv6=off;
 
     include common/http.conf;
 

--- a/packages/curl/buildinfo.json
+++ b/packages/curl/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["openssl", "python-requests"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://curl.haxx.se/download/curl-7.48.0.tar.gz",
-    "sha1": "eac95625b849408362cf6edb0bc9489da317ba30"
+    "url": "https://curl.haxx.se/download/curl-7.59.0.tar.gz",
+    "sha1": "1a9bd7e201e645207b23a4b4dc38a32cc494a638"
   }
 }

--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -4,7 +4,7 @@ import sys
 import threading
 
 from flask import Flask, Response
-from flask.ext.compress import Compress
+from flask_compress import Compress
 
 from history.statebuffer import BufferCollection, BufferUpdater
 

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "8bda9b7098a795ab39293215e873792645192712",
-    "ref_origin": "v1.9.4"
+    "ref": "b66ee7aef741799e69fe504d689ab01d7721642c",
+    "ref_origin": "v1.9.6"
   }
 }

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
-      "ref_origin": "1.9.x"
-    }
+  "requires": [
+    "mesos",
+    "boost-libs"
+  ],
+  "single_source": {
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "e46209d55e6e5be2caa2e49ca3c32bdfec5bd427",
+    "ref_origin": "1.9"
+  }
 }

--- a/packages/mesos/README.md
+++ b/packages/mesos/README.md
@@ -1,6 +1,27 @@
 <H2>Patches to cherry-pick on top of open source Apache Mesos before building in DC/OS</h2>
 All commits can be found in the repository at <a href="https://github.com/mesosphere/mesos/">https://github.com/mesosphere/mesos/</a>.
 
+<h3>Critical backports that are not in Mesos 1.2.3</h3>
+<li>[8594503910fc35a8cbf33d4c270d6d0e33276b03] Promoted log level to warning for disconnected events in exec.cpp.
+<li>[e0889bf81890202cc3c55ce36c5f0e037f720761] Ensured command executor always honors shutdown request.
+<li>[59d17c833bd464e2e16d1cd685193f4f3277a925] Ensured executor adapter propagates error and shutdown messages.
+<li>[13a07821db91c8e2787421a63abcb422aaa171f4] Terminated driver-based executors if kill arrives before launch task.
+<li>[d566462f8af1739d718a994885334ad7063dce86] Reaped the container process directly in Docker executor.
+<li>[f03e2a1545ef1e70269c33245503c3efb215b7c5] Windows: Fixed flaky Docker command health check test.
+<li>[c5479b6e1a140728e60390ae77f5430dcacc014c] Prevented Docker library from terminating incorrect processes.
+<li>[2d17e0b9098c3f455eac5ceb82ac5021b23e55ce] Updated discard handling for Docker 'stop' and 'pull' commands.
+<li>[e7c9c1da92be006c161ccfba6e3ae6bfc5b46276] Ensured that Docker containerizer returns a failed Future in one case.
+<li>[721dee01bce444b06f71b68a68eb741dd331ed9f] Updated discard handling in `Docker::inspect()`.
+<li>[088498968dadef1b98e0d98d02044b7172dc1a56] Avoided orphan subprocess in the Docker library.
+<li>[a28a0daacb20b9acd68c0bd1ed86cb51afc66ff1] Handled hanging docker `stop`, `inspect` commands in docker executor.
+<li>[fa7106d947300d9eebe0dbeea3bed84dac187419] Added overload of process::await that takes and returns single future.
+<li>[314a117446f9f7f6e05d319a53c1eb9235cbe247] Fixed compile issue for backporting by removing 'AwaitSingleAbandon'.
+<li>[89a430b525c4612606af419ab88f7383217464ab] Added inspect retries to the Docker executor.
+<li>[abfa0229c5017e1644c301192c877e36ba7fe177] Added inspect retries to the docker containerizer in `update` method.
+<li>[1d104c8584dbcc398d709ced6271971593471991] Fixed an issue with the scheduler driver subscribe backoff time.
+<li>[4a0d0de518b71330667a186f0c01846a82922135] Libprocess: Fixed a crash in the presence of request/response trailers.
+<li>[563f24caba5c3dd07350bd8f6f1aef2dbfb87bb5] Stout: Ensured exceptions are caught for `picojson::parse()`.
+
 <h3>WebUI magic for DC/OS' reverse proxy</h3>
 <li>[9659ca424cbc9bd7c3942e6f48dc1bbd1b2f27cc] Mesos UI: Change paths, pailer, and logs to work with a reverse proxy.
 <li>[0e61b936bf383572d2613b5ff8af045339f8c633] Revert "Fixed the broken metrics information of master in WebUI."
@@ -11,9 +32,3 @@ All commits can be found in the repository at <a href="https://github.com/mesosp
 <h3>GPU-related workarounds</h3>
 <li>[cdec8ecded25db8c8d8ac0a4838b9f7e3d9285d1] Updated mesos containerizer to ignore GPU isolator creation failure.
 <li>[bd983e54c7d941db4a67c1d5659a60014b3fec71] Added '--filter_gpu_resources' flag to the mesos master.
-
-<h3>Critical backports that are not in Mesos 1.2.3</h3>
-<li>[13a07821db91c8e2787421a63abcb422aaa171f4] Terminated driver-based executors if kill arrives before launch task.
-<li>[59d17c833bd464e2e16d1cd685193f4f3277a925] Ensured executor adapter propagates error and shutdown messages.
-<li>[e0889bf81890202cc3c55ce36c5f0e037f720761] Ensured command executor always honors shutdown request.
-<li>[8594503910fc35a8cbf33d4c270d6d0e33276b03] Promoted log level to warning for disconnected events in exec.cpp.

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,10 +1,15 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
+  "requires": [
+    "openssl",
+    "libevent",
+    "curl",
+    "boost-libs"
+  ],
+  "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "05ba66b1ea2d00f3d784ac732f95f237dff652a8",
-    "ref_origin" : "dcos-mesos-post-1.2.3-abfa022"
+    "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
+    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-563f24c"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
@@ -12,13 +17,13 @@
   },
   "state_directory": true,
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    },
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144,
+      "vm.swappiness": 1
+    }
   }
 }

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -1,0 +1,26 @@
+{
+  "kind": "git",
+  "git": "https://github.com/mesosphere/mesos",
+  "patches": [
+    {
+      "ref": "d4b525e4ee76ebd3518e651ad3bad00e4d6fc3f6",
+      "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy."
+    },
+    {
+      "ref": "56483bfa58fac720ac9cf7df96dc9bb4cf4df0c0",
+      "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
+    },
+    {
+      "ref": "8aed90470dd250ab6ca3bc67923c152cd4419eb2",
+      "description": "Set LIBPROCESS_IP into docker container."
+    },
+    {
+      "ref": "da39a5a3ad05c7cc277a7f7602c29f40c57cef39",
+      "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
+    },
+    {
+      "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
+      "description": "Added '--filter_gpu_resources' flag to the mesos master."
+    }
+  ]
+}

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -6,7 +6,9 @@ import os
 import re
 import shutil
 import socketserver
+import stat
 import subprocess
+import tempfile
 from contextlib import contextmanager, ExitStack
 from itertools import chain
 from multiprocessing import Process
@@ -20,13 +22,6 @@ import yaml
 from teamcity.messages import TeamcityServiceMessages
 
 from pkgpanda.exceptions import FetchError, ValidationError
-
-
-json_prettyprint_args = {
-    "sort_keys": True,
-    "indent": 2,
-    "separators": (',', ':')
-}
 
 
 def variant_str(variant):
@@ -159,8 +154,8 @@ def load_yaml(filename):
 
 
 def write_yaml(filename, data, **kwargs):
-    with open(filename, "w+") as f:
-        return yaml.safe_dump(data, f, **kwargs)
+    dumped_yaml = yaml.safe_dump(data, **kwargs)
+    write_string(filename, dumped_yaml)
 
 
 def make_file(name):
@@ -169,13 +164,45 @@ def make_file(name):
 
 
 def write_json(filename, data):
-    with open(filename, "w+") as f:
-        return json.dump(data, f, **json_prettyprint_args)
+    dumped_json = json_prettyprint(data=data)
+    write_string(filename, dumped_json)
 
 
 def write_string(filename, data):
-    with open(filename, "w+") as f:
-        return f.write(data)
+    """
+    Write a string to a file.
+    Overwrite any data in that file.
+
+    We use an atomic write practice of creating a temporary file and then
+    moving that temporary file to the given ``filename``. This prevents race
+    conditions such as the file being read by another process after it is
+    opened here but not yet written to.
+
+    It also prevents us from creating or truncating a file before we fail to
+    write data to it because of low disk space.
+
+    If no file already exists at ``filename``, the new file is created with
+    permissions 0o644.
+    """
+    prefix = os.path.basename(filename)
+    tmp_file_dir = os.path.dirname(os.path.realpath(filename))
+    fd, temporary_filename = tempfile.mkstemp(prefix=prefix, dir=tmp_file_dir)
+
+    try:
+        permissions = os.stat(filename).st_mode
+    except FileNotFoundError:
+        permissions = 0o644
+
+    try:
+        try:
+            os.write(fd, data.encode())
+        finally:
+            os.close(fd)
+        os.chmod(temporary_filename, stat.S_IMODE(permissions))
+        os.replace(temporary_filename, filename)
+    except Exception:
+        os.remove(temporary_filename)
+        raise
 
 
 def load_string(filename):
@@ -184,7 +211,12 @@ def load_string(filename):
 
 
 def json_prettyprint(data):
-    return json.dumps(data, **json_prettyprint_args)
+    return json.dumps(
+        data,
+        sort_keys=True,
+        indent=2,
+        separators=(',', ':'),
+    )
 
 
 def if_exists(fn, *args, **kwargs):


### PR DESCRIPTION
* [1.9] Increase executor reregistration timeout to 10 seconds. #2696 
* Fixed bug in `calculate_ip_detect_public_contents()`.  #2731 
* [1.9] Bump curl from 7.48 to 7.59  #2757 
* [Ready for Review] Backport Adminrouter DNS entry TTL override of 5 seconds to 1.9 OSS #2772
* [DCOS-14199][1.9] Write strings to files atomically in pkgpanda.util  #2786 
* Bump dcos-ui 1.9.6 in 1.9 release  #2787
* [1.9] Bump Mesos to nightly mesosphere/1.2.x 563f24c #2807 