### PR TITLE
[1.10] Use ngx.timer.every() for the AR cache update

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -13,8 +13,27 @@ local util = require "util"
 --
 -- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
 --
--- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
+-- Before changing CACHE_POLL_PERIOD, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
+--
+-- Initial timer-triggered cache update early after nginx startup:
+-- It makes sense to have this initial timer-triggered cache
+-- update _early_ after nginx startup at all, and it makes sense to make it
+-- very early, so that we reduce the likelihood for an HTTP request to be slowed
+-- down when it is incoming _before_ the normally scheduled periodic cache
+-- update (example: the HTTP request comes in 15 seconds after nginx startup,
+-- and the first regular timer-triggered cache update is triggered only 25
+-- seconds after nginx startup).
+--
+-- It makes sense to have this time window not be too narrow, especially not
+-- close to 0 seconds: under a lot of load there *will* be HTTP requests
+-- incoming before the initial timer-triggered update, even if the first
+-- timer callback is scheduled to be executed after 0 seconds.
+-- There is code in place for handling these HTTP requests, and that code path
+-- must be kept explicit, regularly exercised, and well-tested. There is a test
+-- harness test that tests/exercises it, but it overrides the default values
+-- with the ones that allow for testability. So the idea is that we leave
+-- initial update scheduled after 2 seconds, as opposed to 0 seconds.
 --
 -- All are in units of seconds. Below are the defaults:
 local _CONFIG = {}
@@ -557,12 +576,16 @@ end
 
 
 local function periodically_refresh_cache(auth_token)
-    -- This function is invoked from within init_worker_by_lua code.
-    -- ngx.timer.at() can be called here, whereas most of the other ngx.*
-    -- API is not available.
+  -- This function is invoked from within init_worker_by_lua code.
+  -- ngx.timer.every() is called here, a more robust alternative to
+  -- ngx.timer.at() as suggested by the openresty/lua-nginx-module
+  -- documentation:
+  -- https://github.com/openresty/lua-nginx-module/tree/v0.10.9#ngxtimerat
+  -- See https://jira.mesosphere.com/browse/DCOS-38248 for details on the
+  -- cache update problems caused by the recursive use of ngx.timer.at()
 
     timerhandler = function(premature)
-        -- Handler for recursive timer invocation.
+        -- Handler for periodic timer invocation.
         -- Within a timer callback, plenty of the ngx.* API is available,
         -- with the exception of e.g. subrequests. As ngx.sleep is also not
         -- available in the current context, the recommended approach of
@@ -575,24 +598,26 @@ local function periodically_refresh_cache(auth_token)
 
         -- Invoke timer business logic.
         refresh_cache(true, auth_token)
-
-        -- Register new timer.
-        local ok, err = ngx.timer.at(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
-        if not ok then
-            ngx.log(ngx.ERR, "Failed to create timer: " .. err)
-        else
-            ngx.log(ngx.INFO, "Created recursive timer for cache updating.")
-        end
     end
 
-    -- Trigger initial timer, about CACHE_FIRST_POLL_DELAY seconds after
+    -- Trigger the initial cache update CACHE_FIRST_POLL_DELAY seconds after
     -- Nginx startup.
     local ok, err = ngx.timer.at(_CONFIG.CACHE_FIRST_POLL_DELAY, timerhandler)
     if not ok then
         ngx.log(ngx.ERR, "Failed to create timer: " .. err)
         return
     else
-        ngx.log(ngx.INFO, "Created initial recursive timer for cache updating.")
+        ngx.log(ngx.INFO, "Created initial timer for cache updating.")
+    end
+
+    -- Trigger the timer, every CACHE_POLL_PERIOD seconds after
+    -- Nginx startup.
+    local ok, err = ngx.timer.every(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
+    if not ok then
+        ngx.log(ngx.ERR, "Failed to create timer: " .. err)
+        return
+    else
+        ngx.log(ngx.INFO, "Created periodic timer for cache updating.")
     end
 end
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -82,8 +82,9 @@ class TestCache:
         # Make regular polling occur faster than usual to speed up the tests.
         ar = nginx_class(cache_poll_period=cache_poll_period, cache_expiration=3)
 
-        # In total, we should get three cache updates in given time frame:
-        timeout = CACHE_FIRST_POLL_DELAY + cache_poll_period * 2 + 1
+        # In total, we should get three cache updates in given time frame plus
+        # one NOOP due to cache not being expired yet:
+        timeout = cache_poll_period * 3 + 1
 
         with GuardedSubprocess(ar):
             lbf = LineBufferFilter(filter_regexp,
@@ -769,7 +770,7 @@ class TestCache:
             execution_number):
         # Nginx resolver enforces 5s (grep for `resolver ... valid=Xs`), so it
         # is VERY important to use cache pool period of >5s.
-        cache_poll_period = 6
+        cache_poll_period = 8
         ar = nginx_class(
             cache_poll_period=cache_poll_period,
             cache_expiration=cache_poll_period - 1,
@@ -792,9 +793,9 @@ class TestCache:
 
             dns_server_mock.set_dns_entry('leader.mesos.', ip="127.0.0.3", ttl=2)
 
-            # First poll (2s) + normal poll interval(4s) < 2 * normal poll
-            # interval(4s)
-            time.sleep(cache_poll_period * 2)
+            # First poll, request triggered (0s) + normal poll interval(6s)
+            # < # interval(6s) + 2
+            time.sleep(cache_poll_period + 2)
 
         mesosmock_pre_reqs = mocker.send_command(
             endpoint_id='http://127.0.0.2:5050',


### PR DESCRIPTION
## High-level description
This is a backport of https://github.com/dcos/dcos/pull/2989 for 1.10

The lua code has been using ngx.timer.at() for the AR cache update. This can lead to the problem described in the JIRA ticket below. This PR replaces ngx.timer.at() with a more robust alternative of ngx.timer.every(), which also fixes the problem described in the JIRA ticket below.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS-38248

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
