### PR TITLE
chore(dcos-ui): bump DC/OS UI master+v2.14.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,7 +73,7 @@ Format of the entries must be.
 
 * Mesos now uses the jemalloc memory profiler by default. (DCOS_OSS-2137)
 
-* Updated DC/OS UI to master+v2.3.0 [Changelog](https://github.com/dcos/dcos-ui/releases)
+* Updated DC/OS UI to master+v2.14.0 [Changelog](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.14.0)
 
 * Replaced the dcos-diagnostics check runner with dcos-check-runner. (DCOS_OSS-3491)
 

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -1,7 +1,8 @@
+
 {
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.3.0.tar.gz",
-    "sha1": "bdf48d7789a1febfb215e66ab962d16f78d9fc21"
+    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.14.0.tar.gz",
+    "sha1": "590a8ec93b5f869f427cd1f650efa6465c3efe1f"
   }
 }


### PR DESCRIPTION
## High-level description

Many changes on DC/OS UI

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

[DCOS_OSS-3801](https://jira.mesosphere.com/browse/DCOS_OSS-3801) - Support docker parameters in Metronome jobs.
[DCOS-37650](https://jira.mesosphere.com/browse/DCOS-37650) - change default request error message
[DCOS_OSS-3992](https://jira.mesosphere.com/browse/DCOS_OSS-3992) - getUsedResources not applicable to Service
[DCOS-40673](https://jira.mesosphere.com/browse/DCOS-40673) - prevent header bar from overlapping popup-like ui
[DCOS-40353](https://jira.mesosphere.com/browse/DCOS-40353) - update list/grid toggle style
[DCOS-40495](https://jira.mesosphere.com/browse/DCOS-40495) -  Remove the (Local) addition when the local region is "N/A"
[DCOS-20989](https://jira.mesosphere.com/browse/DCOS-20989) - use CosmosPackagesStores icons for Services Page
[DCOS-40646](https://jira.mesosphere.com/browse/DCOS-40646) - add base tech version parsing to services table
[DCOS-21235](https://jira.mesosphere.com/browse/DCOS-21235) - fix search overflow firefox
[DCOS-40158](https://jira.mesosphere.com/browse/DCOS-40158) - Removes left padding for tasks page and nodes page
[DCOS-40046](https://jira.mesosphere.com/browse/DCOS-40046) - retrieve non leader data from diagnostics
[DCOS-39153](https://jira.mesosphere.com/browse/DCOS-39153) - add tabs to NodesPage
[DCOS-40019](https://jira.mesosphere.com/browse/DCOS-40019) - prevent text flicker
[DCOS-20273](https://jira.mesosphere.com/browse/DCOS-20273) - detect that field value is disabled when unique selected
[DCOS-39906](https://jira.mesosphere.com/browse/DCOS-39906) - add service version to services table
[DCOS-39905](https://jira.mesosphere.com/browse/DCOS-39905) -  add package version information to framework struct
[DCOS-40506](https://jira.mesosphere.com/browse/DCOS-40506) - sort Nodes table by health
[DCOS-20340](https://jira.mesosphere.com/browse/DCOS-20340) - enlarge heading and wrap catalog screenshots
[DCOS-38652](https://jira.mesosphere.com/browse/DCOS-38652) - cypress update to 3.1.0
[DCOS-21183](https://jira.mesosphere.com/browse/DCOS-21183) - do not duplicate container names
[DCOS-39945](https://jira.mesosphere.com/browse/DCOS-39945) - color nodes table progress bars
[DCOS-39960](https://jira.mesosphere.com/browse/DCOS-39960) - right align tasks column
[DCOS_OSS-3968](https://jira.mesosphere.com/browse/DCOS_OSS-3968)- mesos-client update to 0.2.4
[DCOS-39944](https://jira.mesosphere.com/browse/DCOS-39944) - update chart colors in resources
[DCOS-40491](https://jira.mesosphere.com/browse/DCOS-40491) - marathon bump version to 1.7.49-f24b03af3
[DCOS-39675](https://jira.mesosphere.com/browse/DCOS-39675) - upgrade ui-kit to 1.8.0
[DCOS-39674](https://jira.mesosphere.com/browse/DCOS-39674) - upgrade ui-kit to 1.8.0
[DCOS-39677](https://jira.mesosphere.com/browse/DCOS-39677) - upgrade ui-kit to 1.8.0
[DCOS-39961](https://jira.mesosphere.com/browse/DCOS-39961) - left align column names with bar
[DCOS-39626](https://jira.mesosphere.com/browse/DCOS-39626) - change resource switch to dropdown
[DCOS-39877](https://jira.mesosphere.com/browse/DCOS-39877) - apply changes in fuzzy search directly
[DCOS-38889](https://jira.mesosphere.com/browse/DCOS-38889) -  reset column sort direction
[DCOS-39959](https://jira.mesosphere.com/browse/DCOS-39959) -  add consistency to link
[DCOS-39972](https://jira.mesosphere.com/browse/DCOS-39972) - fix spacing between node dials and filter
[DCOS-39963](https://jira.mesosphere.com/browse/DCOS-39963) -  cluster dropdown extra margin
[DCOS-40037](https://jira.mesosphere.com/browse/DCOS-40037) - change name column label to host
[DCOS-40039](https://jira.mesosphere.com/browse/DCOS-40039) - add tasks column
[DCOS-39160](https://jira.mesosphere.com/browse/DCOS-39160) - add ip column sorting and contents
[DCOS-22381](https://jira.mesosphere.com/browse/DCOS-22381) - use our fork of http-server

## Related tickets (optional)

Other tickets related to this change:
## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
