### PR TITLE
(1.11) Bump mesos agent check timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## DC/OS 1.11.4
+
+
+### Notable changes
+
+### Fixed and improved
+
+### Security updates
+
+
 ## DC/OS 1.11.3
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ### Notable changes
 
+* Increased the timeout for the `mesos_agent_registered_with_masters` check. (DCOS_OSS-2277)
+
 ### Fixed and improved
 
 ### Security updates

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -752,7 +752,7 @@ def calculate_check_config(check_time):
                 'mesos_agent_registered_with_masters': {
                     'description': 'The Mesos agent has registered with the masters',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'agent', 'mesos-metrics'],
-                    'timeout': '1s',
+                    'timeout': '10s',
                     'roles': ['agent']
                 },
                 'journald_dir_permissions': {


### PR DESCRIPTION
## High-level description

This is a 1.11 backport of #2963.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2277](https://jira.mesosphere.com/browse/DCOS_OSS-2277) DCOS Diagnostics Checks Too Aggressive Timeout


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Just bumping a timeout.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]