### PR TITLE
dcos-image: sourcing the proxy.env in dcos-shell

### DIFF
--- a/packages/dcos-image/extra/dcos-shell
+++ b/packages/dcos-image/extra/dcos-shell
@@ -2,7 +2,7 @@
 set -o errexit -o nounset -o pipefail
 
 source /opt/mesosphere/environment.export
-source /opt/mesosphere/etc/proxy.env
+source <(for i in $(cat /opt/mesosphere/etc/proxy.env); do echo export $i; done)
 
 if [ $# -eq 0 ]; then
   exec "$SHELL"

--- a/packages/dcos-image/extra/dcos-shell
+++ b/packages/dcos-image/extra/dcos-shell
@@ -2,6 +2,7 @@
 set -o errexit -o nounset -o pipefail
 
 source /opt/mesosphere/environment.export
+source /opt/mesosphere/etc/proxy.env
 
 if [ $# -eq 0 ]; then
   exec "$SHELL"


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

DC/OS Shell doesn't source the proxy.env file to make explicitly call directly through the proxy if it is present in the environment. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3820](https://jira.mesosphere.com/browse/DCOS_OSS-3820) dcos-shell does not load in proxy environment variables 
## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a change to the environment of the `dcos-shell` which users are typically not sourcing unless they are testing out DC/OS native commands.

  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: DC/OS test already exist. 
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [X] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [X] Test Results: [link to CI job test results for component]
  - [X] Code Coverage (if available): [link to code coverage report]
___

@branden 