### PR TITLE
[Backport 1.10] Add bootstrap ip-detect check for static backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,5 @@
 ## DC/OS 1.10.9
 
-* Updated to [DC/OS UI 1.10.9-rc.1](https://github.com/dcos/dcos-ui/releases/tag/v1.10.9-rc.1)
-
-## DC/OS 1.10.8
-
 ```
 * For any significant improvement to DC/OS add an entry to Fixed and Improved section.
 * For Security updates, please call out in Security updates section.
@@ -16,6 +12,21 @@ Format of the entries must be.
 <new-line>
 * Entry two with no-newlines. (DCOS_OSS_JIRA_2)
 ```
+
+### Notable changes
+
+* Updated to [DC/OS UI 1.10.9-rc.1](https://github.com/dcos/dcos-ui/releases/tag/v1.10.9-rc.1)
+
+
+### Fixed and improved
+
+* Consolidated Exhibitor startup script to abort when the IP address returned by 'ip-detect' is not contained in the known master IP address list. This fixes issues arising from transient errors in the 'ip-detect' script. (COPS-3195)
+
+### Security Updates
+
+
+## DC/OS 1.10.8
+
 
 ### Notable changes
 


### PR DESCRIPTION
## High-level description

Backport of #3209 

This PR aims to exit the bootstrap on a static Exhibitor backend if the IP returned by the ip-detect script does not match any of the IPs configured in the config.yaml master list.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3938](https://jira.mesosphere.com/browse/DCOS_OSS-3938) Static Exhibitor backend bootstrap check: IP returned by ip-detect is contained in configured master list.


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-3485](https://jira.mesosphere.com/browse/COPS-3485) Exhibitor start script accepts invalid ip address for hostname resulting in loss of zookeeper myid cfg file.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
This was tested manually using dcos-e2e with a valid and invalid custom ip-detect script.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
___