### PR TITLE
rexray: upgrade to v0.11.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,3 +57,5 @@ Format of the entries must be.
 * Updated Metronome to 0.5.0. (DCOS_OSS-2338)
 
 * Updated OTP version to 20.3.2 (DCOS_OSS-2378)
+
+* Updated REX-Ray version to 0.11.1 (DCOS_OSS-3597) [rexray v0.11.1](https://github.com/rexray/rexray/releases/tag/v0.11.1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,4 +58,4 @@ Format of the entries must be.
 
 * Updated OTP version to 20.3.2 (DCOS_OSS-2378)
 
-* Updated REX-Ray version to 0.11.1 (DCOS_OSS-3597) [rexray v0.11.1](https://github.com/rexray/rexray/releases/tag/v0.11.1)
+* Updated REX-Ray version to 0.11.2 (DCOS_OSS-3597) [rexray v0.11.2](https://github.com/rexray/rexray/releases/tag/v0.11.2)

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
 import contextlib
+import logging
 import os
 import sys
 
 import boto3
-import botocore
 import requests
 import retrying
 from botocore import exceptions
+
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
 
 
 def is_rate_limit_error(exception):
@@ -41,10 +45,10 @@ def _remove_env_vars(*env_vars):
 
 @retrying.retry(
     wait_exponential_multiplier=1000,
-    wait_exponential_max=300000,
-    stop_max_delay=1800000,
+    wait_exponential_max=300 * 000,
+    stop_max_delay=1800 * 000,
     retry_on_exception=is_rate_limit_error)
-def delete_ec2_volume(name, timeout=300):
+def delete_ec2_volume(name, timeout=600):
     """Delete an EC2 EBS volume by its "Name" tag
 
     Args:
@@ -52,14 +56,18 @@ def delete_ec2_volume(name, timeout=300):
 
     """
     def _force_detach_volume(volume):
+        log.info("Force detaching all volume attachments.")
         for attachment in volume.attachments:
             try:
+                log.info("Volume has attachment: {}".format(attachment))
+                log.info("Detaching volume from instance: {}".format(attachment['InstanceId']))
                 volume.detach_from_instance(
                     DryRun=False,
                     InstanceId=attachment['InstanceId'],
                     Device=attachment['Device'],
                     Force=True)
             except exceptions.ClientError as exc:
+                log.exception("Failed to detach volume")
                 # See the following link for the structure of the exception:
                 # https://github.com/boto/botocore/blob/4d4c86b2bdd4b7a8e110e02abd4367f07137ca47/botocore/exceptions.py#L346
                 err_message = exc.response['Error']['Message']
@@ -68,14 +76,21 @@ def delete_ec2_volume(name, timeout=300):
                 # https://jira.mesosphere.com/browse/DCOS-37441?focusedCommentId=156163&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-156163
                 available_msg = "is in the 'available' state"
                 if err_code == 'IncorrectState' and available_msg in err_message:
+                    log.info("Ignoring benign exception")
                     return
                 raise
 
     @retrying.retry(wait_fixed=30 * 1000, stop_max_delay=timeout * 1000,
-                    retry_on_exception=lambda exc: isinstance(exc, botocore.exceptions.ClientError))
+                    retry_on_exception=lambda exc: isinstance(exc, exceptions.ClientError))
     def _delete_volume(volume):
+        log.info("Trying to delete volume...")
         _force_detach_volume(volume)
-        volume.delete()  # Raises ClientError if the volume is still attached.
+        try:
+            log.info("Issuing volume.delete()")
+            volume.delete()  # Raises ClientError (VolumeInUse) if the volume is still attached.
+        except exceptions.ClientError as exc:
+            log.exception("volume.delete() failed.")
+            raise
 
     def _get_current_aws_region():
         try:
@@ -98,6 +113,7 @@ def delete_ec2_volume(name, timeout=300):
     elif len(volumes) > 1:
         raise Exception('multiple volumes found with name {}'.format(name))
     volume = volumes[0]
+    log.info("Found volume {}".format(volume))
 
     try:
         _delete_volume(volume)
@@ -106,4 +122,5 @@ def delete_ec2_volume(name, timeout=300):
 
 
 if __name__ == '__main__':
+    log.info("Deleting volume {}".format(sys.argv[1]))
     delete_ec2_volume(sys.argv[1])

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -45,8 +45,8 @@ def _remove_env_vars(*env_vars):
 
 @retrying.retry(
     wait_exponential_multiplier=1000,
-    wait_exponential_max=300 * 000,
-    stop_max_delay=1800 * 000,
+    wait_exponential_max=300 * 1000,
+    stop_max_delay=1800 * 1000,
     retry_on_exception=is_rate_limit_error)
 def delete_ec2_volume(name, timeout=600):
     """Delete an EC2 EBS volume by its "Name" tag

--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,5 +9,12 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
+srcdir=$GOPATH/src/github.com/thecodeteam/rexray
+mkdir -p $(dirname $srcdir)
+ln -s /pkg/src/rexray $srcdir
+cd $srcdir
+
+DGOOS=linux make
+
 mkdir -p $PKG_PATH/bin
-tar -C $PKG_PATH/bin/ -xf /pkg/src/$PKG_NAME/*
+mv ./rexray $PKG_PATH/bin

--- a/packages/rexray/build
+++ b/packages/rexray/build
@@ -9,7 +9,7 @@ systemd_slave_public=$PKG_PATH/dcos.target.wants_slave_public/dcos-rexray.servic
 mkdir -p $(dirname $systemd_slave_public)
 cp "$systemd_slave" "$systemd_slave_public"
 
-srcdir=$GOPATH/src/github.com/thecodeteam/rexray
+srcdir=$GOPATH/src/github.com/rexray/rexray
 mkdir -p $(dirname $srcdir)
 ln -s /pkg/src/rexray $srcdir
 cd $srcdir

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,7 +1,8 @@
 {
-  "single_source": {
-    "kind": "url",
-    "url": "https://downloads.dcos.io/packages/rexray/rexray-Linux-x86_64-0.9.0.tar.gz",
-    "sha1": "be07ec9a41e5dc287fbe62006025de8a64392afb"
+  "single_source" : {
+    "kind": "git",
+    "git": "https://github.com/thecodeteam/rexray.git",
+    "ref": "1608180686ac4426b04941b4002fb33b9efd972e",
+    "ref_origin": "v0.11.1"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/rexray/rexray.git",
-    "ref": "1608180686ac4426b04941b4002fb33b9efd972e",
-    "ref_origin": "v0.11.1"
+    "ref": "fc8bfbd2d02c2690fc3a755a9560dd12c88e0852",
+    "ref_origin": "v0.11.2"
   }
 }

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/thecodeteam/rexray.git",
+    "git": "https://github.com/rexray/rexray.git",
     "ref": "1608180686ac4426b04941b4002fb33b9efd972e",
     "ref_origin": "v0.11.1"
   }

--- a/packages/rexray/extra/dcos-rexray.service
+++ b/packages/rexray/extra/dcos-rexray.service
@@ -9,6 +9,7 @@ LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/proxy.env
 Environment=REXRAY_HOME=/
+Environment=DOCKER_LEGACY=true
 # REX-Ray fails to clean up stale lock files by itself.
 ExecStartPre=/bin/rm -f /var/run/libstorage/lsx.lock
 # Allow REX-Ray configuration to be changed during upgrade.


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR bumps REX-Ray from v0.9.0 to v0.11.2. It configures REX-Ray to operate in `DOCKER_LEGACY` mode as the newer version of REX-Ray switched to CSI-based logic. The REX-Ray developers seem to agree as REX-Ray's master branch was recently switched to `DOCKER_LEGACY` by default: https://github.com/rexray/rexray/commit/6162a4c0a35255414e0fb82e18a8ed44800d5749.

This PR also improves the `delete_ec2_volume.py` cleanup script by adding logging and better error handling.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3597](https://jira.mesosphere.com/browse/DCOS_OSS-3597) Upgrade REX-Ray to v0.11.2

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-37441](https://jira.mesosphere.com/browse/DCOS-37441) Triage integration test failures for REX-Ray upgrade
  - [DCOS_OSS-2310](https://jira.mesosphere.com/browse/DCOS_OSS-2310) REX-Ray integration test is flaky after version bump


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This bump was designed to introduce no new test or flakiness. Existing tests should keep working at their current level of flakiness (sad).
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [rexray](https://github.com/rexray/rexray/compare/v0.9.0...v0.11.2)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
