### PR TITLE
Allocate different port than 8080 on master node (DCOS_OSS-3710)

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -27,6 +27,7 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 2181: dcos-exhibitor
  - 2888: dcos-exhibitor
  - 3888: dcos-exhibitor
+ - 4040: dcos-log
  - 5050: dcos-mesos-master
  - 7070: dcos-cosmos
  - 8080: dcos-marathon

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -562,7 +562,8 @@ package:
   - path: /etc_master/dcos-log-config.json
     content: |
       {
-        "role": "master"
+        "role": "master",
+        "port": 4040
       }
   - path: /etc_slave/dcos-log-config.json
     content: |


### PR DESCRIPTION
## High-level description

Avoids port conflict on DC/OS master nodes, allowing Marathon service to start.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3710](https://jira.mesosphere.com/browse/DCOS_OSS-3710) dcos-log port conflict.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I'm not sure how to consistently replicate this behavior.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
