### PR TITLE
chore(dcos-ui): bump DC/OS UI v2.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,8 @@ Format of the entries must be.
 
 * Mesos now uses the jemalloc memory profiler by default. (DCOS_OSS-2137)
 
+* Updated DC/OS UI to master+v2.3.0 [Changelog](https://github.com/dcos/dcos-ui/releases)
+
 * Replaced the dcos-diagnostics check runner with dcos-check-runner. (DCOS_OSS-3491)
 
 * Removed the DC/OS web installer. (DCOS_OSS-2256)

--- a/packages/dcos-ui/build
+++ b/packages/dcos-ui/build
@@ -1,17 +1,3 @@
 #!/bin/bash
 
-cd "/pkg/src/dcos-ui"
-
-npm install -g npm@3.9.1
-
-# Run npm install with `unsafe-perm` flag to run install scripts with root
-# privileges. Without those privileges the installation will fail to write some
-# of the dependencies with the correct user/permissions.
-npm --unsafe-perm install
-
-echo "module.exports = {};" > ./src/js/config/Config.dev.js
-npm run scaffold
-
-npm run build
-
-cp -r dist/ "$PKG_PATH"/usr
+cp -r "/pkg/src/dcos-ui" "$PKG_PATH"/usr/

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -1,9 +1,7 @@
 {
-  "docker": "node:4.4.4",
   "single_source": {
-    "kind": "git",
-    "git": "https://github.com/dcos/dcos-ui.git",
-    "ref": "57553a6be1d9fc07a7153dc8df5c338f1c1e6890",
-    "ref_origin": "v1.12.0-rc.1"
+    "kind": "url_extract",
+    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.3.0.tar.gz",
+    "sha1": "bdf48d7789a1febfb215e66ab962d16f78d9fc21"
   }
 }


### PR DESCRIPTION
## High-level description

This PR updates DC/OS UI to version `master+v2.3.0` previous release was `v1.12.0-rc.1`. we changed the way we integrate into DC/OS between these changes, which is the reason for the new version number.

included in this bump is everything between these tags: 
https://github.com/dcos/dcos-ui/compare/v1.12.0-rc.1...master+v2.3.0

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS_OSS-1550](https://jira.mesosphere.com/browse/DCOS_OSS-1550) - enable service endpoints on ucr
- [DCOS_OSS-1563](https://jira.mesosphere.com/browse/DCOS_OSS-1563) - Update npm
- [DCOS_OSS-1564](https://jira.mesosphere.com/browse/DCOS_OSS-1564) - Update webpack
- [DCOS_OSS-2185](https://jira.mesosphere.com/browse/DCOS_OSS-2185) - Update jest
- [DCOS_OSS-2186](https://jira.mesosphere.com/browse/DCOS_OSS-2186) - Update node
- [DCOS_OSS-2190](https://jira.mesosphere.com/browse/DCOS_OSS-2190) - Check if we need every dependencies we have
- [DCOS_OSS-2206](https://jira.mesosphere.com/browse/DCOS_OSS-2206) - add enzyme for testing renders
- [DCOS_OSS-2233](https://jira.mesosphere.com/browse/DCOS_OSS-2233) - Migrate plugins/services tests to use enzyme
- [DCOS_OSS-2243](https://jira.mesosphere.com/browse/DCOS_OSS-2243) - remove misleading endpoints row from config table
- [DCOS_OSS-2244](https://jira.mesosphere.com/browse/DCOS_OSS-2244) - Implement IP Addresses in Task Detail Config Table
- [DCOS_OSS-2340](https://jira.mesosphere.com/browse/DCOS_OSS-2340) - Nodes detail doesn't load
- [DCOS_OSS-2355](https://jira.mesosphere.com/browse/DCOS_OSS-2355) - When visiting an unknown service a 404 page should be rendered
- [DCOS_OSS-3582](https://jira.mesosphere.com/browse/DCOS_OSS-3582) - update prettier, eslint-plugin-prettier and tslint-config in dcos-ui
- [DCOS-19586](https://jira.mesosphere.com/browse/DCOS-19586) - Update Volume Table and volume detail for pods
- [DCOS-19740](https://jira.mesosphere.com/browse/DCOS-19740) - Framework json-schema validation errors
- [DCOS-19913](https://jira.mesosphere.com/browse/DCOS-19913) - Package name and version missing from UI Service Configuration
- [DCOS-20258](https://jira.mesosphere.com/browse/DCOS-20258) - Pod review screen does not contain the right information
- [DCOS-20949](https://jira.mesosphere.com/browse/DCOS-20949) - JSON editor review screen is broken
- [DCOS-21181](https://jira.mesosphere.com/browse/DCOS-21181) - Update service collection filters to match new service statuses
- [DCOS-21190](https://jira.mesosphere.com/browse/DCOS-21190) - Remove "N/A" from group status
- [DCOS-21266](https://jira.mesosphere.com/browse/DCOS-21266) - Switching files in the UI does not work correctly
- [DCOS-21305](https://jira.mesosphere.com/browse/DCOS-21305) - respect minDcosReleaseVersion
- [DCOS-21335](https://jira.mesosphere.com/browse/DCOS-21335) - Open/Update Standing DC/OS UI PR
- [DCOS-21337](https://jira.mesosphere.com/browse/DCOS-21337) - MesosStream should reconnect on Javascript error
- [DCOS-21359](https://jira.mesosphere.com/browse/DCOS-21359) - Cannot get property `getId` of undefined
- [DCOS-21366](https://jira.mesosphere.com/browse/DCOS-21366) - Time column loose wrap makes rows jump
- [DCOS-21367](https://jira.mesosphere.com/browse/DCOS-21367) - Cannot convert undefined or null to object
- [DCOS-21369](https://jira.mesosphere.com/browse/DCOS-21369) - fix(TasksView): fix undefined service in TasksView
- [DCOS-21370](https://jira.mesosphere.com/browse/DCOS-21370) - check if node exists before relying on it
- [DCOS-21440](https://jira.mesosphere.com/browse/DCOS-21440) - COPS-2661 affecting dcos-ui: DCOS UI does not recognize VIP_0 label
- [DCOS-21469](https://jira.mesosphere.com/browse/DCOS-21469) - Implement IP Addresses in Task Detail Config Table
- [DCOS-21520](https://jira.mesosphere.com/browse/DCOS-21520) - check node version on checkout
- [DCOS-21571](https://jira.mesosphere.com/browse/DCOS-21571) - Update moment to 2.19.3 (CVE-2017-18214)
- [DCOS-21574](https://jira.mesosphere.com/browse/DCOS-21574) - align documentation & comments for the new node version
- [DCOS-21612](https://jira.mesosphere.com/browse/DCOS-21612) - Use badge component in DCOS UI
- [DCOS-21614](https://jira.mesosphere.com/browse/DCOS-21614) - always show cosmos services in json-schema form UI
- [DCOS-21640](https://jira.mesosphere.com/browse/DCOS-21640) - Adapt the data source of Settings > Package to streams
- [DCOS-21701](https://jira.mesosphere.com/browse/DCOS-21701) - Reconnect to the MesosStream if it closes the connection.
- [DCOS-21723](https://jira.mesosphere.com/browse/DCOS-21723) - DCOS UI should start showing allocated resources for frameworks
- [DCOS-21766](https://jira.mesosphere.com/browse/DCOS-21766) - fix release file name
- [DCOS-21784](https://jira.mesosphere.com/browse/DCOS-21784) - Adjust event emitter to prevent upstream error propagation
- [DCOS-21798](https://jira.mesosphere.com/browse/DCOS-21798) - Uncaught TypeError: Cannot read property 'getLabels' of undefined / After Page Reload
- [DCOS-21845](https://jira.mesosphere.com/browse/DCOS-21845) - Improve inline-bootstrap-css
- [DCOS-21846](https://jira.mesosphere.com/browse/DCOS-21846) - Stop webpack from opening the browser when starting
- [DCOS-21847](https://jira.mesosphere.com/browse/DCOS-21847) - Impossible to cancel subshells in npm scripts with `ctrl+c`
- [DCOS-21896](https://jira.mesosphere.com/browse/DCOS-21896) - Upgrade Cypress to 2.1.0
- [DCOS-21921](https://jira.mesosphere.com/browse/DCOS-21921) - use standard-version for releases (OSS)
- [DCOS-21928](https://jira.mesosphere.com/browse/DCOS-21928) - Investigate increased flakyness
- [DCOS-21931](https://jira.mesosphere.com/browse/DCOS-21931) - Dashboard
- [DCOS-21932](https://jira.mesosphere.com/browse/DCOS-21932) - Services
- [DCOS-21933](https://jira.mesosphere.com/browse/DCOS-21933) - Services Tasks
- [DCOS-21935](https://jira.mesosphere.com/browse/DCOS-21935) - Services Debug
- [DCOS-21989](https://jira.mesosphere.com/browse/DCOS-21989) - COPS-3068 affecting dcos-ui: Link on GUI is empty when oAuth is disabled (see screenshot)
- [DCOS-22072](https://jira.mesosphere.com/browse/DCOS-22072) - Implement an extension kit
- [DCOS-22127](https://jira.mesosphere.com/browse/DCOS-22127) - Text search on Nodes page
- [DCOS-22130](https://jira.mesosphere.com/browse/DCOS-22130) - [1.12] Pod volumeMounts break service view
- [DCOS-22259](https://jira.mesosphere.com/browse/DCOS-22259) - [Forward Port] DCOS-19586 volume table for pods
- [DCOS-22293](https://jira.mesosphere.com/browse/DCOS-22293) - Remove InternalStorageMixin from Sidebar.js
- [DCOS-22303](https://jira.mesosphere.com/browse/DCOS-22303) - Adjust mesos stream repeat behavior
- [DCOS-22338](https://jira.mesosphere.com/browse/DCOS-22338) - Cleanup OSS Jenkinsfile (master)
- [DCOS-22349](https://jira.mesosphere.com/browse/DCOS-22349) - Nodes List View
- [DCOS-22362](https://jira.mesosphere.com/browse/DCOS-22362) - Align dashboard graphs
- [DCOS-22393](https://jira.mesosphere.com/browse/DCOS-22393) - Prevent concurrent builds on master
- [DCOS-22402](https://jira.mesosphere.com/browse/DCOS-22402) - [master] Add privacy policy link to the login modal
- [DCOS-22406](https://jira.mesosphere.com/browse/DCOS-22406) - [master] Add privacy policy link to the "Add User" modal
- [DCOS-22414](https://jira.mesosphere.com/browse/DCOS-22414) - Dont wait for EE Pipeline on OSS master builds
- [DCOS-22443](https://jira.mesosphere.com/browse/DCOS-22443) - (Fix NodesPages) guard host.framework_ids before accessing it
- [DCOS-22444](https://jira.mesosphere.com/browse/DCOS-22444) - fix(jest): remove ignore override
- [DCOS-23826](https://jira.mesosphere.com/browse/DCOS-23826) - Always display services by share
- [DCOS-28721](https://jira.mesosphere.com/browse/DCOS-28721) - Group link in filtered results is broken
- [DCOS-28735](https://jira.mesosphere.com/browse/DCOS-28735) - Fix dcos-ui test setup when typescript is involved
- [DCOS-37474](https://jira.mesosphere.com/browse/DCOS-37474) - [master] Change MesosStateStore to apply assignSchedulerTaskField once
- [DCOS-37477](https://jira.mesosphere.com/browse/DCOS-37477) - [master] Adjust DCOSStore to cache the serviceTree and taskLookupTable
- [DCOS-37480](https://jira.mesosphere.com/browse/DCOS-37480) - [master] Adjust service structs to defer spec creation
- [DCOS-37562](https://jira.mesosphere.com/browse/DCOS-37562) - Replace deep-equal with lodash-isEqual
- [DCOS-37612](https://jira.mesosphere.com/browse/DCOS-37612) - Refactor JobMenu - JobsRun
- [DCOS-37613](https://jira.mesosphere.com/browse/DCOS-37613) - [Foundation] Adapt Jobs related requests to the data-layer
- [DCOS-37615](https://jira.mesosphere.com/browse/DCOS-37615) - Refactor Job Details Page
- [DCOS-37618](https://jira.mesosphere.com/browse/DCOS-37618) - Refactor Jobs Menu - Edit, Schedule Toggle
- [DCOS-37721](https://jira.mesosphere.com/browse/DCOS-37721) - [master] Fix Latest PR
- [DCOS-37735](https://jira.mesosphere.com/browse/DCOS-37735) - Unable to Scroll in DC/OS UI
- [DCOS-37750](https://jira.mesosphere.com/browse/DCOS-37750) - Move data logic into a container component
- [DCOS-37751](https://jira.mesosphere.com/browse/DCOS-37751) - Write mediator with GraphQL that fetches the data required for the jobs overview page
- [DCOS-37752](https://jira.mesosphere.com/browse/DCOS-37752) - Refactor UI Components to use new Mediator
- [DCOS-37791](https://jira.mesosphere.com/browse/DCOS-37791) - Connect to Mesos stream as UI loads
- [DCOS-38106](https://jira.mesosphere.com/browse/DCOS-38106) - Refactor the UI components so they only depend on props, and remove the dependency on the store
- [DCOS-38118](https://jira.mesosphere.com/browse/DCOS-38118) - Build a JobModel that covers GraphQL and Typescript typings for the Job Endpoint
- [DCOS-38119](https://jira.mesosphere.com/browse/DCOS-38119) - Create typescript type definitions
- [DCOS-38125](https://jira.mesosphere.com/browse/DCOS-38125) - Implement job detail resolver
- [DCOS-38202](https://jira.mesosphere.com/browse/DCOS-38202) - Implement mediator for JobsModalContainer
- [DCOS-38340](https://jira.mesosphere.com/browse/DCOS-38340) - [master] Unbounded memory use in the UI (Firefox)
- [DCOS-38361](https://jira.mesosphere.com/browse/DCOS-38361) - data-service types
- [DCOS-38400](https://jira.mesosphere.com/browse/DCOS-38400) - [master] Improve the Mesos stream backoff strategy
- [DCOS-38453](https://jira.mesosphere.com/browse/DCOS-38453) - Update JobModel to meet overview requirements
- [DCOS-38475](https://jira.mesosphere.com/browse/DCOS-38475) - Implement GraphQL schema for the RXjs streams
- [DCOS-38479](https://jira.mesosphere.com/browse/DCOS-38479) - Build Breadcrumb Component to use on the Job Detail Page
- [DCOS-38481](https://jira.mesosphere.com/browse/DCOS-38481) - Adapt JobDetailPage to use new Breadcrumb
- [DCOS-38482](https://jira.mesosphere.com/browse/DCOS-38482) - Adapt Job Task Page to use new Breadcrumb
- [DCOS-38483](https://jira.mesosphere.com/browse/DCOS-38483) - Adapt new Menu in Job Detail Page
- [DCOS-38484](https://jira.mesosphere.com/browse/DCOS-38484) - Move to new Job Detail Page
- [DCOS-38491](https://jira.mesosphere.com/browse/DCOS-38491) - Update Breadcrumb to fit Overview needs
- [DCOS-38709](https://jira.mesosphere.com/browse/DCOS-38709) - change Interface of `linearBackoff` helper
- [DCOS-38818](https://jira.mesosphere.com/browse/DCOS-38818) - Add new Table component from ui Kit
- [DCOS-38819](https://jira.mesosphere.com/browse/DCOS-38819) - Add Column for Name
- [DCOS-38820](https://jira.mesosphere.com/browse/DCOS-38820) - Add Column for Zone
- [DCOS-38821](https://jira.mesosphere.com/browse/DCOS-38821) - Add Column for Tasks
- [DCOS-38822](https://jira.mesosphere.com/browse/DCOS-38822) - Add two Columns for CPU
- [DCOS-38823](https://jira.mesosphere.com/browse/DCOS-38823) - Add two columns for Mem
- [DCOS-38824](https://jira.mesosphere.com/browse/DCOS-38824) - Add two Columns for Disk
- [DCOS-38825](https://jira.mesosphere.com/browse/DCOS-38825) - Add two Columns for GPU
- [DCOS-38826](https://jira.mesosphere.com/browse/DCOS-38826) - Add Column for region
- [DCOS-38827](https://jira.mesosphere.com/browse/DCOS-38827) - Add Column for Health
- [DCOS-38850](https://jira.mesosphere.com/browse/DCOS-38850) - Refactor Jobs Resolver to immediately return last known state
- [DCOS-38892](https://jira.mesosphere.com/browse/DCOS-38892) - Fix Job.scheduleStatus fieldresolver
- [DCOS-38939](https://jira.mesosphere.com/browse/DCOS-38939) - Implement System Wide (empty) Header Bar
- [DCOS-38940](https://jira.mesosphere.com/browse/DCOS-38940) - Implement User Dropdown in Header Bar
- [DCOS-38941](https://jira.mesosphere.com/browse/DCOS-38941) - Implement Cluster Dropdown in Header Bar
- [DCOS-38942](https://jira.mesosphere.com/browse/DCOS-38942) - Move Sidebar toggle into Header Bar
- [DCOS-38943](https://jira.mesosphere.com/browse/DCOS-38943) - Implement Logo in Header Bar
- [DCOS-38944](https://jira.mesosphere.com/browse/DCOS-38944) - Fix UI Issues (if present) and implement truncation of Dropdown Text
- [DCOS-39067](https://jira.mesosphere.com/browse/DCOS-39067) - Add correct sort Icon
- [DCOS-39069](https://jira.mesosphere.com/browse/DCOS-39069) - Use HeaderCell from UI Kit in Table Headers
- [DCOS-39074](https://jira.mesosphere.com/browse/DCOS-39074) - Move HeaderBar Component to correct place in dcos-ui
- [DCOS-39112](https://jira.mesosphere.com/browse/DCOS-39112) - Fix compareValues
- [DCOS-39158](https://jira.mesosphere.com/browse/DCOS-39158) - "Agents Table": Add Type Column
- [DCOS-39262](https://jira.mesosphere.com/browse/DCOS-39262) - Tidy up & enable new Nodestable Component	
- [DCOS-39265](https://jira.mesosphere.com/browse/DCOS-39265) - Use Cell from UI Kit for the content of the tables
- [DCOS-39297](https://jira.mesosphere.com/browse/DCOS-39297) - Fix UI Kit release (Again)
- [DCOS-39331](https://jira.mesosphere.com/browse/DCOS-39331) - Add type information to Node struct
- [DCOS-39457](https://jira.mesosphere.com/browse/DCOS-39457) - Implement Navigation to Dashboard via Header Bar Logo
- [DCOS-39654](https://jira.mesosphere.com/browse/DCOS-39654) - Refactor Sidebar toggle
- [DCOS-39663](https://jira.mesosphere.com/browse/DCOS-39663) - [master] COPS-3051 affecting marathon-lb: Marathon-LB Debug page no longer shows deployment problems
- [DCOS-39679](https://jira.mesosphere.com/browse/DCOS-39679) - Implement Authenticated Cluster Dropdown
- [DCOS-39862](https://jira.mesosphere.com/browse/DCOS-39862) - SortableColumnIcon lacks hover status
- [DCOS-39901](https://jira.mesosphere.com/browse/DCOS-39901) - With a long list of nodes only the first two are shown and the others are scrolled




## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
