### PR TITLE
[DCOS_OSS-3620] Bump dcos-test-utils

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "0b16ec116bc779744d7900b1eb2cf62960d141f7",
+    "ref": "c1608590e010ca08c418f8bd9d9ebd764d511d57",
     "ref_origin": "master"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "c7eaecd8c0502e854d4fb1818947fb9d17cbac79",
+    "ref": "0b16ec116bc779744d7900b1eb2cf62960d141f7",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

Bump dcos-test-utils to latest version. This provides better debugging info and allows tests fixtures to be made more robust to network timeouts.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3620](https://jira.mesosphere.com/browse/DCOS_OSS-3620) Log stderr on failing command execution


## Related tickets (optional)

- [DCOS-38213](https://jira.mesosphere.com/browse/DCOS-38213) dcoscli fixture times-out while downloading CLI

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Change to test library
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Changes behavior of tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [changelog](https://github.com/dcos/dcos-test-utils/compare/c7eaecd8c0502e854d4fb1818947fb9d17cbac79...dcos:c1608590e010ca08c418f8bd9d9ebd764d511d57)
  - [x] Test Results: [https://teamcity.mesosphere.io/viewLog.html?buildId=1099248&buildTypeId=DcosIo_DcosTestUtils_ToxIntegrationTest]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
