### PR TITLE
adminrouter: enable gzip compression (DCOS-5978)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,17 @@ Format of the entries must be.
 * Entry two with no-newlines. (DCOS_OSS_JIRA_2)
 ```
 
+### What's new
+
+* Admin Router now supports gzip compression for CSS, Javascript, and JSON MIME types. (DCOS-5978)
+
+
+### Breaking changes
+
+
 
 ### Fixed and improved
+
 * Fixed Docker isolation iptables rule reversal on reboot. (DCOS_OSS-3697)
 
 * Updated CNI plugins to v0.7.1. (DCOS_OSS-3841)

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -13,6 +13,28 @@ server_tokens off;
 
 lua_package_path '$prefix/conf/lib/?.lua;;';
 
+# Offer gzip compression for most common MIME types. This is especially relevant
+# for the DC/OS UI, which is served by Master Admin Router and consumed by
+# browsers. However, on the client side this also applies to non-browser
+# consumers within the cluster (such as native DC/OS components consuming JSON
+# documents, from either Master Admin Router or Agent Admin Router).
+gzip on;
+gzip_disable "msie6";
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_buffers 16 8k;
+gzip_http_version 1.1;
+gzip_types text/plain
+    text/css
+    application/json
+    application/x-javascript
+    text/xml
+    application/xml
+    application/xml+rss
+    text/javascript
+    application/javascript;
+
 # Name: DC/OS Component Package Manager (Pkgpanda)
 # Reference: https://dcos.io/docs/1.10/administering-clusters/component-management/
 upstream pkgpanda {

--- a/packages/dcos-integration-test/extra/test_adminrouter.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter.py
@@ -1,0 +1,16 @@
+__maintainer__ = 'jgehrcke'
+__contact__ = 'dcos-security@mesosphere.io'
+
+
+def test_adminrouter_supports_gzip(dcos_api_session):
+    # Confirm that Master Admin Router offers gzip compression
+    # for requesting .html and .js files (the MIME types
+    # associated with them). It should also offer it for
+    # more MIME types, such as for CSS and others. The
+    # goal of this test however is is not to have complete
+    # coverage.
+    r = dcos_api_session.get('/index.html')
+    assert r.headers['Content-Encoding'] == 'gzip'
+
+    r = dcos_api_session.get('/index.js')
+    assert r.headers['Content-Encoding'] == 'gzip'


### PR DESCRIPTION
## High-level description

This enables gzip compression support in Admin Router for the most common MIME types, and adds a corresponding integration test that fails without this patch applied.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-5978

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]