### PR TITLE
Prune old entries from owners.json, remove me from the list

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -7,11 +7,8 @@
   "klueska": {"slack": "klueska", "jira": "klueska"},
   "MatApple": {"slack": "mat", "jira": "mat"},
   "mnaboka": {"slack": "mnaboka", "jira": "mnaboka"},
-  "mellenburg": {"slack": "mellenburg", "jira": "michael.ellenburg"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
   "orlandohohmeier": {"slack": "orlando", "jira": "orlando"},
   "orsenthil" : {"slack": "skumaran", "jira": "skumaran"},
-  "spahl": {"slack": "seb", "jira": "sebastien"},
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
-  "vespian": {"slack": "prozlach", "jira": "prozlach"}
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"}
 }


### PR DESCRIPTION
## High-level description

This PR removes old entries from owners.json and also removes me from the list.

I am sorry but the amount of noise mergebot is generating is too high for me, trying to create Gmail filters is like playing cat and mouse. I find Jira and Github notifications too important to ignore them/filter them all. 

CC: @orsenthil @gpaul @adamtheturtle @jgehrcke @mhrabovcin @timaa2k @ahairape @sambatyon @jongiddy