### PR TITLE
[Backport 1.11] bump cni plugins version to v0.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## DC/OS 1.11.5
+
+
+### Notable changes
+
+
+### Fixed and improved
+
+* Fixed Docker isolation iptables rule reversal on reboot. (DCOS_OSS-3697)
+
+* Updated CNI plugins to v0.7.1. (DCOS_OSS-3841)
+
+
 ## DC/OS 1.11.4
 
 

--- a/packages/cni/buildinfo.json
+++ b/packages/cni/buildinfo.json
@@ -3,7 +3,7 @@
     "single_source" : {
       "kind": "git",
       "git": "https://github.com/containernetworking/plugins.git",
-      "ref" : "5544d9ced0d6e908fe26e9dbe529c7feb87d21f5",
+      "ref" : "72b62babeeb3d7b25c9809ea9eb9fc9c02cc0f71",
       "ref_origin": "master"
     }
 }


### PR DESCRIPTION
## High-level description

1. Bump cni plugin version to v0.7.1 (latest cni plugin release)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  -  [DCOS_OSS-3841](https://jira.mesosphere.com/browse/DCOS_OSS-3841) Update CNI plugins to latest release

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-40162](https://jira.mesosphere.com/browse/DCOS-40162) CNI bridge plugin DEL might fail

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example]
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
