### PR TITLE
Remove dcos-diagnostics check runner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,8 @@ Format of the entries must be.
 
 ### Notable changes
 
+* Replaced the dcos-diagnostics check runner with dcos-check-runner. (DCOS_OSS-3491)
+
 * Removed the DC/OS web installer. (DCOS_OSS-2256)
 
 * Updated Metronome to 0.5.0. (DCOS_OSS-2338)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -594,8 +594,6 @@ package:
         ],
         "enabled": "{{ telemetry_enabled }}"
       }
-  - path: /etc/dcos-diagnostics-runner-config.json
-    content: {{ check_config_contents }}
   - path: /etc/dcos-check-config.json
     content: {{ check_config_contents }}
   - path: /etc/dcos-diagnostics.env

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "6b1ad82827424beeb2e3ba5d4d3b41a7ceb34dfb",
+    "ref": "f612504f524c74f10b48c0e1a2cdb06820529e50",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import tempfile
-import uuid
 import zipfile
 
 import pytest
@@ -660,51 +659,3 @@ def test_diagnostics_bundle_status(dcos_api_session):
         )
         for required_status_field in required_status_fields:
             assert required_status_field in properties, 'property {} not found'.format(required_status_field)
-
-
-def test_dcos_diagnostics_runner_poststart(dcos_api_session):
-    cmd = [
-        "/opt/mesosphere/bin/dcos-diagnostics",
-        "check",
-        "--check-config",
-        "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json",
-        "node-poststart"
-    ]
-    test_uuid = uuid.uuid4().hex
-    poststart_job = {
-        'id': 'test-dcos-diagnostics-runner-poststart-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(cmd)
-        }
-    }
-
-    dcos_api_session.metronome_one_off(poststart_job)
-
-
-def test_dcos_diagnostics_runner_cluster(dcos_api_session):
-    cmd = [
-        # Set PATH and LD_LIBRARY_PATH to bad values to assert we're using their values from check config.
-        "env",
-        "PATH=badvalue",
-        "LD_LIBRARY_PATH=badvalue",
-        "/opt/mesosphere/bin/dcos-diagnostics",
-        "check",
-        "--check-config",
-        "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json",
-        "cluster"
-    ]
-    test_uuid = uuid.uuid4().hex
-    job = {
-        'id': 'test-dcos-diagnostics-runner-cluster-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(cmd)
-        }
-    }
-
-    dcos_api_session.metronome_one_off(job)


### PR DESCRIPTION
## High-level description

This bumps dcos-diagnostics to remove its check runner, which was moved to a separate component called dcos-check-runner. The dcos-check-runner component was added to DC/OS with https://github.com/dcos/dcos/pull/2921.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3491](https://jira.mesosphere.com/browse/DCOS_OSS-3491) Separate check runner from dcos-diagnostics

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR removes functionality, and removes corresponding tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-diagnostics/compare/6b1ad82827424beeb2e3ba5d4d3b41a7ceb34dfb...f612504f524c74f10b48c0e1a2cdb06820529e50)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-diagnostics/job/dcos-diagnostics-master/2/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-diagnostics/job/dcos-diagnostics-master/2/)
