### PR TITLE
1.12 Merge Train - May 8th

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,10 @@ Format of the entries must be.
 
 * TLS: Admin Router should be configured with both RSA and EC type certificates. (DCOS-22050)
 
+* Disable the 3DES bulk encryption algorithm for Master Admin Router's TLS. (DCOS-21958)
+
+* Disable the TLS 1.1 protocol for Master Admin Router's TLS. (DCOS-22326)
+
 
 ### Notable changes
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -991,7 +991,7 @@ entry = {
         'weights': '',
         'adminrouter_auth_enabled': calculate_adminrouter_auth_enabled,
         'adminrouter_tls_1_0_enabled': 'false',
-        'adminrouter_tls_1_1_enabled': 'true',
+        'adminrouter_tls_1_1_enabled': 'false',
         'adminrouter_tls_1_2_enabled': 'true',
         'adminrouter_tls_cipher_suite': '',
         'oauth_enabled': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1000,10 +1000,11 @@ package:
   - path: /etc/adminrouter-tls-master.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-      # Modulo ChaCha20 cipher.
+      # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+      # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 {% switch adminrouter_tls_cipher_override %}
 {% case "false" %}
-      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+      ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 {% case "true" %}
       ssl_ciphers {{ adminrouter_tls_cipher_suite }};
 {% endswitch %}

--- a/gen/tests/test_adminrouter_tls_conf.py
+++ b/gen/tests/test_adminrouter_tls_conf.py
@@ -30,9 +30,10 @@ class TestAdminRouterTLSConfig:
         expected_configuration = dedent(
             """\
             # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-            # Modulo ChaCha20 cipher.
+            # Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+            # For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
 
-            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+            ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 
             ssl_prefer_server_ciphers on;
             # To manually test which TLS versions are enabled on a node, use
@@ -40,7 +41,7 @@ class TestAdminRouterTLSConfig:
             #
             # See comments on https://jira.mesosphere.com/browse/DCOS-13437 for more
             # details.
-            ssl_protocols TLSv1.1 TLSv1.2;
+            ssl_protocols TLSv1.2;
             """
         )
         assert config['content'] == expected_configuration
@@ -119,7 +120,7 @@ class TestSetCipherOverride:
             config_path: str) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -146,7 +147,7 @@ class TestSetCipherOverride:
             new_config_arguments: Dict[str, str]) -> List[str]:
         """
         Finds the line that looks like:
-        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:EECDH+3DES:RSA+3DES:!MD5;
+        ssl_ciphers EECDH+AES256:RSA+AES256:EECDH+AES128:RSA+AES128:!MD5:!3DES;
         and returns the list of ciphers.
         Args:
             new_config_arguments: Arguments which are added to the 'standard'
@@ -201,7 +202,7 @@ class TestSetCipherOverride:
         ciphers = self.supported_ssl_ciphers_master(
             new_config_arguments=new_arguments,
         )
-        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5']
+        assert ciphers == ['EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES']
 
     @pytest.mark.skipif(pkgpanda.util.is_windows, reason="test fails on Windows reason unknown")
     def test_cipher_master_custom(self):
@@ -280,9 +281,10 @@ class TestToggleTLSVersions:
             new_config_arguments={},
         )
         disable_tls1_protocols = self.supported_tls_protocols_ar_master(
-            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false'},
+            new_config_arguments={'adminrouter_tls_1_0_enabled': 'false',
+                                  'adminrouter_tls_1_1_enabled': 'false'},
         )
-        assert default_protocols == ['TLSv1.1', 'TLSv1.2']
+        assert default_protocols == ['TLSv1.2']
         assert default_protocols == disable_tls1_protocols
 
     @pytest.mark.parametrize(

--- a/owners.json
+++ b/owners.json
@@ -13,6 +13,5 @@
   "orlandohohmeier": {"slack": "orlando", "jira": "orlando"},
   "orsenthil" : {"slack": "skumaran", "jira": "skumaran"},
   "rukletsov": {"slack": "alexr", "jira": "alexr"},
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
-  "vespian": {"slack": "prozlach", "jira": "prozlach"}
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"}
 }

--- a/packages/adminrouter/docker/adminrouter-tls-master.conf
+++ b/packages/adminrouter/docker/adminrouter-tls-master.conf
@@ -1,6 +1,8 @@
 # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
-# Modulo ChaCha20 cipher.
-ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+# Modulo ChaCha20 cipher and 3DES bulk encryption algorithm.
+# For 3DES see https://jira.mesosphere.com/browse/DCOS-21958
+
+ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!3DES;
 ssl_prefer_server_ciphers on;
 
 ssl_protocols TLSv1.1 TLSv1.2;

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -574,6 +574,11 @@ def _download_bundle_from_master(dcos_api_session, master_index):
             # get a list of all files in a zip archive.
             archived_items = z.namelist()
 
+            # validate error log is empty
+            if 'summaryErrorsReport.txt' in archived_items:
+                log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
+                raise AssertionError('summaryErrorsReport.txt must be empty. Got {}'.format(log_data))
+
             # validate all files in zip archive are not empty
             for item in archived_items:
                 assert z.getinfo(item).file_size, 'item {} is empty'.format(item)

--- a/packages/python/windows.buildinfo.json
+++ b/packages/python/windows.buildinfo.json
@@ -21,7 +21,7 @@
     },
     "pip": {
       "kind": "git",
-      "git": "git@github.com:pypa/pip.git",
+      "git": "https://github.com/pypa/pip.git",
       "ref": "8ed4ac1fe6e2a05db41585c10a7b46f16bc60666",
       "ref_origin": "master"
     }


### PR DESCRIPTION
## High-level description

* [1.12/master] Disable the 3DES and TLS 1.1 for Master Admin Router by default in 1.12/master  #2796
* Use HTTPS (rather than SSH) in python buildinfo  #2812
* Metronome 0.4.2 bump on Master  #2827 
* Prune old entries from owners.json, remove me from the list #2836 
* improve dcos-diagnostics integration test #2843