### PR TITLE
[1.11] Added a Mesos patch that makes it possible to enable offer logging.

### DIFF
--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,4 +1,4 @@
-From 439b92bdd91c6a83a6d5bffb8f2abefdfa824211 Mon Sep 17 00:00:00 2001
+From cd1870540fb70dfa0e5db5f9ab9bb3fbf47ddbb1 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
 Subject: [PATCH] Set LIBPROCESS_IP into docker container.
@@ -8,7 +8,7 @@ Subject: [PATCH] Set LIBPROCESS_IP into docker container.
  1 file changed, 5 insertions(+)
 
 diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
-index 1daa13f62..ad8b40b41 100644
+index 5de63f6da..97142eebc 100644
 --- a/src/docker/docker.cpp
 +++ b/src/docker/docker.cpp
 @@ -658,6 +658,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(

--- a/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,4 +1,4 @@
-From 6d478a33ec85904482bae974e43beff8d21f8ce9 Mon Sep 17 00:00:00 2001
+From f1ad107f22982873734d8d9dac743e81bb353188 Mon Sep 17 00:00:00 2001
 From: Gaston Kleiman <gaston.kleiman@gmail.com>
 Date: Mon, 9 Oct 2017 15:19:08 -0700
 Subject: [PATCH] Mesos UI: updated the URL generation to make it work with

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,4 +1,4 @@
-From 27b9f7aad8221ffdf3f7af33e291051b94874771 Mon Sep 17 00:00:00 2001
+From 0bc59bc68dc6ea9c743f23daac603da3f117c32c Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
 Subject: [PATCH] Revert "Fixed the broken metrics information of master in

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,4 +1,4 @@
-From e45fc008bef25373b8f9849e20976d9894f331fc Mon Sep 17 00:00:00 2001
+From f1da678e918ff033a2cb2b2e2c35fa225699e122 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
 Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation

--- a/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
+++ b/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
@@ -1,4 +1,4 @@
-From 27d91e1fe46f09b2c74f2dc4efe4f58ae59ae0a8 Mon Sep 17 00:00:00 2001
+From 91ffbb47d4bf34d9ac22bb942a0aeba7e23eaeeb Mon Sep 17 00:00:00 2001
 From: Benjamin Bannier <benjamin.bannier@mesosphere.io>
 Date: Tue, 20 Mar 2018 10:08:09 +0100
 Subject: [PATCH] Displayed resource provider resources in
@@ -51,7 +51,7 @@ index 3abcc1e71..93cdd7c3d 100644
  
    return OK(serialize(acceptType, evolve(response)), stringify(acceptType));
 diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
-index fb4587931..dc1939230 100644
+index 1b01427f3..bc6ca510b 100644
 --- a/src/tests/api_tests.cpp
 +++ b/src/tests/api_tests.cpp
 @@ -6144,10 +6144,10 @@ TEST_P(AgentAPITest, GetResourceProviders)

--- a/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,0 +1,77 @@
+From 738bbb470d79092f50fa048c683fd17ca2ff3181 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
+Date: Tue, 10 Jul 2018 08:06:32 -0700
+Subject: [PATCH] Improved logging for offers and inverse offers.
+
+Log offer IDs and inverse offer IDs when sending out offers and
+inverse offers so it is easier to match them to their ACCEPT or DECLINE
+calls and removals.
+
+Also log at `VLOG(2)` level which resources are offered.
+
+NOTE: It is possible to enable `VLOG(2)` logs just for `master.cpp` by
+setting the following env variable when starting the master:
+`GLOG_vmodule=master=2`.
+
+Review: https://reviews.apache.org/r/67817/
+---
+ src/master/master.cpp | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 05724f117..cc4674ced 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -8739,6 +8739,9 @@ void Master::offer(
+   // and a single allocation role.
+   ResourceOffersMessage message;
+ 
++  // We keep track of the offer IDs so that we can log them.
++  vector<OfferID> offerIds;
++
+   foreachkey (const string& role, resources) {
+     foreachpair (const SlaveID& slaveId,
+                  const Resources& offered,
+@@ -8883,6 +8886,13 @@ void Master::offer(
+       // Add the offer *AND* the corresponding slave's PID.
+       message.add_offers()->MergeFrom(offer_);
+       message.add_pids(slave->pid);
++
++      offerIds.push_back(offer_.id());
++
++      VLOG(2) << "Sending offer " << offer_.id()
++              << " containing resources " << offered
++              << " on agent " << *slave
++              << " to framework " << *framework;
+     }
+   }
+ 
+@@ -8890,8 +8900,7 @@ void Master::offer(
+     return;
+   }
+ 
+-  LOG(INFO) << "Sending " << message.offers().size()
+-            << " offers to framework " << *framework;
++  LOG(INFO) << "Sending offers " << offerIds << " to framework " << *framework;
+ 
+   framework->send(message);
+ }
+@@ -8979,8 +8988,13 @@ void Master::inverseOffer(
+     return;
+   }
+ 
+-  LOG(INFO) << "Sending " << message.inverse_offers().size()
+-            << " inverse offers to framework " << *framework;
++  vector<OfferID> inverseOfferIds;
++  foreach (const InverseOffer& inverseOffer, message.inverse_offers()) {
++    inverseOfferIds.push_back(inverseOffer.id());
++  }
++
++  LOG(INFO) << "Sending inverse offers " << inverseOfferIds << " to framework "
++            << *framework;
+ 
+   framework->send(message);
+ }
+-- 
+2.16.3
+


### PR DESCRIPTION
## High-level description

This patch adds a DC/OS configuration parameter called `log_offers`.
When this parameter is set to `true` (default value), the mesos masters
will log all offers sent to frameworks.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-38662](https://jira.mesosphere.com/browse/DCOS-38662) Make Mesos optionally log offers sent to frameworks.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Test Results: I manually tested enabling loggingusing `dcos-e2e`.
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**