### PR TITLE
Enable human readable timestamp in dmesg.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* dcos-diagnostics capture `dmesg` with human readable timestamps. (DCOS_OSS-1020)
+
 * Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
 * Node and cluster checks are executed in parallel. (DCOS_OSS-2239)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -875,7 +875,7 @@ package:
           ],
           "LocalCommands": [
               {
-                  "Command": ["dmesg"]
+                  "Command": ["dmesg", "-T"]
               },
               {
                   "Command": ["ip", "addr"]


### PR DESCRIPTION
From dmesg(1):

```
-T, --ctime
          Print human-readable timestamps.

          Be aware that the timestamp could be inaccurate!  The time
          source used for the logs is not updated after system
          SUSPEND/RESUME.
```

  - [DCOS_OSS-1020](https://jira.mesosphere.com/browse/DCOS_OSS-1020) Make dmesg output timestamps in diagnostic bundle human readable.