### PR TITLE
[Backport][1.10] Adds dataDir to ucr bridge cni configuration

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -930,6 +930,7 @@ entry = {
         'ui_banner_footer_content': 'null',
         'ui_banner_image_path': 'null',
         'ui_banner_dismissible': 'null',
+        'dcos_cni_data_dir': '/var/run/dcos/cni/networks',
         'dcos_overlay_config_attempts': '4',
         'dcos_overlay_mtu': '1420',
         'dcos_overlay_enable': "true",

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -248,7 +248,7 @@ def calculate_use_mesos_hooks(mesos_hooks):
         return "true"
 
 
-def validate_network_default_name(dcos_overlay_network_default_name, dcos_overlay_network):
+def validate_network_default_name(overlay_network_default_name, dcos_overlay_network):
     try:
         overlay_network = json.loads(dcos_overlay_network)
     except ValueError as ex:
@@ -256,9 +256,9 @@ def validate_network_default_name(dcos_overlay_network_default_name, dcos_overla
 
     overlay_names = map(lambda overlay: overlay['name'], overlay_network['overlays'])
 
-    assert dcos_overlay_network_default_name in overlay_names, (
+    assert overlay_network_default_name in overlay_names, (
         "Default overlay network name does not reference a defined overlay network: {}".format(
-            dcos_overlay_network_default_name))
+            overlay_network_default_name))
 
 
 def validate_dcos_ucr_default_bridge_subnet(dcos_ucr_default_bridge_subnet):
@@ -944,6 +944,7 @@ entry = {
             }]
         }),
         'dcos_overlay_network_default_name': __dcos_overlay_network_default_name,
+        'dcos_ucr_default_bridge_network_name': 'mesos-bridge',
         'dcos_ucr_default_bridge_subnet': '172.31.254.0/24',
         'dcos_remove_dockercfg_enable': "false",
         'minuteman_min_named_ip': '11.0.0.0',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -148,6 +148,7 @@ package:
           "hairpinMode": true,
           "ipam": {
             "type": "host-local",
+            "dataDir": "{{ dcos_cni_data_dir }}",
             "subnet": "{{ dcos_ucr_default_bridge_subnet }}",
             "routes": [
             { "dst":
@@ -160,6 +161,7 @@ package:
     content: |
       {
         "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
+        "cni_data_dir": "{{ dcos_cni_data_dir }}",
         "network_config":
         {
           "allocate_subnet": true,
@@ -173,6 +175,7 @@ package:
     content: |
       {
         "cni_dir":"/opt/mesosphere/etc/dcos/network/cni",
+        "cni_data_dir": "{{ dcos_cni_data_dir }}",
         "network_config" :
         {
           "allocate_subnet": true,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -126,6 +126,14 @@ package:
           ]
         }
       ].
+  - path: /etc/dcos-cni-networks
+    content: |
+      {
+        "names": [
+            "{{ dcos_overlay_network_default_name }}",
+            "{{ dcos_ucr_default_bridge_network_name }}"
+         ]
+       }
   - path: /etc/overlay/config/master.json
     content: |
       {
@@ -135,7 +143,7 @@ package:
   - path: /etc/dcos/network/cni/ucr-default-bridge.conf
     content: |
       {
-        "name": "mesos-bridge",
+        "name": "{{ dcos_ucr_default_bridge_network_name }}",
         "type" : "mesos-cni-port-mapper",
         "excludeDevices" : ["ucr-br0"],
         "chain": "UCR-DEFAULT-BRIDGE",

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "11b2e62489dd3efe98046d06ef9fa43fb51e8d47", 
+    "ref": "5b3577ec734c866c71c70018b9d0fad67ba8aba0",
     "ref_origin": "1.10"
   }
 }

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -69,6 +69,10 @@ disk_resource_script="$PKG_PATH/bin/make_disk_resources.py"
 cp /pkg/extra/make_disk_resources.py "$disk_resource_script"
 chmod +x "$disk_resource_script"
 
+upgrade_cni_script="$PKG_PATH/bin/upgrade_cni.py"
+cp /pkg/extra/upgrade_cni.py "$upgrade_cni_script"
+chmod +x "$upgrade_cni_script"
+
 mesos_start_wrapper="$PKG_PATH/bin/start_mesos.sh"
 cp /pkg/extra/start_mesos.sh "$mesos_start_wrapper"
 chmod +x "$mesos_start_wrapper"

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -21,5 +21,6 @@ EnvironmentFile=-/run/dcos/etc/mesos-slave-public
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
+ExecStartPre=/opt/mesosphere/bin/upgrade_cni.py /var/lib/cni/networks /var/run/dcos/cni/networks /opt/mesosphere/etc/dcos-cni-networks
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
 ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -21,5 +21,6 @@ EnvironmentFile=-/run/dcos/etc/mesos-slave
 ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
+ExecStartPre=/opt/mesosphere/bin/upgrade_cni.py /var/lib/cni/networks /var/run/dcos/cni/networks /opt/mesosphere/etc/dcos-cni-networks
 ExecStartPre=/bin/bash -c 'for i in /proc/sys/net/ipv4/conf/*/rp_filter; do echo 2 > $i; echo -n "$i: "; cat $i; done'
 ExecStart=$PKG_PATH/bin/start_mesos.sh $PKG_PATH/bin/mesos-agent

--- a/packages/mesos/extra/upgrade_cni.py
+++ b/packages/mesos/extra/upgrade_cni.py
@@ -1,0 +1,45 @@
+#!/opt/mesosphere/bin/python3
+
+import json
+import os
+import shutil
+import sys
+
+
+def main(old_dir, new_dir, networks):
+    '''
+    Moves all the directories in networks from old_dir to new_dir
+
+    @type old_dir: str, old CNI directory
+    @type new_dir: str, new CNI directory
+    @type networks: list, names of the directories to move
+    '''
+    print('Upgrading CNI directory from {} to {}'.format(old_dir, new_dir))
+    for name in networks:
+        src = os.path.join(old_dir, name)
+        if not os.path.exists(src):
+            print('{} already moved'.format(src))
+        else:
+            dst = os.path.join(new_dir, name)
+            shutil.move(src, dst)
+            print('{} moved to {}'.format(src, dst))
+    print('CNI upgrade completed')
+
+
+def readfile(filename):
+    with open(filename) as f:
+        data = json.loads(f.read())
+        return [name for name in data['names']]
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 4:
+        print('Usage: ./upgrage_cni.py <old-cni-dir> <new-cni-dir> <file-with-network-names')
+        sys.exit(1)
+
+    try:
+        networks = readfile(sys.argv[3])
+        main(sys.argv[1], sys.argv[2], networks)
+    except Exception as e:
+        print('ERROR: An exception occurred while upgrading the CNI directory {}'.format(e), file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Currently, host-local ipam cni plugin uses a persistent location
on the disk as its data dir where it keeps the information about
allocated IP addresses. This leads to orphan IP addresses if
the agent reboots. This patch moves the data dir to a tmpfs location
so that all the allocated IP addresses are recycled upon agent reboot.

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3750](https://jira.mesosphere.com/browse/DCOS_OSS-3750) CNI module should store configuration on a tmpfs dir


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
