### PR TITLE
[master] Increase timeout for package download

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -331,6 +331,11 @@ location /package/ {
     include includes/disable-request-response-buffering.conf;
     include includes/http-11.conf;
 
+    # Package installation can require large downloads, increasing the chance
+    # for intermittent network connectivity to cause a problem.  Increase
+    # timeouts to make package download more robust.
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
     proxy_pass $upstream_cosmos;
 }
 

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -331,9 +331,11 @@ location /package/ {
     include includes/disable-request-response-buffering.conf;
     include includes/http-11.conf;
 
-    # Package installation can require large downloads, increasing the chance
-    # for intermittent network connectivity to cause a problem.  Increase
-    # timeouts to make package download more robust.
+    # Cosmos buffers the entire package before sending a large download.  On
+    # slow networks, this can lead to AdminRouter timing-out the connection.
+    # Increase timeouts from default 60s to make package download more robust.
+    # See https://jira.mesosphere.com/browse/DCOS_OSS-3639 for potential
+    # improvement to Cosmos.
     proxy_send_timeout 300s;
     proxy_read_timeout 300s;
     proxy_pass $upstream_cosmos;


### PR DESCRIPTION
## High-level description

Installing packages through the CLI can occasionally timeout, especially on intermittent connections. The CLI exits with a message like: 
```
Error while fetching [https://172.17.0.2/package/resource?url=https://downloads.mesosphere.io/cli/binaries/linux/x86...61d301f571fe26883b5122d567ac4b79bae7febbd2090c81b6cdda523659eb43/dcos-enterprise-cli]: HTTP 504: "Gateway Time-out"
```

This change increases the timeout in the AdminRouter server, while it is acting as a proxy to Cosmos, to reduce the chance of this occurring.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-38258](https://jira.mesosphere.com/browse/DCOS-38258) Add a longer timeout for package loading


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-38213](https://jira.mesosphere.com/browse/DCOS-38213) dcoscli fixture times-out while downloading CLI


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Fixes a problem with intermittent network delays, which is difficult to test systematically. I will add comments on manual testing.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
