### PR TITLE
gen/build_deploy/bash: Allow SELinux preflight check to pass on Enfor…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,3 +84,5 @@ Format of the entries must be.
 * Updated OTP version to 20.3.2 (DCOS_OSS-2378)
 
 * Updated REX-Ray version to 0.11.2 (DCOS_OSS-3597) [rexray v0.11.2](https://github.com/rexray/rexray/releases/tag/v0.11.2)
+
+* DC/OS can now be installed with SELinux in enforcing mode with the "targeted" policy loaded (DCOS-38953)


### PR DESCRIPTION
## High-level description

Previously a preflight check errored when installing DC/OS with SELinux in enforcing mode.
Now, that error is only if installing DC/OS with SELinux in enforcing mode with a loaded policy which is not "targeted".

This was a collaborative effort with @mhrabovcin .

### Manual Testing

To test this, we created the following script, which matches in part the new code we are adding:

```sh
#/usr/bin/env bash

set -ex

function print_status() {
   echo -n ""
}

OVERALL_RC=0

function check_selinux() {
  ENABLED=$(getenforce)
  RC=0

  if [[ $ENABLED == 'Enforcing' ]]; then
    LOADED_POLICY_LINE=$(sestatus | grep "Loaded policy name:")
    ALLOWED_LOADED_POLICY_LINE="Loaded policy name:             targeted"
    if [ "$LOADED_POLICY_LINE" != "$ALLOWED_LOADED_POLICY_LINE" ]; then
      RC=1
    fi
  fi

  MESSAGE="Is SELinux in disabled mode, permissive mode or in enforcing mode with the targeted policy loaded?"
  print_status $RC "$MESSAGE"
  (( OVERALL_RC += $RC ))
  echo $RC
}


my_code=$(check_selinux)
echo "$my_code"
exit $my_code
```

We created a CentOS VM with the following Vagrantfile:

```
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "centos/7"
end
```

We ran this script in the following SELinux modes, changing SELinux modes and policies by:

* Changing the policy values in `/etc/selinux/config`
* Running `sudo setenforce 0` and `sudo setenforce 1`

We viewed the statuses using ``sudo sestatus`` to confirm.


| Current Mode  | Loaded Policy | Result |
| ------------- | ------------- | ------ |
| enforcing     | targeted      | 0      |
| permissive    | targeted      | 0      |
| disabled      | n/a           | 0      |
| enforcing     | mls           | 1      |


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40132](https://jira.mesosphere.com/browse/DCOS-40132) Change SELinux preflight check to allow enforcing-targeted mode

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-40653](https://jira.mesosphere.com/browse/DCOS-40653) Decide what to do wrt SELinux + DC/OS OSS

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This will be done in https://jira.mesosphere.com/browse/DCOS-40145
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)