### PR TITLE
Bump mesos agent check timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Increased the timeout for the `mesos_agent_registered_with_masters` check. (DCOS_OSS-2277)
+
 * Enabled Windows-based pkgpanda builds. (DCOS_OSS-1899)
 
 * DC/OS Metrics: moved the prometheus producer from port 9273 to port 61091. (DCOS_OSS-2368)

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -768,7 +768,7 @@ def calculate_check_config(check_time):
                 'mesos_agent_registered_with_masters': {
                     'description': 'The Mesos agent has registered with the masters',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'agent', 'mesos-metrics'],
-                    'timeout': '1s',
+                    'timeout': '10s',
                     'roles': ['agent']
                 },
                 'journald_dir_permissions': {


### PR DESCRIPTION
## High-level description

This increases the timeout for the `mesos_agent_registered_with_masters` check, which asserts that a DC/OS agent's Mesos agent has registered with the cluster's Mesos masters. [DCOS_OSS-2277](https://jira.mesosphere.com/browse/DCOS_OSS-2277) reports the check sometimes taking a little more than a second, so this PR bumps it to 10 seconds, which should provide ample headroom.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2277](https://jira.mesosphere.com/browse/DCOS_OSS-2277) DCOS Diagnostics Checks Too Aggressive Timeout

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Just bumping a timeout.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]