### PR TITLE
Fix ftype=1 check for dcos-docker (DCOS_OSS-3549)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,17 @@ Format of the entries must be.
 * Disable the 3DES bulk encryption algorithm for Master Admin Router's TLS. (DCOS_OSS-3537)
 
 
+## DC/OS 1.10.8
+
+### Notable changes
+
+### Fixed and improved
+
+* Fixed ftype=1 check for dcos-docker (DCOS_OSS-3549)
+
+### Security
+
+
 ### TODO: (skumaran) - Include CHANGES.md for 1.10.6 release.
 
 

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -293,8 +293,10 @@ function d_type_enabled_if_xfs()
         DIRNAME="$(dirname "$DIRNAME")"
     done
     read -r filesystem_device filesystem_type <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2}')"
-    if [[ "$filesystem_type" == "xfs" ]]; then
-        echo -n -e "Checking if $DIRNAME is mounted with \"fytpe=1\": "
+    # -b $filesystem_device check is there prevent this from failing in certain special dcos-docker configs
+    # see https://jira.mesosphere.com/browse/DCOS_OSS-3549
+    if [[ "$filesystem_type" == "xfs" && -b "$filesystem_device" ]]; then
+        echo -n -e "Checking if $DIRNAME is mounted with \"ftype=1\": "
         ftype_value="$(xfs_info $filesystem_device | grep -oE ftype=[0-9])"
         if [[ "$ftype_value" != "ftype=1" ]]; then
             RC=1


### PR DESCRIPTION
## High-level description
Fixes ftype=1 install time check for dcos-docker

What features does this change enable? What bugs does this change fix?
https://github.com/dcos/dcos/pull/2822 breaks dcos-docker for very specific (rare but valid dcos-docker) configuration (https://jira.mesosphere.com/browse/DCOS_OSS-3549). This fixes that

If the device being used for docker root directory is not accessible the xfs_info check fails. I have added a block device check before xfs_info check to skip ftype=1 check
 
## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3549](https://jira.mesosphere.com/browse/DCOS_OSS-3549) ftype=1 pre-flight check has broken dcos-docker for configurations using devicemapper 


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**