### PR TITLE
dcos-check-runner: run dcos-checks-poststart.service as root 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@
 
 * Improve the way statsd timers are handled in dcos-metrics (DCOS-38083)
 
+* Fix logging of dcos-checks-poststart results to the journal. (DCOS_OSS-3804)
+
+
 ### Security updates
 
 

--- a/packages/dcos-checks/extra/dcos-checks-poststart.service
+++ b/packages/dcos-checks/extra/dcos-checks-poststart.service
@@ -5,5 +5,6 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-diagnostics.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-diagnostics-extra.env
 StandardOutput=journal
-User=dcos_diagnostics
+User=root
+Group=root
 ExecStart=/opt/mesosphere/bin/dcos-diagnostics check node-poststart


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

_This is a backport to `1.11` of https://github.com/dcos/dcos/pull/3083._

This PR changes the dcos-checks-poststart.service unit, which periodically runs dcos-checks, to execute as the `root` user. This service accepts no user interaction, serves no requests, and is expected to have any permission necessary in order to assert the health of any component in the system: it simulates the operator periodically checking her cluster. It makes no sense to restrict this service's permissions.

This has the happy side-effect of working around what appears to be a bug in journald where logs are sent to the main journal but are not tagged with the systemd unit that emitted them. This therefore greatly improves the debug experience around `dcos-checks-poststart.service` which, right now, logs either nothing or broken log lines.

The journal bug is likely https://bugs.freedesktop.org/show_bug.cgi?id=50184

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3804](https://jira.mesosphere.com/browse/DCOS_OSS-3804) dcos-checks-poststart: run as root

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: 
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___