### PR TITLE
1.11 Train 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Fixed and improved
 
+* Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
 ### Security updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 * Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
+* L4LB unstable when something is deployed in the cluster (DCOS_OSS-3602)
+
 ### Security updates
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,16 @@
 
 * L4LB unstable when something is deployed in the cluster (DCOS_OSS-3602)
 
+* Prevent metric names beginning with a number in prometheus output (DCOS_OSS-2360)
+
+* Add task labels as tags on container metrics (DCOS_OSS-3304)
+
+* Increase the mesos agent response timeout for dcos-metrics (DCOS-37452)
+
+* Prevent cosmos-specific labels being sent as metrics tags (DCOS-37451)
+
+* Improve the way statsd timers are handled in dcos-metrics (DCOS-38083)
+
 ### Security updates
 
 

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -1,5 +1,9 @@
 client_max_body_size 1024M;
-access_log syslog:server=unix:/dev/log;
+# The syslog facility here is set to daemon because
+# systemd SyslogFacility defaults to daemon and
+# therefore all other DC/OS services log to it.
+# https://jira.mesosphere.com/browse/DCOS-38622
+access_log syslog:server=unix:/dev/log,facility=daemon;
 include mime.types;
 default_type application/octet-stream;
 sendfile on;

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -11,9 +11,23 @@ local util = require "util"
 --
 -- CACHE_FIRST_POLL_DELAY << CACHE_EXPIRATION < CACHE_POLL_PERIOD < CACHE_MAX_AGE_SOFT_LIMIT < CACHE_MAX_AGE_HARD_LIMIT
 --
--- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
 --
 -- Before changing CACHE_POLL_PERIOD, please check the comment for resolver
+--
+-- There are 3 requests (2xMarathon + Mesos) made to upstream components.
+-- The cache should be kept locked for the whole time until
+-- the responses are received from all the components. Therefore,
+-- 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2) <= CACHE_REFRESH_LOCK_TIMEOUT
+-- The 2s delay between requests is choosen arbitrarily.
+-- On the other hand, the documentation
+-- (https://github.com/openresty/lua-resty-lock#new) says that the
+-- CACHE_REFRESH_LOCK_TIMEOUT should not exceed the expiration time, which
+-- is equal to 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2). Taking into account
+-- both constraints, we would have to set CACHE_REFRESH_LOCK_TIMEOUT =
+-- 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2). We set it to
+-- 3 * CACHE_BACKEND_REQUEST_TIMEOUT hoping that the 2 requests to Marathon and
+-- 1 request to Mesos will be done immediately one after another.
+-- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
 --
 -- Initial timer-triggered cache update early after nginx startup:
@@ -42,8 +56,8 @@ local env_vars = {CACHE_FIRST_POLL_DELAY = 2,
                   CACHE_EXPIRATION = 20,
                   CACHE_MAX_AGE_SOFT_LIMIT = 75,
                   CACHE_MAX_AGE_HARD_LIMIT = 259200,
-                  CACHE_BACKEND_REQUEST_TIMEOUT = 10,
-                  CACHE_REFRESH_LOCK_TIMEOUT = 20,
+                  CACHE_BACKEND_REQUEST_TIMEOUT = 60,
+                  CACHE_REFRESH_LOCK_TIMEOUT = 180,
                   }
 
 for key, value in pairs(env_vars) do
@@ -537,7 +551,8 @@ local function refresh_cache(from_timer, auth_token)
         ngx.log(ngx.INFO, "Executing cache refresh triggered by request")
         -- Cache content is required for current request
         -- processing. Wait for lock acquisition, for at
-        -- most 20 seconds.
+        -- most _CONFIG.CACHE_REFRESH_LOCK_TIMEOUT * 3 seconds (2xMarathon +
+        -- 1 Mesos request).
         lock = shmlock:new("shmlocks", {timeout=_CONFIG.CACHE_REFRESH_LOCK_TIMEOUT,
                                         exptime=lock_ttl })
         local elapsed, err = lock:lock("cache")

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -13,8 +13,27 @@ local util = require "util"
 --
 -- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
 --
--- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
+-- Before changing CACHE_POLL_PERIOD, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
+--
+-- Initial timer-triggered cache update early after nginx startup:
+-- It makes sense to have this initial timer-triggered cache
+-- update _early_ after nginx startup at all, and it makes sense to make it
+-- very early, so that we reduce the likelihood for an HTTP request to be slowed
+-- down when it is incoming _before_ the normally scheduled periodic cache
+-- update (example: the HTTP request comes in 15 seconds after nginx startup,
+-- and the first regular timer-triggered cache update is triggered only 25
+-- seconds after nginx startup).
+--
+-- It makes sense to have this time window not be too narrow, especially not
+-- close to 0 seconds: under a lot of load there *will* be HTTP requests
+-- incoming before the initial timer-triggered update, even if the first
+-- timer callback is scheduled to be executed after 0 seconds.
+-- There is code in place for handling these HTTP requests, and that code path
+-- must be kept explicit, regularly exercised, and well-tested. There is a test
+-- harness test that tests/exercises it, but it overrides the default values
+-- with the ones that allow for testability. So the idea is that we leave
+-- initial update scheduled after 2 seconds, as opposed to 0 seconds.
 --
 -- All are in units of seconds. Below are the defaults:
 local _CONFIG = {}
