### PR TITLE
Azure ARM templates fix DCOS_OSS_3805

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Azure ARM Template: Update the Linux SKU and Version in Azure ARM template. (DCOS_OSS-3805)
+
 * Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
 * Node and cluster checks are executed in parallel. (DCOS_OSS-2239)

--- a/gen/azure/templates/acs.json
+++ b/gen/azure/templates/acs.json
@@ -145,14 +145,14 @@
     },
     "linuxSku": {
       "type": "string",
-      "defaultValue": "16.04.0-LTS",
+      "defaultValue": "16.04-LTS",
       "metadata": {
         "description": "This is the linux sku used by the linux cluster"
       }
     },
     "linuxVersion": {
       "type": "string",
-      "defaultValue": "16.04.201606270",
+      "defaultValue": "16.04.201807240",
       "metadata": {
         "description": "This is the linux version used by the linux cluster"
       }

--- a/gen/azure/templates/azuredeploy.json
+++ b/gen/azure/templates/azuredeploy.json
@@ -75,7 +75,7 @@
     "vmSize": "Standard_A5",
     "osPublisher": "Canonical",
     "osOffer": "UbuntuServer",
-    "osSKU": "16.04.0-LTS",
+    "osSKU": "16.04-LTS",
     "osVersion": "latest",
     "vmsPerStorageAccount": 10,
     "storageAccountsCount": "[add(div(add(parameters('numberOfPrivateSlaves'),parameters('numberOfPublicSlaves')),variables('vmsPerStorageAccount')),mod(add(mod(add(parameters('numberOfPrivateSlaves'),parameters('numberOfPublicSlaves')), variables('vmsPerStorageAccount')),2), add(mod(add(parameters('numberOfPrivateSlaves'),parameters('numberOfPublicSlaves')), variables('vmsPerStorageAccount')),1)))]",


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

The ARM template that is currently available for download in DC/OS website (https://downloads.dcos.io/dcos/stable/azure.html) is using an old version of Ubuntu.

This Ubuntu version contains an old version of cloud-init, which has a bug that affects the stability of the cluster (see here - https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1686514).

 

This bug in cloud-init is fixed in newer versions of Ubuntu. The newest version available is "16.04.201807030", which is available on SKU "16.04-LTS" (and not "16.04.0-LTS").

 

This issue is opened to ask for an update to the Azure ARM template, so it will point to an Ubuntu version that is not affected by this cloud-init bug.
https://jira.mesosphere.com/browse/DCOS_OSS-3805

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3805](https://jira.mesosphere.com/browse/DCOS_OSS-3805) Update the Linux SKU and Version in Azure ARM template

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This test gets performed automatically by the teamcity integration test for ARM templates. 
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
