### PR TITLE
[1.10] Fix typo in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@ Format of the entries must be.
 
 * Prevent cosmos-specific labels being sent as metrics tags (DCOS-37451)
 
-* Improve the way statsd timers are handled in dcos-metrcs (DCOS-38083)
+* Improve the way statsd timers are handled in dcos-metrics (DCOS-38083)
 
 ### Security Updates
 


### PR DESCRIPTION
## High-level description

This PR simply fixes a typo in the changelog in 1.10 which I introduced in #2849. That PR was time-sensitive, hence this follow-up. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-38083](https://jira.mesosphere.com/browse/DCOS-38083) Improve the way statsd timers are handled in dcos-metrics

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: it's literally just the changelog
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
