### PR TITLE
Fixes hard-coded `python3.5` for build_local.sh

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -38,7 +38,7 @@ EOF
 fi
 
 # Create a Python virtual environment to install the DC/OS tools to.
-python3.5 -m venv /tmp/dcos_build_venv
+python3 -m venv /tmp/dcos_build_venv #--without-pip --system-site-packages
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools


### PR DESCRIPTION
## High-level description
The top level directory `build_local.sh` script can be used to build DC/OS in an local environment.
This script did some assumptions on the users local environment, which led to issues with newer Ubuntu versions that ship with python3.6 (or anything newer than 3.5 in the future).
Ubuntu has the 'bug' that makes it a requirement to install pythons `venv`
module as a system package to be able to use `pip` inside any venv. See
https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847.
This Ubuntu specific system package however only adds support for their latest
shipped python version, which (at least on 18.04, if not earlier) is 3.6.

Please note that all the workarounds in the linked Ubuntu bug tracker (using system side pip for example) do not apply for our use-case, as we have scripts that update pip inside the temporary venv.

## Corresponding DC/OS tickets (obligatory)

None yet, I think.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a development only change which should be backwards compatible.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
I don't think we have any tests covering these build scripts.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
