### PR TITLE
Add checks API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Format of the entries must be.
 
 * Mesos: Expose memory profiling endpoints. (DCOS_OSS-2137)
 
+* Added an API for checks at /system/checks/ on all cluster nodes. (DCOS_OSS-1406)
+
 * Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
 * Node and cluster checks are executed in parallel. (DCOS_OSS-2239)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -623,12 +623,18 @@ package:
   - path: /etc_master/dcos-check-runner.yaml
     content: |
         role: master
+        systemd-socket: true
+        base-uri: /system/checks
   - path: /etc_slave/dcos-check-runner.yaml
     content: |
         role: agent
+        systemd-socket: true
+        base-uri: /system/checks
   - path: /etc_slave_public/dcos-check-runner.yaml
     content: |
         role: agent  # Checks don't distinguish between public and private agents.
+        systemd-socket: true
+        base-uri: /system/checks
   - path: /etc/dcos-diagnostics.env
     content: |
       DCOS_DIAGNOSTICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-diagnostics-config.json

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -624,17 +624,17 @@ package:
     content: |
         role: master
         systemd-socket: true
-        base-uri: /system/checks
+        base-uri: /system/checks/v1
   - path: /etc_slave/dcos-check-runner.yaml
     content: |
         role: agent
         systemd-socket: true
-        base-uri: /system/checks
+        base-uri: /system/checks/v1
   - path: /etc_slave_public/dcos-check-runner.yaml
     content: |
         role: agent  # Checks don't distinguish between public and private agents.
         systemd-socket: true
-        base-uri: /system/checks
+        base-uri: /system/checks/v1
   - path: /etc/dcos-diagnostics.env
     content: |
       DCOS_DIAGNOSTICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-diagnostics-config.json

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -617,6 +617,9 @@ package:
       }
   - path: /etc/dcos-check-config.json
     content: {{ check_config_contents }}
+  - path: /etc/dcos-check-runner.env
+    content: |
+      DCOS_CHECK_RUNNER_CONFIG_PATH=/opt/mesosphere/etc/dcos-check-runner.yaml
   - path: /etc_master/dcos-check-runner.yaml
     content: |
         role: master

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -479,9 +479,33 @@
         <label class="heading"><span class="route-type toggle-route-type">File</span> <span class="route-desc">retrieves static files.</span> </label>
         </input>
       </li>
+      <li class="route route-type-unknown">
+        <input type="checkbox" data-type="unknown" checked="checked">
+        <label class="heading"><span class="route-type toggle-route-type">Unknown</span> <span class="route-desc">unrecognized routing mechanism.</span> </label>
+        </input>
+      </li>
     </ul>
   </div>
   <ul class="resources">
+    <li id="resource-other" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="other" href="#other" aria-hidden="true" class="toggle-route-group" data-id="other">
+            <div class="arrow arrow-right"></div>Other</a>
+        </h2>
+        <span class="options"><a href="#other" class="toggle-route-group" data-id="other">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-other" class="routes">
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/</code></span>
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-metadata" class="resource">
       <div class="heading">
         <h2>
@@ -579,6 +603,43 @@
         <span class="options"><a href="#system" class="toggle-route-group" data-id="system">Show/Hide</a> </span>
       </div>
       <ul id="routes-system" class="routes">
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/system/checks/</code></span>
+            </h3>
+            <span class="route-desc">Node and cluster checks</span>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>unix:/run/dcos/dcos-checks-api.sock</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Checks API
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
         <li class="route route-type-proxy">
           <div class="heading">
             <h3>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -607,7 +607,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/system/checks/</code></span>
+              <span class="route-path"><code>/system/checks/v1</code></span>
             </h3>
             <span class="route-desc">Node and cluster checks</span>
           </div>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -38,14 +38,14 @@ routes:
       path: 'http://$backend'
       backend: pkgpanda
     path: /pkgpanda/
-  /system/checks/:
+  /system/checks/v1:
     group: System
     matcher: path
     description: Node and cluster checks
     proxy:
       path: 'http://$backend'
       backend: dcos_checks_api
