### PR TITLE
[1.10] update diagnostics bundle endpoints for mesos agent nodes

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -718,12 +718,12 @@ package:
               },
               {
                   "Port": 5051,
-                  "Uri": "/slave/flags",
+                  "Uri": "/flags",
                   "Role":["agent", "agent_public"]
               },
               {
                   "Port": 5051,
-                  "Uri": "/slave/state",
+                  "Uri": "/state",
                   "Role":["agent", "agent_public"]
               },
               {


### PR DESCRIPTION
## High-level description

Endpoints `/slave/flags` and `/slave/state` responds
with 404 Not Found and empyt body. This causes
diagnostics bundle to contain empty file.
After this cange proper data will be fetched from Mesos Agent.

Backport: 9146aa519e884bc8e49043b3712ec12a63fb72cf #2512

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)