### PR TITLE
1.10: Accessibility to zk is a requirement for Marathon to start

### DIFF
--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -44,6 +44,7 @@ EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment
 Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
+ExecStartPre=/bin/ping -c1 zk-1.zk
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStart=/opt/mesosphere/bin/marathon.sh
 EOF


### PR DESCRIPTION
Backport of #1690

# High Level Description

Adding Required Precondition for marathon startup

# Related Issues

- MARATHON-7390 Marathon Unable to Connect to Zookeeper - No Retries.
