### PR TITLE
Metronome 0.3.6 bump with docker params

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -3,8 +3,8 @@
     "single_source": {
         "kind": "url_extract",
         "url":
-            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.5/metronome-0.3.5.tgz",
-        "sha1": "2ff7c41ff969e3c552194b7338f9e0ca14a3deb5"
+            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.6/metronome-0.3.6.tgz",
+        "sha1": "494364b6766f5b824a2e4bc8c7307a901f458ae2"
     },
     "username": "dcos_metronome",
     "state_directory": true


### PR DESCRIPTION
## High-level description

* Adds Docker Param support to Metronome for Jobs.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3688](https://jira.mesosphere.com/browse/DCOS_OSS-3688) Release Metronome 0.3.6  on DCOS 1.9.


## Related tickets (optional)

Other tickets related to this change:

- [DCOS_OSS-2564](https://jira.mesosphere.com/browse/DCOS_OSS-2564) Allow Docker Params for Job Runs

- [DCOS_OSS-2519](https://jira.mesosphere.com/browse/DCOS_OSS-2519) Metronome allows creating jobs with no command and no image.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [change log](https://github.com/dcos/metronome/compare/v0.3.5...v0.3.6)
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/51/
  - [ ] Code Coverage (if available): [link to code coverage report]
