### PR TITLE
Remove references to web installer in error messages

### DIFF
--- a/dcos_installer/config.py
+++ b/dcos_installer/config.py
@@ -99,15 +99,11 @@ class Config():
         except FileNotFoundError as ex:
             raise NoConfigError(
                 "No config file found at {}. See the DC/OS documentation for the "
-                "available configuration options. You can also use the GUI web installer (--web), "
-                "which provides a guided configuration and installation for simple "
-                "deployments.".format(self.config_path)) from ex
+                "available configuration options.".format(self.config_path)) from ex
         except OSError as ex:
             raise NoConfigError(
                 "Failed to open config file at {}: {}. See the DC/OS documentation to learn "
-                "how to create a config file. You can also use the GUI web installer (--web), "
-                "which provides a guided configuration and installation for simple "
-                "deployments.".format(self.config_path, ex)) from ex
+                "how to create a config file.".format(self.config_path, ex)) from ex
         except YamlParseError as ex:
             raise NoConfigError("Unable to load configuration file. {}".format(ex)) from ex
 


### PR DESCRIPTION
## High-level description

This removes outdated references to the web installer, which was removed from DC/OS in 1.12.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3618](https://jira.mesosphere.com/browse/DCOS_OSS-3618) Genconf error message references nonexistent web installer

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Followup change from removing the web installer, which is already mentioned in the changelog.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This changes the wording in an error message, which isn't covered by a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]