### PR TITLE
[1.11] packages/java: Update Java to 8u181 version

### DIFF
--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.io/java/jdk-8u152-linux-x64.tar.gz",
-      "sha1": "1a3c0f86fcfdec6156f8256c87fbdcc04caea242"
+      "url": "https://downloads.mesosphere.io/java/jdk-8u181-linux-x64.tar.gz",
+      "sha1": "35e4a57f20cfa06a9731674810731d442641cf1e"
     }
   },
   "environment": {


### PR DESCRIPTION
Backport of https://github.com/dcos/dcos/pull/3224

## High-level description

Update java to version 1.8.0_181 which includes security updates.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3932](https://jira.mesosphere.com/browse/DCOS_OSS-3932) [1.11] packages/java: Update java to version 1.8.0_181

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]