### PR TITLE
[1.9] Prevent dcos-history leaking auth tokens

### DIFF
--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -14,6 +14,17 @@ state_buffer = None
 log = logging.getLogger(__name__)
 add_headers_cb = None
 
+# These headers are common to requests to mesos and client responses
+headers = {
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Headers": "accept, accept-charset, accept-encoding, " +
+                                    "accept-language, authorization, content-length, " +
+                                    "content-type, host, origin, proxy-connection, " +
+                                    "referer, user-agent, x-requested-with",
+    "Access-Control-Allow-Methods": "HEAD, GET, PUT, POST, PATCH, DELETE",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Max-Age": "86400"}
+
 
 try:
     import dcos_auth_python
@@ -31,15 +42,6 @@ def headers_cb():
     defaults in this method. This method can be set by adding a dcos_auth_python package
     with a get_auth_headers method
     """
-    headers = {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Headers": "accept, accept-charset, accept-encoding, " +
-                                        "accept-language, authorization, content-length, " +
-                                        "content-type, host, origin, proxy-connection, " +
-                                        "referer, user-agent, x-requested-with",
-        "Access-Control-Allow-Methods": "HEAD, GET, PUT, POST, PATCH, DELETE",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Max-Age": "86400"}
     if add_headers_cb:
         headers.update(add_headers_cb())
     return headers
@@ -99,7 +101,7 @@ def _buffer_response_(name):
 
 
 def _response_(content):
-    return Response(response=content, content_type="application/json", headers=headers_cb())
+    return Response(response=content, content_type="application/json", headers=headers)
 
 
 def route(app):

--- a/packages/dcos-history/extra/history/server_util.py
+++ b/packages/dcos-history/extra/history/server_util.py
@@ -42,9 +42,10 @@ def headers_cb():
     defaults in this method. This method can be set by adding a dcos_auth_python package
     with a get_auth_headers method
     """
+    return_headers = headers.copy()
     if add_headers_cb:
-        headers.update(add_headers_cb())
-    return headers
+        return_headers.update(add_headers_cb())
+    return return_headers
 
 
 def update():

--- a/packages/dcos-history/extra/test_history_service.py
+++ b/packages/dcos-history/extra/test_history_service.py
@@ -143,7 +143,8 @@ def test_data_recovery(monkeypatch, tmpdir):
 
 def test_add_headers(history_service):
     resp = history_service[0].get('/history/minute')
-    # check that new header is added
-    assert resp.headers['Authorization'] == 'test'
+    # check that auth header is not added to response - this would leak the
+    # auth token back to the user
+    assert 'Authorization' not in resp.headers
     # check that original headers are still there
     assert resp.headers['Access-Control-Max-Age'] == '86400'


### PR DESCRIPTION
## High-level description

dcos-history used a common method for creating the headers used to make
requests to mesos (which could have an Authorization header set with a token)
and making responses to the client.

This led to the auth token being leaked in the header.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40373](https://jira.mesosphere.com/browse/DCOS-40373) History service returns its auth token in the header

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: there is actually no changelog in 1.9
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
