### PR TITLE
[1.10] Bump dcos-metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,14 @@ Format of the entries must be.
 
 * Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)
 
+* Add task labels as tags on container metrics (DCOS_OSS-3304)
+
+* Increase the mesos agent response timeout for dcos-metrics (DCOS-37452)
+
+* Prevent cosmos-specific labels being sent as metrics tags (DCOS-37451)
+
+* Improve the way statsd timers are handled in dcos-metrcs (DCOS-38083)
+
 ### Security Updates
 
 

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "74c87c68631573f90ab921b2d1fc3f0cb216f019",
+    "ref": "aabb980cf2edc7d53d82025024844cdb92180b17",
     "ref_origin": "1.10.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3304](https://jira.mesosphere.com/browse/DCOS_OSS-3304) Metrics emitted by containers do not contain tags from labels
  - [DCOS-37452](https://jira.mesosphere.com/browse/DCOS-37452) Increase the mesos agent response timeout for dcos-metrics
  - [DCOS-37451](https://jira.mesosphere.com/browse/DCOS-37451) Filter cosmos bookkeeping tags from metrics	
  - [DCOS-38083](https://jira.mesosphere.com/browse/DCOS-38083) Statsd timers are reported incorrectly by dcos-metrics	

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/74c87c68631573f90ab921b2d1fc3f0cb216f019...aabb980cf2edc7d53d82025024844cdb92180b17)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/11/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/11/cobertura/)
