### PR TITLE
Change Adminrouter access_log logging facility to daemon [Backport 1.10]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
+
 * Root Marathon support for post-installation configuration of flags and JVM settings has been improved. (DCOS_OSS-3556)
 
 * Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -1,5 +1,9 @@
 client_max_body_size 1024M;
-access_log syslog:server=unix:/dev/log;
+# The syslog facility here is set to daemon because
+# systemd SyslogFacility defaults to daemon and
+# therefore all other DC/OS services log to it.
+# https://jira.mesosphere.com/browse/DCOS-38622
+access_log syslog:server=unix:/dev/log,facility=daemon;
 include mime.types;
 default_type application/octet-stream;
 sendfile on;


### PR DESCRIPTION
## High-level description

This PR changes the Adminrouter `access_log` syslog facility from `local7` (nginx implicit default) to `daemon`.
Since `daemon` is the default syslog facility for journald logs that do not have a syslog facility assigned, all other components of DC/OS appear to `rsyslog` as logging to `daemon` and therefore end up under `/var/log/messages`. Now Adminrouter access_log are also found in `/var/log/messages` instead of `/var/log/boot.log` with the `rsyslog` default configuration on `CentOS 7`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3793)](https://jira.mesosphere.com/browse/DCOS_OSS-3793) Change Adminrouter access_log syslog logging facility to daemon.

## Related tickets (optional)

 - [DCOS-38622](https://jira.mesosphere.com/browse/DCOS-38622) set 'access_log /dev/stdout' in Admin Router's config (for both, Master and Agent Admin Router).

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
There is no meaningful way to test this as the change is only visible with specific external software installed (`rsyslog` in this case).
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)