### PR TITLE
[1.12] Allow customization of JAVA options for root Marathon, and other changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ Format of the entries must be.
 
 * Fixed ftype=1 check for dcos-docker (DCOS_OSS-3549)
 
+* Root Marathon support for post-installation configuration of flags and JVM settings has been improved. (DCOS_OSS-3556)
+
+* Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)
 
 ### Security Updates
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -991,6 +991,7 @@ entry = {
         'ip6_detect_contents': calculate_ip6_detect_contents,
         'dns_search': '',
         'auth_cookie_secure_flag': 'false',
+        'marathon_java_args': '',
         'master_dns_bindall': 'true',
         'mesos_dns_ip_sources': '["host", "netinfo"]',
         'mesos_dns_set_truncate_bit': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -943,8 +943,11 @@ package:
       "tracking":{"enabled":{{ telemetry_enabled }},"metadata":{{ ui_telemetry_metadata }}},"mesos":{"logging-strategy":"{{ mesos_container_log_sink }}"}}}}
   - path: /etc_master/marathon
     content: |
+      # This file will be overwritten on DC/OS upgrade.
+      # For post-installation customization, edit the file /var/lib/dcos/marathon/environment
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
       LIBPROCESS_PORT=15101
+      MARATHON_JAVA_ARGS={{ marathon_java_args }}
 {% switch dcos_overlay_enable %}
 {% case "true" %}
       MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -17,6 +17,11 @@ cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/marathon/bin/marathon"
 chmod +x "$PKG_PATH/marathon/bin/marathon"
 cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/marathon/lib"
 
+marathon_wrapper="$PKG_PATH/bin/marathon.sh"
+mkdir -p "$(dirname "$marathon_wrapper")"
+envsubst '$PKG_PATH' < /pkg/extra/marathon.sh > "$marathon_wrapper"
+chmod +x "$marathon_wrapper"
+
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")
 
@@ -31,33 +36,15 @@ StartLimitInterval=0
 RestartSec=15
 LimitNOFILE=16384
 PermissionsStartOnly=True
+# The env files in /opt are overwritten on upgrade
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
-EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+# The env file in /var/lib/dcos is for post-install configuration and persists with upgrades.
+EnvironmentFile=-/var/lib/dcos/marathon/environment
 Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/bin/ping -c1 zk-1.zk
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
-ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStart=$PKG_PATH/marathon/bin/marathon \\
-    -Duser.dir=/var/lib/dcos/marathon \\
-    -J-server \\
-    -J-verbose:gc \\
-    -J-XX:+PrintGCDetails \\
-    -J-XX:+PrintGCTimeStamps \\
-    --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
-    --default_accepted_resource_roles "*" \\
-    --mesos_role "slave_public" \\
-    --max_instances_per_offer 100 \\
-    --task_launch_timeout 86400000 \\
-    --decline_offer_duration 300000 \\
-    --revive_offers_for_new_apps \\
-    --zk_compression \\
-    --mesos_leader_ui_url "/mesos" \\
-    --enable_features "vips,task_killing,external_volumes,gpu_resources" \\
-    --mesos_authentication_principal "dcos_marathon" \\
-    --mesos_user "root"
+ExecStart=/opt/mesosphere/bin/marathon.sh
 EOF

--- a/packages/marathon/extra/marathon.sh
+++ b/packages/marathon/extra/marathon.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+export LIBPROCESS_IP=$($MESOS_IP_DISCOVERY_COMMAND)
+
+: ${MARATHON_HOSTNAME="$LIBPROCESS_IP"}
+: ${MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES="*"}
+: ${MARATHON_MESOS_ROLE="slave_public"}
+: ${MARATHON_MAX_INSTANCES_PER_OFFER=100}
+: ${MARATHON_TASK_LAUNCH_TIMEOUT=86400000}
+: ${MARATHON_DECLINE_OFFER_DURATION=300000}
+: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources"}
+: ${MARATHON_MESOS_AUTHENTICATION_PRINCIPAL="dcos_marathon"}
+: ${MARATHON_MESOS_USER="root"}
+
+if [ -z "${MARATHON_DISABLE_ZK_COMPRESSION+x}" ]; then
+  MARATHON_ZK_COMPRESSION=""
+fi
+
+if [ -z "${MARATHON_DISABLE_REVIVE_OFFERS_FOR_NEW_APPS+x}" ]; then
+  MARATHON_REVIVE_OFFERS_FOR_NEW_APPS=""
+fi
+
+
+export JAVA_OPTS="${MARATHON_JAVA_ARGS-}"
+export -n MARATHON_JAVA_ARGS
+export MARATHON_HOSTNAME MARATHON_MESOS_ROLE MARATHON_MAX_INSTANCES_PER_OFFER \
+       MARATHON_TASK_LAUNCH_TIMEOUT MARATHON_DECLINE_OFFER_DURATION MARATHON_ENABLE_FEATURES \
+       MARATHON_MESOS_AUTHENTICATION_PRINCIPAL MARATHON_MESOS_USER MARATHON_ZK_COMPRESSION \
+       MARATHON_REVIVE_OFFERS_FOR_NEW_APPS
+
+# TODO (DCOS_OSS-3592) - move this variable to the exported list after MARATHON-8254 is fixed, and remove --default_accepted_resources_roles below
+export -n MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES
+
+exec $PKG_PATH/marathon/bin/marathon \
+    -Duser.dir=/var/lib/dcos/marathon \
+    -J-server \
+    -J-verbose:gc \
+    -J-XX:+PrintGCDetails \
+    -J-XX:+PrintGCTimeStamps \
+    --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \
+    --mesos_leader_ui_url "/mesos" \
+    --default_accepted_resource_roles "${MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES}"


### PR DESCRIPTION
Forwardport of 0fcc0828..589ef2cd / #2918

- post-installation environment variable configuration can now be placed in
  /var/lib/dcos/marathon/environment
- JVM parameters can be specified via MARATHON_JAVA_ARGS
- environment.ip.marathon file is gone; instead we have a launching script to
  set these vars
- Add some comments to init file to help users know where environment variables
  can be placed
- Add docs at the top of env var files
- Allow DCOS config variables to be overridden
