### PR TITLE
[1.10] Prevent dcos-history leaking auth tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ Format of the entries must be.
 
 ### Security Updates
 
+* Prevent dcos-history leaking auth tokens (DCOS-40373)
+
 * Update Java to 8u181. (DCOS_OSS-3933)
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,7 +61,7 @@ Format of the entries must be.
 
 * Prevent cosmos-specific labels being sent as metrics tags (DCOS-37451)
 
-* Improve the way statsd timers are handled in dcos-metrcs (DCOS-38083)
+* Improve the way statsd timers are handled in dcos-metrics (DCOS-38083)
 
 ### Security Updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,15 +13,6 @@ Format of the entries must be.
 * Entry two with no-newlines. (DCOS_OSS_JIRA_2)
 ```
 
-* Updated to [DC/OS UI 1.10.9-rc.1](https://github.com/dcos/dcos-ui/releases/tag/v1.10.9-rc.1)
-
-
-### Security Updates
-
-* Update Java to 8u181. (DCOS_OSS-3933)
-
-
-## DC/OS 1.10.8
 
 ### Notable changes
 
@@ -32,7 +23,12 @@ Format of the entries must be.
 
 * Consolidated Exhibitor startup script to abort when the IP address returned by 'ip-detect' is not contained in the known master IP address list. This fixes issues arising from transient errors in the 'ip-detect' script. (COPS-3195)
 
+* Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
+
+
 ### Security Updates
+
+* Update Java to 8u181. (DCOS_OSS-3933)
 
 
 ## DC/OS 1.10.8
@@ -48,8 +44,6 @@ Format of the entries must be.
 ### Fixed and improved
 
 * L4LB unstable when something is deployed in the cluster (DCOS_OSS-3602)
-
-* Admin Router: Change 'access_log' syslog facility from 'local7' to 'daemon'. (DCOS_OSS-3793)
 
 * Root Marathon support for post-installation configuration of flags and JVM settings has been improved. (DCOS_OSS-3556)
 

--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -14,6 +14,17 @@ state_buffer = None
 log = logging.getLogger(__name__)
 add_headers_cb = None
 
+# These headers are common to requests to mesos and client responses
+headers = {
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Headers": "accept, accept-charset, accept-encoding, " +
+                                    "accept-language, authorization, content-length, " +
+                                    "content-type, host, origin, proxy-connection, " +
+                                    "referer, user-agent, x-requested-with",
+    "Access-Control-Allow-Methods": "HEAD, GET, PUT, POST, PATCH, DELETE",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Max-Age": "86400"}
+
 
 try:
     import dcos_auth_python
@@ -31,15 +42,6 @@ def headers_cb():
     defaults in this method. This method can be set by adding a dcos_auth_python package
     with a get_auth_headers method
     """
-    headers = {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Headers": "accept, accept-charset, accept-encoding, " +
-                                        "accept-language, authorization, content-length, " +
-                                        "content-type, host, origin, proxy-connection, " +
-                                        "referer, user-agent, x-requested-with",
-        "Access-Control-Allow-Methods": "HEAD, GET, PUT, POST, PATCH, DELETE",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Max-Age": "86400"}
     if add_headers_cb:
         headers.update(add_headers_cb())
     return headers
@@ -99,7 +101,7 @@ def _buffer_response_(name):
 
 
 def _response_(content):
-    return Response(response=content, content_type="application/json", headers=headers_cb())
+    return Response(response=content, content_type="application/json", headers=headers)
 
 
 def route(app):

--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -42,9 +42,10 @@ def headers_cb():
     defaults in this method. This method can be set by adding a dcos_auth_python package
     with a get_auth_headers method
     """
+    return_headers = headers.copy()
     if add_headers_cb:
-        headers.update(add_headers_cb())
-    return headers
+        return_headers.update(add_headers_cb())
+    return return_headers
 
 
 def update():

--- a/packages/dcos-history/extra/test_history_service.py
+++ b/packages/dcos-history/extra/test_history_service.py
@@ -143,7 +143,8 @@ def test_data_recovery(monkeypatch, tmpdir):
 
 def test_add_headers(history_service):
     resp = history_service[0].get('/history/minute')
-    # check that new header is added
-    assert resp.headers['Authorization'] == 'test'
+    # check that auth header is not added to response - this would leak the
+    # auth token back to the user
+    assert 'Authorization' not in resp.headers
     # check that original headers are still there
     assert resp.headers['Access-Control-Max-Age'] == '86400'


### PR DESCRIPTION
## High-level description

dcos-history used a common method for creating the headers used to make
requests to mesos (which could have an Authorization header set with a token)
and making responses to the client.

This led to the auth token being leaked in the header.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40373](https://jira.mesosphere.com/browse/DCOS-40373) History service returns its auth token in the header

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
