### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 9a5a749

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,12 +1,12 @@
 {
   "requires": [
-    "mesos",
+    "mesos", 
     "boost-libs"
-  ],
+  ], 
   "single_source": {
-    "kind": "git",
-    "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "325f2d99cdd6b65569424ce24ed27dc9f6d5f93e",
+    "kind": "git", 
+    "git": "https://github.com/dcos/dcos-mesos-modules.git", 
+    "ref": "325f2d99cdd6b65569424ce24ed27dc9f6d5f93e", 
     "ref_origin": "1.11"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,28 +1,28 @@
 {
   "requires": [
-    "openssl",
-    "libevent",
-    "curl",
+    "openssl", 
+    "libevent", 
+    "curl", 
     "boost-libs"
-  ],
+  ], 
   "single_source": {
-    "kind": "git",
-    "git": "https://github.com/apache/mesos",
-    "ref": "aedbcfd5dc5b4352bf34088fa91d6ceeabcc641f",
+    "kind": "git", 
+    "git": "https://github.com/apache/mesos", 
+    "ref": "9a5a74902b6adc186d7ce304ccd0929ea0cad70a", 
     "ref_origin": "1.5.x"
-  },
+  }, 
   "environment": {
-    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
+    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib", 
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
-  },
-  "state_directory": true,
+  }, 
+  "state_directory": true, 
   "sysctl": {
     "dcos-mesos-slave": {
-      "vm.max_map_count": 262144,
+      "vm.max_map_count": 262144, 
       "vm.swappiness": 1
-    },
+    }, 
     "dcos-mesos-slave-public": {
-      "vm.max_map_count": 262144,
+      "vm.max_map_count": 262144, 
       "vm.swappiness": 1
     }
   }


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    [https://github.com/apache/mesos diff](https://github.com/apache/mesos/compare/aedbcfd5dc5b4352bf34088fa91d6ceeabcc641f...9a5a74902b6adc186d7ce304ccd0929ea0cad70a)
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
