### PR TITLE
1.10 Train

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Root Marathon support for post-installation configuration of flags and JVM settings has been improved. (DCOS_OSS-3556)
+
+* Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)
 
 ### Security Updates
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -908,6 +908,7 @@ entry = {
         'ip_detect_public_contents': calculate_ip_detect_public_contents,
         'dns_search': '',
         'auth_cookie_secure_flag': 'false',
+        'marathon_java_args': '',
         'master_dns_bindall': 'true',
         'mesos_dns_ip_sources': '["host", "netinfo"]',
         'mesos_dns_set_truncate_bit': 'true',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -888,8 +888,11 @@ package:
       "tracking":{"enabled":{{ telemetry_enabled }},"metadata":{{ ui_telemetry_metadata }}},"mesos":{"logging-strategy":"{{ mesos_container_log_sink }}"}}}}
   - path: /etc_master/marathon
     content: |
+      # This file will be overwritten on DC/OS upgrade.
+      # For post-installation customization, edit the file /var/lib/dcos/marathon/environment
       MARATHON_ZK=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/marathon
       LIBPROCESS_PORT=15101
+      MARATHON_JAVA_ARGS={{ marathon_java_args }}
 {% switch dcos_overlay_enable %}
 {% case "true" %}
       MARATHON_DEFAULT_NETWORK_NAME={{ dcos_overlay_network_default_name }}

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -13,8 +13,27 @@ local util = require "util"
 --
 -- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
 --
--- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
+-- Before changing CACHE_POLL_PERIOD, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
+--
+-- Initial timer-triggered cache update early after nginx startup:
+-- It makes sense to have this initial timer-triggered cache
+-- update _early_ after nginx startup at all, and it makes sense to make it
+-- very early, so that we reduce the likelihood for an HTTP request to be slowed
+-- down when it is incoming _before_ the normally scheduled periodic cache
+-- update (example: the HTTP request comes in 15 seconds after nginx startup,
+-- and the first regular timer-triggered cache update is triggered only 25
+-- seconds after nginx startup).
+--
+-- It makes sense to have this time window not be too narrow, especially not
+-- close to 0 seconds: under a lot of load there *will* be HTTP requests
+-- incoming before the initial timer-triggered update, even if the first
+-- timer callback is scheduled to be executed after 0 seconds.
+-- There is code in place for handling these HTTP requests, and that code path
+-- must be kept explicit, regularly exercised, and well-tested. There is a test
+-- harness test that tests/exercises it, but it overrides the default values
+-- with the ones that allow for testability. So the idea is that we leave
+-- initial update scheduled after 2 seconds, as opposed to 0 seconds.
 --
 -- All are in units of seconds. Below are the defaults:
 local _CONFIG = {}
@@ -557,12 +576,16 @@ end
 
 
 local function periodically_refresh_cache(auth_token)
-    -- This function is invoked from within init_worker_by_lua code.
-    -- ngx.timer.at() can be called here, whereas most of the other ngx.*
-    -- API is not available.
+  -- This function is invoked from within init_worker_by_lua code.
+  -- ngx.timer.every() is called here, a more robust alternative to
+  -- ngx.timer.at() as suggested by the openresty/lua-nginx-module
+  -- documentation:
+  -- https://github.com/openresty/lua-nginx-module/tree/v0.10.9#ngxtimerat
+  -- See https://jira.mesosphere.com/browse/DCOS-38248 for details on the
+  -- cache update problems caused by the recursive use of ngx.timer.at()
 
     timerhandler = function(premature)
-        -- Handler for recursive timer invocation.
+        -- Handler for periodic timer invocation.
         -- Within a timer callback, plenty of the ngx.* API is available,
         -- with the exception of e.g. subrequests. As ngx.sleep is also not
         -- available in the current context, the recommended approach of
@@ -575,24 +598,26 @@ local function periodically_refresh_cache(auth_token)
 
         -- Invoke timer business logic.
         refresh_cache(true, auth_token)
