### PR TITLE
[1.11] Bump dcos-metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
 
 * CNI module now stores configuration on a tmpfs dir, allocated IP addresses are recycled upon agent reboot. (DCOS_OSS-3750)
 
+* Add debug route to metrics API (DCOS-37454)
+
 ### Security updates
 
 

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "a12c05763657f4d914dc2f90e887b40396eb8f4e",
+    "ref": "f7ce9e5a5a8ac4412096c053b9114ffac07a134c",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This PR adds a /debug endpoint to the /v0 API which yields all objects in the store. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-37454](https://jira.mesosphere.com/browse/DCOS-37454) Metrics reported to Prometheus inconsistent with stored metrics


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is an undocumented debug endpoint for legacy code, I didn't deem it necessary
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-metrics/compare/a12c05763657f4d914dc2f90e887b40396eb8f4e...f7ce9e5a5a8ac4412096c053b9114ffac07a134c)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/13/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/13/)