@@ -556,15 +575,15 @@ end
 
 local function periodically_refresh_cache(auth_token)
     -- This function is invoked from within init_worker_by_lua code.
-    -- ngx.timer.at() can be called here, whereas most of the other ngx.*
-    -- API is not available.
+    -- ngx.timer.every() is called here, a more robust alternative to
+    -- ngx.timer.at() as suggested by the openresty/lua-nginx-module
+    -- documentation:
+    -- https://github.com/openresty/lua-nginx-module/tree/v0.10.9#ngxtimerat
+    -- See https://jira.mesosphere.com/browse/DCOS-38248 for details on the
+    -- cache update problems caused by the recursive use of ngx.timer.at()
 
     timerhandler = function(premature)
-        -- Handler for recursive timer invocation.
-        -- Within a timer callback, plenty of the ngx.* API is available,
-        -- with the exception of e.g. subrequests. As ngx.sleep is also not
-        -- available in the current context, the recommended approach of
-        -- implementing periodic tasks is via recursively defined timers.
+        -- Handler for periodic timer invocation.
 
         -- Premature timer execution: worker process tries to shut down.
         if premature then
@@ -573,24 +592,26 @@ local function periodically_refresh_cache(auth_token)
 
         -- Invoke timer business logic.
         refresh_cache(true, auth_token)
-
-        -- Register new timer.
-        local ok, err = ngx.timer.at(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
-        if not ok then
-            ngx.log(ngx.ERR, "Failed to create timer: " .. err)
-        else
-            ngx.log(ngx.INFO, "Created recursive timer for cache updating.")
-        end
     end
 
-    -- Trigger initial timer, about CACHE_FIRST_POLL_DELAY seconds after
+    -- Trigger the initial cache update CACHE_FIRST_POLL_DELAY seconds after
     -- Nginx startup.
     local ok, err = ngx.timer.at(_CONFIG.CACHE_FIRST_POLL_DELAY, timerhandler)
     if not ok then
         ngx.log(ngx.ERR, "Failed to create timer: " .. err)
         return
     else
-        ngx.log(ngx.INFO, "Created initial recursive timer for cache updating.")
+        ngx.log(ngx.INFO, "Created initial timer for cache updating.")
+    end
+
+    -- Trigger the timer, every CACHE_POLL_PERIOD seconds after
+    -- Nginx startup.
+    local ok, err = ngx.timer.every(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
+    if not ok then
+        ngx.log(ngx.ERR, "Failed to create timer: " .. err)
+        return
+    else
+        ngx.log(ngx.INFO, "Created periodic timer for cache updating.")
     end
 end
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -82,8 +82,9 @@ class TestCache:
         # Make regular polling occur faster than usual to speed up the tests.
         ar = nginx_class(cache_poll_period=cache_poll_period, cache_expiration=3)
 
-        # In total, we should get three cache updates in given time frame:
-        timeout = CACHE_FIRST_POLL_DELAY + cache_poll_period * 2 + 1
+        # In total, we should get three cache updates in given time frame plus
+        # one NOOP due to cache not being expired yet:
+        timeout = cache_poll_period * 3 + 1
 
         with GuardedSubprocess(ar):
             lbf = LineBufferFilter(filter_regexp,
@@ -769,7 +770,7 @@ class TestCache:
             execution_number):
         # Nginx resolver enforces 5s (grep for `resolver ... valid=Xs`), so it
         # is VERY important to use cache pool period of >5s.
-        cache_poll_period = 6
+        cache_poll_period = 8
         ar = nginx_class(
             cache_poll_period=cache_poll_period,
             cache_expiration=cache_poll_period - 1,
@@ -792,9 +793,9 @@ class TestCache:
 
             dns_server_mock.set_dns_entry('leader.mesos.', ip="127.0.0.3", ttl=2)
 
-            # First poll (2s) + normal poll interval(4s) < 2 * normal poll
-            # interval(4s)
-            time.sleep(cache_poll_period * 2)
+            # First poll, request triggered (0s) + normal poll interval(6s)
+            # interval(6s) + 2
+            time.sleep(cache_poll_period + 2)
 
         mesosmock_pre_reqs = mocker.send_command(
             endpoint_id='http://127.0.0.2:5050',

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "4d63ddb74c9297b1f2b4328a238da4212b802546",
+    "ref": "a12c05763657f4d914dc2f90e887b40396eb8f4e",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "2dcd3bf655fc6d382d16a418ec82699b5bae8446",
+      "ref": "0f269553af3e7a45b03503e186c84f22ef31ef4e",
       "ref_origin": "1.11.x"
     }
   },

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/apache/mesos", 
-    "ref": "fc8e9746ba5df1e19980ac57a384b7de73ff9e58", 
+    "ref": "2440c7310627c835fe828aef6b28b8d072e7371c", 
     "ref_origin": "1.5.x"
   }, 
   "environment": {


### PR DESCRIPTION
## High-level description

> Manually Created.

(Please check for merge-conflicts resolved)

* #3054  - [1.11] Use ngx.timer.every() for the AR cache update
* #3058 - [1.11] Bump Mesos to nightly 1.5.x 2440c73
* #3061  - [1.11] Tuning the Lua HTTP client recv() timeout 
* #3072 - Change Adminrouter access_log logging facility to daemon [Backport 1.11]
* #3077 - [1.11] Bump dcos-net
* #2850 - [1.11] Bump DC/OS Metrics 