-    path: /system/checks/
+    path: /system/checks/v1
   /system/health/v1:
     group: System
     matcher: path

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -1,5 +1,8 @@
 ngindox: 0.1.0
 backends:
+  dcos_checks_api:
+    server: 'unix:/run/dcos/dcos-checks-api.sock'
+    name: DC/OS Checks API
   dcos_diagnostics:
     server: 'unix:/run/dcos/dcos-diagnostics.sock'
     name: DC/OS Diagnostics
@@ -17,6 +20,10 @@ backends:
     name: DC/OS Component Package Manager (Pkgpanda)
     reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
+  /:
+    group: Other
+    matcher: path
+    path: /
   /dcos-metadata/dcos-version.json:
     group: Metadata
     matcher: path
@@ -31,6 +38,14 @@ routes:
       path: 'http://$backend'
       backend: pkgpanda
     path: /pkgpanda/
+  /system/checks/:
+    group: System
+    matcher: path
+    description: Node and cluster checks
+    proxy:
+      path: 'http://$backend'
+      backend: dcos_checks_api
+    path: /system/checks/
   /system/health/v1:
     group: System
     matcher: path

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -1781,7 +1781,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/system/checks/</code></span>
+              <span class="route-path"><code>/system/checks/v1</code></span>
             </h3>
             <span class="route-desc">Node and cluster checks</span>
           </div>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -494,6 +494,11 @@
         <label class="heading"><span class="route-type toggle-route-type">Rewrite</span> <span class="route-desc">retrieves resources from another route.</span> </label>
         </input>
       </li>
+      <li class="route route-type-unknown">
+        <input type="checkbox" data-type="unknown" checked="checked">
+        <label class="heading"><span class="route-type toggle-route-type">Unknown</span> <span class="route-desc">unrecognized routing mechanism.</span> </label>
+        </input>
+      </li>
     </ul>
   </div>
   <ul class="resources">
@@ -934,6 +939,53 @@
         </li>
       </ul>
     </li>
+    <li id="resource-dcos-net" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="dcos-net" href="#dcos-net" aria-hidden="true" class="toggle-route-group" data-id="dcos-net">
+            <div class="arrow arrow-right"></div>DC/OS Net</a>
+        </h2>
+        <span class="options"><a href="#dcos-net" class="toggle-route-group" data-id="dcos-net">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-dcos-net" class="routes">
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/navstar/lashup/key</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend/lashup/key</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>127.0.0.1:62080</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Net
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-exhibitor" class="resource">
       <div class="heading">
         <h2>
@@ -1100,7 +1152,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>$historyservice_upstream</code>
+                  <code>$leader_host</code>
                 </td>
               </tr>
             </table>
@@ -1492,53 +1544,6 @@
         </li>
       </ul>
     </li>
-    <li id="resource-dcos-net" class="resource">
-      <div class="heading">
-        <h2>
-          <a id="dcos-net" href="#dcos-net" aria-hidden="true" class="toggle-route-group" data-id="dcos-net">
-            <div class="arrow arrow-right"></div>DC/OS Net</a>
-        </h2>
-        <span class="options"><a href="#dcos-net" class="toggle-route-group" data-id="dcos-net">Show/Hide</a> </span>
-      </div>
-      <ul id="routes-dcos-net" class="routes">
-        <li class="route route-type-proxy">
-          <div class="heading">
-            <h3>
-              <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/navstar/lashup/key</code></span>
-            </h3>
-          </div>
-          <div class="route-meta" style="display:none">
-            <table>
-              <tr>
-                <td>
-                  Path:
-                </td>
-                <td>
-                  <code>http://$backend/lashup/key</code>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Server:
-                </td>
-                <td>
-                  <code>127.0.0.1:62080</code>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Backend:
-                </td>
-                <td>
-                  DC/OS Net
-                </td>
-              </tr>
-            </table>
-          </div>
-        </li>
-      </ul>
-    </li>
     <li id="resource-other" class="resource">
       <div class="heading">
         <h2>
