### PR TITLE
[1.12/master] Tuning the Lua HTTP client recv() timeout

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -11,8 +11,19 @@ local util = require "util"
 --
 -- CACHE_FIRST_POLL_DELAY << CACHE_EXPIRATION < CACHE_POLL_PERIOD < CACHE_MAX_AGE_SOFT_LIMIT < CACHE_MAX_AGE_HARD_LIMIT
 --
--- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
---
+-- There are 3 requests (2xMarathon + Mesos) made to upstream components.
+-- The cache should be kept locked for the whole time until
+-- the responses are received from all the components. Therefore,
+-- 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2) <= CACHE_REFRESH_LOCK_TIMEOUT
+-- The 2s delay between requests is choosen arbitrarily.
+-- On the other hand, the documentation
+-- (https://github.com/openresty/lua-resty-lock#new) says that the
+-- CACHE_REFRESH_LOCK_TIMEOUT should not exceed the expiration time, which
+-- is equal to 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2). Taking into account
+-- both constraints, we would have to set CACHE_REFRESH_LOCK_TIMEOUT =
+-- 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2). We set it to
+-- 3 * CACHE_BACKEND_REQUEST_TIMEOUT hoping that the 2 requests to Marathon and
+-- 1 request to Mesos will be done immediately one after another.
 -- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
 --
@@ -23,8 +34,8 @@ local env_vars = {CACHE_FIRST_POLL_DELAY = 2,
                   CACHE_EXPIRATION = 20,
                   CACHE_MAX_AGE_SOFT_LIMIT = 75,
                   CACHE_MAX_AGE_HARD_LIMIT = 259200,
-                  CACHE_BACKEND_REQUEST_TIMEOUT = 10,
-                  CACHE_REFRESH_LOCK_TIMEOUT = 20,
+                  CACHE_BACKEND_REQUEST_TIMEOUT = 60,
+                  CACHE_REFRESH_LOCK_TIMEOUT = 180,
                   }
 
 for key, value in pairs(env_vars) do
@@ -547,7 +558,8 @@ local function refresh_cache(from_timer, auth_token)
         ngx.log(ngx.INFO, "Executing cache refresh triggered by request")
         -- Cache content is required for current request
         -- processing. Wait for lock acquisition, for at
-        -- most 20 seconds.
+        -- most _CONFIG.CACHE_REFRESH_LOCK_TIMEOUT * 3 seconds (2xMarathon +
+        -- 1 Mesos request).
         lock = shmlock:new("shmlocks", {timeout=_CONFIG.CACHE_REFRESH_LOCK_TIMEOUT,
                                         exptime=lock_ttl })
         local elapsed, err = lock:lock("cache")


### PR DESCRIPTION
This is a forward-port of https://github.com/dcos/dcos/pull/3041

## High-level description

This PR increases the timeout of the Lua HTTP client from 10 to 60sec to accomodate for the longer response times from upstream DC/OS components (e.g. Mesos and Marathon). See the corresponding JIRA ticket for details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS-38323

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
