### PR TITLE
Don't skip checks that are limited to a specific role

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -596,6 +596,15 @@ package:
       }
   - path: /etc/dcos-check-config.json
     content: {{ check_config_contents }}
+  - path: /etc_master/dcos-check-runner.yaml
+    content: |
+        role: master
+  - path: /etc_slave/dcos-check-runner.yaml
+    content: |
+        role: agent
+  - path: /etc_slave_public/dcos-check-runner.yaml
+    content: |
+        role: agent  # Checks don't distinguish between public and private agents.
   - path: /etc/dcos-diagnostics.env
     content: |
       DCOS_DIAGNOSTICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-diagnostics-config.json

--- a/packages/dcos-check-runner/buildinfo.json
+++ b/packages/dcos-check-runner/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-check-runner.git",
-    "ref": "519d5c7d3b94222f5b99d38893a8543819a18567",
+    "ref": "cca21b6180295de5daf21b5b1a9da0514c34f204",
     "ref_origin": "master"
   },
   "username": "dcos_check_runner"


### PR DESCRIPTION
## High-level description

This fixes a bug where checks that are defined to run only on masters or agents do not get executed by the check runner.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-38309](https://jira.mesosphere.com/browse/DCOS-38309) DC/OS checks with role limitations are not being run by dcos-check-runner


## Related tickets (optional)

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fixes a bug that has not made it into a release.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tests added upstream which verify that the check runner will fail with an error if its role is not "master" or "agent", and runs checks with a variety of roles and role filters and verifies that all expected checks are executed according to the role.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-check-runner/compare/519d5c7d3b94222f5b99d38893a8543819a18567...cca21b6180295de5daf21b5b1a9da0514c34f204
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-check-runner%2Fdcos-check-runner-master/detail/dcos-check-runner-master/102/pipeline)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-check-runner%2Fdcos-check-runner-master/detail/dcos-check-runner-master/102/pipeline)