### PR TITLE
Add Telegraf as a DC/OS component

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1138,3 +1138,83 @@ package:
     content: {{ fault_domain_detect_contents }}
 {% case "false" %}
 {% endswitch %}
+  - path: /etc/telegraf.env
+    content: |
+      TELEGRAF_CONFIG_FILE=/opt/mesosphere/etc/telegraf/telegraf.conf
+      TELEGRAF_CONFIG_DIR=/opt/mesosphere/etc/telegraf/telegraf.d/
+  - path: /etc/telegraf/telegraf.conf
+    content: |
+      # Telegraf config for all nodes
+      [global_tags]
+        # Tags to be applied to all metrics.
+        dcos_cluster_name="{{ cluster_name }}"
+        dcos_cluster_id="$DCOS_CLUSTER_ID"
+      [agent]
+        ## Default data collection interval for all inputs
+        interval = "10s"
+        ## Rounds collection interval to 'interval'
+        ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+        round_interval = true
+        ## Telegraf will send metrics to outputs in batches of at most
+        ## metric_batch_size metrics.
+        ## This controls the size of writes that Telegraf sends to output plugins.
+        metric_batch_size = 1000
+        ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+        ## output, and will flush this buffer on a successful write. Oldest metrics
+        ## are dropped first when this buffer fills.
+        ## This buffer only fills when writes fail to output plugin(s).
+        metric_buffer_limit = 10000
+        ## Collection jitter is used to jitter the collection by a random amount.
+        ## Each plugin will sleep for a random time within jitter before collecting.
+        ## This can be used to avoid many plugins querying things like sysfs at the
+        ## same time, which can have a measurable effect on the system.
+        collection_jitter = "0s"
+        ## Default flushing interval for all outputs. You shouldn't set this below
+        ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+        flush_interval = "10s"
+        ## Jitter the flush interval by a random amount. This is primarily to avoid
+        ## large write spikes for users running a large number of telegraf instances.
+        ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+        flush_jitter = "0s"
+        ## By default or when set to "0s", precision will be set to the same
+        ## timestamp order as the collection interval, with the maximum being 1s.
+        ##   ie, when interval = "10s", precision will be "1s"
+        ##       when interval = "250ms", precision will be "1ms"
+        ## Precision will NOT be used for service inputs. It is up to each individual
+        ## service input to set the timestamp at the appropriate precision.
+        ## Valid time units are "ns", "us", "ms", "s".
+        precision = ""
+        ## Logging configuration:
+        ## Run telegraf with debug log messages.
+        debug = false
+        ## Run telegraf in quiet mode (error log messages only).
+        quiet = false
+        ## Specify the log file name. The empty string means to log to stderr.
+        logfile = ""
+        ## Override default hostname, if empty use os.Hostname()
+        hostname = ""
+        ## If set to true, do no set the "host" tag in the telegraf agent.
+        omit_hostname = false
+      # Read metrics about cpu usage
+      [[inputs.cpu]]
+        ## Whether to report per-cpu stats or not
+        percpu = true
+        ## Whether to report total system cpu stats or not
+        totalcpu = true
+        ## If true, collect raw CPU time metrics.
+        collect_cpu_time = false
+        ## If true, compute and report the sum of all non-idle CPU states.
+        report_active = false
+      [[inputs.mem]]
+      # Telegraf refuses to start if no outputs are defined. This will eventually be
+      # replaced with real outputs.
+      [[outputs.discard]]
+  - path: /etc_master/telegraf/telegraf.d/master.conf
+    content: |
+      # Additional Telegraf config for masters
+  - path: /etc_slave/telegraf/telegraf.d/agent.conf
+    content: |
+      # Additional Telegraf config for agents
+  - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
+    content: |
+      # Additional Telegraf config for agents

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -72,6 +72,7 @@ bootstrappers = {
     'dcos-history': noop,
     'dcos-mesos-dns': noop,
     'dcos-net': noop,
+    'dcos-telegraf': noop,
 }
 
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -72,7 +72,8 @@ bootstrappers = {
     'dcos-history': noop,
     'dcos-mesos-dns': noop,
     'dcos-net': noop,
-    'dcos-telegraf': noop,
+    'dcos-telegraf-master': noop,
+    'dcos-telegraf-agent': noop,
 }
 
 

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -178,7 +178,8 @@ def test_signal_service(dcos_api_session):
         'pkgpanda-api-service',
         'signal-timer',
         'checks-poststart-service',
