### PR TITLE
Run checks in parallel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Node and cluster checks are executed in parallel. (DCOS_OSS-2239)
+
 * Enabled Windows-based pkgpanda builds. (DCOS_OSS-1899)
 
 * DC/OS Metrics: moved the prometheus producer from port 9273 to port 61091. (DCOS_OSS-2368)

--- a/packages/dcos-check-runner/buildinfo.json
+++ b/packages/dcos-check-runner/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-check-runner.git",
-    "ref": "1a241be934d81b4c146c0d5cc0f3d1a337ab23f3",
+    "ref": "519d5c7d3b94222f5b99d38893a8543819a18567",
     "ref_origin": "master"
   },
   "username": "dcos_check_runner"


### PR DESCRIPTION
## High-level description

This bumps dcos-check-runner to pull in a new capability to run checks in parallel.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2239](https://jira.mesosphere.com/browse/DCOS_OSS-2239) Run checks in parallel

## Related tickets (optional)

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Test added to dcos-check-runner.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-check-runner/compare/1a241be934d81b4c146c0d5cc0f3d1a337ab23f3...519d5c7d3b94222f5b99d38893a8543819a18567
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-check-runner/job/dcos-check-runner-master/6/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-check-runner/job/dcos-check-runner-master/6/)