### PR TITLE
1.10 train2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Format of the entries must be.
 
 * L4LB unstable when something is deployed in the cluster (DCOS_OSS-3602)
 
+* Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
+
 * Root Marathon support for post-installation configuration of flags and JVM settings has been improved. (DCOS_OSS-3556)
 
 * Root Marathon heap size can be customized during installation. (DCOS_OSS-3556)

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -1,5 +1,9 @@
 client_max_body_size 1024M;
-access_log syslog:server=unix:/dev/log;
+# The syslog facility here is set to daemon because
+# systemd SyslogFacility defaults to daemon and
+# therefore all other DC/OS services log to it.
+# https://jira.mesosphere.com/browse/DCOS-38622
+access_log syslog:server=unix:/dev/log,facility=daemon;
 include mime.types;
 default_type application/octet-stream;
 sendfile on;

--- a/packages/adminrouter/extra/src/includes/main/agent.conf
+++ b/packages/adminrouter/extra/src/includes/main/agent.conf
@@ -1,0 +1,3 @@
+events {
+    worker_connections 10000;
+}

--- a/packages/adminrouter/extra/src/includes/main/common.conf
+++ b/packages/adminrouter/extra/src/includes/main/common.conf
@@ -20,10 +20,6 @@ env CACHE_MAX_AGE_HARD_LIMIT;
 env CACHE_BACKEND_REQUEST_TIMEOUT;
 env CACHE_REFRESH_LOCK_TIMEOUT;
 
-events {
-    worker_connections 1024;
-}
-
 # Run worker processes in dcos_adminrouter group to
 # restrict access to unix socket files.
 user nobody dcos_adminrouter;

--- a/packages/adminrouter/extra/src/includes/main/master.conf
+++ b/packages/adminrouter/extra/src/includes/main/master.conf
@@ -1,0 +1,3 @@
+events {
+    worker_connections 1024;
+}

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -12,7 +12,6 @@ local util = require "util"
 -- CACHE_FIRST_POLL_DELAY << CACHE_EXPIRATION < CACHE_POLL_PERIOD < CACHE_MAX_AGE_SOFT_LIMIT < CACHE_MAX_AGE_HARD_LIMIT
 --
 --
--- Before changing CACHE_POLL_PERIOD, please check the comment for resolver
 -- There are 3 requests (2xMarathon + Mesos) made to upstream components.
 -- The cache should be kept locked for the whole time until
 -- the responses are received from all the components. Therefore,
@@ -25,6 +24,7 @@ local util = require "util"
 -- 3 * (CACHE_BACKEND_REQUEST_TIMEOUT + 2). We set it to
 -- 3 * CACHE_BACKEND_REQUEST_TIMEOUT hoping that the 2 requests to Marathon and
 -- 1 request to Mesos will be done immediately one after another.
+--
 -- Before changing CACHE_POLL_INTERVAL, please check the comment for resolver
 -- statement configuration in includes/http/master.conf
 --

--- a/packages/adminrouter/extra/src/nginx.agent.conf
+++ b/packages/adminrouter/extra/src/nginx.agent.conf
@@ -1,4 +1,5 @@
 include includes/main/common.conf;
+include includes/main/agent.conf;
 include includes/main/open/common.conf;
 
 http {

--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -1,4 +1,5 @@
 include includes/main/common.conf;
+include includes/main/master.conf;
 include includes/main/open/common.conf;
 
 http {

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -3,8 +3,8 @@
     "single_source": {
         "kind": "url_extract",
         "url":
-            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.2/metronome-0.4.2.tgz",
-        "sha1": "61652afa0f1209635dcf9839f985ae5ee64486ba"
+            "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.3/metronome-0.4.3.tgz",
+        "sha1": "9105f72d3dfe2c4400772a6825f4910c54b9ef57"
     },
     "username": "dcos_metronome",
     "state_directory": true


### PR DESCRIPTION
## High-level description

Manually Created Train

* #3036  Change Adminrouter access_log logging facility to daemon [Backport 1.10] 
* #3065 [1.10] Increased the limit on worker_connections to 10K for Agent AR
* #3066 Corrected comment to keep the docs readable
* #3071 Metronome 0.4.3 bump for 1.10 



