### PR TITLE
Check cache when creating Mesos resources using make_disk_resources.py.

### DIFF
--- a/packages/mesos/extra/make_disk_resources.py
+++ b/packages/mesos/extra/make_disk_resources.py
@@ -1,5 +1,6 @@
 #!/opt/mesosphere/bin/python3
 
+import argparse
 import json
 import os
 import re
@@ -92,9 +93,23 @@ def get_disk_free(path):
     return (path, floor(float(shutil.disk_usage(path).free) / MB))
 
 
-def get_mounts_and_freespace(matching_mounts):
+def get_mounts_and_freespace(matching_mounts, cache_mounts):
+    '''
+    We have previously seen, when only using the free disks available,
+    issues when restarting an agent after adding a new volume.
+    This is because Mesos does not tolerate changes in the amount of
+    disk space available for mounted volumes. If the volume was used
+    by a framework before the restart, the Mesos agent would refuse to
+    start due to incompatible agent resources (DCOS_OSS-3921).
+    This is why we keep a cache and use the previous amount of free space.
+    '''
     for mount, free_space in map(get_disk_free, matching_mounts):
-        net_free_space = free_space - TOLERANCE_MB
+
+        if mount in cache_mounts:
+            net_free_space = cache_mounts[mount]
+        else:
+            net_free_space = free_space - TOLERANCE_MB
+
         if net_free_space <= 0:
             # Per @cmaloney and @lingmann, we should hard exit here if volume
             # doesn't have sufficient space.
@@ -106,7 +121,7 @@ def get_mounts_and_freespace(matching_mounts):
 
 def _handle_root_volume(root_volume, role):
     os.makedirs(root_volume, exist_ok=True)
-    for common, _ in make_disk_resources_json(get_mounts_and_freespace([root_volume]), role):
+    for common, _ in make_disk_resources_json(get_mounts_and_freespace([root_volume], {}), role):
         yield common, {}
 
 
@@ -116,11 +131,11 @@ def stitch(parts):
     return common
 
 
-def main(output_env_file):
+def main(output_env_file, cache_env_file):
     '''
     Find mounts and freespace matching MOUNT_PATTERN, create RESOURCES for the
     disks, and merge the list of disk resources with optionally existing
-    MESOS_RESOURCES environment varianble.
+    MESOS_RESOURCES environment variable.
 
     @type output_env_file: str, filename to write resources
     '''
@@ -128,7 +143,27 @@ def main(output_env_file):
         print('Volume discovery assumed to be completed because {} exists'.format(output_env_file))
         return
 
-    mounts_dfree = list(get_mounts_and_freespace(find_mounts_matching(MOUNT_PATTERN)))
+    cache_mounts = {}
+    if os.path.exists(cache_env_file):
+        print('Mesos resources cache used for mount volumes because {} exists'.format(cache_env_file))
+        with open(cache_env_file) as f:
+            data = None
+            # The Mesos resources file is not a clean JSON file, it has comments
+            # and quotation marks that need to be filtered. This is why we
+            # enumerate the file instead of loading it entirely as a JSON file.
+            #
+            # Changing the formatting of the file could break the caching logic
+            # but test_make_disk_resources in DC/OS EE should detect such a bug.
+            for _, line in enumerate(f):
+                if line.startswith('MESOS_RESOURCES'):
+                    data = json.loads(line[len('MESOS_RESOURCES=\''):-2])
+            for item in data:
+                if item["name"] == "disk" and "disk" in item and "source" in item["disk"]:
+                    mount_volume = item["disk"]["source"]["mount"]["root"]
+                    cache_mounts[mount_volume] = item["scalar"]["value"]
+
+    current_mounts = find_mounts_matching(MOUNT_PATTERN)
+    mounts_dfree = list(get_mounts_and_freespace(current_mounts, cache_mounts))
     print('Found matching mounts : {}'.format(mounts_dfree))
 
     role = os.getenv('MESOS_DEFAULT_ROLE', '*')
@@ -169,11 +204,17 @@ def main(output_env_file):
 
 
 if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument("output", help="file where to write resources")
+    PARSER.add_argument("--cache", help="file containing the Mesos resources cache")
+    ARGS = PARSER.parse_args()
+
+    if not ARGS.cache:
+        # By default, the path of the cache is <ouput_file_path>.cache.
+        ARGS.cache = '{}.cache'.format(ARGS.output)
+
     try:
-        main(sys.argv[1])
-    except KeyError as e:
-        print('ERROR: Missing key {}'.format(e), file=sys.stderr)
-        sys.exit(1)
-    except VolumeDiscoveryException as e:
-        print('ERROR: {}'.format(e), file=sys.stderr)
+        main(ARGS.output, ARGS.cache)
+    except VolumeDiscoveryException as err:
+        print('ERROR: {}'.format(err), file=sys.stderr)
         sys.exit(1)

--- a/packages/mesos/extra/make_disk_resources.py
+++ b/packages/mesos/extra/make_disk_resources.py
@@ -61,7 +61,7 @@ class VolumeDiscoveryException(Exception):
 
 def find_mounts_matching(pattern):
     '''
-    find all matching mounts from the output of the mount command
+    Find all matching mounts from the output of the mount command
     '''
     print('Looking for mounts matching pattern "{}"'.format(pattern.pattern))
     mounts = subprocess.check_output(['mount'], universal_newlines=True)


### PR DESCRIPTION
This concerns agents and the file `/var/lib/dcos/mesos-resources`.
We previously used the free space on the agent's mounted volumes
when using `make_disk_resources.py` to create the Mesos resources
file.

We recently saw that the Mesos agent would not restart due to this
behavior for a specific case: a mount volume is used on an agent
by a framework, the agent is stopped and a new volume is mounted.
This is because, when adding an agent, we create again the Mesos
resources file and, if a mount volume is used, its free disk space
will have decreased. Mesos will then not accept to restart as it
cannot find the volume (due to the change of value).

To fix this, we now use a cache to know what was the original free
amount of disk space available on the mount volumes. When the Mesos
resources file is getting created again, we check for the mounted
volumes in the cache and use the amount of disk displayed there.
Due to the use of a new argument, a default value, and a condition
checking for the cache file, these changes will not negatively
impact users updating to a version of DC/OS including this fix.

The [documentation](https://docs.mesosphere.com/1.12/storage/mount-disk-resources/) regarding mounting a new volume will be updated
as the file `/var/lib/dcos/mesos-resources` should be moved to
`/var/lib/dcos/mesos-resources.cache` instead of being removed
when adding a new mount volume.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3921](https://jira.mesosphere.com/browse/DCOS_OSS-3921) COPS-3527 make_disk_resources uses free instead of total amount of disk space available on mount volumes.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