@@ -1587,6 +1592,46 @@
                 </td>
                 <td>
                   <a href="https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/">https://dcos.io/docs/1.10/networking/mesos-dns/mesos-dns-api/</a>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>@service_default</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>$upstream_url</code>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>@service_requnbuffered</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>$upstream_url</code>
                 </td>
               </tr>
             </table>
@@ -1712,25 +1757,13 @@
         <span class="options"><a href="#service" class="toggle-route-group" data-id="service">Show/Hide</a> </span>
       </div>
       <ul id="routes-service" class="routes">
-        <li class="route route-type-proxy">
+        <li class="route route-type-unknown">
           <div class="heading">
             <h3>
-              <span class="route-type">Proxy</span>
+              <span class="route-type">Unknown</span>
               <span class="route-path"><code>/service/(?&lt;service_path&gt;.+)</code></span>
             </h3>
             <span class="route-desc">Proxy to services running on DC/OS</span>
-          </div>
-          <div class="route-meta" style="display:none">
-            <table>
-              <tr>
-                <td>
-                  Path:
-                </td>
-                <td>
-                  <code>$upstream_url</code>
-                </td>
-              </tr>
-            </table>
           </div>
         </li>
       </ul>
@@ -1744,6 +1777,43 @@
         <span class="options"><a href="#system" class="toggle-route-group" data-id="system">Show/Hide</a> </span>
       </div>
       <ul id="routes-system" class="routes">
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/system/checks/</code></span>
+            </h3>
+            <span class="route-desc">Node and cluster checks</span>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>unix:/run/dcos/dcos-checks-api.sock</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Checks API
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
         <li class="route route-type-proxy">
           <div class="heading">
             <h3>
@@ -1900,7 +1970,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>$mleader_host/system/v1$url$is_args$query_string</code>
+                  <code>$leader_host/system/v1$url$is_args$query_string</code>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -310,14 +310,14 @@ routes:
         replacement: /service/$1/
         type: permanent
     path: '/service/(?<serviceid>[0-9a-zA-Z-.]+)'
-  /system/checks/:
+  /system/checks/v1:
     group: System
     matcher: path
     description: Node and cluster checks
     proxy:
       path: 'http://$backend'
       backend: dcos_checks_api
-    path: /system/checks/
+    path: /system/checks/v1
   /system/health/v1:
     group: System
     matcher: path

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -1,5 +1,8 @@
 ngindox: 0.1.0
 backends:
+  dcos_checks_api:
+    server: 'unix:/run/dcos/dcos-checks-api.sock'
+    name: DC/OS Checks API
   dcos_diagnostics:
     server: '127.0.0.1:1050'
     name: DC/OS Diagnostics
@@ -115,6 +118,13 @@ routes:
         replacement: /$1
         type: break
     path: /cosmos/service/
+  /navstar/lashup/key:
+    group: DC/OS Net
+    matcher: path
+    proxy:
+      path: 'http://$backend/lashup/key'
+      backend: dcos_net
+    path: /navstar/lashup/key
   /exhibitor:
     group: Exhibitor
     matcher: exact
@@ -149,7 +159,7 @@ routes:
     group: History
     matcher: path
     proxy:
-      path: $historyservice_upstream
+      path: $leader_host
     path: /dcos-history-service/
   /marathon:
     group: Marathon
@@ -245,13 +255,6 @@ routes:
     lua:
       file: conf/lib/metadata.lua
     path: /metadata
-  /navstar/lashup/key:
-    group: DC/OS Net
-    matcher: path
-    proxy:
-      path: 'http://$backend/lashup/key'
-      backend: dcos_net
-    path: /navstar/lashup/key
   /internal/mesos_dns/:
     group: Other
     matcher: path
@@ -259,6 +262,18 @@ routes:
       path: 'http://$backend/'
       backend: mesos_dns
     path: /internal/mesos_dns/
+  '@service_default':
+    group: Other
+    matcher: path
+    proxy:
+      path: $upstream_url
+    path: '@service_default'
+  '@service_requnbuffered':
+    group: Other
+    matcher: path
+    proxy:
+      path: $upstream_url
+    path: '@service_requnbuffered'
   /package/:
     group: Package
     matcher: path
