### PR TITLE
Exclude `dcos-check-runner` package on Windows

### DIFF
--- a/packages/windows.treeinfo.json
+++ b/packages/windows.treeinfo.json
@@ -18,6 +18,7 @@
     "cni",
     "cosmos",
     "curl",
+    "dcos-check-runner",
     "dcos-checks",
     "dcos-cni",
     "dcos-diagnostics",


### PR DESCRIPTION
## High-level description

Disable building `dcos-check-runner` package on Windows; it currently fails as it doesn't not include a `build.ps1` script.