-
-        -- Register new timer.
-        local ok, err = ngx.timer.at(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
-        if not ok then
-            ngx.log(ngx.ERR, "Failed to create timer: " .. err)
-        else
-            ngx.log(ngx.INFO, "Created recursive timer for cache updating.")
-        end
     end
 
-    -- Trigger initial timer, about CACHE_FIRST_POLL_DELAY seconds after
+    -- Trigger the initial cache update CACHE_FIRST_POLL_DELAY seconds after
     -- Nginx startup.
     local ok, err = ngx.timer.at(_CONFIG.CACHE_FIRST_POLL_DELAY, timerhandler)
     if not ok then
         ngx.log(ngx.ERR, "Failed to create timer: " .. err)
         return
     else
-        ngx.log(ngx.INFO, "Created initial recursive timer for cache updating.")
+        ngx.log(ngx.INFO, "Created initial timer for cache updating.")
+    end
+
+    -- Trigger the timer, every CACHE_POLL_PERIOD seconds after
+    -- Nginx startup.
+    local ok, err = ngx.timer.every(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
+    if not ok then
+        ngx.log(ngx.ERR, "Failed to create timer: " .. err)
+        return
+    else
+        ngx.log(ngx.INFO, "Created periodic timer for cache updating.")
     end
 end
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -82,8 +82,9 @@ class TestCache:
         # Make regular polling occur faster than usual to speed up the tests.
         ar = nginx_class(cache_poll_period=cache_poll_period, cache_expiration=3)
 
-        # In total, we should get three cache updates in given time frame:
-        timeout = CACHE_FIRST_POLL_DELAY + cache_poll_period * 2 + 1
+        # In total, we should get three cache updates in given time frame plus
+        # one NOOP due to cache not being expired yet:
+        timeout = cache_poll_period * 3 + 1
 
         with GuardedSubprocess(ar):
             lbf = LineBufferFilter(filter_regexp,
@@ -769,7 +770,7 @@ class TestCache:
             execution_number):
         # Nginx resolver enforces 5s (grep for `resolver ... valid=Xs`), so it
         # is VERY important to use cache pool period of >5s.
-        cache_poll_period = 6
+        cache_poll_period = 8
         ar = nginx_class(
             cache_poll_period=cache_poll_period,
             cache_expiration=cache_poll_period - 1,
@@ -792,9 +793,9 @@ class TestCache:
 
             dns_server_mock.set_dns_entry('leader.mesos.', ip="127.0.0.3", ttl=2)
 
-            # First poll (2s) + normal poll interval(4s) < 2 * normal poll
-            # interval(4s)
-            time.sleep(cache_poll_period * 2)
+            # First poll, request triggered (0s) + normal poll interval(6s)
+            # < # interval(6s) + 2
+            time.sleep(cache_poll_period + 2)
 
         mesosmock_pre_reqs = mocker.send_command(
             endpoint_id='http://127.0.0.2:5050',

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -17,6 +17,11 @@ cp -rp /pkg/src/marathon/bin/marathon "$PKG_PATH/marathon/bin/marathon"
 chmod +x "$PKG_PATH/marathon/bin/marathon"
 cp -rpn /pkg/src/marathon/lib/*.jar "$PKG_PATH/marathon/lib"
 
+marathon_wrapper="$PKG_PATH/bin/marathon.sh"
+mkdir -p "$(dirname "$marathon_wrapper")"
+envsubst '$PKG_PATH' < /pkg/extra/marathon.sh > "$marathon_wrapper"
+chmod +x "$marathon_wrapper"
+
 marathon_service="$PKG_PATH/dcos.target.wants_master/dcos-marathon.service"
 mkdir -p $(dirname "$marathon_service")
 
@@ -31,32 +36,14 @@ StartLimitInterval=0
 RestartSec=15
 LimitNOFILE=16384
 PermissionsStartOnly=True
+# The env files in /opt are overwritten on upgrade
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
-EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
+# The env file in /var/lib/dcos is for post-install configuration and persists with upgrades.
+EnvironmentFile=-/var/lib/dcos/marathon/environment
 Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
-ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'
-ExecStart=$PKG_PATH/marathon/bin/marathon \\
-    -Duser.dir=/var/lib/dcos/marathon \\
-    -J-server \\
-    -J-verbose:gc \\
-    -J-XX:+PrintGCDetails \\
-    -J-XX:+PrintGCTimeStamps \\
-    --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \\
-    --default_accepted_resource_roles "*" \\
-    --mesos_role "slave_public" \\
-    --max_instances_per_offer 100 \\
-    --task_launch_timeout 86400000 \\
-    --decline_offer_duration 300000 \\
-    --revive_offers_for_new_apps \\
-    --zk_compression \\
-    --mesos_leader_ui_url "/mesos" \\
-    --enable_features "vips,task_killing,external_volumes,gpu_resources" \\
-    --mesos_authentication_principal "dcos_marathon" \\
-    --mesos_user "root"
+ExecStart=/opt/mesosphere/bin/marathon.sh
 EOF

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.8/marathon-1.5.8.tgz",
-    "sha1" : "359fabb498652b2b06077331b2dca9036f1a1b4c"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.10/marathon-1.5.10.tgz",
+    "sha1" : "e3ac761cf95399d147bb47cdf3c712e6bc89a32a"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/extra/marathon.sh
+++ b/packages/marathon/extra/marathon.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+export LIBPROCESS_IP=$($MESOS_IP_DISCOVERY_COMMAND)
+
+: ${MARATHON_HOSTNAME="$LIBPROCESS_IP"}
+: ${MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES="*"}
+: ${MARATHON_MESOS_ROLE="slave_public"}
+: ${MARATHON_MAX_INSTANCES_PER_OFFER=100}
+: ${MARATHON_TASK_LAUNCH_TIMEOUT=86400000}
+: ${MARATHON_DECLINE_OFFER_DURATION=300000}
+: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources"}
+: ${MARATHON_MESOS_AUTHENTICATION_PRINCIPAL="dcos_marathon"}
+: ${MARATHON_MESOS_USER="root"}
+
+if [ -z "${MARATHON_DISABLE_ZK_COMPRESSION+x}" ]; then
+  MARATHON_ZK_COMPRESSION=""
+fi
+
+if [ -z "${MARATHON_DISABLE_REVIVE_OFFERS_FOR_NEW_APPS+x}" ]; then
+  MARATHON_REVIVE_OFFERS_FOR_NEW_APPS=""
+fi
+
+
+export JAVA_OPTS="${MARATHON_JAVA_ARGS-}"
+export -n MARATHON_JAVA_ARGS
+export MARATHON_HOSTNAME MARATHON_MESOS_ROLE MARATHON_MAX_INSTANCES_PER_OFFER \
+       MARATHON_TASK_LAUNCH_TIMEOUT MARATHON_DECLINE_OFFER_DURATION MARATHON_ENABLE_FEATURES \
+       MARATHON_MESOS_AUTHENTICATION_PRINCIPAL MARATHON_MESOS_USER MARATHON_ZK_COMPRESSION \
+       MARATHON_REVIVE_OFFERS_FOR_NEW_APPS
+
+# TODO (DCOS_OSS-3592) - move this variable to the exported list after MARATHON-8254 is fixed, and remove --default_accepted_resources_roles below
+export -n MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES
+
+exec $PKG_PATH/marathon/bin/marathon \
+    -Duser.dir=/var/lib/dcos/marathon \
+    -J-server \
+    -J-verbose:gc \
+    -J-XX:+PrintGCDetails \
+    -J-XX:+PrintGCTimeStamps \
+    --master zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos \
+    --mesos_leader_ui_url "/mesos" \
+    --default_accepted_resource_roles "${MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES}"

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/apache/mesos", 
-    "ref": "04f49674ca25fd0bea0ef4cd0d744429e9614a12", 
+    "ref": "e7b117e0d9072a50756dd90e12d691af572aed7c", 
     "ref_origin": "1.4.x"
   }, 
   "environment": {


### PR DESCRIPTION
> PRs had merge conflict, and manual resolution was required to create this train.

Please review carefully.

----

#3029 - (Backport) Allow customization of JAVA options for root Marathon, and other changes
#3040 - [1.10] Use ngx.timer.every() for the AR cache update 
#3041 -  [1.10] Tuning the Lua HTTP client recv() timeout
#3044 - Marathon bump 1.5.10 
#3030 - [1.10] Bump Mesos to nightly 1.4.x e7b117e 