### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 9343f42

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8",
-    "ref_origin": "dcos-mesos-1.5.x-nightly-aedbcfd"
+    "ref": "d3bdbd8725e6a0c56a32efd241cc1052a75c3d72",
+    "ref_origin": "dcos-mesos-1.5.x-nightly-9343f42"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -3,23 +3,23 @@
   "git": "https://github.com/mesosphere/mesos",
   "patches": [
     {
-      "ref": "20e5654a294f599b637efadf32206e7b15398081",
+      "ref": "e6a42f59191bd34fd5e586b053cc837b62cf9cca",
       "description": "Set LIBPROCESS_IP into docker container."
     },
     {
-      "ref": "77ae0475cc692acb359afad6a26f4566460af2ec",
+      "ref": "9f11f3adf459a48eda77c7bffa5a5c5c2130b3ef",
       "description": "Mesos UI: updated the URL generation to make it work with adminrouter."
     },
     {
-      "ref": "f01e1ecc7ee9e9879d7059f8862a389f9f9c25c6",
+      "ref": "3ccc2e93daaa9efc92890929b70497c39cd4c0e3",
       "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
     },
     {
-      "ref": "1adcbaf630abe383fc3b7b28f8fdbf0bfa212d1b",
+      "ref": "560f129d15f050a337a915ff57694270481199c2",
       "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
     },
     {
-      "ref": "09b92d822658b9563103d86ad45a9a7fdf85f271",
+      "ref": "d3bdbd8725e6a0c56a32efd241cc1052a75c3d72",
       "description": "Displayed resource provider resources in GET_RESOURCE_PROVIDER response."
     }
   ]


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest 1.5.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8...d3bdbd8725e6a0c56a32efd241cc1052a75c3d72)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
