### PR TITLE
Add a service to automatically drain Mesos node on reboot/halt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@ Format of the entries must be.
 
 * Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)
 
+* Mesos: Drain agent node automatically on reboot or shutdown. (DCOS_OSS-3672) 
+
 ### Security Updates
 
 * Update cURL to 7.59. (DCOS_OSS-2367)

--- a/packages/mesos/extra/dcos-drain-mesos-agent-public.service
+++ b/packages/mesos/extra/dcos-drain-mesos-agent-public.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Drain Mesos Agent: Stop Mesos tasks on shutdown/reboot
+Before=shutdown.target reboot.target halt.target
+After=dcos-mesos-slave-public.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStop=/usr/bin/systemctl kill -s SIGUSR1 dcos-mesos-slave-public.service

--- a/packages/mesos/extra/dcos-drain-mesos-agent.service
+++ b/packages/mesos/extra/dcos-drain-mesos-agent.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Drain Mesos Agent: Stop Mesos tasks on shutdown/reboot
+Before=shutdown.target reboot.target halt.target
+After=dcos-mesos-slave.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStop=/usr/bin/systemctl kill -s SIGUSR1 dcos-mesos-slave.service


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR adds systemd units that are executed when a mesos agent (or public agent) node is rebooted (or shutdown), sends a SIGUSR1 to the agent process to try to gracefully drain the agent of its tasks . Details here : https://jira.mesosphere.com/browse/DCOS_OSS-3672 
## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS--3672](https://jira.mesosphere.com/browse/DCOS_OSS-3672) Automatically drain DC/OS agents before host reboot/shutdown



## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
