### PR TITLE
Implement bootstrap methods for telegraf

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -45,6 +45,16 @@ def dcos_metrics_agent(b, opts):
 
 
 @check_root
+def dcos_telegraf_master(b, opts):
+    b.cluster_id('/var/lib/dcos/cluster-id')
+
+
+@check_root
+def dcos_telegraf_agent(b, opts):
+    b.cluster_id('/var/lib/dcos/cluster-id', readonly=True)
+
+
+@check_root
 def dcos_oauth(b, opts):
     b.generate_oauth_secret('/var/lib/dcos/dcos-oauth/auth-token-secret')
 
@@ -72,8 +82,8 @@ bootstrappers = {
     'dcos-history': noop,
     'dcos-mesos-dns': noop,
     'dcos-net': noop,
-    'dcos-telegraf-master': noop,
-    'dcos-telegraf-agent': noop,
+    'dcos-telegraf-master': dcos_telegraf_master,
+    'dcos-telegraf-agent': dcos_telegraf_agent,
 }
 
 


### PR DESCRIPTION
DC/OS Telegraf needs the `/var/lib/dcos/cluster-id` file in order to start. Without this, if no other service is creating the `cluster-id` file, the service will just continuously restart.

Usually one does not see any issues if they have `dcos-metrics` enabled. Since `dcos-metrics` service is not mandatory we need the following fix so `dcos-telegraf` service can be able to start.

## High-level description

Fix bug for DC/OS Telegraf.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3947](https://jira.mesosphere.com/browse/DCOS_OSS-3947) DC/OS Telegraf missing bootstrap action.

## Checklist for the PR

  - [x] Implement bootstrap methods for `dcos-telegraf-master` and `dcos-telegraf-agent`
  - [x] Add condition for `/var/lib/dcos/cluster-id` file existence to the Telegraf systemd service file 
