### PR TITLE
Increase the limit on worker_connections to 10K

### DIFF
--- a/packages/adminrouter/extra/src/includes/main/common.conf
+++ b/packages/adminrouter/extra/src/includes/main/common.conf
@@ -21,7 +21,7 @@ env CACHE_BACKEND_REQUEST_TIMEOUT;
 env CACHE_REFRESH_LOCK_TIMEOUT;
 
 events {
-    worker_connections 1024;
+    worker_connections 10000;
 }
 
 # Run worker processes in dcos_adminrouter group to


### PR DESCRIPTION
This PR increases the limit on the number of connections (worker_connections) to 10K for Admin Router.

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/SOAK-80

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]