### PR TITLE
Mute `pkgpanda/test_util:test_write_string` on Windows

### DIFF
--- a/pkgpanda/test_util.py
+++ b/pkgpanda/test_util.py
@@ -373,6 +373,8 @@ def test_split_by_token():
     ]
 
 
+# TODO: DCOS_OSS-3508 - muted Windows tests requiring investigation
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows and Linux permissions parsed differently")
 def test_write_string(tmpdir):
     """
     `pkgpanda.util.write_string` writes or overwrites a file with permissions


### PR DESCRIPTION
### High-level description
`pkgpanda/test_util.py::test_write_string` was written before having Windows unit testing was enabled on PRs, and is thusly failing.

### Corresponding DC/OS tickets
These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

[DCOS_OSS-3508](https://jira.mesosphere.com/browse/DCOS_OSS-3508)- pkgpanda/test_util.py has muted Windows tests requiring investigation