### PR TITLE
Adding some members of the security team to `owners.json`

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -1,4 +1,5 @@
 {
+  "MatApple": {"slack": "mat", "jira": "mat"},
   "amitaekbote": {"slack": "amitaekbote", "jira": "aekbote"},
   "branden": {"slack": "branden", "jira": "branden"},
   "dgoel": {"slack": "dgoel", "jira": "dgoel"},
@@ -6,17 +7,16 @@
   "gpaul": {"slack": "gpaul", "jira": "gpaul"},
   "greggomann": {"slack": "greg", "jira": "greg"},
   "jgehrcke": {"slack": "jp", "jira": "jp"},
+  "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
   "karya0": {"slack": "kapil", "jira": "kapil"},
   "klueska": {"slack": "klueska", "jira": "klueska"},
-  "MatApple": {"slack": "mat", "jira": "mat"},
-  "mnaboka": {"slack": "mnaboka", "jira": "mnaboka"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
+  "mnaboka": {"slack": "mnaboka", "jira": "mnaboka"},
   "nLight": {"slack": "drozhkov", "jira": "drozhkov"},
   "orlandohohmeier": {"slack": "orlando", "jira": "orlando"},
   "orsenthil" : {"slack": "skumaran", "jira": "skumaran"},
   "rukletsov": {"slack": "alexr", "jira": "alexr"},
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
   "sambatyon": {"slack": "alexander", "jira": "alexander"},
-  "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
   "timaa2k": {"slack": "tweidner", "jira": "timweidner"}
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
 }

--- a/owners.json
+++ b/owners.json
@@ -15,5 +15,8 @@
   "orlandohohmeier": {"slack": "orlando", "jira": "orlando"},
   "orsenthil" : {"slack": "skumaran", "jira": "skumaran"},
   "rukletsov": {"slack": "alexr", "jira": "alexr"},
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"}
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
+  "sambatyon": {"slack": "alexander", "jira": "alexander"},
+  "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
+  "timaa2k": {"slack": "tweidner", "jira": "timweidner"}
 }

--- a/owners.json
+++ b/owners.json
@@ -1,5 +1,4 @@
 {
-  "MatApple": {"slack": "mat", "jira": "mat"},
   "amitaekbote": {"slack": "amitaekbote", "jira": "aekbote"},
   "branden": {"slack": "branden", "jira": "branden"},
   "dgoel": {"slack": "dgoel", "jira": "dgoel"},
@@ -10,6 +9,7 @@
   "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
   "karya0": {"slack": "kapil", "jira": "kapil"},
   "klueska": {"slack": "klueska", "jira": "klueska"},
+  "MatApple": {"slack": "mat", "jira": "mat"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
   "mnaboka": {"slack": "mnaboka", "jira": "mnaboka"},
   "nLight": {"slack": "drozhkov", "jira": "drozhkov"},
@@ -17,6 +17,6 @@
   "orsenthil" : {"slack": "skumaran", "jira": "skumaran"},
   "rukletsov": {"slack": "alexr", "jira": "alexr"},
   "sambatyon": {"slack": "alexander", "jira": "alexander"},
-  "timaa2k": {"slack": "tweidner", "jira": "timweidner"}
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
+  "timaa2k": {"slack": "tweidner", "jira": "timweidner"},
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"}
 }


### PR DESCRIPTION
## High-level description

The security team has been taking the responsibility of acting as shepherds to land PR's into DC/OS, however only two members of the team have ownership status, causing them to always stay involved in the shepherding of PR's, therefore this adds some extra members of the team to the owners entry so that the load can be reduced on those members with ownership.

New members are:
@sambatyon
@jongiddy 
@timaa2k 


## Corresponding DC/OS tickets (obligatory)


## Related tickets (optional)


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
