### PR TITLE
Added support for toggling the logging of offers sent by Mesos.

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -963,6 +963,7 @@ entry = {
         lambda mesos_agent_work_dir: validate_absolute_path(mesos_agent_work_dir),
         lambda licensing_enabled: validate_true_false(licensing_enabled),
         lambda enable_mesos_ipv6_discovery: validate_true_false(enable_mesos_ipv6_discovery),
+        lambda log_offers: validate_true_false(log_offers),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -1074,7 +1075,8 @@ entry = {
         'fault_domain_detect_filename': 'genconf/fault-domain-detect',
         'fault_domain_detect_contents': calculate_fault_domain_detect_contents,
         'license_key_contents': '',
-        'enable_mesos_ipv6_discovery': 'false'
+        'enable_mesos_ipv6_discovery': 'false',
+        'log_offers': 'true'
     },
     'must': {
         'fault_domain_enabled': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -492,6 +492,11 @@ package:
       GLOG_drop_log_memory=false
       LIBPROCESS_NUM_WORKER_THREADS=16
       SASL_PATH=/opt/mesosphere/lib/sasl2
+{% switch log_offers %}
+{% case "true" %}
+      GLOG_vmodule=master=2
+{% case "false" %}
+{% endswitch %}
   - path: /etc/mesos-master-provider
     content: |
       MESOS_CLUSTER={{ cluster_name }}


### PR DESCRIPTION
## High-level description

This patch adds a DC/OS configuration parameter called `log_offers`.
When this parameter is set to `true` (default value), the mesos masters
will log all offers sent to frameworks.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-38662](https://jira.mesosphere.com/browse/DCOS-38662) Make Mesos optionally log offers sent to frameworks.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Test Results: I manually tested toggling the new config option using `dcos-e2e`.
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**