### PR TITLE
Add information to diagnostics bundle

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -836,6 +836,11 @@ package:
                   "Port": 5051,
                   "Uri": "/overlay-agent/overlay",
                   "Role": ["agent", "agent_public"]
+              },
+              {
+                  "Port": 5051,
+                  "Uri": "/containers",
+                  "Role": ["agent", "agent_public"]
               }
           ],
           "LocalFiles": [

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -728,6 +728,11 @@ package:
                   "Role": ["master"]
               },
               {
+                  "Port": 5050,
+                  "Uri": "/quota",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8080,
                   "Uri": "/metrics",
                   "Role": ["master"]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -894,6 +894,9 @@ package:
                   "Command": ["ifconfig", "-a"]
               },
               {
+                  "Command": ["ps", "aux", "ww"]
+              },
+              {
                   "Command": ["/opt/mesosphere/bin/curl", "-s", "-S", "http://localhost:62080/v1/vips"]
               }
           ]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -878,6 +878,15 @@ package:
               },
               {
                   "Location": "/proc/net/fib_trie"
+              },
+              {
+                  "Location": "/proc/cmdline"
+              },
+              {
+                  "Location": "/proc/cpuinfo"
+              },
+              {
+                  "Location": "/proc/meminfo"
               }
           ],
           "LocalCommands": [

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -516,13 +516,18 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',
-                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz'] + expected_common_files
+                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz', '5050-quota.json'
+                             ] + expected_common_files
+
+    expected_agent_common_files = ['5051-containers.json']
 
     # for agent host
-    expected_agent_files = ['dcos-mesos-slave.service.gz', '5051-containers.json'] + expected_common_files
+    expected_agent_files = ['dcos-mesos-slave.service.gz'
+                            ] + expected_agent_common_files + expected_common_files
 
     # for public agent host
-    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'] + expected_common_files
+    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'
+                                   ] + expected_agent_common_files + expected_common_files
 
     def _read_from_zip(z: zipfile.ZipFile, item: str, to_json=True):
         # raises KeyError if item is not in zipfile.

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -511,7 +511,8 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz']
+                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz',
+                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -518,7 +518,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                              'var/lib/dcos/exhibitor/conf/zoo.cfg.gz'] + expected_common_files
 
     # for agent host
-    expected_agent_files = ['dcos-mesos-slave.service.gz'] + expected_common_files
+    expected_agent_files = ['dcos-mesos-slave.service.gz', '5051-containers.json'] + expected_common_files
 
     # for public agent host
     expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'] + expected_common_files

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -511,7 +511,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz']
+                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',


### PR DESCRIPTION
This PR adds folowing information to diagnostics bundle

* [`/quota`](http://mesos.apache.org/documentation/latest/endpoints/master/quota/)
* [`/containers`](http://mesos.apache.org/documentation/latest/endpoints/slave/containers/)
* [`/proc/[cmdline|cpuinfo|meminfo]`](http://man7.org/linux/man-pages/man5/proc.5.html) – additional hardware infro
* [`ps aux www`](http://man7.org/linux/man-pages/man1/ps.1.html) – lists all proceses with wide information about them