### PR TITLE
Bump telegraf version, introducing dcos related metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,3 +73,5 @@ Format of the entries must be.
 * Updated OTP version to 20.3.2 (DCOS_OSS-2378)
 
 * Updated REX-Ray version to 0.11.2 (DCOS_OSS-3597) [rexray v0.11.2](https://github.com/rexray/rexray/releases/tag/v0.11.2)
+
+* Introduced Telegraf as a DC/OS component responsible for metrics. (DCOS_OSS-3714)

--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -7,7 +7,8 @@ The following is a list of ports used by internal DC/OS services, and their corr
 ### TCP
 
  - 53: dcos-net (dns)
- - 61091: dcos-metrics
+ - 61091: dcos-telegraf
+ - 61092: dcos-metrics
  - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1219,19 +1219,19 @@ package:
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
         # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
+        mesos_agent_url = "http://$NODE_PRIVATE_IP:5051"
       # Read metrics from one or many prometheus clients
       [[inputs.prometheus]]
         # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
+        mesos_agent_url = "http://$NODE_PRIVATE_IP:5051"
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
         # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
+        mesos_agent_url = "http://$NODE_PRIVATE_IP:5051"
       # Read metrics from one or many prometheus clients
       [[inputs.prometheus]]
         # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
+        mesos_agent_url = "http://$NODE_PRIVATE_IP:5051"

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1206,9 +1206,18 @@ package:
         ## If true, compute and report the sum of all non-idle CPU states.
         report_active = false
       [[inputs.mem]]
-      # Telegraf refuses to start if no outputs are defined. This will eventually be
-      # replaced with real outputs.
-      [[outputs.discard]]
+      # Plugin for monitoring mesos container resource consumption
+      [[inputs.dcos_containers]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"
+      # Read metrics from one or many prometheus clients
+      [[inputs.prometheus]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"
+      # Configuration for the Prometheus client to spawn
+      [[outputs.prometheus_client]]
+        ## Address to listen on
+        listen = ":61091"
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1206,14 +1206,6 @@ package:
         ## If true, compute and report the sum of all non-idle CPU states.
         report_active = false
       [[inputs.mem]]
-      # Plugin for monitoring mesos container resource consumption
-      [[inputs.dcos_containers]]
-        # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
-      # Read metrics from one or many prometheus clients
-      [[inputs.prometheus]]
-        # The address of the local Mesos agent
-        mesos_agent_url = "http://$IP_ADDRESS:5051"
       # Configuration for the Prometheus client to spawn
       [[outputs.prometheus_client]]
         ## Address to listen on
@@ -1224,6 +1216,22 @@ package:
   - path: /etc_slave/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
+      # Plugin for monitoring mesos container resource consumption
+      [[inputs.dcos_containers]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"
+      # Read metrics from one or many prometheus clients
+      [[inputs.prometheus]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
+      # Plugin for monitoring mesos container resource consumption
+      [[inputs.dcos_containers]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"
+      # Read metrics from one or many prometheus clients
+      [[inputs.prometheus]]
+        # The address of the local Mesos agent
+        mesos_agent_url = "http://$IP_ADDRESS:5051"

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -3,7 +3,7 @@ package:
     content: |
       producers:
         prometheus:
-          port: 61091
+          port: 61092
   - path: /etc/dcos-metrics.env
     content: |
       DCOS_METRICS_CONFIG_PATH=/opt/mesosphere/etc/dcos-metrics-config.yaml

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/telegraf.git",
-    "ref": "93c9a2333c72ad8a95d39c6e0d10613337335455",
+    "ref": "9748e22a5879fe08ced230130b32822bcbe2b2f7",
     "ref_origin": "1.7.2-dcos-dev"
   },
   "username": "dcos_telegraf"

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/mesosphere/telegraf.git",
-    "ref": "23dcbd617340213a1269c7d95f45ba5a0a90de3f",
-    "ref_origin": "1.7.2-dcos"
+    "ref": "93c9a2333c72ad8a95d39c6e0d10613337335455",
+    "ref_origin": "1.7.2-dcos-dev"
   },
   "username": "dcos_telegraf"
 }

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -16,7 +16,7 @@ cluster_id="$(cat ${cluster_id_file})"
 export DCOS_CLUSTER_ID="${cluster_id}"
 
 # Export the IP address
-export IP_ADDRESS="$(/opt/mesosphere/bin/detect_ip)"
+export NODE_PRIVATE_IP="$(/opt/mesosphere/bin/detect_ip)"
 
 # Start telegraf.
 exec /opt/mesosphere/bin/telegraf "$@"

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -15,5 +15,8 @@ cluster_id="$(cat ${cluster_id_file})"
 # Export the cluster ID to an env var so telegraf config can reference it.
 export DCOS_CLUSTER_ID="${cluster_id}"
 
+# Export the IP address
+export IP_ADDRESS="$(/opt/mesosphere/bin/detect_ip)"
+
 # Start telegraf.
 exec /opt/mesosphere/bin/telegraf "$@"


### PR DESCRIPTION
## High-level description

This PR bumps telegraf to include two custom input plugins, a prometheus output, and related configuration. It builds on top of #3120. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3716](https://jira.mesosphere.com/browse/DCOS_OSS-3716) Write a Telegraf input plugin to get data for each container
 - [DCOS_OSS-3717](https://jira.mesosphere.com/browse/DCOS_OSS-3717) Add Mesos service discovery to the Telegraf prometheus metrics input plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/mesosphere/telegraf/23dcbd617340213a1269c7d95f45ba5a0a90de3f...93c9a2333c72ad8a95d39c6e0d10613337335455)
  - [ ] Test Results: [link to CI job test results for component] (CI is not yet set up)
  - [ ] Code Coverage (if available): [link to code coverage report] (CI is not yet set up)
