### PR TITLE
Modifies test relying on mesos logging in the stdout of a task

### DIFF
--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -136,7 +136,14 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
 
 
 def test_files_api(dcos_api_session):
+    '''
+    This test verifies that the standard output and error of a Mesos task can be
+    read. We check that neither standard output nor error are empty files. Since
+    the default `marathon_test_app()` does not write to its standard output the
+    task definition is modified to output something there.
+    '''
     app, test_uuid = test_helpers.marathon_test_app()
+    app['cmd'] = 'echo $DCOS_TEST_UUID && ' + app['cmd']
 
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']


### PR DESCRIPTION
## High-level description

Mesos was modified so that it no longer logs information on tasks standard output, however, some tests relied in this functionality to verify the api to check the output of tasks.

The quick fix was to modify the task definition so that it writes something into its own standard output.

Note that this PR does not change the behavior of the current master, however no mesos bump can be done until this test is modified since all its bumps will fail on  `test_mesos.test_files_api()`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3558](https://jira.mesosphere.com/browse/DCOS_OSS-3558) Nightly Mesos bump breaks DC/OS tests due to expected stdout logging..


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: It modifies a unit test.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The change is in the test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
