### PR TITLE
bumping marathon to 1.6.537

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.352-044939181/marathon-1.6.352-044939181.tgz",
-    "sha1": "2c9e0136a3bc59c8f243230efc96c2c653500d0b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.537-f1482264a/marathon-1.6.537-f1482264a.tgz",
+    "sha1": "082ff896f4072b10a29f017bca9b6f71fafeef23"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8354](https://jira.mesosphere.com/browse/MARATHON-8354) Bump Marathon 1.6.537 on DCOS 1.12.


## Related tickets (optional)

Other tickets related to this change:

  - [MARATHON-8309](https://jira.mesosphere.com/browse/MARATHON-8309) Optional Suppression.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/044939181...f1482264a)
  - [x] Test Results: [ci](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.6/8/)
  - [x] Code Coverage (if available): N/A
