### PR TITLE
[1.10] Add information to diagnostics bundle

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -106,7 +106,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.2',
+        'version': '1.10.3',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -976,7 +976,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.2',
+        'dcos_version': '1.10.3',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -719,6 +719,16 @@ package:
                   "Role":["agent", "agent_public"]
               },
               {
+                  "Port": 5051,
+                  "Uri": "/containers",
+                  "Role": ["agent", "agent_public"]
+              },
+              {
+                  "Port": 5050,
+                  "Uri": "/quota",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8123,
                   "Uri": "/v1/config",
                   "Role": ["master"]
@@ -767,11 +777,23 @@ package:
               {
                   "Location": "/var/lib/dcos/exhibitor/conf/zoo.cfg",
                   "Role": ["master"]
+              },
+              {
+                  "Location": "/proc/cmdline"
+              },
+              {
+                  "Location": "/proc/cpuinfo"
+              },
+              {
+                  "Location": "/proc/meminfo"
               }
           ],
           "LocalCommands": [
               {
                   "Command": ["dmesg"]
+              },
+              {
+                  "Command": ["ps", "aux", "ww"]
               }
           ]
         }

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -509,17 +509,22 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz']
+                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-1.output.gz',
+                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',
-                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz'] + expected_common_files
+                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz', '5050-quota.json'] + expected_common_files
+
+    expected_agent_common_files = ['5051-containers.json']
 
     # for agent host
-    expected_agent_files = ['dcos-mesos-slave.service.gz'] + expected_common_files
+    expected_agent_files = ['dcos-mesos-slave.service.gz'
+                            ] + expected_agent_common_files + expected_common_files
 
     # for public agent host
-    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'] + expected_common_files
+    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'
+                                   ]  + expected_agent_common_files + expected_common_files
 
     def _read_from_zip(z: zipfile.ZipFile, item: str, to_json=True):
         # raises KeyError if item is not in zipfile.


### PR DESCRIPTION
## High-level description
  
Backport #3211
    
This PR adds folowing information to diagnostics bundle
    * [`/quota`](http://mesos.apache.org/documentation/latest/endpoints/master/quota/)
    * [`/containers`](http://mesos.apache.org/documentation/latest/endpoints/slave/containers/)
    * [`/proc/[cmdline|cpuinfo|meminfo]`](http://man7.org/linux/man-pages/man5/proc.5.html) – additional hardware infro
    * [`ps aux www`](http://man7.org/linux/man-pages/man1/ps.1.html) – lists all proceses with wide information about them
    
## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3958](https://jira.mesosphere.com/browse/DCOS_OSS-3958): Add information to diagnostics bundle

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)