### PR TITLE
Metronome 0.4.2 bump on 1.11 [cherry-pick to 1.11.2]

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.5.0/metronome-0.5.0.tgz",
-    "sha1": "b2c3b5c2ad4bfc45da82cc13538c23c483d05062"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.2/metronome-0.4.2.tgz",
+    "sha1": "61652afa0f1209635dcf9839f985ae5ee64486ba"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
Cherry-pick of https://github.com/dcos/dcos/pull/2826 to 1.11.2.