### PR TITLE
improve dcos-diagnostics integration test

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -571,12 +571,13 @@ def _download_bundle_from_master(dcos_api_session, master_index):
             assert zipfile.is_zipfile(bundle_full_location)
             z = zipfile.ZipFile(bundle_full_location)
 
-            # validate error log is empty
-            log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
-            assert log_data, 'summaryErrorsReport.txt must be empty. Got {}'.format(log_data)
-
             # get a list of all files in a zip archive.
             archived_items = z.namelist()
+
+            # validate error log is empty
+            if 'summaryErrorsReport.txt' in archived_items:
+                log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
+                raise AssertionError('summaryErrorsReport.txt must be empty. Got {}'.format(log_data))
 
             # validate all files in zip archive are not empty
             for item in archived_items:

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -571,6 +571,10 @@ def _download_bundle_from_master(dcos_api_session, master_index):
             assert zipfile.is_zipfile(bundle_full_location)
             z = zipfile.ZipFile(bundle_full_location)
 
+            # validate error log is empty
+            log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
+            assert log_data, 'summaryErrorsReport.txt must be empty. Got {}'.format(log_data)
+
             # get a list of all files in a zip archive.
             archived_items = z.namelist()
 


### PR DESCRIPTION
## High-level description

Improve integration test for dcos-diagnostics component.
An error log file inside the diagnostics bundle called `summaryErrorsReport.txt` should be empty.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-25670](https://jira.mesosphere.com/browse/DCOS-25670)


## Related tickets (optional)

Other tickets related to this change:

  - N/A


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
