### PR TITLE
gen/calc: normalize check timeouts

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -712,6 +712,15 @@ def calculate_check_config_contents(check_config, custom_checks, check_search_pa
 
 
 def calculate_check_config(check_time):
+    # We consider only two timeouts:
+    # * 1s for immediate checks (such as checking for the presence of CLI utilities).
+    # * 30s for any check which is expected to take more than 1s.
+    #
+    # The 30s value was chosen arbitrarily. It may be increased in the future as required.
+    # We chose not to use a value greater than 1min, as the checks are automatically executed
+    # in parallel every minute.
+    instant_check_timeout = "1s"
+    normal_check_timeout = "30s"
     check_config = {
         'node_checks': {
             'checks': {
@@ -719,62 +728,62 @@ def calculate_check_config(check_time):
                     'description': 'All DC/OS components are healthy.',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'master', 'components',
                             '--exclude=dcos-checks-poststart.timer,dcos-checks-poststart.service'],
-                    'timeout': '3s',
+                    'timeout': normal_check_timeout,
                     'roles': ['master']
                 },
                 'components_agent': {
                     'description': 'All DC/OS components are healthy',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'agent', 'components', '--port', '61001',
                             '--exclude=dcos-checks-poststart.service,dcos-checks-poststart.timer'],
-                    'timeout': '3s',
+                    'timeout': normal_check_timeout,
                     'roles': ['agent']
                 },
                 'xz': {
                     'description': 'The xz utility is available',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'xz'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'tar': {
                     'description': 'The tar utility is available',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'tar'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'curl': {
                     'description': 'The curl utility is available',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'curl'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'unzip': {
                     'description': 'The unzip utility is available',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'unzip'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'ifconfig': {
                     'description': 'The ifconfig utility is available',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'executable', 'ifconfig'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'ip_detect_script': {
                     'description': 'The IP detect script produces valid output',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'ip'],
-                    'timeout': '1s'
+                    'timeout': instant_check_timeout
                 },
                 'mesos_master_replog_synchronized': {
                     'description': 'The Mesos master has synchronized its replicated log',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'master', 'mesos-metrics'],
-                    'timeout': '30s',
+                    'timeout': normal_check_timeout,
                     'roles': ['master']
                 },
                 'mesos_agent_registered_with_masters': {
                     'description': 'The Mesos agent has registered with the masters',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', '--role', 'agent', 'mesos-metrics'],
-                    'timeout': '1s',
+                    'timeout': instant_check_timeout,
                     'roles': ['agent']
                 },
                 'journald_dir_permissions': {
                     'description': 'Journald directory has the right owners and permissions',
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'journald'],
-                    'timeout': '1s',
+                    'timeout': instant_check_timeout,
                 },
             },
             'prestart': [],
@@ -800,7 +809,7 @@ def calculate_check_config(check_time):
         check_config['node_checks']['checks'][clock_sync_check_name] = {
             'description': 'System clock is in sync.',
             'cmd': ['/opt/mesosphere/bin/dcos-checks', 'time'],
-            'timeout': '1s'
+            'timeout': instant_check_timeout
         }
         check_config['node_checks']['poststart'].append(clock_sync_check_name)
 


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR normalizes dcos-checks timeouts to either `1s` or `30s` depending on whether the check is supposed to succeed virtually instantly, or whether it may take a few seconds to complete. The `30s` option is taken from the fact that it is the current highest timeout and @timaa2k and I see no reason to go higher.

The associated Enterprise PR fixes a bug where the `mesos_master_replog_synchronized` never got updated from 1s to 30s due to the weird interaction between the Open and EE repositories.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-39571](https://jira.mesosphere.com/browse/DCOS-39571) dcos-checks-poststart: fix timeouts to fix flakiness


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is not a user-facing change.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Just a refactoring.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___