### PR TITLE
Marathon 1.6.544 bump on DC/OS 1.11

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.535-dae1ce111/marathon-1.6.535-dae1ce111.tgz",
-    "sha1": "9caee4650bbb210ac2d7228476f706106e24bbb3"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.544-6b23a51d9/marathon-1.6.544-6b23a51d9.tgz",
+    "sha1": "f30f75e28d550da263e55caed376a43bd4a1dc73"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3979](https://jira.mesosphere.com/browse/DCOS_OSS-3979) Marathon 1.6.544 bump on DC/OS 1.11.


## Related tickets (optional)

Other tickets related to this change:


- [MARATHON-7568](https://jira.mesosphere.com/browse/MARATHON-7568) /v2/info leak some ZK credentials
- [MARATHON-7390](https://jira.mesosphere.com/browse/MARATHON-7390) Marathon Unable to Connect to Zookeeper - No Retries
- [MARATHON-8084](https://jira.mesosphere.com/browse/MARATHON-8084) Properly forward HTTP requests from proxy
- [PR-6445](https://github.com/mesosphere/marathon/pull/6445) Fix broken offer rejection statistics when maintenance mode is enabled 
- [MARATHON-8326](https://jira.mesosphere.com/browse/MARATHON-8326) Add "wipe=true" support for pod's instances endpoint


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/v1.6.535...6b23a51d9)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.6/15/)
  - [x] Code Coverage (if available): N/A
