### PR TITLE
Bumping dcos-test-utils version

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "c1608590e010ca08c418f8bd9d9ebd764d511d57",
+    "ref": "5361c8623cd0751f9312cf79b66dde6f09da1e74",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description 

Bumps dcos-test-utils version to include support for Windows nodes

## Related PRs (optional)
https://github.com/dcos/dcos-test-utils/pull/56

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review):  https://github.com/dcos/dcos-test-utils/compare/c1608590e010ca08c418f8bd9d9ebd764d511d57...5361c8623cd0751f9312cf79b66dde6f09da1e74
