### PR TITLE
Bump cosmos to latest snapshot version

### DIFF
--- a/packages/cosmos/buildinfo.json
+++ b/packages/cosmos/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url",
-    "url": "https://downloads.dcos.io/cosmos/0.6.0-SNAPSHOT-339-master-7917458253/cosmos-server-0.6.0-SNAPSHOT-339-master-7917458253-one-jar.jar",
-    "sha1": "34b9b7605e4840fd3ed2be3a891581b18de2285b"
+    "url": "https://downloads.dcos.io/cosmos/0.6.0-SNAPSHOT-340-master-472c1ac546/cosmos-server-0.6.0-SNAPSHOT-340-master-472c1ac546-one-jar.jar",
+    "sha1": "14f28dfbec832a026375c328a71f3bac37a3b735"
   },
   "username": "dcos_cosmos",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Increase client payload limit when cosmos is talking to marathon.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-34435](https://jira.mesosphere.com/browse/DCOS-34435) Cosmos is limited to loading a max payload of 5MB when talking to /v2/apps from Marathon. Increase this limit.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is just an increase in the http client payload limit. This is hidden from the user.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There are no tests currently possible to make marathon return a > 5Mb file. This was observed under load testing.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Diff](https://github.com/dcos/cosmos/compare/791745825358a133e0a16ba332a76f0584bc7733...472c1ac5467a68477b89d1f147c34eca3b0b8143)
  - [x] Test Results: [link to CI job test results for component](https://teamcity.mesosphere.io/viewLog.html?buildId=1059083&tab=buildResultsDiv&buildTypeId=DcosIo_Cosmos_Ci)
  - [x] Code Coverage (if available): [link to code coverage report](https://teamcity.mesosphere.io/viewLog.html?buildId=1059080&tab=buildResultsDiv&buildTypeId=DcosIo_Cosmos_Scoverag)
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