@@ -284,8 +299,6 @@ routes:
     group: Service
     matcher: regex
     description: Proxy to services running on DC/OS
-    proxy:
-      path: $upstream_url
     path: /service/(?<service_path>.+)
   '/service/(?<serviceid>[0-9a-zA-Z-.]+)':
     group: Service
@@ -297,6 +310,14 @@ routes:
         replacement: /service/$1/
         type: permanent
     path: '/service/(?<serviceid>[0-9a-zA-Z-.]+)'
+  /system/checks/:
+    group: System
+    matcher: path
+    description: Node and cluster checks
+    proxy:
+      path: 'http://$backend'
+      backend: dcos_checks_api
+    path: /system/checks/
   /system/health/v1:
     group: System
     matcher: path
@@ -325,7 +346,7 @@ routes:
     matcher: regex
     description: System proxy to the master node with the Marathon leader
     proxy:
-      path: $mleader_host/system/v1$url$is_args$query_string
+      path: $leader_host/system/v1$url$is_args$query_string
     path: /system/v1/leader/marathon(?<url>.*)
   /system/v1/leader/mesos(?<url>.*):
     group: System

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -24,3 +24,8 @@ upstream pkgpanda {
 upstream log {
     server unix:/run/dcos/dcos-log.sock;
 }
+
+# Name: DC/OS Checks API
+upstream dcos_checks_api {
+    server unix:/run/dcos/dcos-checks-api.sock;
+}

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -66,6 +66,18 @@ location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0
     proxy_pass $agentaddr:$adminrouter_agent_port;
 }
 
+# Group: System
+# Description: Node and cluster checks
+location /system/checks/v1 {
+    access_by_lua_block {
+        auth.access_system_checks_endpoint();
+        util.clear_dcos_cookies();
+    }
+
+    include includes/proxy-headers.conf;
+    proxy_pass http://dcos_checks_api;
+}
+
 # Group: Mesos DNS
 # Description: Redirect to add trailing slash
 # Visibility: hidden

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -75,6 +75,7 @@ location /system/checks/v1 {
     }
 
     include includes/proxy-headers.conf;
+    proxy_set_header Authorization "";
     proxy_pass http://dcos_checks_api;
 }
 

