### PR TITLE
Remove duplicated code in dcos diagnostics test

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -598,9 +598,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(master_folder + 'dcos-mesos-master.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_master_file in expected_master_files:
-                    expected_file = master_folder + expected_master_file
-                    assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
+                verify_archived_items(master_folder, archived_items, expected_master_files)
 
             # make sure all required log files for agent node are in place.
             for slave_ip in dcos_api_session.slaves:
@@ -615,9 +613,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(agent_folder + 'dcos-mesos-slave.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_agent_file in expected_agent_files:
-                    expected_file = agent_folder + expected_agent_file
-                    assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
+                verify_archived_items(agent_folder, archived_items, expected_agent_files)
 
             # make sure all required log files for public agent node are in place.
             for public_slave_ip in dcos_api_session.public_slaves:
@@ -632,9 +628,13 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(agent_public_folder + 'dcos-mesos-slave-public.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_public_agent_file in expected_public_agent_files:
-                    expected_file = agent_public_folder + expected_public_agent_file
-                    assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+                verify_archived_items(agent_public_folder, archived_items, expected_public_agent_files)
+
+
+def verify_archived_items(folder, archived_items, expected_files):
+    for expected_file in expected_files:
+        expected_file = folder + expected_file
+        assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
 
 
 def test_bundle_delete(dcos_api_session):


### PR DESCRIPTION
Extract common code responsible for searching expected files
in diagnostic bundle to a function `verify_archived_items`.