### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 8a1bd29

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "95c2d1dd95bd848d15c687fb8b31b6ba52e1ac25", 
+    "ref": "2ad4a4156614ca6dd096b23fbebaf3a915836f0d", 
     "ref_origin": "1.11"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/apache/mesos", 
-    "ref": "74a6f3cdb8206b41f96e1ebf5981783ea999c250", 
+    "ref": "8a1bd29e9ff862fc7e1563ddf4df42c9e30e5acc", 
     "ref_origin": "1.5.x"
   }, 
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/74a6f3cdb8206b41f96e1ebf5981783ea999c250...8a1bd29e9ff862fc7e1563ddf4df42c9e30e5acc
    https://github.com/dcos/dcos-mesos-modules/compare/95c2d1dd95bd848d15c687fb8b31b6ba52e1ac25...2ad4a4156614ca6dd096b23fbebaf3a915836f0d
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
