### PR TITLE
Updated timeout of mesos_master_replog_synchronized check, now 30s (1.10 backport).

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -705,7 +705,7 @@ def calculate_check_config(check_time):
                 'mesos_master_replog_synchronized': {
                     'description': 'The Mesos master has synchronized its replicated log',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'master', 'mesos-metrics'],
-                    'timeout': '1s',
+                    'timeout': '30s',
                     'roles': ['master']
                 },
                 'mesos_agent_registered_with_masters': {


### PR DESCRIPTION
Was previously 1s, which fails on large clusters due to the time spent getting `:5050/metrics/snapshot`. Running `time /opt/mesosphere/bin/dcos-checks --verbose --role master mesos-metrics` takes more than 4 seconds in some of our clusters.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-34593](https://jira.mesosphere.com/browse/DCOS-34593) (private)`:5050/metrics/snapshot` runtime block update

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___