### PR TITLE
Cleanup python versioning

### DIFF
--- a/pkgpanda/test_resources/opt/mesosphere/packages/pkg1--12345/check/hello_world_ok.py
+++ b/pkgpanda/test_resources/opt/mesosphere/packages/pkg1--12345/check/hello_world_ok.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 print('Hello World')
 assert 1 == 1

--- a/pkgpanda/test_resources/opt/mesosphere/packages/pkg2--12345/check/failed_check.py
+++ b/pkgpanda/test_resources/opt/mesosphere/packages/pkg2--12345/check/failed_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 print('I exist to fail...')
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,24 +26,15 @@ testpaths =
   ssh
   test_util
 
-[testenv:py35-syntax]
-platform=linux|darwin
+[testenv:py3-syntax]
+platform=linux|darwin|win32
 passenv =
     TEAMCITY_VERSION
 commands =
   pip install -e flake8_dcos_lint
   flake8 --verbose
 
-[testenv:py36-syntax-win32]
-platform=win32
-passenv =
-    TEAMCITY_VERSION
-commands =
-  pip install -e flake8_dcos_lint
-  flake8 --verbose
-
-
-[testenv:py35-unittests]
+[testenv:py3-unittests]
 platform=linux|darwin
 # See the following link for AWS_* environment variables:
 # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
@@ -63,7 +54,6 @@ passenv =
 deps =
   dnspython
   pytest==3.3.2
-  pytest-catchlog==1.2.2
   PyYAML
   webtest
   webtest-aiohttp==1.1.0
@@ -71,7 +61,7 @@ deps =
 commands=
   pytest --basetemp={envtmpdir} {posargs}
 
-[testenv:py36-unittests-win32]
+[testenv:py3-unittests-win32]
 platform=win32
 testpaths =
   dcos_installer
@@ -97,7 +87,6 @@ deps =
   dnspython
   teamcity-messages
   pytest==3.3.2
-  pytest-catchlog==1.2.2
   PyYAML
   webtest
   webtest-aiohttp==1.1.0
@@ -108,7 +97,7 @@ commands=
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a
 # specific working directory (something that should be fixed).
-[testenv:py35-pkgpanda-build]
+[testenv:py3-pkgpanda-build]
 platform=linux|darwin
 passenv =
   TEAMCITY_VERSION
@@ -120,7 +109,7 @@ changedir=pkgpanda/build/tests
 commands=
   pytest --basetemp={envtmpdir} {posargs} build_integration_test.py
 
-[testenv:py36-pkgpanda-build-win32]
+[testenv:py3-pkgpanda-build-win32]
 platform=win32
 passenv =
   TEAMCITY_VERSION
@@ -133,19 +122,8 @@ commands=
   py.test --basetemp={envtmpdir} {posargs} build_integration_test.py
 
 
-[testenv:py35-bootstrap]
-platform=linux|darwin
-passenv =
-  TEAMCITY_VERSION
-deps=
-  pytest==3.3.2
-changedir=packages/bootstrap/extra
-commands=
-  pip install .
-  pytest --basetemp={envtmpdir} {posargs}
-  
-[testenv:py36-bootstrap-win32]
-platform=win32
+[testenv:py3-bootstrap]
+platform=linux|darwin|win32
 passenv =
   TEAMCITY_VERSION
 deps=


### PR DESCRIPTION
It looks like we are inconsistent about Python version used in Windows and Linux. This PR changes all usages of explicit version 3.5 or 3.6 or just 3.

This also fixes problem on Ubuntu 18.04 where there is no `/usr/bin/python` that causes tests to break.