### PR TITLE
[master] Bump Mesos to nightly master 2198b96

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "af814bf5c7cbe42d10644f3214f1ad2a450390da", 
+    "ref": "351315d5c4ce03e3c8a759093de5957929fa9f88", 
     "ref_origin": "master"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/apache/mesos", 
-    "ref": "285d82080748cd69044c226950274c7046048c4b", 
+    "ref": "2198b961d24b788564d36490cf52f78d7ec07655", 
     "ref_origin": "master"
   }, 
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    [https://github.com/apache/mesos diff](https://github.com/apache/mesos/compare/285d82080748cd69044c226950274c7046048c4b...2198b961d24b788564d36490cf52f78d7ec07655)
    [https://github.com/dcos/dcos-mesos-modules diff](https://github.com/dcos/dcos-mesos-modules/compare/af814bf5c7cbe42d10644f3214f1ad2a450390da...351315d5c4ce03e3c8a759093de5957929fa9f88)
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
