### PR TITLE
bump metronome on dcos 1.12 to 0.5.0

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.2/metronome-0.4.2.tgz",
-    "sha1": "61652afa0f1209635dcf9839f985ae5ee64486ba"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.5.0/metronome-0.5.0.tgz",
+    "sha1": "b2c3b5c2ad4bfc45da82cc13538c23c483d05062"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3897](https://jira.mesosphere.com/browse/DCOS_OSS-3897) Upgrade Metronome to 0.5.0 on DCOS 1.12.


## Related tickets (optional)

Other tickets related to this change:

  - [METRONOME-246](https://jira.mesosphere.com/browse/METRONOME-246) Support Secrets.
  - [METRONOME-238](https://jira.mesosphere.com/browse/METRONOME-238) Migrate from joda time to Java time.
  - [METRONOME-218](https://jira.mesosphere.com/browse/METRONOME-218) Better handling of errors with zk storage.
  -  Large move to the latest Marathon 1.6 as a library



## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/v0.4.1...v0.5.0)
  - [x] Test Results: [CI/Test](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/42/)
  - [x] Code Coverage (if available): N/A
