### PR TITLE
1.9: Accessibility to zk is a requirement for Marathon to start

### DIFF
--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -25,6 +25,7 @@ EnvironmentFile=/opt/mesosphere/etc/marathon
 EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment.ip.marathon
 ExecStartPre=/bin/ping -c1 leader.mesos
+ExecStartPre=/bin/ping -c1 zk-1.zk
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStartPre=/bin/bash -c 'echo "HOST_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /var/lib/dcos/marathon/environment.ip.marathon'
 ExecStartPre=/bin/bash -c 'echo "MARATHON_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /var/lib/dcos/marathon/environment.ip.marathon'


### PR DESCRIPTION
Backport of #1690

# High Level Description

Adding Required Precondition for marathon startup

# Related Issues

- MARATHON-7390 Marathon Unable to Connect to Zookeeper - No Retries.
