### PR TITLE
[1.9] Bump Mesos to nightly mesosphere/1.2.x cb79076

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/mesosphere/mesos",
-    "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
-    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-563f24c"
+    "ref": "1296f66a67cc498b522caae16c2617977592bd70",
+    "ref_origin": "dcos-mesos-mesosphere/1.2.x-nightly-cb79076"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/patches.json
+++ b/packages/mesos/patches.json
@@ -3,23 +3,23 @@
   "git": "https://github.com/mesosphere/mesos",
   "patches": [
     {
-      "ref": "d4b525e4ee76ebd3518e651ad3bad00e4d6fc3f6",
+      "ref": "4999edc46fe4320017f17abccaa7ec3778541952",
       "description": "Mesos UI: Change paths, pailer, and logs to work with a reverse proxy."
     },
     {
-      "ref": "56483bfa58fac720ac9cf7df96dc9bb4cf4df0c0",
+      "ref": "0f0e61f264bfe84bc79e335691dd55a9d0ba6c95",
       "description": "Revert \"Fixed the broken metrics information of master in WebUI.\""
     },
     {
-      "ref": "8aed90470dd250ab6ca3bc67923c152cd4419eb2",
+      "ref": "b26215ad124850c38bacd047b6c12164025816d1",
       "description": "Set LIBPROCESS_IP into docker container."
     },
     {
-      "ref": "da39a5a3ad05c7cc277a7f7602c29f40c57cef39",
+      "ref": "e0047ff103b9cf57ac9859749d03d91e8a0e113e",
       "description": "Updated mesos containerizer to ignore GPU isolator creation failure."
     },
     {
-      "ref": "bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f",
+      "ref": "1296f66a67cc498b522caae16c2617977592bd70",
       "description": "Added '--filter_gpu_resources' flag to the mesos master."
     }
   ]


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest mesosphere/1.2.x branch of Mesos.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last Mesos version integrated:
    [mesosphere/mesos diff](https://github.com/mesosphere/mesos/compare/bf8d2f21f403d8650ee9beeed7f7f2e55b79fc6f...1296f66a67cc498b522caae16c2617977592bd70)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