--- a/packages/adminrouter/extra/src/includes/server/open/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/agent.conf
@@ -9,7 +9,7 @@ location /pkgpanda/ {
 
 # Group: System
 # Description: Node and cluster checks
-location /system/checks/ {
+location /system/checks/v1 {
     include includes/proxy-headers.conf;
     proxy_pass http://dcos_checks_api;
 }

--- a/packages/adminrouter/extra/src/includes/server/open/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/agent.conf
@@ -8,6 +8,13 @@ location /pkgpanda/ {
 }
 
 # Group: System
+# Description: Node and cluster checks
+location /system/checks/ {
+    include includes/proxy-headers.conf;
+    proxy_pass http://dcos_checks_api;
+}
+
+# Group: System
 # Description: Component service status
 location /system/health/v1 {
     include includes/proxy-headers.conf;

--- a/packages/adminrouter/extra/src/includes/server/open/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/agent.conf
@@ -11,6 +11,8 @@ location /pkgpanda/ {
 # Description: Node and cluster checks
 location /system/checks/v1 {
     include includes/proxy-headers.conf;
+
+    proxy_set_header Authorization "";
     proxy_pass http://dcos_checks_api;
 }
 

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -13,7 +13,7 @@ location /pkgpanda/ {
 
 # Group: System
 # Description: Node and cluster checks
-location /system/checks/ {
+location /system/checks/v1 {
     access_by_lua_block {
         auth.access_system_checks_endpoint();
         util.clear_dcos_cookies();

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -12,6 +12,18 @@ location /pkgpanda/ {
 }
 
 # Group: System
+# Description: Node and cluster checks
+location /system/checks/ {
+    access_by_lua_block {
+        auth.access_system_checks_endpoint();
+        util.clear_dcos_cookies();
+    }
+
+    include includes/proxy-headers.conf;
+    proxy_pass http://dcos_checks_api;
+}
+
+# Group: System
 # Description: Component service status
 location /system/health/v1 {
     access_by_lua_block {

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -12,18 +12,6 @@ location /pkgpanda/ {
 }
 
 # Group: System
-# Description: Node and cluster checks
-location /system/checks/v1 {
-    access_by_lua_block {
-        auth.access_system_checks_endpoint();
-        util.clear_dcos_cookies();
-    }
-
-    include includes/proxy-headers.conf;
-    proxy_pass http://dcos_checks_api;
-}
-
-# Group: System
 # Description: Component service status
 location /system/health/v1 {
     access_by_lua_block {

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -130,6 +130,11 @@ function _M.init(use_auth)
         return res.do_authn_and_authz_or_exit()
     end
 
+    -- /system/checks/
+    res.access_system_checks_endpoint = function()
+        return res.do_authn_and_authz_or_exit()
+    end
+
     -- /system/health/v1
     res.access_system_health_endpoint = function()
         return res.do_authn_and_authz_or_exit()

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -130,7 +130,7 @@ function _M.init(use_auth)
         return res.do_authn_and_authz_or_exit()
     end
 
-    -- /system/checks/
+    -- /system/checks/v1
     res.access_system_checks_endpoint = function()
         return res.do_authn_and_authz_or_exit()
     end

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/common.py
@@ -127,6 +127,9 @@ class MockerBase:
             ReflectingUnixSocketEndpoint('/run/dcos/dcos-diagnostics.sock'))
         # DC/OS Metronome
         res.append(ReflectingTcpIpEndpoint(ip='127.0.0.1', port=9000))
+        # Checks API
+        res.append(
+            ReflectingUnixSocketEndpoint('/run/dcos/dcos-checks-api.sock'))
         # TODO - other endpoints common for all flavours go here...
 
         return res

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -279,6 +279,44 @@ endpoint_tests:
       - master
       - agent
 
+######### /system/checks/ endpoint
+  - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: true
+        auth_token_is_forwarded: skip
+        test_paths:
+          - /system/checks/v1/node/
+          - /system/checks/v1/cluster/
+    type:
+      - agent
+  - tests:
+      are_upstream_req_headers_ok:
+        skip_authcookie_filtering_test: false
+        auth_token_is_forwarded: skip
+        test_paths:
+          - /system/checks/v1/node/
+          - /system/checks/v1/cluster/
+    type:
+      - master
+  - tests:
+      is_response_correct:
+        expect_http_status: 200
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /system/checks/v1/node/
+          - /system/checks/v1/cluster/
+      # Check Open/EE config for this test:
+      is_upstream_req_ok:
+        expected_http_ver: HTTP/1.0
+        test_paths:
+          - expected: /system/checks/v1/node/
+            sent: /system/checks/v1/node/
+          - expected: /system/checks/v1/cluster/
+            sent: /system/checks/v1/cluster/
+    type:
+      - master
+      - agent
+
 ######### /system/v1/agent/ endpoint
 # Agent A
   - tests:

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -301,7 +301,7 @@ endpoint_tests:
   - tests:
       is_response_correct:
         expect_http_status: 200
-        nocaching_headers_are_sent: skip
+        nocaching_headers_are_sent: false
         test_paths:
           - /system/checks/v1/node/
           - /system/checks/v1/cluster/

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -283,7 +283,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: true
-        auth_token_is_forwarded: skip
+        auth_token_is_forwarded: false
         test_paths:
           - /system/checks/v1/node/
           - /system/checks/v1/cluster/
@@ -292,7 +292,7 @@ endpoint_tests:
   - tests:
       are_upstream_req_headers_ok:
         skip_authcookie_filtering_test: false
-        auth_token_is_forwarded: skip
+        auth_token_is_forwarded: false
         test_paths:
           - /system/checks/v1/node/
           - /system/checks/v1/cluster/

--- a/packages/dcos-check-runner/build
+++ b/packages/dcos-check-runner/build
@@ -14,3 +14,11 @@ cp /pkg/extra/dcos-checks-poststart.service "$service"
 timer="$PKG_PATH/dcos.target.wants/dcos-checks-poststart.timer"
 mkdir -p "$(dirname "$timer")"
 cp /pkg/extra/dcos-checks-poststart.timer "$timer"
+
+# Create the checks API service and socket
+service="$PKG_PATH/dcos.target.wants/dcos-checks-api.service"
+mkdir -p "$(dirname "$service")"
+cp /pkg/extra/dcos-checks-api.service "$service"
+socket="$PKG_PATH/dcos.target.wants/dcos-checks-api.socket"
+mkdir -p "$(dirname "$socket")"
+cp /pkg/extra/dcos-checks-api.socket "$socket"

--- a/packages/dcos-check-runner/buildinfo.json
+++ b/packages/dcos-check-runner/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-check-runner.git",
-    "ref": "cca21b6180295de5daf21b5b1a9da0514c34f204",
+    "ref": "c7d061ebdbce76f53994173d1e3e626c0722ab3d",
     "ref_origin": "master"
   },
   "username": "dcos_check_runner"

--- a/packages/dcos-check-runner/extra/dcos-checks-api.service
+++ b/packages/dcos-check-runner/extra/dcos-checks-api.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=DC/OS Checks API: Provides node and cluster checks
+
+[Service]
+Restart=always
+StartLimitInterval=0
+
+LimitNOFILE=16384
+
+Sockets=dcos-checks-api.socket
+
+PermissionsStartOnly=True
+User=dcos_check_runner
+# Allow r/w access to the socket file
+SupplementaryGroups=dcos_adminrouter
+EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=/opt/mesosphere/etc/dcos-check-runner.env
+ExecStart=/opt/mesosphere/bin/dcos-check-runner http-server --config ${DCOS_DIAGNOSTICS_CONFIG_PATH}

--- a/packages/dcos-check-runner/extra/dcos-checks-api.socket
+++ b/packages/dcos-check-runner/extra/dcos-checks-api.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=DC/OS Checks API Socket: socket for DC/OS Checks API
+
+[Socket]
+ListenStream=/run/dcos/dcos-checks-api.sock
+SocketUser=root
+SocketGroup=dcos_adminrouter
+SocketMode=0660

--- a/packages/dcos-check-runner/extra/dcos-checks-poststart.service
+++ b/packages/dcos-check-runner/extra/dcos-checks-poststart.service
@@ -2,7 +2,8 @@
 Description=DC/OS Poststart Checks: Run node-poststart checks
 [Service]
 EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=/opt/mesosphere/etc/dcos-check-runner.env
 StandardOutput=journal
 User=root
 Group=root
-ExecStart=/opt/mesosphere/bin/dcos-check-runner check node-poststart
+ExecStart=/opt/mesosphere/bin/dcos-check-runner check node-poststart --config ${DCOS_CHECK_RUNNER_CONFIG_PATH}

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import uuid
 
@@ -63,12 +64,12 @@ def test_checks_api(dcos_api_session):
     for nodes in [dcos_api_session.masters, dcos_api_session.slaves, dcos_api_session.public_slaves]:
         if nodes:
             check_nodes.append(random.choice(nodes))
-    print('Testing', checks_uri, 'on these nodes:', check_nodes)
+    logging.info('Testing %s on these nodes: %s', checks_uri, ', '.join(check_nodes))
 
     for node in check_nodes:
         for check_type in ['node', 'cluster']:
             uri = '{}{}/'.format(checks_uri, check_type)
-            print('Testing', uri, 'on', node)
+            logging.info('Testing %s on %s', uri, node)
 
             # List checks
             r = dcos_api_session.get(uri, node=node)

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -1,0 +1,54 @@
+import uuid
+
+
+__maintainer__ = 'branden'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
+
+
+def test_checks_cli(dcos_api_session):
+    base_cmd = [
+        '/opt/mesosphere/bin/dcos-shell',
+        'dcos-check-runner',
+        'check',
+    ]
+    test_uuid = uuid.uuid4().hex
+
+    # Poststart node checks should pass.
+    dcos_api_session.metronome_one_off({
+        'id': 'test-checks-node-poststart-' + test_uuid,
+        'run': {
+            'cpus': .1,
+            'mem': 128,
+            'disk': 0,
+            'cmd': ' '.join(base_cmd + ['node-poststart']),
+        },
+    })
+
+    # Cluster checks should pass.
+    dcos_api_session.metronome_one_off({
+        'id': 'test-checks-cluster-' + test_uuid,
+        'run': {
+            'cpus': .1,
+            'mem': 128,
+            'disk': 0,
+            'cmd': ' '.join(base_cmd + ['cluster']),
+        },
+    })
+
+    # Check runner should only use the PATH and LD_LIBRARY_PATH from check config.
+    dcos_api_session.metronome_one_off({
+        'id': 'test-checks-env-' + test_uuid,
+        'run': {
+            'cpus': .1,
+            'mem': 128,
+            'disk': 0,
+            'cmd': ' '.join([
+                'env',
+                'PATH=badvalue',
+                'LD_LIBRARY_PATH=badvalue',
+                '/opt/mesosphere/bin/dcos-check-runner',
+                'check',
+                'node-poststart',
+            ]),
+        },
+    })

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -58,7 +58,7 @@ def test_checks_cli(dcos_api_session):
 
 def test_checks_api(dcos_api_session):
     """Test the checks API at /system/checks/"""
-    checks_uri = '/system/checks/'
+    checks_uri = '/system/checks/v1/'
     # Test that we can list and run node and cluster checks on a master, agent, and public agent.
     check_nodes = []
     for nodes in [dcos_api_session.masters, dcos_api_session.slaves, dcos_api_session.public_slaves]:

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -130,6 +130,8 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
         'dcos-oauth.service',
     ]
     all_node_units = [
+        'dcos-checks-api.service',
+        'dcos-checks-api.socket',
         'dcos-diagnostics.service',
         'dcos-diagnostics.socket',
         'dcos-gen-resolvconf.service',

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -1,7 +1,6 @@
 # Various tests that don't fit into the other categories and don't make their own really.
 
 import os
-import uuid
 
 import pytest
 import yaml
@@ -41,52 +40,3 @@ def test_profile_symlink():
     symlink_target = expanded_config['profile_symlink_target']
     expected_symlink_source = expanded_config['profile_symlink_source']
     assert expected_symlink_source == os.readlink(symlink_target)
-
-
-def test_checks(dcos_api_session):
-    base_cmd = [
-        '/opt/mesosphere/bin/dcos-shell',
-        'dcos-check-runner',
-        'check',
-    ]
-    test_uuid = uuid.uuid4().hex
-
-    # Poststart node checks should pass.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-node-poststart-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(base_cmd + ['node-poststart']),
-        },
-    })
-
-    # Cluster checks should pass.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-cluster-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(base_cmd + ['cluster']),
-        },
-    })
-
-    # Check runner should only use the PATH and LD_LIBRARY_PATH from check config.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-env-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join([
-                'env',
-                'PATH=badvalue',
-                'LD_LIBRARY_PATH=badvalue',
-                '/opt/mesosphere/bin/dcos-check-runner',
-                'check',
-                'node-poststart',
-            ]),
-        },
-    })


### PR DESCRIPTION
## High-level description

This adds an API for DC/OS checks at `/system/checks/` on all cluster nodes.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-1406](https://jira.mesosphere.com/browse/DCOS_OSS-1406) Checks runner HTTP API

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-check-runner/compare/cca21b6180295de5daf21b5b1a9da0514c34f204...c7d061ebdbce76f53994173d1e3e626c0722ab3d
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-check-runner%2Fdcos-check-runner-master/detail/dcos-check-runner-master/104/pipeline)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fdcos-check-runner%2Fdcos-check-runner-master/detail/dcos-check-runner-master/104/pipeline)