### PR TITLE
Add timestamp for dmesg, distro version, timedatectl and systemd unit status to diag bundle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,8 @@ Format of the entries must be.
 
 * Fix logging of dcos-checks-poststart results to the journal. (DCOS_OSS-3804)
 
+* Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
+
 
 ### Security Updates
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -800,6 +800,11 @@ package:
                   "Role": ["master"]
               },
               {
+                  "Port": 8080,
+                  "Uri": "/v2/pods",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8181,
                   "Uri": "/exhibitor/v1/cluster/list",
                   "Role": ["master"]
@@ -923,7 +928,7 @@ package:
           ],
           "LocalCommands": [
               {
-                  "Command": ["dmesg"]
+                  "Command": ["dmesg", "-T"]
               },
               {
                   "Command": ["ip", "addr"]
@@ -939,6 +944,15 @@ package:
               },
               {
                   "Command": ["/opt/mesosphere/bin/curl", "-s", "-S", "http://localhost:62080/v1/vips"]
+              },
+              {
+                  "Command": ["timedatectl"]
+              },
+              {
+                  "Command": ["/bin/sh", "-c", "cat /etc/*-release"]
+              },
+              {
+                  "Command": ["systemctl", "list-units", "dcos*"]
               }
           ]
         }

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -508,11 +508,14 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     bundles = _get_bundle_list(dcos_api_session)
     assert bundles
 
-    expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
+    expected_common_files = ['dmesg_-T-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
                              'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz',
-                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz']
+                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz',
+                             'optmesospherebincurl_-s_-S_http:localhost:62080v1vips-5.output.gz',
+                             'timedatectl-6.output.gz', 'binsh_-c_cat etc*-release-7.output.gz',
+                             'systemctl_list-units_dcos*-8.output.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',


### PR DESCRIPTION
This is only for 1.12 OSS I will backport and do a PR for EE after this gets approved

## High-level description
Get following additional things in a diag bundle 
1) Have dmesg with human readable timestamp
2) `timedatectl` for ruling out time sync issues 
3) Get distro version to rule out untested distro bugs
4) Get DC/OS systemd unit status
5) /v2/pods marathon endpoint
 
What features does this change enable? What bugs does this change fix?
Reduced back and forth while debugging cluster issues since more data is collected in the bundle

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3861](https://jira.mesosphere.com/browse/DCOS_OSS-3861) Add more diagnostics data(e.g. timestamp for dmesg, distro version, systemd unit status etc) into the bundle


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
