### PR TITLE
[master] Bump Mesos to nightly master 40b40d9

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["mesos", "boost-libs"],
-    "single_source" : {
-      "kind": "git",
-      "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "683d3c137ed66d6e9a7e5da622f62a7ce962d4d1",
-      "ref_origin": "master"
-    }
+  "requires": [
+    "mesos", 
+    "boost-libs"
+  ], 
+  "single_source": {
+    "kind": "git", 
+    "git": "https://github.com/dcos/dcos-mesos-modules.git", 
+    "ref": "a0e2ab778a7984d2a30c57221de560835abdd958", 
+    "ref_origin": "master"
+  }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,24 +1,29 @@
 {
-  "requires": ["openssl", "libevent", "curl", "boost-libs"],
-  "single_source" : {
-    "kind": "git",
-    "git": "https://github.com/apache/mesos",
-    "ref": "a1c6a7a3c54518f97a34f28b1792885b928b948c",
-    "ref_origin" : "master"
-  },
+  "requires": [
+    "openssl", 
+    "libevent", 
+    "curl", 
+    "boost-libs"
+  ], 
+  "single_source": {
+    "kind": "git", 
+    "git": "https://github.com/apache/mesos", 
+    "ref": "40b40d9b73221388e583fc140280f1eb2b48b832", 
+    "ref_origin": "master"
+  }, 
   "environment": {
-    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
+    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib", 
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
-  },
-  "state_directory": true,
+  }, 
+  "state_directory": true, 
   "sysctl": {
-      "dcos-mesos-slave": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      },
-      "dcos-mesos-slave-public": {
-          "vm.max_map_count": 262144,
-          "vm.swappiness": 1
-      }
+    "dcos-mesos-slave": {
+      "vm.max_map_count": 262144, 
+      "vm.swappiness": 1
+    }, 
+    "dcos-mesos-slave-public": {
+      "vm.max_map_count": 262144, 
+      "vm.swappiness": 1
+    }
   }
 }


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    [https://github.com/apache/mesos diff](https://github.com/apache/mesos/compare/a1c6a7a3c54518f97a34f28b1792885b928b948c...40b40d9b73221388e583fc140280f1eb2b48b832)
    [https://github.com/dcos/dcos-mesos-modules diff](https://github.com/dcos/dcos-mesos-modules/compare/683d3c137ed66d6e9a7e5da622f62a7ce962d4d1...a0e2ab778a7984d2a30c57221de560835abdd958)
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
