### PR TITLE
Marathon Maintenance mode on by default for DCOS

### DIFF
--- a/packages/marathon/extra/marathon.sh
+++ b/packages/marathon/extra/marathon.sh
@@ -9,7 +9,7 @@ export LIBPROCESS_IP=$($MESOS_IP_DISCOVERY_COMMAND)
 : ${MARATHON_MAX_INSTANCES_PER_OFFER=100}
 : ${MARATHON_TASK_LAUNCH_TIMEOUT=86400000}
 : ${MARATHON_DECLINE_OFFER_DURATION=300000}
-: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources"}
+: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources,maintenance_mode"}
 : ${MARATHON_MESOS_AUTHENTICATION_PRINCIPAL="dcos_marathon"}
 : ${MARATHON_MESOS_USER="root"}
 


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8361](https://jira.mesosphere.com/browse/MARATHON-8361) Enable support for Mesos maintenance mode by default.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A
  - [x] Test Results: [N/A
  - [x] Code Coverage (if available): N/A