-        'checks-poststart-timer']
+        'checks-poststart-timer',
+        'telegraf-service']
     slave_units = [
         'mesos-slave-service']
     public_slave_units = [

--- a/packages/telegraf/build
+++ b/packages/telegraf/build
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+set -o nounset
+
+project="github.com/influxdata/telegraf"
+project_src_path="$GOPATH/src/$project"
+
+# Add the project to $GOPATH.
+mkdir -p $(dirname $project_src_path)
+ln -s /pkg/src/$PKG_NAME $project_src_path
+
+# Build telegraf and add it to the package.
+mkdir -p $PKG_PATH/bin/
+(cd $project_src_path && make deps && make telegraf)
+mv $project_src_path/telegraf $PKG_PATH/bin/
+# Add the telegraf startup script to the package.
+cp /pkg/extra/start_telegraf.sh $PKG_PATH/bin/
+
+# Add the dcos-telegraf unit file to the package.
+mkdir -p $PKG_PATH/dcos.target.wants/
+cp /pkg/extra/dcos-telegraf.service $PKG_PATH/dcos.target.wants/

--- a/packages/telegraf/build
+++ b/packages/telegraf/build
@@ -4,6 +4,10 @@ set -o errexit
 set -o xtrace
 set -o nounset
 
+# Install the package that provides envsubst.
+apt-get update && apt-get install gettext-base
+which envsubst
+
 project="github.com/influxdata/telegraf"
 project_src_path="$GOPATH/src/$project"
 
@@ -18,6 +22,19 @@ mv $project_src_path/telegraf $PKG_PATH/bin/
 # Add the telegraf startup script to the package.
 cp /pkg/extra/start_telegraf.sh $PKG_PATH/bin/
 
-# Add the dcos-telegraf unit file to the package.
-mkdir -p $PKG_PATH/dcos.target.wants/
-cp /pkg/extra/dcos-telegraf.service $PKG_PATH/dcos.target.wants/
+# Create dcos-telegraf unit files.
+# Telegraf uses one service account on masters and another on agents and public agents.
+unit_template="/pkg/extra/dcos-telegraf.service"
+master_unit="$PKG_PATH/dcos.target.wants_master/dcos-telegraf.service"
+agent_unit="$PKG_PATH/dcos.target.wants_slave/dcos-telegraf.service"
+agent_public_unit="$PKG_PATH/dcos.target.wants_slave_public/dcos-telegraf.service"
+
+# Add the master unit file to the package.
+mkdir -p $(dirname $master_unit)
+SERVICE_ACCOUNT="dcos-telegraf-master" envsubst '${SERVICE_ACCOUNT}' < $unit_template > $master_unit
+
+# Add the agent unit files to the package.
+for unit in $agent_unit $agent_public_unit; do
+  mkdir -p $(dirname $unit)
+  SERVICE_ACCOUNT="dcos-telegraf-agent" envsubst '${SERVICE_ACCOUNT}' < $unit_template > $unit
+done

--- a/packages/telegraf/build
+++ b/packages/telegraf/build
@@ -31,10 +31,10 @@ agent_public_unit="$PKG_PATH/dcos.target.wants_slave_public/dcos-telegraf.servic
 
 # Add the master unit file to the package.
 mkdir -p $(dirname $master_unit)
-SERVICE_ACCOUNT="dcos-telegraf-master" envsubst '${SERVICE_ACCOUNT}' < $unit_template > $master_unit
+SERVICE="dcos-telegraf-master" envsubst '${SERVICE}' < $unit_template > $master_unit
 
 # Add the agent unit files to the package.
 for unit in $agent_unit $agent_public_unit; do
   mkdir -p $(dirname $unit)
-  SERVICE_ACCOUNT="dcos-telegraf-agent" envsubst '${SERVICE_ACCOUNT}' < $unit_template > $unit
+  SERVICE="dcos-telegraf-agent" envsubst '${SERVICE}' < $unit_template > $unit
 done

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "docker": "golang:1.10",
+  "docker": "golang:1.10-stretch",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/telegraf.git",

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -1,0 +1,10 @@
+{
+  "docker": "golang:1.10",
+  "single_source" : {
+    "kind": "git",
+    "git": "https://github.com/mesosphere/telegraf.git",
+    "ref": "23dcbd617340213a1269c7d95f45ba5a0a90de3f",
+    "ref_origin": "1.7.2-dcos"
+  },
+  "username": "dcos_telegraf"
+}

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -14,5 +14,5 @@ EnvironmentFile=/opt/mesosphere/etc/telegraf.env
 
 LimitNOFILE=16384
 
-ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE_ACCOUNT}
+ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -14,5 +14,5 @@ EnvironmentFile=/opt/mesosphere/etc/telegraf.env
 
 LimitNOFILE=16384
 
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-telegraf
+ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE_ACCOUNT}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Telegraf: collects and reports metrics
+
+[Service]
+Restart=always
+StartLimitInterval=0
+RestartSec=5
+
+User=dcos_telegraf
+PermissionsStartOnly=True
+
+EnvironmentFile=/opt/mesosphere/environment
+EnvironmentFile=/opt/mesosphere/etc/telegraf.env
+
+LimitNOFILE=16384
+
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-telegraf
+ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+set -o nounset
+
+# Read the cluster ID.
+cluster_id_file="/var/lib/dcos/cluster-id"
+if [ ! -f "${cluster_id_file}" ]; then
+  echo "Missing required file: ${cluster_id_file}" >&2
+  exit 1
+fi
+cluster_id="$(cat ${cluster_id_file})"
+
+# Export the cluster ID to an env var so telegraf config can reference it.
+export DCOS_CLUSTER_ID="${cluster_id}"
+
+# Start telegraf.
+exec /opt/mesosphere/bin/telegraf "$@"

--- a/packages/windows.treeinfo.json
+++ b/packages/windows.treeinfo.json
@@ -76,6 +76,7 @@
     "six",
     "strace",
     "teamcity-messages",
+    "telegraf",
     "toybox"
   ]
 }


### PR DESCRIPTION
## High-level description

This PR adds a new `dcos-telegraf` component, intended to eventually replace `dcos-metrics` in 1.12. `dcos-metrics` will be removed in a later PR once `dcos-telegraf` is ready to replace it.

This PR configures Telegraf to collect CPU and memory metrics from hosts, and then discard them. Further PRs will configure Telegraf to collect more metrics. Outputs will be added to replace `dcos-metrics` when it's removed in a later PR.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3715](https://jira.mesosphere.com/browse/DCOS_OSS-3715) Create a build script for telegraf

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Nothing user-facing yet, since Telegraf doesn't expose the metrics it collects.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: We now expect a `dcos-telegraf` component to be running on all nodes after a cluster is deployed. If Telegraf fails to start, checks will fail.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): Adding a brand new component so changelog isn't applicable.
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/18/pipeline) (One test is failing due to unresolved CI infra problems.)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/18/pipeline)