### PR TITLE
1.11 train 08/29

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,8 @@
 
 * Add debug route to metrics API (DCOS-37454)
 
+* Add per-framework metrics to the Mesos master (DCOS_OSS-3991)
+
 ### Security updates
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+## DC/OS 1.11.6
+
+### Notable changes
+
+
+### Fixed and improved
+
+* Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
+
+### Security updates
+
+
 ## DC/OS 1.11.5
 
 ### Notable changes

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -721,6 +721,11 @@ package:
                   "Role": ["master"]
               },
               {
+                  "Port": 5050,
+                  "Uri": "/quota",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8080,
                   "Uri": "/metrics",
                   "Role": ["master"]
@@ -829,6 +834,11 @@ package:
                   "Port": 5051,
                   "Uri": "/overlay-agent/overlay",
                   "Role": ["agent", "agent_public"]
+              },
+              {
+                  "Port": 5051,
+                  "Uri": "/containers",
+                  "Role": ["agent", "agent_public"]
               }
           ],
           "LocalFiles": [
@@ -866,6 +876,15 @@ package:
               },
               {
                   "Location": "/proc/net/fib_trie"
+              },
+              {
+                  "Location": "/proc/cmdline"
+              },
+              {
+                  "Location": "/proc/cpuinfo"
+              },
+              {
+                  "Location": "/proc/meminfo"
               }
           ],
           "LocalCommands": [
@@ -880,6 +899,9 @@ package:
               },
               {
                   "Command": ["ifconfig", "-a"]
+              },
+              {
+                  "Command": ["ps", "aux", "ww"]
               },
               {
                   "Command": ["/opt/mesosphere/bin/curl", "-s", "-S", "http://localhost:62080/v1/vips"]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -766,6 +766,11 @@ package:
                   "Role": ["master"]
               },
               {
+                  "Port": 8080,
+                  "Uri": "/v2/pods",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8181,
                   "Uri": "/exhibitor/v1/cluster/list",
                   "Role": ["master"]
@@ -889,7 +894,7 @@ package:
           ],
           "LocalCommands": [
               {
-                  "Command": ["dmesg"]
+                  "Command": ["dmesg", "-T"]
               },
               {
                   "Command": ["ip", "addr"]
@@ -905,6 +910,15 @@ package:
               },
               {
                   "Command": ["/opt/mesosphere/bin/curl", "-s", "-S", "http://localhost:62080/v1/vips"]
+              },
+              {
+                  "Command": ["timedatectl"]
+              },
+              {
+                  "Command": ["/bin/sh", "-c", "cat /etc/*-release"]
+              },
+              {
+                  "Command": ["systemctl", "list-units", "dcos*"]
               }
           ]
         }

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -506,17 +506,23 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz']
+                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz',
+                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',
-                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz'] + expected_common_files
+                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz', '5050-quota.json'
+                             ] + expected_common_files
+
+    expected_agent_common_files = ['5051-containers.json']
 
     # for agent host
-    expected_agent_files = ['dcos-mesos-slave.service.gz'] + expected_common_files
+    expected_agent_files = ['dcos-mesos-slave.service.gz'
+                            ] + expected_agent_common_files + expected_common_files
 
     # for public agent host
-    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'] + expected_common_files
+    expected_public_agent_files = ['dcos-mesos-slave-public.service.gz'
+                                   ] + expected_agent_common_files + expected_common_files
 
     def _read_from_zip(z: zipfile.ZipFile, item: str, to_json=True):
         # raises KeyError if item is not in zipfile.

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -503,11 +503,13 @@ def _download_bundle_from_master(dcos_api_session, master_index):
     bundles = _get_bundle_list(dcos_api_session)
     assert bundles
 
-    expected_common_files = ['dmesg-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
+    expected_common_files = ['dmesg_-T-0.output.gz', 'opt/mesosphere/active.buildinfo.full.json.gz',
                              'opt/mesosphere/etc/dcos-version.json.gz', 'opt/mesosphere/etc/expanded.config.json.gz',
                              'opt/mesosphere/etc/user.config.yaml.gz', 'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz',
-                             'proc/cmdline.gz', 'proc/cpuinfo.gz', 'proc/meminfo.gz']
+                             'var/lib/dcos/cluster-id.gz', 'ps_aux_ww-4.output.gz', 'proc/cmdline.gz',
+                             'proc/cpuinfo.gz', 'proc/meminfo.gz', 'var/lib/dcos/cluster-id.gz',
+                             'timedatectl-5.output.gz', 'binsh_-c_cat etc*-release-6.output.gz',
+                             'systemctl_list-units_dcos*-7.output.gz']
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,4 +1,4 @@
-From cd1870540fb70dfa0e5db5f9ab9bb3fbf47ddbb1 Mon Sep 17 00:00:00 2001
+From 2b066c3f5be8648fcc8a472eba93cbc99ff21219 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
 Subject: [PATCH] Set LIBPROCESS_IP into docker container.
@@ -24,5 +24,5 @@ index 5de63f6da..97142eebc 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,4 +1,4 @@
-From f1ad107f22982873734d8d9dac743e81bb353188 Mon Sep 17 00:00:00 2001
+From 7fafef398a76d7743e5783971930abf6463c6f12 Mon Sep 17 00:00:00 2001
 From: Gaston Kleiman <gaston.kleiman@gmail.com>
 Date: Mon, 9 Oct 2017 15:19:08 -0700
 Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
@@ -47,5 +47,5 @@ index 59665869d..6e0a40f93 100644
              'Mesos Master (' + $scope.$location.host() + ':' + $scope.$location.port() + ')');
        }
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,4 +1,4 @@
-From 0bc59bc68dc6ea9c743f23daac603da3f117c32c Mon Sep 17 00:00:00 2001
+From 6c083a82e4dc2388790800282c8e66caf18d4c7b Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
 Subject: [PATCH] Revert "Fixed the broken metrics information of master in
@@ -9,7 +9,7 @@ This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
 In DC/OS, redirection to the leading master is handled by the
 Adminrouter component.
 ---
- src/webui/master/static/js/controllers.js | 24 +++++++-----------------
+ src/webui/master/static/js/controllers.js | 24 +++++++----------------
  1 file changed, 7 insertions(+), 17 deletions(-)
 
 diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
@@ -69,5 +69,5 @@ index 6e0a40f93..8d9b5f49d 100644
              $timeout(pollMetrics, $scope.delay);
            }
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,4 +1,4 @@
-From f1da678e918ff033a2cb2b2e2c35fa225699e122 Mon Sep 17 00:00:00 2001
+From e35849bfc3125167f1825f493e094c2fd0d2cd7f Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
 Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
@@ -45,5 +45,5 @@ index c0fe435ae..14ae172b0 100644
      }
    }
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
+++ b/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
@@ -1,4 +1,4 @@
-From 91ffbb47d4bf34d9ac22bb942a0aeba7e23eaeeb Mon Sep 17 00:00:00 2001
+From 670df95cd6a568e752599bf186af0fa2e7182cac Mon Sep 17 00:00:00 2001
 From: Benjamin Bannier <benjamin.bannier@mesosphere.io>
 Date: Tue, 20 Mar 2018 10:08:09 +0100
 Subject: [PATCH] Displayed resource provider resources in
@@ -87,5 +87,5 @@ index 1b01427f3..bc6ca510b 100644
  
  
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,4 +1,4 @@
-From 738bbb470d79092f50fa048c683fd17ca2ff3181 Mon Sep 17 00:00:00 2001
+From d45d6a45de2ebc437302675c53fabdf2fb1a1d11 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Tue, 10 Jul 2018 08:06:32 -0700
 Subject: [PATCH] Improved logging for offers and inverse offers.
@@ -73,5 +73,5 @@ index 05724f117..cc4674ced 100644
    framework->send(message);
  }
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
+++ b/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
@@ -1,0 +1,148 @@
+From 163e53494c411baee82effb272473c2eca82a09b Mon Sep 17 00:00:00 2001
+From: Benjamin Mahler <bmahler@apache.org>
+Date: Fri, 27 Apr 2018 16:06:53 -0700
+Subject: [PATCH] Introduced a push-based gauge metric.
+
+A push-based gauge differs from a pull-based gauge in that the
+client is responsible for pushing the latest value into the gauge
+whenever it changes. This can be challenging in some cases as it
+requires the client to have a good handle on when the gauge value
+changes (rather than just computing the current value when asked).
+
+It is highly recommended to use push-based gauges if possible as
+they provide significant performance benefits over pull-based
+gauges. Pull-based gauge suffer from delays getting processed on
+the event queue of a `Process`, as well as incur computation cost
+on the `Process` each time the metrics are collected. Push-based
+gauges, on the other hand, incur no cost to the owning `Process`
+when metrics are collected, and instead incur a trivial cost when
+the `Process` pushes new values in.
+
+Review: https://reviews.apache.org/r/66828/
+---
+ 3rdparty/libprocess/include/Makefile.am       |   1 +
+ .../include/process/metrics/push_gauge.hpp    | 100 ++++++++++++++++++
+ 2 files changed, 101 insertions(+)
+ create mode 100644 3rdparty/libprocess/include/process/metrics/push_gauge.hpp
+
+diff --git a/3rdparty/libprocess/include/Makefile.am b/3rdparty/libprocess/include/Makefile.am
+index 84877a233..94e6d153f 100644
+--- a/3rdparty/libprocess/include/Makefile.am
++++ b/3rdparty/libprocess/include/Makefile.am
+@@ -46,6 +46,7 @@ nobase_include_HEADERS =		\
+   process/mutex.hpp			\
+   process/metrics/counter.hpp		\
+   process/metrics/gauge.hpp		\
++  process/metrics/push_gauge.hpp	\
+   process/metrics/metric.hpp		\
+   process/metrics/metrics.hpp		\
+   process/metrics/timer.hpp		\
+diff --git a/3rdparty/libprocess/include/process/metrics/push_gauge.hpp b/3rdparty/libprocess/include/process/metrics/push_gauge.hpp
+new file mode 100644
+index 000000000..5c3984617
+--- /dev/null
++++ b/3rdparty/libprocess/include/process/metrics/push_gauge.hpp
+@@ -0,0 +1,100 @@
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License
++
++#ifndef __PROCESS_METRICS_PUSH_GAUGE_HPP__
++#define __PROCESS_METRICS_PUSH_GAUGE_HPP__
++
++#include <memory>
++#include <string>
++
++#include <process/metrics/metric.hpp>
++
++namespace process {
++namespace metrics {
++
++// A Metric that represents an instantaneous measurement of a value
++// (e.g. number of items in a queue).
++//
++// A push-based gauge differs from a pull-based gauge in that the
++// client is responsible for pushing the latest value into the gauge
++// whenever it changes. This can be challenging in some cases as it
++// requires the client to have a good handle on when the gauge value
++// changes (rather than just computing the current value when asked).
++//
++// NOTE: It is highly recommended to use push-based gauges if
++// possible as they provide significant performance benefits over
++// pull-based gauges. Pull-based gauge suffer from delays getting
++// processed on the event queue of a `Process`, as well as incur
++// computation cost on the `Process` each time the metrics are
++// collected. Push-based gauges, on the other hand, incur no cost
++// to the owning `Process` when metrics are collected, and instead
++// incur a trivial cost when the `Process` pushes new values in.
++class PushGauge : public Metric
++{
++public:
++  // 'name' is the unique name for the instance of Gauge being constructed.
++  // It will be the key exposed in the JSON endpoint.
++  //
++  // 'f' is the function that is called when the Metric value is requested.
++  // The user of `Gauge` must ensure that `f` is safe to execute up until
++  // the removal of the `Gauge` (via `process::metrics::remove(...)`) is
++  // complete.
++  explicit PushGauge(const std::string& name)
++    : Metric(name, None()), data(new Data()) {}
++
++  virtual ~PushGauge() {}
++
++  virtual Future<double> value() const
++  {
++    return static_cast<double>(data->value.load());
++  }
++
++  PushGauge& operator=(int64_t v)
++  {
++    data->value.store(v);
++    push(v);
++    return *this;
++  }
++
++  PushGauge& operator++() { return *this += 1; }
++
++  PushGauge& operator+=(int64_t v)
++  {
++    int64_t prev = data->value.fetch_add(v);
++    push(static_cast<double>(prev + v));
++    return *this;
++  }
++
++  PushGauge& operator--() { return *this -= 1; }
++
++  PushGauge& operator-=(int64_t v)
++  {
++    int64_t prev = data->value.fetch_sub(v);
++    push(static_cast<double>(prev - v));
++    return *this;
++  }
++
++private:
++  struct Data
++  {
++    explicit Data() : value(0) {}
++
++    std::atomic<int64_t> value;
++  };
++
++  std::shared_ptr<Data> data;
++};
++
++} // namespace metrics {
++} // namespace process {
++
++#endif // __PROCESS_METRICS_PUSH_GAUGE_HPP__
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
+++ b/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
@@ -1,0 +1,70 @@
+From ab0413838dd9f61a46f481583220ba1b73b6e2ec Mon Sep 17 00:00:00 2001
+From: Benjamin Mahler <bmahler@apache.org>
+Date: Fri, 27 Apr 2018 16:06:58 -0700
+Subject: [PATCH] Added a test for PushGauge.
+
+Review: https://reviews.apache.org/r/66830/
+---
+ .../libprocess/src/tests/metrics_tests.cpp    | 32 +++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/3rdparty/libprocess/src/tests/metrics_tests.cpp b/3rdparty/libprocess/src/tests/metrics_tests.cpp
+index bb7c9e37e..d394a42bf 100644
+--- a/3rdparty/libprocess/src/tests/metrics_tests.cpp
++++ b/3rdparty/libprocess/src/tests/metrics_tests.cpp
+@@ -31,6 +31,7 @@
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/gauge.hpp>
+ #include <process/metrics/metrics.hpp>
++#include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/timer.hpp>
+ 
+ namespace authentication = process::http::authentication;
+@@ -47,6 +48,7 @@ using http::Unauthorized;
+ 
+ using metrics::Counter;
+ using metrics::Gauge;
++using metrics::PushGauge;
+ using metrics::Timer;
+ 
+ using process::Clock;
+@@ -170,6 +172,36 @@ TEST_F(MetricsTest, THREADSAFE_Gauge)
+ }
+ 
+ 
++TEST_F(MetricsTest, PushGauge)
++{
++  // Gauge with a value.
++  PushGauge gauge("test/gauge");
++
++  AWAIT_READY(metrics::add(gauge));
++
++  AWAIT_EXPECT_EQ(0.0, gauge.value());
++
++  ++gauge;
++  AWAIT_EXPECT_EQ(1.0, gauge.value());
++
++  gauge += 42;
++  AWAIT_EXPECT_EQ(43.0, gauge.value());
++
++  --gauge;
++  AWAIT_EXPECT_EQ(42.0, gauge.value());
++
++  gauge -= 42;
++  AWAIT_EXPECT_EQ(0.0, gauge.value());
++
++  gauge = 42;
++  AWAIT_EXPECT_EQ(42.0, gauge.value());
++
++  EXPECT_NONE(gauge.statistics());
++
++  AWAIT_READY(metrics::remove(gauge));
++}
++
++
+ TEST_F(MetricsTest, Statistics)
+ {
+   Counter counter("test/counter", process::TIME_SERIES_WINDOW);
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
+++ b/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
@@ -1,0 +1,357 @@
+From c588ccbca32d79b8553f0b0d45d0921ac2f607aa Mon Sep 17 00:00:00 2001
+From: Benjamin Mahler <bmahler@apache.org>
+Date: Fri, 27 Apr 2018 16:07:01 -0700
+Subject: [PATCH] Renamed Gauge to PullGauge and documented differences to
+ PushGauge.
+
+Given `PushGauge`, it makes sense to explicitly distinguish the two
+gauge types and document the the caveats of `PullGauge`.
+
+Review: https://reviews.apache.org/r/66831/
+---
+ 3rdparty/libprocess/include/Makefile.am       |  2 +-
+ .../include/process/metrics/gauge.hpp         | 58 --------------
+ .../include/process/metrics/metric.hpp        |  2 +-
+ .../include/process/metrics/pull_gauge.hpp    | 77 +++++++++++++++++++
+ .../libprocess/include/process/system.hpp     | 14 ++--
+ .../libprocess/src/tests/metrics_tests.cpp    | 51 ++++++------
+ .../libprocess/src/tests/system_tests.cpp     |  2 +-
+ 7 files changed, 116 insertions(+), 90 deletions(-)
+ delete mode 100644 3rdparty/libprocess/include/process/metrics/gauge.hpp
+ create mode 100644 3rdparty/libprocess/include/process/metrics/pull_gauge.hpp
+
+diff --git a/3rdparty/libprocess/include/Makefile.am b/3rdparty/libprocess/include/Makefile.am
+index 94e6d153f..e1605df86 100644
+--- a/3rdparty/libprocess/include/Makefile.am
++++ b/3rdparty/libprocess/include/Makefile.am
+@@ -45,7 +45,7 @@ nobase_include_HEADERS =		\
+   process/mime.hpp			\
+   process/mutex.hpp			\
+   process/metrics/counter.hpp		\
+-  process/metrics/gauge.hpp		\
++  process/metrics/pull_gauge.hpp	\
+   process/metrics/push_gauge.hpp	\
+   process/metrics/metric.hpp		\
+   process/metrics/metrics.hpp		\
+diff --git a/3rdparty/libprocess/include/process/metrics/gauge.hpp b/3rdparty/libprocess/include/process/metrics/gauge.hpp
+deleted file mode 100644
+index 474f8e80b..000000000
+--- a/3rdparty/libprocess/include/process/metrics/gauge.hpp
++++ /dev/null
+@@ -1,58 +0,0 @@
+-// Licensed under the Apache License, Version 2.0 (the "License");
+-// you may not use this file except in compliance with the License.
+-// You may obtain a copy of the License at
+-//
+-//     http://www.apache.org/licenses/LICENSE-2.0
+-//
+-// Unless required by applicable law or agreed to in writing, software
+-// distributed under the License is distributed on an "AS IS" BASIS,
+-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-// See the License for the specific language governing permissions and
+-// limitations under the License
+-
+-#ifndef __PROCESS_METRICS_GAUGE_HPP__
+-#define __PROCESS_METRICS_GAUGE_HPP__
+-
+-#include <functional>
+-#include <memory>
+-#include <string>
+-
+-#include <process/metrics/metric.hpp>
+-
+-namespace process {
+-namespace metrics {
+-
+-// A Metric that represents an instantaneous value evaluated when
+-// 'value' is called.
+-class Gauge : public Metric
+-{
+-public:
+-  // 'name' is the unique name for the instance of Gauge being constructed.
+-  // It will be the key exposed in the JSON endpoint.
+-  //
+-  // 'f' is the function that is called when the Metric value is requested.
+-  // The user of `Gauge` must ensure that `f` is safe to execute up until
+-  // the removal of the `Gauge` (via `process::metrics::remove(...)`) is
+-  // complete.
+-  Gauge(const std::string& name, const std::function<Future<double>()>& f)
+-    : Metric(name, None()), data(new Data(f)) {}
+-
+-  virtual ~Gauge() {}
+-
+-  virtual Future<double> value() const { return data->f(); }
+-
+-private:
+-  struct Data
+-  {
+-    explicit Data(const std::function<Future<double>()>& _f) : f(_f) {}
+-
+-    const std::function<Future<double>()> f;
+-  };
+-
+-  std::shared_ptr<Data> data;
+-};
+-
+-} // namespace metrics {
+-} // namespace process {
+-
+-#endif // __PROCESS_METRICS_GAUGE_HPP__
+diff --git a/3rdparty/libprocess/include/process/metrics/metric.hpp b/3rdparty/libprocess/include/process/metrics/metric.hpp
+index 21f162d5b..2c4a154bb 100644
+--- a/3rdparty/libprocess/include/process/metrics/metric.hpp
++++ b/3rdparty/libprocess/include/process/metrics/metric.hpp
+@@ -29,7 +29,7 @@
+ namespace process {
+ namespace metrics {
+ 
+-// The base class for Metrics such as Counter and Gauge.
++// The base class for Metrics.
+ class Metric {
+ public:
+   virtual ~Metric() {}
+diff --git a/3rdparty/libprocess/include/process/metrics/pull_gauge.hpp b/3rdparty/libprocess/include/process/metrics/pull_gauge.hpp
+new file mode 100644
+index 000000000..5c2a22742
+--- /dev/null
++++ b/3rdparty/libprocess/include/process/metrics/pull_gauge.hpp
+@@ -0,0 +1,77 @@
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License
++
++#ifndef __PROCESS_METRICS_PULL_GAUGE_HPP__
++#define __PROCESS_METRICS_PULL_GAUGE_HPP__
++
++#include <functional>
++#include <memory>
++#include <string>
++
++#include <process/metrics/metric.hpp>
++
++namespace process {
++namespace metrics {
++
++// A Metric that represents an instantaneous measurement of a value
++// (e.g. number of items in a queue).
++//
++// A pull-based gauge differs from a push-based gauge in that the
++// client does not need to worry about when to compute a new gauge
++// value and instead provides the value function to invoke during
++// metrics collection. This makes the client logic simpler but comes
++// with significant performance disadvantages. If this function
++// dispatches to a `Process`, metrics collection will be exposed to
++// delays while the dispatches work their way through the event
++// queues. Also, gauges can be expensive to compute (e.g. loop over
++// all items while counting how many match a criteria) and therefore
++// can lead to a performance degradation on critial `Process`es
++// during metrics collection.
++//
++// NOTE: Due to the performance disadvantages of pull-based gauges,
++// it is recommended to use push-based gauges where possible.
++// Pull-based gauges should ideally (1) be used on `Process`es that
++// experience very light load, and (2) use functions that do not
++// perform heavyweight computation to compute the value (e.g. looping
++// over a large collection).
++class PullGauge : public Metric
++{
++public:
++  // 'name' is the unique name for the instance of Gauge being constructed.
++  // It will be the key exposed in the JSON endpoint.
++  //
++  // 'f' is the function that is called when the Metric value is requested.
++  // The user of `Gauge` must ensure that `f` is safe to execute up until
++  // the removal of the `Gauge` (via `process::metrics::remove(...)`) is
++  // complete.
++  PullGauge(const std::string& name, const std::function<Future<double>()>& f)
++    : Metric(name, None()), data(new Data(f)) {}
++
++  virtual ~PullGauge() {}
++
++  virtual Future<double> value() const { return data->f(); }
++
++private:
++  struct Data
++  {
++    explicit Data(const std::function<Future<double>()>& _f) : f(_f) {}
++
++    const std::function<Future<double>()> f;
++  };
++
++  std::shared_ptr<Data> data;
++};
++
++} // namespace metrics {
++} // namespace process {
++
++#endif // __PROCESS_METRICS_PULL_GAUGE_HPP__
+diff --git a/3rdparty/libprocess/include/process/system.hpp b/3rdparty/libprocess/include/process/system.hpp
+index 21bd3300b..ab6455fe6 100644
+--- a/3rdparty/libprocess/include/process/system.hpp
++++ b/3rdparty/libprocess/include/process/system.hpp
+@@ -20,7 +20,7 @@
+ #include <process/http.hpp>
+ #include <process/process.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/os.hpp>
+@@ -183,14 +183,14 @@ private:
+     return http::OK(object, request.url.query.get("jsonp"));
+   }
+ 
+-  metrics::Gauge load_1min;
+-  metrics::Gauge load_5min;
+-  metrics::Gauge load_15min;
++  metrics::PullGauge load_1min;
++  metrics::PullGauge load_5min;
++  metrics::PullGauge load_15min;
+ 
+-  metrics::Gauge cpus_total;
++  metrics::PullGauge cpus_total;
+ 
+-  metrics::Gauge mem_total_bytes;
+-  metrics::Gauge mem_free_bytes;
++  metrics::PullGauge mem_total_bytes;
++  metrics::PullGauge mem_free_bytes;
+ };
+ 
+ } // namespace process {
+diff --git a/3rdparty/libprocess/src/tests/metrics_tests.cpp b/3rdparty/libprocess/src/tests/metrics_tests.cpp
+index d394a42bf..41fd737b0 100644
+--- a/3rdparty/libprocess/src/tests/metrics_tests.cpp
++++ b/3rdparty/libprocess/src/tests/metrics_tests.cpp
+@@ -29,8 +29,8 @@
+ #include <process/time.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
+ #include <process/metrics/metrics.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/timer.hpp>
+ 
+@@ -47,7 +47,7 @@ using http::Response;
+ using http::Unauthorized;
+ 
+ using metrics::Counter;
+-using metrics::Gauge;
++using metrics::PullGauge;
+ using metrics::PushGauge;
+ using metrics::Timer;
+ 
+@@ -64,7 +64,7 @@ using process::UPID;
+ using std::map;
+ using std::string;
+ 
+-class GaugeProcess : public Process<GaugeProcess>
++class PullGaugeProcess : public Process<PullGaugeProcess>
+ {
+ public:
+   double get()
+@@ -143,14 +143,14 @@ TEST_F(MetricsTest, Counter)
+ }
+ 
+ 
+-TEST_F(MetricsTest, THREADSAFE_Gauge)
++TEST_F(MetricsTest, PullGauge)
+ {
+-  GaugeProcess process;
+-  PID<GaugeProcess> pid = spawn(&process);
++  PullGaugeProcess process;
++  PID<PullGaugeProcess> pid = spawn(&process);
+   ASSERT_TRUE(pid);
+ 
+-  // Gauge with a value.
+-  Gauge gauge("test/gauge", defer(pid, &GaugeProcess::get));
++  // PullGauge with a value.
++  PullGauge gauge("test/gauge", defer(pid, &PullGaugeProcess::get));
+ 
+   AWAIT_READY(metrics::add(gauge));
+ 
+@@ -159,7 +159,7 @@ TEST_F(MetricsTest, THREADSAFE_Gauge)
+   AWAIT_READY(metrics::remove(gauge));
+ 
+   // Failing gauge.
+-  gauge = Gauge("test/failedgauge", defer(pid, &GaugeProcess::fail));
++  gauge = PullGauge("test/failedgauge", defer(pid, &PullGaugeProcess::fail));
+ 
+   AWAIT_READY(metrics::add(gauge));
+ 
+@@ -242,14 +242,14 @@ TEST_F(MetricsTest, THREADSAFE_Snapshot)
+ 
+   Clock::pause();
+ 
+-  // Add a gauge and a counter.
+-  GaugeProcess process;
+-  PID<GaugeProcess> pid = spawn(&process);
++  // Add a pull-gauge and a counter.
++  PullGaugeProcess process;
++  PID<PullGaugeProcess> pid = spawn(&process);
+   ASSERT_TRUE(pid);
+ 
+-  Gauge gauge("test/gauge", defer(pid, &GaugeProcess::get));
+-  Gauge gaugeFail("test/gauge_fail", defer(pid, &GaugeProcess::fail));
+-  Gauge gaugeConst("test/gauge_const", []() { return 99.0; });
++  PullGauge gauge("test/gauge", defer(pid, &PullGaugeProcess::get));
++  PullGauge gaugeFail("test/gauge_fail", defer(pid, &PullGaugeProcess::fail));
++  PullGauge gaugeConst("test/gauge_const", []() { return 99.0; });
+   Counter counter("test/counter");
+ 
+   AWAIT_READY(metrics::add(gauge));
+@@ -331,15 +331,22 @@ TEST_F(MetricsTest, THREADSAFE_SnapshotTimeout)
+   // Advance the clock to avoid rate limit.
+   Clock::advance(Seconds(1));
+ 
+-  // Add gauges and a counter.
+-  GaugeProcess process;
+-  PID<GaugeProcess> pid = spawn(&process);
++  // Add pull-gauges and a counter.
++  PullGaugeProcess process;
++  PID<PullGaugeProcess> pid = spawn(&process);
+   ASSERT_TRUE(pid);
+ 
+-  Gauge gauge("test/gauge", defer(pid, &GaugeProcess::get));
+-  Gauge gaugeFail("test/gauge_fail", defer(pid, &GaugeProcess::fail));
+-  Gauge gaugeTimeout("test/gauge_timeout", defer(pid, &GaugeProcess::pending));
+-  Counter counter("test/counter");
++  PullGauge gauge(
++      "test/gauge",
++      defer(pid, &PullGaugeProcess::get));
++  PullGauge gaugeFail(
++      "test/gauge_fail",
++      defer(pid, &PullGaugeProcess::fail));
++  PullGauge gaugeTimeout(
++      "test/gauge_timeout",
++      defer(pid, &PullGaugeProcess::pending));
++  Counter counter(
++      "test/counter");
+ 
+   AWAIT_READY(metrics::add(gauge));
+   AWAIT_READY(metrics::add(gaugeFail));
+diff --git a/3rdparty/libprocess/src/tests/system_tests.cpp b/3rdparty/libprocess/src/tests/system_tests.cpp
+index 6beb973e0..4a193d778 100644
+--- a/3rdparty/libprocess/src/tests/system_tests.cpp
++++ b/3rdparty/libprocess/src/tests/system_tests.cpp
+@@ -30,7 +30,7 @@ namespace http = process::http;
+ using process::Future;
+ 
+ // MESOS-1433
+-// This test is disabled as the Gauges that are used for these metrics
++// This test is disabled as the pull-gauges that are used for these metrics
+ // may return Failures. In this case we do not put the metric into the
+ // endpoint. This has been observed specifically for the memory
+ // metrics. If in the future we put the error message from the Failure
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
+++ b/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
@@ -1,0 +1,958 @@
+From 24861367975f9d63906082a92d1d900b89ee782e Mon Sep 17 00:00:00 2001
+From: Benjamin Mahler <bmahler@apache.org>
+Date: Fri, 27 Apr 2018 16:07:05 -0700
+Subject: [PATCH] Updated mesos source for Gauge -> PullGauge renaming.
+
+Review: https://reviews.apache.org/r/66832/
+---
+ src/examples/balloon_framework.cpp            |  8 +--
+ src/examples/disk_full_framework.cpp          |  8 +--
+ src/examples/long_lived_framework.cpp         |  8 +--
+ src/log/log.hpp                               |  2 +-
+ src/log/metrics.hpp                           |  6 +--
+ src/master/allocator/mesos/metrics.cpp        | 32 +++++------
+ src/master/allocator/mesos/metrics.hpp        | 26 ++++-----
+ src/master/allocator/sorter/drf/metrics.cpp   |  6 +--
+ src/master/allocator/sorter/drf/metrics.hpp   |  4 +-
+ src/master/master.hpp                         |  2 +-
+ src/master/metrics.cpp                        | 28 +++++-----
+ src/master/metrics.hpp                        | 54 +++++++++----------
+ src/master/registrar.cpp                      | 10 ++--
+ src/sched/sched.cpp                           |  6 +--
+ src/scheduler/scheduler.cpp                   |  6 +--
+ src/slave/containerizer/fetcher_process.hpp   |  6 +--
+ .../mesos/isolators/filesystem/linux.hpp      |  4 +-
+ src/slave/gc_process.hpp                      |  4 +-
+ src/slave/metrics.cpp                         | 28 +++++-----
+ src/slave/metrics.hpp                         | 36 ++++++-------
+ src/slave/slave.hpp                           |  2 +-
+ 21 files changed, 143 insertions(+), 143 deletions(-)
+
+diff --git a/src/examples/balloon_framework.cpp b/src/examples/balloon_framework.cpp
+index 817d71322..4e74a9fac 100644
+--- a/src/examples/balloon_framework.cpp
++++ b/src/examples/balloon_framework.cpp
+@@ -30,7 +30,7 @@
+ #include <process/time.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/bytes.hpp>
+@@ -57,7 +57,7 @@ using google::protobuf::RepeatedPtrField;
+ using process::Clock;
+ using process::defer;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ using process::metrics::Counter;
+ 
+ const double CPUS_PER_TASK = 0.1;
+@@ -379,8 +379,8 @@ private:
+       process::metrics::remove(abnormal_terminations);
+     }
+ 
+-    process::metrics::Gauge uptime_secs;
+-    process::metrics::Gauge registered;
++    process::metrics::PullGauge uptime_secs;
++    process::metrics::PullGauge registered;
+ 
+     process::metrics::Counter tasks_finished;
+     process::metrics::Counter tasks_oomed;
+diff --git a/src/examples/disk_full_framework.cpp b/src/examples/disk_full_framework.cpp
+index d75f76953..3819b2114 100644
+--- a/src/examples/disk_full_framework.cpp
++++ b/src/examples/disk_full_framework.cpp
+@@ -28,7 +28,7 @@
+ #include <process/time.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/bytes.hpp>
+@@ -47,7 +47,7 @@ using std::string;
+ using process::Clock;
+ using process::defer;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ using process::metrics::Counter;
+ 
+ const double CPUS_PER_TASK = 0.1;
+@@ -322,8 +322,8 @@ private:
+       process::metrics::remove(abnormal_terminations);
+     }
+ 
+-    process::metrics::Gauge uptime_secs;
+-    process::metrics::Gauge registered;
++    process::metrics::PullGauge uptime_secs;
++    process::metrics::PullGauge registered;
+ 
+     process::metrics::Counter tasks_finished;
+     process::metrics::Counter tasks_disk_full;
+diff --git a/src/examples/long_lived_framework.cpp b/src/examples/long_lived_framework.cpp
+index 943160d5a..920dc9477 100644
+--- a/src/examples/long_lived_framework.cpp
++++ b/src/examples/long_lived_framework.cpp
+@@ -34,7 +34,7 @@
+ #include <process/time.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/flags.hpp>
+@@ -85,7 +85,7 @@ using process::TLDR;
+ 
+ using process::http::OK;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ using process::metrics::Counter;
+ 
+ // NOTE: Per-task resources are nominal because all of the resources for the
+@@ -483,8 +483,8 @@ private:
+       process::metrics::remove(abnormal_terminations);
+     }
+ 
+-    process::metrics::Gauge uptime_secs;
+-    process::metrics::Gauge subscribed;
++    process::metrics::PullGauge uptime_secs;
++    process::metrics::PullGauge subscribed;
+ 
+     process::metrics::Counter offers_received;
+     process::metrics::Counter tasks_launched;
+diff --git a/src/log/log.hpp b/src/log/log.hpp
+index be038d19d..7cba0b1c8 100644
+--- a/src/log/log.hpp
++++ b/src/log/log.hpp
+@@ -26,7 +26,7 @@
+ #include <process/process.hpp>
+ #include <process/shared.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ #include <stout/nothing.hpp>
+ 
+diff --git a/src/log/metrics.hpp b/src/log/metrics.hpp
+index b537e0a78..4a9efcef9 100644
+--- a/src/log/metrics.hpp
++++ b/src/log/metrics.hpp
+@@ -19,7 +19,7 @@
+ 
+ #include <string>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ namespace mesos {
+ namespace internal {
+@@ -36,9 +36,9 @@ struct Metrics
+ 
+   ~Metrics();
+ 
+-  process::metrics::Gauge recovered;
++  process::metrics::PullGauge recovered;
+ 
+-  process::metrics::Gauge ensemble_size;
++  process::metrics::PullGauge ensemble_size;
+ };
+ 
+ } // namespace log {
+diff --git a/src/master/allocator/mesos/metrics.cpp b/src/master/allocator/mesos/metrics.cpp
+index 4892dbce6..5194f5b3b 100644
+--- a/src/master/allocator/mesos/metrics.cpp
++++ b/src/master/allocator/mesos/metrics.cpp
+@@ -20,7 +20,7 @@
+ 
+ #include <mesos/quota/quota.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/hashmap.hpp>
+@@ -29,7 +29,7 @@
+ 
+ using std::string;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ 
+ namespace mesos {
+ namespace internal {
+@@ -67,13 +67,13 @@ Metrics::Metrics(const HierarchicalAllocatorProcess& _allocator)
+   string resources[] = {"cpus", "mem", "disk"};
+ 
+   foreach (const string& resource, resources) {
+-    Gauge total(
++    PullGauge total(
+         "allocator/mesos/resources/" + resource + "/total",
+         defer(allocator,
+               &HierarchicalAllocatorProcess::_resources_total,
+               resource));
+ 
+-    Gauge offered_or_allocated(
++    PullGauge offered_or_allocated(
+         "allocator/mesos/resources/" + resource + "/offered_or_allocated",
+         defer(allocator,
+               &HierarchicalAllocatorProcess::_resources_offered_or_allocated,
+@@ -96,27 +96,27 @@ Metrics::~Metrics()
+   process::metrics::remove(allocation_run);
+   process::metrics::remove(allocation_run_latency);
+ 
+-  foreach (const Gauge& gauge, resources_total) {
++  foreach (const PullGauge& gauge, resources_total) {
+     process::metrics::remove(gauge);
+   }
+ 
+-  foreach (const Gauge& gauge, resources_offered_or_allocated) {
++  foreach (const PullGauge& gauge, resources_offered_or_allocated) {
+     process::metrics::remove(gauge);
+   }
+ 
+   foreachkey (const string& role, quota_allocated) {
+-    foreachvalue (const Gauge& gauge, quota_allocated[role]) {
++    foreachvalue (const PullGauge& gauge, quota_allocated[role]) {
+       process::metrics::remove(gauge);
+     }
+   }
+ 
+   foreachkey (const string& role, quota_guarantee) {
+-    foreachvalue (const Gauge& gauge, quota_guarantee[role]) {
++    foreachvalue (const PullGauge& gauge, quota_guarantee[role]) {
+       process::metrics::remove(gauge);
+     }
+   }
+ 
+-  foreachvalue (const Gauge& gauge, offer_filters_active) {
++  foreachvalue (const PullGauge& gauge, offer_filters_active) {
+     process::metrics::remove(gauge);
+   }
+ }
+@@ -126,21 +126,21 @@ void Metrics::setQuota(const string& role, const Quota& quota)
+ {
+   CHECK(!quota_allocated.contains(role));
+ 
+-  hashmap<string, Gauge> allocated;
+-  hashmap<string, Gauge> guarantees;
++  hashmap<string, PullGauge> allocated;
++  hashmap<string, PullGauge> guarantees;
+ 
+   foreach (const Resource& resource, quota.info.guarantee()) {
+     CHECK_EQ(Value::SCALAR, resource.type());
+     double value = resource.scalar().value();
+ 
+-    Gauge guarantee = Gauge(
++    PullGauge guarantee = PullGauge(
+         "allocator/mesos/quota"
+         "/roles/" + role +
+         "/resources/" + resource.name() +
+         "/guarantee",
+         process::defer([value]() { return value; }));
+ 
+-    Gauge offered_or_allocated(
++    PullGauge offered_or_allocated(
+         "allocator/mesos/quota"
+         "/roles/" + role +
+         "/resources/" + resource.name() +
+@@ -166,7 +166,7 @@ void Metrics::removeQuota(const string& role)
+ {
+   CHECK(quota_allocated.contains(role));
+ 
+-  foreachvalue (const Gauge& gauge, quota_allocated[role]) {
++  foreachvalue (const PullGauge& gauge, quota_allocated[role]) {
+     process::metrics::remove(gauge);
+   }
+ 
+@@ -178,7 +178,7 @@ void Metrics::addRole(const string& role)
+ {
+   CHECK(!offer_filters_active.contains(role));
+ 
+-  Gauge gauge(
++  PullGauge gauge(
+       "allocator/mesos/offer_filters/roles/" + role + "/active",
+       defer(allocator,
+             &HierarchicalAllocatorProcess::_offer_filters_active,
+@@ -192,7 +192,7 @@ void Metrics::addRole(const string& role)
+ 
+ void Metrics::removeRole(const string& role)
+ {
+-  Option<Gauge> gauge = offer_filters_active.get(role);
++  Option<PullGauge> gauge = offer_filters_active.get(role);
+ 
+   CHECK_SOME(gauge);
+ 
+diff --git a/src/master/allocator/mesos/metrics.hpp b/src/master/allocator/mesos/metrics.hpp
+index d56a10b2d..6d386225c 100644
+--- a/src/master/allocator/mesos/metrics.hpp
++++ b/src/master/allocator/mesos/metrics.hpp
+@@ -23,7 +23,7 @@
+ #include <mesos/quota/quota.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/timer.hpp>
+ 
+ #include <process/pid.hpp>
+@@ -56,12 +56,12 @@ struct Metrics
+   const process::PID<HierarchicalAllocatorProcess> allocator;
+ 
+   // Number of dispatch events currently waiting in the allocator process.
+-  process::metrics::Gauge event_queue_dispatches;
++  process::metrics::PullGauge event_queue_dispatches;
+ 
+   // TODO(bbannier) This metric is identical to `event_queue_dispatches`, but
+   // uses a name deprecated in 1.0. This metric should be removed after the
+   // deprecation cycle.
+-  process::metrics::Gauge event_queue_dispatches_;
++  process::metrics::PullGauge event_queue_dispatches_;
+ 
+   // Number of times the allocation algorithm has run.
+   process::metrics::Counter allocation_runs;
+@@ -72,22 +72,22 @@ struct Metrics
+   // The latency of allocation runs due to the batching of allocation requests.
+   process::metrics::Timer<Milliseconds> allocation_run_latency;
+ 
+-  // Gauges for the total amount of each resource in the cluster.
+-  std::vector<process::metrics::Gauge> resources_total;
++  // PullGauges for the total amount of each resource in the cluster.
++  std::vector<process::metrics::PullGauge> resources_total;
+ 
+-  // Gauges for the allocated amount of each resource in the cluster.
+-  std::vector<process::metrics::Gauge> resources_offered_or_allocated;
++  // PullGauges for the allocated amount of each resource in the cluster.
++  std::vector<process::metrics::PullGauge> resources_offered_or_allocated;
+ 
+-  // Gauges for the per-role quota allocation for each resource.
+-  hashmap<std::string, hashmap<std::string, process::metrics::Gauge>>
++  // PullGauges for the per-role quota allocation for each resource.
++  hashmap<std::string, hashmap<std::string, process::metrics::PullGauge>>
+     quota_allocated;
+ 
+-  // Gauges for the per-role quota guarantee for each resource.
+-  hashmap<std::string, hashmap<std::string, process::metrics::Gauge>>
++  // PullGauges for the per-role quota guarantee for each resource.
++  hashmap<std::string, hashmap<std::string, process::metrics::PullGauge>>
+     quota_guarantee;
+ 
+-  // Gauges for the per-role count of active offer filters.
+-  hashmap<std::string, process::metrics::Gauge> offer_filters_active;
++  // PullGauges for the per-role count of active offer filters.
++  hashmap<std::string, process::metrics::PullGauge> offer_filters_active;
+ };
+ 
+ } // namespace internal {
+diff --git a/src/master/allocator/sorter/drf/metrics.cpp b/src/master/allocator/sorter/drf/metrics.cpp
+index ff63fbac5..ece151c79 100644
+--- a/src/master/allocator/sorter/drf/metrics.cpp
++++ b/src/master/allocator/sorter/drf/metrics.cpp
+@@ -30,7 +30,7 @@ using std::string;
+ using process::UPID;
+ using process::defer;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ 
+ namespace mesos {
+ namespace internal {
+@@ -48,7 +48,7 @@ Metrics::Metrics(
+ 
+ Metrics::~Metrics()
+ {
+-  foreachvalue (const Gauge& gauge, dominantShares) {
++  foreachvalue (const PullGauge& gauge, dominantShares) {
+     process::metrics::remove(gauge);
+   }
+ }
+@@ -58,7 +58,7 @@ void Metrics::add(const string& client)
+ {
+   CHECK(!dominantShares.contains(client));
+ 
+-  Gauge gauge(
++  PullGauge gauge(
+       path::join(prefix, client, "/shares/", "/dominant"),
+       defer(context, [this, client]() {
+         // The client may have been removed if the dispatch
+diff --git a/src/master/allocator/sorter/drf/metrics.hpp b/src/master/allocator/sorter/drf/metrics.hpp
+index 61568cb52..1ff7489ee 100644
+--- a/src/master/allocator/sorter/drf/metrics.hpp
++++ b/src/master/allocator/sorter/drf/metrics.hpp
+@@ -21,7 +21,7 @@
+ 
+ #include <process/pid.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ #include <stout/hashmap.hpp>
+ 
+@@ -51,7 +51,7 @@ struct Metrics
+   const std::string prefix;
+ 
+   // Dominant share of each client.
+-  hashmap<std::string, process::metrics::Gauge> dominantShares;
++  hashmap<std::string, process::metrics::PullGauge> dominantShares;
+ };
+ 
+ } // namespace allocator {
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 43676bd55..61809de88 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -2094,7 +2094,7 @@ private:
+   // copyable metric types only.
+   std::shared_ptr<Metrics> metrics;
+ 
+-  // Gauge handlers.
++  // PullGauge handlers.
+   double _uptime_secs()
+   {
+     return (process::Clock::now() - startTime).secs();
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index 64fc829ac..5c1d08664 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -17,7 +17,7 @@
+ #include <string>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/foreach.hpp>
+@@ -26,7 +26,7 @@
+ #include "master/metrics.hpp"
+ 
+ using process::metrics::Counter;
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ 
+ using std::string;
+ 
+@@ -300,15 +300,15 @@ Metrics::Metrics(const Master& master)
+   const string resources[] = {"cpus", "gpus", "mem", "disk"};
+ 
+   foreach (const string& resource, resources) {
+-    Gauge total(
++    PullGauge total(
+         "master/" + resource + "_total",
+         defer(master, &Master::_resources_total, resource));
+ 
+-    Gauge used(
++    PullGauge used(
+         "master/" + resource + "_used",
+         defer(master, &Master::_resources_used, resource));
+ 
+-    Gauge percent(
++    PullGauge percent(
+         "master/" + resource + "_percent",
+         defer(master, &Master::_resources_percent, resource));
+ 
+@@ -322,15 +322,15 @@ Metrics::Metrics(const Master& master)
+   }
+ 
+   foreach (const string& resource, resources) {
+-    Gauge total(
++    PullGauge total(
+         "master/" + resource + "_revocable_total",
+         defer(master, &Master::_resources_revocable_total, resource));
+ 
+-    Gauge used(
++    PullGauge used(
+         "master/" + resource + "_revocable_used",
+         defer(master, &Master::_resources_revocable_used, resource));
+ 
+-    Gauge percent(
++    PullGauge percent(
+         "master/" + resource + "_revocable_percent",
+         defer(master, &Master::_resources_revocable_percent, resource));
+ 
+@@ -440,32 +440,32 @@ Metrics::~Metrics()
+   process::metrics::remove(slave_unreachable_completed);
+   process::metrics::remove(slave_unreachable_canceled);
+ 
+-  foreach (const Gauge& gauge, resources_total) {
++  foreach (const PullGauge& gauge, resources_total) {
+     process::metrics::remove(gauge);
+   }
+   resources_total.clear();
+ 
+-  foreach (const Gauge& gauge, resources_used) {
++  foreach (const PullGauge& gauge, resources_used) {
+     process::metrics::remove(gauge);
+   }
+   resources_used.clear();
+ 
+-  foreach (const Gauge& gauge, resources_percent) {
++  foreach (const PullGauge& gauge, resources_percent) {
+     process::metrics::remove(gauge);
+   }
+   resources_percent.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_total) {
++  foreach (const PullGauge& gauge, resources_revocable_total) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_total.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_used) {
++  foreach (const PullGauge& gauge, resources_revocable_used) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_used.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_percent) {
++  foreach (const PullGauge& gauge, resources_revocable_percent) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_percent.clear();
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index f701efec0..1ef74dedf 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -21,7 +21,7 @@
+ #include <vector>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/hashmap.hpp>
+@@ -41,28 +41,28 @@ struct Metrics
+ 
+   ~Metrics();
+ 
+-  process::metrics::Gauge uptime_secs;
+-  process::metrics::Gauge elected;
++  process::metrics::PullGauge uptime_secs;
++  process::metrics::PullGauge elected;
+ 
+-  process::metrics::Gauge slaves_connected;
+-  process::metrics::Gauge slaves_disconnected;
+-  process::metrics::Gauge slaves_active;
+-  process::metrics::Gauge slaves_inactive;
+-  process::metrics::Gauge slaves_unreachable;
++  process::metrics::PullGauge slaves_connected;
++  process::metrics::PullGauge slaves_disconnected;
++  process::metrics::PullGauge slaves_active;
++  process::metrics::PullGauge slaves_inactive;
++  process::metrics::PullGauge slaves_unreachable;
+ 
+-  process::metrics::Gauge frameworks_connected;
+-  process::metrics::Gauge frameworks_disconnected;
+-  process::metrics::Gauge frameworks_active;
+-  process::metrics::Gauge frameworks_inactive;
++  process::metrics::PullGauge frameworks_connected;
++  process::metrics::PullGauge frameworks_disconnected;
++  process::metrics::PullGauge frameworks_active;
++  process::metrics::PullGauge frameworks_inactive;
+ 
+-  process::metrics::Gauge outstanding_offers;
++  process::metrics::PullGauge outstanding_offers;
+ 
+   // Task state metrics.
+-  process::metrics::Gauge tasks_staging;
+-  process::metrics::Gauge tasks_starting;
+-  process::metrics::Gauge tasks_running;
+-  process::metrics::Gauge tasks_unreachable;
+-  process::metrics::Gauge tasks_killing;
++  process::metrics::PullGauge tasks_staging;
++  process::metrics::PullGauge tasks_starting;
++  process::metrics::PullGauge tasks_running;
++  process::metrics::PullGauge tasks_unreachable;
++  process::metrics::PullGauge tasks_killing;
+   process::metrics::Counter tasks_finished;
+   process::metrics::Counter tasks_failed;
+   process::metrics::Counter tasks_killed;
+@@ -167,9 +167,9 @@ struct Metrics
+   process::metrics::Counter recovery_slave_removals;
+ 
+   // Process metrics.
+-  process::metrics::Gauge event_queue_messages;
+-  process::metrics::Gauge event_queue_dispatches;
+-  process::metrics::Gauge event_queue_http_requests;
++  process::metrics::PullGauge event_queue_messages;
++  process::metrics::PullGauge event_queue_dispatches;
++  process::metrics::PullGauge event_queue_http_requests;
+ 
+   // Successful registry operations.
+   process::metrics::Counter slave_registrations;
+@@ -192,14 +192,14 @@ struct Metrics
+   process::metrics::Counter slave_unreachable_canceled;
+ 
+   // Non-revocable resources.
+-  std::vector<process::metrics::Gauge> resources_total;
+-  std::vector<process::metrics::Gauge> resources_used;
+-  std::vector<process::metrics::Gauge> resources_percent;
++  std::vector<process::metrics::PullGauge> resources_total;
++  std::vector<process::metrics::PullGauge> resources_used;
++  std::vector<process::metrics::PullGauge> resources_percent;
+ 
+   // Revocable resources.
+-  std::vector<process::metrics::Gauge> resources_revocable_total;
+-  std::vector<process::metrics::Gauge> resources_revocable_used;
+-  std::vector<process::metrics::Gauge> resources_revocable_percent;
++  std::vector<process::metrics::PullGauge> resources_revocable_total;
++  std::vector<process::metrics::PullGauge> resources_revocable_used;
++  std::vector<process::metrics::PullGauge> resources_revocable_percent;
+ 
+   void incrementTasksStates(
+       const TaskState& state,
+diff --git a/src/master/registrar.cpp b/src/master/registrar.cpp
+index ffb458208..f6ce6fd97 100644
+--- a/src/master/registrar.cpp
++++ b/src/master/registrar.cpp
+@@ -30,7 +30,7 @@
+ #include <process/owned.hpp>
+ #include <process/process.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ #include <process/metrics/timer.hpp>
+ 
+@@ -67,7 +67,7 @@ using process::http::OK;
+ 
+ using process::http::authentication::Principal;
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ using process::metrics::Timer;
+ 
+ using std::deque;
+@@ -174,14 +174,14 @@ private:
+       process::metrics::remove(state_store);
+     }
+ 
+-    Gauge queued_operations;
+-    Gauge registry_size_bytes;
++    PullGauge queued_operations;
++    PullGauge registry_size_bytes;
+ 
+     Timer<Milliseconds> state_fetch;
+     Timer<Milliseconds> state_store;
+   } metrics;
+ 
+-  // Gauge handlers.
++  // PullGauge handlers.
+   double _queued_operations()
+   {
+     return operations.size();
+diff --git a/src/sched/sched.cpp b/src/sched/sched.cpp
+index 613a33b7d..ea5927cf7 100644
+--- a/src/sched/sched.cpp
++++ b/src/sched/sched.cpp
+@@ -61,7 +61,7 @@
+ #include <process/process.hpp>
+ #include <process/protobuf.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/abort.hpp>
+@@ -1613,8 +1613,8 @@ private:
+     }
+ 
+     // Process metrics.
+-    process::metrics::Gauge event_queue_messages;
+-    process::metrics::Gauge event_queue_dispatches;
++    process::metrics::PullGauge event_queue_messages;
++    process::metrics::PullGauge event_queue_dispatches;
+   } metrics;
+ 
+   double _event_queue_messages()
+diff --git a/src/scheduler/scheduler.cpp b/src/scheduler/scheduler.cpp
+index 07d2b37e0..c04cfbc42 100644
+--- a/src/scheduler/scheduler.cpp
++++ b/src/scheduler/scheduler.cpp
+@@ -56,7 +56,7 @@
+ #include <process/process.hpp>
+ #include <process/protobuf.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <process/ssl/flags.hpp>
+@@ -814,8 +814,8 @@ private:
+     }
+ 
+     // Process metrics.
+-    process::metrics::Gauge event_queue_messages;
+-    process::metrics::Gauge event_queue_dispatches;
++    process::metrics::PullGauge event_queue_messages;
++    process::metrics::PullGauge event_queue_dispatches;
+   } metrics;
+ 
+   double _event_queue_messages()
+diff --git a/src/slave/containerizer/fetcher_process.hpp b/src/slave/containerizer/fetcher_process.hpp
+index 034fe34fe..56fecf237 100644
+--- a/src/slave/containerizer/fetcher_process.hpp
++++ b/src/slave/containerizer/fetcher_process.hpp
+@@ -28,7 +28,7 @@
+ #include <process/process.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ #include <stout/hashmap.hpp>
+ 
+@@ -258,8 +258,8 @@ private:
+     process::metrics::Counter task_fetches_succeeded;
+     process::metrics::Counter task_fetches_failed;
+ 
+-    process::metrics::Gauge cache_size_total_bytes;
+-    process::metrics::Gauge cache_size_used_bytes;
++    process::metrics::PullGauge cache_size_total_bytes;
++    process::metrics::PullGauge cache_size_used_bytes;
+   } metrics;
+ 
+   const Flags flags;
+diff --git a/src/slave/containerizer/mesos/isolators/filesystem/linux.hpp b/src/slave/containerizer/mesos/isolators/filesystem/linux.hpp
+index d933af4e5..99a6f0daa 100644
+--- a/src/slave/containerizer/mesos/isolators/filesystem/linux.hpp
++++ b/src/slave/containerizer/mesos/isolators/filesystem/linux.hpp
+@@ -23,7 +23,7 @@
+ #include <process/owned.hpp>
+ #include <process/pid.hpp>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ #include <stout/hashmap.hpp>
+ 
+@@ -94,7 +94,7 @@ private:
+         const process::PID<LinuxFilesystemIsolatorProcess>& isolator);
+     ~Metrics();
+ 
+-    process::metrics::Gauge containers_new_rootfs;
++    process::metrics::PullGauge containers_new_rootfs;
+   } metrics;
+ 
+   double _containers_new_rootfs();
+diff --git a/src/slave/gc_process.hpp b/src/slave/gc_process.hpp
+index 920c6ba1f..84c83d36a 100644
+--- a/src/slave/gc_process.hpp
++++ b/src/slave/gc_process.hpp
+@@ -29,7 +29,7 @@
+ #include <process/timer.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ #include <stout/duration.hpp>
+ #include <stout/hashmap.hpp>
+@@ -95,7 +95,7 @@ private:
+ 
+     process::metrics::Counter path_removals_succeeded;
+     process::metrics::Counter path_removals_failed;
+-    process::metrics::Gauge path_removals_pending;
++    process::metrics::PullGauge path_removals_pending;
+   } metrics;
+ 
+   const std::string workDir;
+diff --git a/src/slave/metrics.cpp b/src/slave/metrics.cpp
+index 0eb2b59ed..3dc2bc0cd 100644
+--- a/src/slave/metrics.cpp
++++ b/src/slave/metrics.cpp
+@@ -16,7 +16,7 @@
+ 
+ #include <string>
+ 
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/foreach.hpp>
+@@ -30,7 +30,7 @@ namespace mesos {
+ namespace internal {
+ namespace slave {
+ 
+-using process::metrics::Gauge;
++using process::metrics::PullGauge;
+ 
+ Metrics::Metrics(const Slave& slave)
+   : uptime_secs(
+@@ -133,15 +133,15 @@ Metrics::Metrics(const Slave& slave)
+   const string resources[] = {"cpus", "gpus", "mem", "disk"};
+ 
+   foreach (const string& resource, resources) {
+-    Gauge total(
++    PullGauge total(
+         "slave/" + resource + "_total",
+         defer(slave, &Slave::_resources_total, resource));
+ 
+-    Gauge used(
++    PullGauge used(
+         "slave/" + resource + "_used",
+         defer(slave, &Slave::_resources_used, resource));
+ 
+-    Gauge percent(
++    PullGauge percent(
+         "slave/" + resource + "_percent",
+         defer(slave, &Slave::_resources_percent, resource));
+ 
+@@ -155,15 +155,15 @@ Metrics::Metrics(const Slave& slave)
+   }
+ 
+   foreach (const string& resource, resources) {
+-    Gauge total(
++    PullGauge total(
+         "slave/" + resource + "_revocable_total",
+         defer(slave, &Slave::_resources_revocable_total, resource));
+ 
+-    Gauge used(
++    PullGauge used(
+         "slave/" + resource + "_revocable_used",
+         defer(slave, &Slave::_resources_revocable_used, resource));
+ 
+-    Gauge percent(
++    PullGauge percent(
+         "slave/" + resource + "_revocable_percent",
+         defer(slave, &Slave::_resources_revocable_percent, resource));
+ 
+@@ -214,32 +214,32 @@ Metrics::~Metrics()
+ 
+   process::metrics::remove(container_launch_errors);
+ 
+-  foreach (const Gauge& gauge, resources_total) {
++  foreach (const PullGauge& gauge, resources_total) {
+     process::metrics::remove(gauge);
+   }
+   resources_total.clear();
+ 
+-  foreach (const Gauge& gauge, resources_used) {
++  foreach (const PullGauge& gauge, resources_used) {
+     process::metrics::remove(gauge);
+   }
+   resources_used.clear();
+ 
+-  foreach (const Gauge& gauge, resources_percent) {
++  foreach (const PullGauge& gauge, resources_percent) {
+     process::metrics::remove(gauge);
+   }
+   resources_percent.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_total) {
++  foreach (const PullGauge& gauge, resources_revocable_total) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_total.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_used) {
++  foreach (const PullGauge& gauge, resources_revocable_used) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_used.clear();
+ 
+-  foreach (const Gauge& gauge, resources_revocable_percent) {
++  foreach (const PullGauge& gauge, resources_revocable_percent) {
+     process::metrics::remove(gauge);
+   }
+   resources_revocable_percent.clear();
+diff --git a/src/slave/metrics.hpp b/src/slave/metrics.hpp
+index 3fc933ca6..2adff6664 100644
+--- a/src/slave/metrics.hpp
++++ b/src/slave/metrics.hpp
+@@ -20,7 +20,7 @@
+ #include <vector>
+ 
+ #include <process/metrics/counter.hpp>
+-#include <process/metrics/gauge.hpp>
++#include <process/metrics/pull_gauge.hpp>
+ 
+ 
+ namespace mesos {
+@@ -35,26 +35,26 @@ struct Metrics
+ 
+   ~Metrics();
+ 
+-  process::metrics::Gauge uptime_secs;
+-  process::metrics::Gauge registered;
++  process::metrics::PullGauge uptime_secs;
++  process::metrics::PullGauge registered;
+ 
+   process::metrics::Counter recovery_errors;
+ 
+-  process::metrics::Gauge frameworks_active;
++  process::metrics::PullGauge frameworks_active;
+ 
+-  process::metrics::Gauge tasks_staging;
+-  process::metrics::Gauge tasks_starting;
+-  process::metrics::Gauge tasks_running;
+-  process::metrics::Gauge tasks_killing;
++  process::metrics::PullGauge tasks_staging;
++  process::metrics::PullGauge tasks_starting;
++  process::metrics::PullGauge tasks_running;
++  process::metrics::PullGauge tasks_killing;
+   process::metrics::Counter tasks_finished;
+   process::metrics::Counter tasks_failed;
+   process::metrics::Counter tasks_killed;
+   process::metrics::Counter tasks_lost;
+   process::metrics::Counter tasks_gone;
+ 
+-  process::metrics::Gauge executors_registering;
+-  process::metrics::Gauge executors_running;
+-  process::metrics::Gauge executors_terminating;
++  process::metrics::PullGauge executors_registering;
++  process::metrics::PullGauge executors_running;
++  process::metrics::PullGauge executors_terminating;
+   process::metrics::Counter executors_terminated;
+   process::metrics::Counter executors_preempted;
+ 
+@@ -64,19 +64,19 @@ struct Metrics
+   process::metrics::Counter valid_framework_messages;
+   process::metrics::Counter invalid_framework_messages;
+ 
+-  process::metrics::Gauge executor_directory_max_allowed_age_secs;
++  process::metrics::PullGauge executor_directory_max_allowed_age_secs;
+ 
+   process::metrics::Counter container_launch_errors;
+ 
+   // Non-revocable resources.
+-  std::vector<process::metrics::Gauge> resources_total;
+-  std::vector<process::metrics::Gauge> resources_used;
+-  std::vector<process::metrics::Gauge> resources_percent;
++  std::vector<process::metrics::PullGauge> resources_total;
++  std::vector<process::metrics::PullGauge> resources_used;
++  std::vector<process::metrics::PullGauge> resources_percent;
+ 
+   // Revocable resources.
+-  std::vector<process::metrics::Gauge> resources_revocable_total;
+-  std::vector<process::metrics::Gauge> resources_revocable_used;
+-  std::vector<process::metrics::Gauge> resources_revocable_percent;
++  std::vector<process::metrics::PullGauge> resources_revocable_total;
++  std::vector<process::metrics::PullGauge> resources_revocable_used;
++  std::vector<process::metrics::PullGauge> resources_revocable_percent;
+ };
+ 
+ } // namespace slave {
+diff --git a/src/slave/slave.hpp b/src/slave/slave.hpp
+index ca8cc65bd..b74e44e92 100644
+--- a/src/slave/slave.hpp
++++ b/src/slave/slave.hpp
+@@ -664,7 +664,7 @@ private:
+   process::Future<Nothing> publishResources(
+       const Option<Resources>& additionalResources = None());
+ 
+-  // Gauge methods.
++  // PullGauge methods.
+   double _frameworks_active()
+   {
+     return static_cast<double>(frameworks.size());
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
+++ b/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
@@ -1,0 +1,103 @@
+From f2333b09a468d213a7f3f0d28be2a25e2de03782 Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:57:56 -0700
+Subject: [PATCH] Enabled per-framework metrics in the master.
+
+The `FrameworkMetrics` struct will be used to track per-framework
+metrics in the master.
+
+Review: https://reviews.apache.org/r/67962/
+---
+ src/master/master.hpp  |  8 +++++++-
+ src/master/metrics.cpp | 16 ++++++++++++++++
+ src/master/metrics.hpp | 13 +++++++++++++
+ 3 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 61809de88..367060738 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -2894,6 +2894,9 @@ struct Framework
+   Option<process::Owned<Heartbeater<scheduler::Event, v1::scheduler::Event>>>
+     heartbeater;
+ 
++  // This is used for per-framwork metrics.
++  FrameworkMetrics metrics;
++
+ private:
+   Framework(Master* const _master,
+             const Flags& masterFlags,
+@@ -2908,8 +2911,11 @@ private:
+       registeredTime(time),
+       reregisteredTime(time),
+       completedTasks(masterFlags.max_completed_tasks_per_framework),
+-      unreachableTasks(masterFlags.max_unreachable_tasks_per_framework)
++      unreachableTasks(masterFlags.max_unreachable_tasks_per_framework),
++      metrics(_info)
+   {
++    CHECK(_info.has_id());
++
+     foreach (const std::string& role, roles) {
+       // NOTE: It's possible that we're already being tracked under the role
+       // because a framework can unsubscribe from a role while it still has
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index 5c1d08664..beeb700df 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -16,6 +16,8 @@
+ 
+ #include <string>
+ 
++#include <process/http.hpp>
++
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+@@ -510,6 +512,20 @@ void Metrics::incrementTasksStates(
+ }
+ 
+ 
++FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
++  : frameworkInfo(_frameworkInfo) {}
++
++
++FrameworkMetrics::~FrameworkMetrics() {}
++
++
++string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo)
++{
++  // Percent-encode the framework name to avoid characters like '/' and ' '.
++  return "master/frameworks/" + process::http::encode(frameworkInfo.name()) +
++    "/" + stringify(frameworkInfo.id()) + "/";
++}
++
+ } // namespace master {
+ } // namespace internal {
+ } // namespace mesos {
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index 1ef74dedf..9f10aecba 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -207,6 +207,19 @@ struct Metrics
+       const TaskStatus::Reason& reason);
+ };
+ 
++
++struct FrameworkMetrics
++{
++  explicit FrameworkMetrics(const FrameworkInfo& _frameworkInfo);
++
++  ~FrameworkMetrics();
++
++  const FrameworkInfo frameworkInfo;
++};
++
++
++std::string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo);
++
+ } // namespace master {
+ } // namespace internal {
+ } // namespace mesos {
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
+++ b/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
@@ -1,0 +1,163 @@
+From 0b6d72b563bc536b623ac45177f12eb27e6279c8 Mon Sep 17 00:00:00 2001
+From: Gilbert Song <songzihao1990@gmail.com>
+Date: Wed, 1 Aug 2018 07:58:06 -0700
+Subject: [PATCH] Added per-framework 'subscribed' metric and helpers.
+
+Review: https://reviews.apache.org/r/66820/
+---
+ src/master/master.cpp  | 17 ++++++++++++-----
+ src/master/master.hpp  |  6 +++++-
+ src/master/metrics.cpp | 12 ++++++++++--
+ src/master/metrics.hpp |  3 +++
+ 4 files changed, 30 insertions(+), 8 deletions(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index cc4674ced..e31fd5532 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -452,6 +452,13 @@ void Framework::untrackUnderRole(const string& role)
+ }
+ 
+ 
++void Framework::setFrameworkState(const Framework::State& _state)
++{
++  state = _state;
++  metrics.subscribed = state == Framework::State::ACTIVE ? 1 : 0;
++}
++
++
+ void Master::initialize()
+ {
+   LOG(INFO) << "Master " << info_.id() << " (" << info_.hostname() << ")"
+@@ -3234,7 +3241,7 @@ void Master::_subscribe(
+       // NOTE: We do this after recovering resources (above) so that
+       // the allocator has the correct view of the framework's share.
+       if (!framework->active()) {
+-        framework->state = Framework::State::ACTIVE;
++        framework->setFrameworkState(Framework::State::ACTIVE);
+         allocator->activateFramework(framework->id());
+       }
+ 
+@@ -3348,7 +3355,7 @@ void Master::disconnect(Framework* framework)
+ 
+   LOG(INFO) << "Disconnecting framework " << *framework;
+ 
+-  framework->state = Framework::State::DISCONNECTED;
++  framework->setFrameworkState(Framework::State::DISCONNECTED);
+ 
+   if (framework->pid.isSome()) {
+     // Remove the framework from authenticated. This is safe because
+@@ -3371,7 +3378,7 @@ void Master::deactivate(Framework* framework, bool rescind)
+ 
+   LOG(INFO) << "Deactivating framework " << *framework;
+ 
+-  framework->state = Framework::State::INACTIVE;
++  framework->setFrameworkState(Framework::State::INACTIVE);
+ 
+   // Tell the allocator to stop allocating resources to this framework.
+   allocator->deactivateFramework(framework->id());
+@@ -9418,7 +9425,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+   }
+ 
+   // Activate the framework.
+-  framework->state = Framework::State::ACTIVE;
++  framework->setFrameworkState(Framework::State::ACTIVE);
+   allocator->activateFramework(framework->id());
+ 
+   // Export framework metrics if a principal is specified in `FrameworkInfo`.
+@@ -9568,7 +9575,7 @@ void Master::_failoverFramework(Framework* framework)
+   // NOTE: We do this after recovering resources (above) so that
+   // the allocator has the correct view of the framework's share.
+   if (!framework->active()) {
+-    framework->state = Framework::State::ACTIVE;
++    framework->setFrameworkState(Framework::State::ACTIVE);
+     allocator->activateFramework(framework->id());
+   }
+ 
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 367060738..6352f7e28 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -1737,6 +1737,7 @@ private:
+   Master& operator=(const Master&); // No assigning.
+ 
+   friend struct Framework;
++  friend struct FrameworkMetrics;
+   friend struct Metrics;
+   friend struct Slave;
+   friend struct SlavesWriter;
+@@ -2798,6 +2799,8 @@ struct Framework
+   void trackUnderRole(const std::string& role);
+   void untrackUnderRole(const std::string& role);
+ 
++  void setFrameworkState(const State& _state);
++
+   Master* const master;
+ 
+   FrameworkInfo info;
+@@ -2907,7 +2910,6 @@ private:
+       info(_info),
+       roles(protobuf::framework::getRoles(_info)),
+       capabilities(_info.capabilities()),
+-      state(state),
+       registeredTime(time),
+       reregisteredTime(time),
+       completedTasks(masterFlags.max_completed_tasks_per_framework),
+@@ -2916,6 +2918,8 @@ private:
+   {
+     CHECK(_info.has_id());
+ 
++    setFrameworkState(state);
++
+     foreach (const std::string& role, roles) {
+       // NOTE: It's possible that we're already being tracked under the role
+       // because a framework can unsubscribe from a role while it still has
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index beeb700df..af687f749 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -513,10 +513,18 @@ void Metrics::incrementTasksStates(
+ 
+ 
+ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+-  : frameworkInfo(_frameworkInfo) {}
++  : frameworkInfo(_frameworkInfo),
++    subscribed(
++        getFrameworkMetricPrefix(frameworkInfo) + "subscribed")
++{
++  process::metrics::add(subscribed);
++}
+ 
+ 
+-FrameworkMetrics::~FrameworkMetrics() {}
++FrameworkMetrics::~FrameworkMetrics()
++{
++  process::metrics::remove(subscribed);
++}
+ 
+ 
+ string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo)
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index 9f10aecba..d3f093f9d 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -22,6 +22,7 @@
+ 
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/pull_gauge.hpp>
++#include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/hashmap.hpp>
+@@ -215,6 +216,8 @@ struct FrameworkMetrics
+   ~FrameworkMetrics();
+ 
+   const FrameworkInfo frameworkInfo;
++
++  process::metrics::PushGauge subscribed;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
+++ b/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
@@ -1,0 +1,157 @@
+From 8ff7622b2eebb14e48256533011073199610fcda Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:14 -0700
+Subject: [PATCH] Added per-framework metrics for scheduler calls.
+
+Review: https://reviews.apache.org/r/67776/
+---
+ src/master/http.cpp    |  2 ++
+ src/master/master.cpp  |  6 ++++++
+ src/master/metrics.cpp | 43 +++++++++++++++++++++++++++++++++++++++++-
+ src/master/metrics.hpp |  7 +++++++
+ 4 files changed, 57 insertions(+), 1 deletion(-)
+
+diff --git a/src/master/http.cpp b/src/master/http.cpp
+index 1f9aac44f..f4cd2dc68 100644
+--- a/src/master/http.cpp
++++ b/src/master/http.cpp
+@@ -1056,6 +1056,8 @@ Future<Response> Master::Http::scheduler(
+     return BadRequest("Framework cannot be found");
+   }
+ 
++  framework->metrics.incrementCall(call.type());
++
+   // TODO(greggomann): Move this implicit scheduler authorization
+   // into the authorizer. See MESOS-7399.
+   if (principal.isSome() && principal != framework->info.principal()) {
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index e31fd5532..132eda971 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -2487,6 +2487,8 @@ void Master::receive(
+     return;
+   }
+ 
++  framework->metrics.incrementCall(call.type());
++
+   // This is possible when master --> framework link is broken (i.e., one
+   // way network partition) and the framework is not aware of it. There
+   // is no way for driver based frameworks to detect this in the absence
+@@ -2808,6 +2810,8 @@ void Master::_subscribe(
+ 
+     addFramework(framework, suppressedRoles);
+ 
++    framework->metrics.incrementCall(scheduler::Call::SUBSCRIBE);
++
+     FrameworkRegisteredMessage message;
+     message.mutable_framework_id()->MergeFrom(framework->id());
+     message.mutable_master_info()->MergeFrom(info_);
+@@ -2841,6 +2845,8 @@ void Master::_subscribe(
+ 
+   CHECK_NOTNULL(framework);
+ 
++  framework->metrics.incrementCall(scheduler::Call::SUBSCRIBE);
++
+   if (!framework->recovered()) {
+     // The framework has previously been registered with this master;
+     // it may or may not currently be connected.
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index af687f749..5a32aad6a 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -16,6 +16,8 @@
+ 
+ #include <string>
+ 
++#include <mesos/scheduler/scheduler.hpp>
++
+ #include <process/http.hpp>
+ 
+ #include <process/metrics/counter.hpp>
+@@ -515,15 +517,54 @@ void Metrics::incrementTasksStates(
+ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+   : frameworkInfo(_frameworkInfo),
+     subscribed(
+-        getFrameworkMetricPrefix(frameworkInfo) + "subscribed")
++        getFrameworkMetricPrefix(frameworkInfo) + "subscribed"),
++    calls(
++        getFrameworkMetricPrefix(frameworkInfo) + "calls")
+ {
+   process::metrics::add(subscribed);
++
++  // Add metrics for scheduler calls.
++  process::metrics::add(calls);
++  for (int index = 0;
++       index < scheduler::Call::Type_descriptor()->value_count();
++       index++) {
++    const google::protobuf::EnumValueDescriptor* descriptor =
++      scheduler::Call::Type_descriptor()->value(index);
++
++    const scheduler::Call::Type type =
++      static_cast<scheduler::Call::Type>(descriptor->number());
++
++    if (type == scheduler::Call::UNKNOWN) {
++      continue;
++    }
++
++    Counter counter = Counter(
++        getFrameworkMetricPrefix(frameworkInfo) + "calls/" +
++        strings::lower(descriptor->name()));
++
++    call_types.put(type, counter);
++    process::metrics::add(counter);
++  }
+ }
+ 
+ 
+ FrameworkMetrics::~FrameworkMetrics()
+ {
+   process::metrics::remove(subscribed);
++
++  process::metrics::remove(calls);
++  foreachvalue (const Counter& counter, call_types) {
++    process::metrics::remove(counter);
++  }
++}
++
++
++void FrameworkMetrics::incrementCall(const scheduler::Call::Type& callType)
++{
++  CHECK(call_types.contains(callType));
++
++  call_types.get(callType).get()++;
++  calls++;
+ }
+ 
+ 
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index d3f093f9d..7a7b3a316 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -20,6 +20,8 @@
+ #include <string>
+ #include <vector>
+ 
++#include <mesos/scheduler/scheduler.hpp>
++
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/pull_gauge.hpp>
+ #include <process/metrics/push_gauge.hpp>
+@@ -215,9 +217,14 @@ struct FrameworkMetrics
+ 
+   ~FrameworkMetrics();
+ 
++  void incrementCall(const scheduler::Call::Type& callType);
++
+   const FrameworkInfo frameworkInfo;
+ 
+   process::metrics::PushGauge subscribed;
++
++  process::metrics::Counter calls;
++  hashmap<scheduler::Call::Type, process::metrics::Counter> call_types;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
+++ b/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
@@ -1,0 +1,176 @@
+From 93cdc622f7cfd625efe6350f9749401df069fe5d Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:22 -0700
+Subject: [PATCH] Added per-framework metrics for scheduler events.
+
+Review: https://reviews.apache.org/r/67809/
+---
+ src/master/master.hpp  | 22 +++++++++++++++++++---
+ src/master/metrics.cpp | 41 ++++++++++++++++++++++++++++++++++++++++-
+ src/master/metrics.hpp |  5 +++++
+ 3 files changed, 64 insertions(+), 4 deletions(-)
+
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 6352f7e28..431e8732c 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -346,13 +346,16 @@ public:
+               const Message& _heartbeatMessage,
+               const HttpConnection& _http,
+               const Duration& _interval,
+-              const Option<Duration>& _delay = None())
++              const Option<Duration>& _delay = None(),
++              const Option<lambda::function<void(const Message&)>>&
++                _callback = None())
+     : process::ProcessBase(process::ID::generate("heartbeater")),
+       logMessage(_logMessage),
+       heartbeatMessage(_heartbeatMessage),
+       http(_http),
+       interval(_interval),
+-      delay(_delay) {}
++      delay(_delay),
++      callback(_callback) {}
+ 
+ protected:
+   virtual void initialize() override
+@@ -374,6 +377,10 @@ private:
+     if (http.closed().isPending()) {
+       VLOG(2) << "Sending heartbeat to " << logMessage;
+ 
++      if (callback.isSome()) {
++        callback.get()(heartbeatMessage);
++      }
++
+       Message message(heartbeatMessage);
+       http.send<Message, Event>(message);
+     }
+@@ -386,6 +393,7 @@ private:
+   HttpConnection http;
+   const Duration interval;
+   const Option<Duration> delay;
++  const Option<lambda::function<void(const Message&)>> callback;
+ };
+ 
+ 
+@@ -2324,6 +2332,10 @@ struct Framework
+                    << " framework " << *this;
+     }
+ 
++    // TODO(gilbert): add a helper to transform `SchedulerDriver` API messages
++    // directly to v0 events.
++    metrics.incrementEvent(devolve(evolve(message)));
++
+     if (http.isSome()) {
+       if (!http.get().send(message)) {
+         LOG(WARNING) << "Unable to send event to framework " << *this << ":"
+@@ -2786,7 +2798,11 @@ struct Framework
+           "framework " + stringify(info.id()),
+           event,
+           http.get(),
+-          DEFAULT_HEARTBEAT_INTERVAL);
++          DEFAULT_HEARTBEAT_INTERVAL,
++          None(),
++          [this](const scheduler::Event& event) {
++            this->metrics.incrementEvent(event);
++          });
+ 
+     process::spawn(heartbeater.get().get());
+   }
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index 5a32aad6a..bd424ba80 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -519,7 +519,9 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+     subscribed(
+         getFrameworkMetricPrefix(frameworkInfo) + "subscribed"),
+     calls(
+-        getFrameworkMetricPrefix(frameworkInfo) + "calls")
++        getFrameworkMetricPrefix(frameworkInfo) + "calls"),
++    events(
++        getFrameworkMetricPrefix(frameworkInfo) + "events")
+ {
+   process::metrics::add(subscribed);
+ 
+@@ -545,6 +547,29 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+     call_types.put(type, counter);
+     process::metrics::add(counter);
+   }
++
++  // Add metrics for scheduler events.
++  process::metrics::add(events);
++  for (int index = 0;
++       index < scheduler::Event::Type_descriptor()->value_count();
++       index++) {
++    const google::protobuf::EnumValueDescriptor* descriptor =
++      scheduler::Event::Type_descriptor()->value(index);
++
++    const scheduler::Event::Type type =
++      static_cast<scheduler::Event::Type>(descriptor->number());
++
++    if (type == scheduler::Event::UNKNOWN) {
++      continue;
++    }
++
++    Counter counter = Counter(
++        getFrameworkMetricPrefix(frameworkInfo) + "events/" +
++        strings::lower(descriptor->name()));
++
++    event_types.put(type, counter);
++    process::metrics::add(counter);
++  }
+ }
+ 
+ 
+@@ -556,6 +581,11 @@ FrameworkMetrics::~FrameworkMetrics()
+   foreachvalue (const Counter& counter, call_types) {
+     process::metrics::remove(counter);
+   }
++
++  process::metrics::remove(events);
++  foreachvalue (const Counter& counter, event_types) {
++    process::metrics::remove(counter);
++  }
+ }
+ 
+ 
+@@ -575,6 +605,15 @@ string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo)
+     "/" + stringify(frameworkInfo.id()) + "/";
+ }
+ 
++
++void FrameworkMetrics::incrementEvent(const scheduler::Event& event)
++{
++  CHECK(event_types.contains(event.type()));
++
++  event_types.get(event.type()).get()++;
++  events++;
++}
++
+ } // namespace master {
+ } // namespace internal {
+ } // namespace mesos {
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index 7a7b3a316..fac4440da 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -219,12 +219,17 @@ struct FrameworkMetrics
+ 
+   void incrementCall(const scheduler::Call::Type& callType);
+ 
++  void incrementEvent(const scheduler::Event& event);
++
+   const FrameworkInfo frameworkInfo;
+ 
+   process::metrics::PushGauge subscribed;
+ 
+   process::metrics::Counter calls;
+   hashmap<scheduler::Call::Type, process::metrics::Counter> call_types;
++
++  process::metrics::Counter events;
++  hashmap<scheduler::Event::Type, process::metrics::Counter> event_types;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
+++ b/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
@@ -1,0 +1,146 @@
+From c217ed0a3ae273d7e9fa7cb7573da0f8ff537b64 Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:25 -0700
+Subject: [PATCH] Added per-framework offer metrics.
+
+Review: https://reviews.apache.org/r/67812/
+---
+ src/master/master.cpp  | 14 ++++++++++++++
+ src/master/metrics.cpp | 20 +++++++++++++++++++-
+ src/master/metrics.hpp |  5 +++++
+ 3 files changed, 38 insertions(+), 1 deletion(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 132eda971..91f907c1f 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -4029,6 +4029,8 @@ void Master::accept(
+     // Validate the offers.
+     error = validation::offer::validate(accept.offer_ids(), this, framework);
+ 
++    size_t offersAccepted = 0;
++
+     // Compute offered resources and remove the offers. If the
+     // validation failed, return resources to the allocator.
+     foreach (const OfferID& offerId, accept.offer_ids()) {
+@@ -4046,6 +4048,8 @@ void Master::accept(
+           slaveId = offer->slave_id();
+           allocationInfo = offer->allocation_info();
+           offeredResources += offer->resources();
++
++          offersAccepted++;
+         }
+ 
+         removeOffer(offer);
+@@ -4057,6 +4061,8 @@ void Master::accept(
+       LOG(WARNING) << "Ignoring accept of offer " << offerId
+                    << " since it is no longer valid";
+     }
++
++    framework->metrics.offers_accepted += offersAccepted;
+   }
+ 
+   // If invalid, send TASK_DROPPED for the launch attempts. If the
+@@ -5570,6 +5576,8 @@ void Master::decline(
+ 
+   ++metrics->messages_decline_offers;
+ 
++  size_t offersDeclined = 0;
++
+   //  Return resources to the allocator.
+   foreach (const OfferID& offerId, decline.offer_ids()) {
+     Offer* offer = getOffer(offerId);
+@@ -5581,6 +5589,8 @@ void Master::decline(
+           decline.filters());
+ 
+       removeOffer(offer);
++
++      offersDeclined++;
+       continue;
+     }
+ 
+@@ -5589,6 +5599,8 @@ void Master::decline(
+     LOG(WARNING) << "Ignoring decline of offer " << offerId
+                  << " since it is no longer valid";
+   }
++
++  framework->metrics.offers_declined += offersDeclined;
+ }
+ 
+ 
+@@ -8915,6 +8927,7 @@ void Master::offer(
+ 
+   LOG(INFO) << "Sending offers " << offerIds << " to framework " << *framework;
+ 
++  framework->metrics.offers_sent += message.offers().size();
+   framework->send(message);
+ }
+ 
+@@ -10839,6 +10852,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
+   if (rescind) {
+     RescindResourceOfferMessage message;
+     message.mutable_offer_id()->MergeFrom(offer->id());
++    framework->metrics.offers_rescinded++;
+     framework->send(message);
+   }
+ 
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index bd424ba80..d62514c0e 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -521,10 +521,23 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+     calls(
+         getFrameworkMetricPrefix(frameworkInfo) + "calls"),
+     events(
+-        getFrameworkMetricPrefix(frameworkInfo) + "events")
++        getFrameworkMetricPrefix(frameworkInfo) + "events"),
++    offers_sent(
++        getFrameworkMetricPrefix(frameworkInfo) + "offers/sent"),
++    offers_accepted(
++        getFrameworkMetricPrefix(frameworkInfo) + "offers/accepted"),
++    offers_declined(
++        getFrameworkMetricPrefix(frameworkInfo) + "offers/declined"),
++    offers_rescinded(
++        getFrameworkMetricPrefix(frameworkInfo) + "offers/rescinded")
+ {
+   process::metrics::add(subscribed);
+ 
++  process::metrics::add(offers_sent);
++  process::metrics::add(offers_accepted);
++  process::metrics::add(offers_declined);
++  process::metrics::add(offers_rescinded);
++
+   // Add metrics for scheduler calls.
+   process::metrics::add(calls);
+   for (int index = 0;
+@@ -586,6 +599,11 @@ FrameworkMetrics::~FrameworkMetrics()
+   foreachvalue (const Counter& counter, event_types) {
+     process::metrics::remove(counter);
+   }
++
++  process::metrics::remove(offers_sent);
++  process::metrics::remove(offers_accepted);
++  process::metrics::remove(offers_declined);
++  process::metrics::remove(offers_rescinded);
+ }
+ 
+ 
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index fac4440da..b6fe20fb5 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -230,6 +230,11 @@ struct FrameworkMetrics
+ 
+   process::metrics::Counter events;
+   hashmap<scheduler::Event::Type, process::metrics::Counter> event_types;
++
++  process::metrics::Counter offers_sent;
++  process::metrics::Counter offers_accepted;
++  process::metrics::Counter offers_declined;
++  process::metrics::Counter offers_rescinded;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
+++ b/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
@@ -1,0 +1,204 @@
+From 40b3167eccc12f5b043fff96ccc79a747b914eec Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:31 -0700
+Subject: [PATCH] Added per-framework metrics for task states.
+
+Review: https://reviews.apache.org/r/67813/
+---
+ src/master/master.cpp  | 18 ++++++++++++--
+ src/master/master.hpp  |  2 ++
+ src/master/metrics.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++
+ src/master/metrics.hpp |  7 ++++++
+ 4 files changed, 79 insertions(+), 2 deletions(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 91f907c1f..d341eb2e8 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -10279,6 +10279,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+   // task transitioned to a new state.
+   bool sendSubscribersUpdate = false;
+ 
++  Framework* framework = getFramework(task->framework_id());
++
+   // Set 'removable' to true if this is the first time the task
+   // transitioned to a removable state. Also set the latest state.
+   bool removable;
+@@ -10292,6 +10294,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+         sendSubscribersUpdate = true;
+       }
+ 
++      if (framework != nullptr) {
++        // When we observe a transition away from a non-terminal state,
++        // decrement the relevant metric.
++        framework->metrics.decrementActiveTaskState(task->state());
++        framework->metrics.incrementTaskState(latestState.get());
++      }
++
+       task->set_state(latestState.get());
+     }
+   } else {
+@@ -10305,6 +10314,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+         sendSubscribersUpdate = true;
+       }
+ 
++      if (framework != nullptr) {
++        // When we observe a transition away from a non-terminal state,
++        // decrement the relevant metric.
++        framework->metrics.decrementActiveTaskState(task->state());
++        framework->metrics.incrementTaskState(status.state());
++      }
++
+       task->set_state(status.state());
+     }
+   }
+@@ -10336,7 +10352,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+     // transitioned to `TASK_KILLED` by `removeFramework()`, thus
+     // `sendSubscribersUpdate` shouldn't have been set to true.
+     // TODO(chhsiao): This may be changed after MESOS-6608 is resolved.
+-    Framework* framework = getFramework(task->framework_id());
+     CHECK_NOTNULL(framework);
+ 
+     subscribers.send(
+@@ -10365,7 +10380,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+ 
+     slave->recoverResources(task);
+ 
+-    Framework* framework = getFramework(task->framework_id());
+     if (framework != nullptr) {
+       framework->recoverResources(task);
+     }
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 431e8732c..40df26b81 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -2280,6 +2280,8 @@ struct Framework
+       }
+     }
+ 
++    metrics.incrementTaskState(task->state());
++
+     if (!master->subscribers.subscribed.empty()) {
+       master->subscribers.send(
+           protobuf::master::event::createTaskAdded(*task),
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index d62514c0e..91c5ed167 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -22,6 +22,7 @@
+ 
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/pull_gauge.hpp>
++#include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/foreach.hpp>
+@@ -31,6 +32,7 @@
+ 
+ using process::metrics::Counter;
+ using process::metrics::PullGauge;
++using process::metrics::PushGauge;
+ 
+ using std::string;
+ 
+@@ -583,6 +585,30 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+     event_types.put(type, counter);
+     process::metrics::add(counter);
+   }
++
++  // Add metrics for both active and terminal task states.
++  for (int index = 0; index < TaskState_descriptor()->value_count(); index++) {
++    const google::protobuf::EnumValueDescriptor* descriptor =
++      TaskState_descriptor()->value(index);
++
++    const TaskState state = static_cast<TaskState>(descriptor->number());
++
++    if (protobuf::isTerminalState(state)) {
++      Counter counter = Counter(
++          getFrameworkMetricPrefix(frameworkInfo) + "tasks/terminal/" +
++          strings::lower(descriptor->name()));
++
++      terminal_task_states.put(state, counter);
++      process::metrics::add(counter);
++    } else {
++      PushGauge gauge = PushGauge(
++          getFrameworkMetricPrefix(frameworkInfo) + "tasks/active/" +
++          strings::lower(TaskState_Name(state)));
++
++      active_task_states.put(state, gauge);
++      process::metrics::add(gauge);
++    }
++  }
+ }
+ 
+ 
+@@ -604,6 +630,14 @@ FrameworkMetrics::~FrameworkMetrics()
+   process::metrics::remove(offers_accepted);
+   process::metrics::remove(offers_declined);
+   process::metrics::remove(offers_rescinded);
++
++  foreachvalue (const Counter& counter, terminal_task_states) {
++    process::metrics::remove(counter);
++  }
++
++  foreachvalue (const PushGauge& gauge, active_task_states) {
++    process::metrics::remove(gauge);
++  }
+ }
+ 
+ 
+@@ -616,6 +650,26 @@ void FrameworkMetrics::incrementCall(const scheduler::Call::Type& callType)
+ }
+ 
+ 
++void FrameworkMetrics::incrementTaskState(const TaskState& state)
++{
++  if (protobuf::isTerminalState(state)) {
++    CHECK(terminal_task_states.contains(state));
++    terminal_task_states.get(state).get()++;
++  } else {
++    CHECK(active_task_states.contains(state));
++    active_task_states.get(state).get() += 1;
++  }
++}
++
++
++void FrameworkMetrics::decrementActiveTaskState(const TaskState& state)
++{
++  CHECK(active_task_states.contains(state));
++
++  active_task_states.get(state).get() -= 1;
++}
++
++
+ string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo)
+ {
+   // Percent-encode the framework name to avoid characters like '/' and ' '.
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index b6fe20fb5..071246b71 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -221,6 +221,9 @@ struct FrameworkMetrics
+ 
+   void incrementEvent(const scheduler::Event& event);
+ 
++  void incrementTaskState(const TaskState& state);
++  void decrementActiveTaskState(const TaskState& state);
++
+   const FrameworkInfo frameworkInfo;
+ 
+   process::metrics::PushGauge subscribed;
+@@ -235,6 +238,10 @@ struct FrameworkMetrics
+   process::metrics::Counter offers_accepted;
+   process::metrics::Counter offers_declined;
+   process::metrics::Counter offers_rescinded;
++
++  hashmap<TaskState, process::metrics::Counter> terminal_task_states;
++
++  hashmap<TaskState, process::metrics::PushGauge> active_task_states;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
+++ b/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
@@ -1,0 +1,150 @@
+From 6c07c4f760d54b3d0d8de08f1cda75a4dcb84fa3 Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:39 -0700
+Subject: [PATCH] Added per-framework metrics for offer operations.
+
+Review: https://reviews.apache.org/r/67814/
+---
+ src/master/master.cpp  | 14 ++++++++++++++
+ src/master/metrics.cpp | 41 ++++++++++++++++++++++++++++++++++++++++-
+ src/master/metrics.hpp |  5 +++++
+ 3 files changed, 59 insertions(+), 1 deletion(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index d341eb2e8..42fce66ed 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -5112,6 +5112,10 @@ void Master::_accept(
+                       << (launchExecutor ?
+                           " new executor" : " existing executor");
+ 
++            // Increment this metric here for LAUNCH since it
++            // does not make use of the `_apply()` function.
++            framework->metrics.incrementOperation(operation);
++
+             send(slave->pid, message);
+           }
+         }
+@@ -5319,6 +5323,10 @@ void Master::_accept(
+                   << *slave << " on "
+                   << (launchExecutor ? " new executor" : " existing executor");
+ 
++        // Increment this metric here for LAUNCH_GROUP since it
++        // does not make use of the `_apply()` function.
++        framework->metrics.incrementOperation(operation);
++
+         send(slave->pid, message);
+ 
+         break;
+@@ -10828,6 +10836,12 @@ void Master::_apply(
+ 
+     send(slave->pid, message);
+   }
++
++  if (framework != nullptr) {
++    // We increment per-framework operation metrics for all operations except
++    // LAUNCH and LAUNCH_GROUP here.
++    framework->metrics.incrementOperation(operationInfo);
++  }
+ }
+ 
+ 
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index 91c5ed167..6ec826596 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -531,7 +531,9 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+     offers_declined(
+         getFrameworkMetricPrefix(frameworkInfo) + "offers/declined"),
+     offers_rescinded(
+-        getFrameworkMetricPrefix(frameworkInfo) + "offers/rescinded")
++        getFrameworkMetricPrefix(frameworkInfo) + "offers/rescinded"),
++    operations(
++        getFrameworkMetricPrefix(frameworkInfo) + "operations")
+ {
+   process::metrics::add(subscribed);
+ 
+@@ -609,6 +611,29 @@ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+       process::metrics::add(gauge);
+     }
+   }
++
++  // Add metrics for offer operations.
++  process::metrics::add(operations);
++  for (int index = 0;
++       index < Offer::Operation::Type_descriptor()->value_count();
++       index++) {
++    const google::protobuf::EnumValueDescriptor* descriptor =
++      Offer::Operation::Type_descriptor()->value(index);
++
++    const Offer::Operation::Type type =
++      static_cast<Offer::Operation::Type>(descriptor->number());
++
++    if (type == Offer::Operation::UNKNOWN) {
++      continue;
++    }
++
++    Counter counter =
++      Counter(getFrameworkMetricPrefix(frameworkInfo) +
++      "operations/" + strings::lower(descriptor->name()));
++
++    operation_types.put(type, counter);
++    process::metrics::add(counter);
++  }
+ }
+ 
+ 
+@@ -638,6 +663,11 @@ FrameworkMetrics::~FrameworkMetrics()
+   foreachvalue (const PushGauge& gauge, active_task_states) {
+     process::metrics::remove(gauge);
+   }
++
++  process::metrics::remove(operations);
++  foreachvalue (const Counter& counter, operation_types) {
++    process::metrics::remove(counter);
++  }
+ }
+ 
+ 
+@@ -670,6 +700,15 @@ void FrameworkMetrics::decrementActiveTaskState(const TaskState& state)
+ }
+ 
+ 
++void FrameworkMetrics::incrementOperation(const Offer::Operation& operation)
++{
++  CHECK(operation_types.contains(operation.type()));
++
++  operation_types.get(operation.type()).get()++;
++  operations++;
++}
++
++
+ string getFrameworkMetricPrefix(const FrameworkInfo& frameworkInfo)
+ {
+   // Percent-encode the framework name to avoid characters like '/' and ' '.
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index 071246b71..7ce3941b2 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -224,6 +224,8 @@ struct FrameworkMetrics
+   void incrementTaskState(const TaskState& state);
+   void decrementActiveTaskState(const TaskState& state);
+ 
++  void incrementOperation(const Offer::Operation& operation);
++
+   const FrameworkInfo frameworkInfo;
+ 
+   process::metrics::PushGauge subscribed;
+@@ -242,6 +244,9 @@ struct FrameworkMetrics
+   hashmap<TaskState, process::metrics::Counter> terminal_task_states;
+ 
+   hashmap<TaskState, process::metrics::PushGauge> active_task_states;
++
++  process::metrics::Counter operations;
++  hashmap<Offer::Operation::Type, process::metrics::Counter> operation_types;
+ };
+ 
+ 
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
@@ -1,0 +1,85 @@
+From e869c6699a0724409e5f7ad7d3603c430e228a25 Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:45 -0700
+Subject: [PATCH] Enabled per-framework metrics in the allocator.
+
+The `FrameworkMetrics` struct will hold per-framework metrics tracked
+by the allocator.
+
+Review: https://reviews.apache.org/r/66843/
+---
+ src/master/allocator/mesos/hierarchical.cpp |  3 ++-
+ src/master/allocator/mesos/hierarchical.hpp |  2 ++
+ src/master/allocator/mesos/metrics.cpp      |  7 +++++++
+ src/master/allocator/mesos/metrics.hpp      | 10 ++++++++++
+ 4 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
+index 58155ad4c..5b32b3da2 100644
+--- a/src/master/allocator/mesos/hierarchical.cpp
++++ b/src/master/allocator/mesos/hierarchical.cpp
+@@ -140,7 +140,8 @@ HierarchicalAllocatorProcess::Framework::Framework(
+   : roles(protobuf::framework::getRoles(frameworkInfo)),
+     suppressedRoles(_suppressedRoles),
+     capabilities(frameworkInfo.capabilities()),
+-    active(_active) {}
++    active(_active),
++    metrics(new FrameworkMetrics(frameworkInfo)) {}
+ 
+ 
+ void HierarchicalAllocatorProcess::initialize(
+diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
+index ec45e163e..ff96beea3 100644
+--- a/src/master/allocator/mesos/hierarchical.hpp
++++ b/src/master/allocator/mesos/hierarchical.hpp
+@@ -332,6 +332,8 @@ protected:
+     hashmap<SlaveID, hashset<InverseOfferFilter*>> inverseOfferFilters;
+ 
+     bool active;
++
++    process::Owned<FrameworkMetrics> metrics;
+   };
+ 
+   double _event_queue_dispatches()
+diff --git a/src/master/allocator/mesos/metrics.cpp b/src/master/allocator/mesos/metrics.cpp
+index 5194f5b3b..7a4b153db 100644
+--- a/src/master/allocator/mesos/metrics.cpp
++++ b/src/master/allocator/mesos/metrics.cpp
+@@ -201,6 +201,13 @@ void Metrics::removeRole(const string& role)
+   process::metrics::remove(gauge.get());
+ }
+ 
++
++FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
++  : frameworkInfo(_frameworkInfo) {}
++
++
++FrameworkMetrics::~FrameworkMetrics() {}
++
+ } // namespace internal {
+ } // namespace allocator {
+ } // namespace master {
+diff --git a/src/master/allocator/mesos/metrics.hpp b/src/master/allocator/mesos/metrics.hpp
+index 6d386225c..daac93f7e 100644
+--- a/src/master/allocator/mesos/metrics.hpp
++++ b/src/master/allocator/mesos/metrics.hpp
+@@ -90,6 +90,16 @@ struct Metrics
+   hashmap<std::string, process::metrics::PullGauge> offer_filters_active;
+ };
+ 
++
++struct FrameworkMetrics
++{
++  explicit FrameworkMetrics(const FrameworkInfo& _frameworkInfo);
++
++  ~FrameworkMetrics();
++
++  const FrameworkInfo frameworkInfo;
++};
++
+ } // namespace internal {
+ } // namespace allocator {
+ } // namespace master {
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
+++ b/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
@@ -1,0 +1,29 @@
+From 91d34c441c80c2088c58fd978eee4adc0193fd31 Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:48 -0700
+Subject: [PATCH] Changed the 'capacity_' member of 'BoundedHashMap' to
+ non-const.
+
+This prevents the assignment operator from being implicitly deleted.
+
+Review: https://reviews.apache.org/r/66855/
+---
+ 3rdparty/stout/include/stout/boundedhashmap.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/3rdparty/stout/include/stout/boundedhashmap.hpp b/3rdparty/stout/include/stout/boundedhashmap.hpp
+index 09a9b96f0..f73ec6b66 100644
+--- a/3rdparty/stout/include/stout/boundedhashmap.hpp
++++ b/3rdparty/stout/include/stout/boundedhashmap.hpp
+@@ -149,7 +149,7 @@ public:
+   typename list::const_iterator end() const { return entries_.cend(); }
+ 
+ private:
+-  const size_t capacity_;
++  size_t capacity_;
+   list entries_; // Key-value pairs ordered by insertion order.
+   map keys_; // Map from key to "pointer" to key's location in list.
+ };
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
@@ -1,0 +1,570 @@
+From 7307642eba6d968079e00c35681fd7414d734bbb Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:58:49 -0700
+Subject: [PATCH] Tracked completed framework metrics in the allocator.
+
+This ensures that per-framework metrics which are tracked in the
+allocator will be retained as long as the per-framework metrics
+which are tracked in the master.
+
+Review: https://reviews.apache.org/r/66856/
+---
+ include/mesos/allocator/allocator.hpp       |  3 +-
+ src/master/allocator/mesos/allocator.hpp    | 12 ++++---
+ src/master/allocator/mesos/hierarchical.cpp | 15 +++++++--
+ src/master/allocator/mesos/hierarchical.hpp |  8 ++++-
+ src/master/master.cpp                       |  3 +-
+ src/tests/allocator.hpp                     | 11 ++++---
+ src/tests/api_tests.cpp                     |  4 +--
+ src/tests/master_allocator_tests.cpp        | 36 ++++++++++-----------
+ src/tests/master_quota_tests.cpp            | 20 ++++++------
+ src/tests/reservation_tests.cpp             |  6 ++--
+ src/tests/resource_offers_tests.cpp         |  2 +-
+ src/tests/slave_recovery_tests.cpp          |  2 +-
+ 12 files changed, 73 insertions(+), 49 deletions(-)
+
+diff --git a/include/mesos/allocator/allocator.hpp b/include/mesos/allocator/allocator.hpp
+index c19ab64ff..fadd4e8e3 100644
+--- a/include/mesos/allocator/allocator.hpp
++++ b/include/mesos/allocator/allocator.hpp
+@@ -103,7 +103,8 @@ public:
+       bool filterGpuResources = true,
+       const Option<DomainInfo>& domain = None(),
+       const Option<std::vector<Resources>>&
+-        minAllocatableResources = None()) = 0;
++        minAllocatableResources = None(),
++      const size_t maxCompletedFrameworks = 0) = 0;
+ 
+   /**
+    * Informs the allocator of the recovered state from the master.
+diff --git a/src/master/allocator/mesos/allocator.hpp b/src/master/allocator/mesos/allocator.hpp
+index 900c8ee40..d5f2f794d 100644
+--- a/src/master/allocator/mesos/allocator.hpp
++++ b/src/master/allocator/mesos/allocator.hpp
+@@ -60,7 +60,8 @@ public:
+         fairnessExcludeResourceNames = None(),
+       bool filterGpuResources = true,
+       const Option<DomainInfo>& domain = None(),
+-      const Option<std::vector<Resources>>& minAllocatableResources = None());
++      const Option<std::vector<Resources>>& minAllocatableResources = None(),
++      const size_t maxCompletedFrameworks = 0);
+ 
+   void recover(
+       const int expectedAgentCount,
+@@ -208,7 +209,8 @@ public:
+       bool filterGpuResources = true,
+       const Option<DomainInfo>& domain = None(),
+       const Option<std::vector<Resources>>&
+-        minAllocatableResources = None()) = 0;
++        minAllocatableResources = None(),
++      const size_t maxCompletedFrameworks = 0) = 0;
+ 
+   virtual void recover(
+       const int expectedAgentCount,
+@@ -364,7 +366,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
+     const Option<std::set<std::string>>& fairnessExcludeResourceNames,
+     bool filterGpuResources,
+     const Option<DomainInfo>& domain,
+-    const Option<std::vector<Resources>>& minAllocatableResources)
++    const Option<std::vector<Resources>>& minAllocatableResources,
++    const size_t maxCompletedFrameworks)
+ {
+   process::dispatch(
+       process,
+@@ -375,7 +378,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
+       fairnessExcludeResourceNames,
+       filterGpuResources,
+       domain,
+-      minAllocatableResources);
++      minAllocatableResources,
++      maxCompletedFrameworks);
+ }
+ 
+ 
+diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
+index 5b32b3da2..c39685bcc 100644
+--- a/src/master/allocator/mesos/hierarchical.cpp
++++ b/src/master/allocator/mesos/hierarchical.cpp
+@@ -157,7 +157,8 @@ void HierarchicalAllocatorProcess::initialize(
+     const Option<set<string>>& _fairnessExcludeResourceNames,
+     bool _filterGpuResources,
+     const Option<DomainInfo>& _domain,
+-    const Option<std::vector<Resources>>& _minAllocatableResources)
++    const Option<std::vector<Resources>>& _minAllocatableResources,
++    const size_t maxCompletedFrameworks)
+ {
+   allocationInterval = _allocationInterval;
+   offerCallback = _offerCallback;
+@@ -169,6 +170,10 @@ void HierarchicalAllocatorProcess::initialize(
+   initialized = true;
+   paused = false;
+ 
++  completedFrameworkMetrics =
++    BoundedHashMap<FrameworkID, process::Owned<FrameworkMetrics>>(
++        maxCompletedFrameworks);
++
+   // Resources for quota'ed roles are allocated separately and prior to
+   // non-quota'ed roles, hence a dedicated sorter for quota'ed roles is
+   // necessary.
+@@ -313,7 +318,7 @@ void HierarchicalAllocatorProcess::removeFramework(
+   CHECK(initialized);
+   CHECK(frameworks.contains(frameworkId)) << frameworkId;
+ 
+-  const Framework& framework = frameworks.at(frameworkId);
++  Framework& framework = frameworks.at(frameworkId);
+ 
+   foreach (const string& role, framework.roles) {
+     // Might not be in 'frameworkSorters[role]' because it
+@@ -338,6 +343,12 @@ void HierarchicalAllocatorProcess::removeFramework(
+     untrackFrameworkUnderRole(frameworkId, role);
+   }
+ 
++  // Transfer ownership of this framework's metrics to
++  // `completedFrameworkMetrics`.
++  completedFrameworkMetrics.set(
++      frameworkId,
++      Owned<FrameworkMetrics>(framework.metrics.release()));
++
+   // Do not delete the filters contained in this
+   // framework's `offerFilters` hashset yet, see comments in
+   // HierarchicalAllocatorProcess::reviveOffers and
+diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
+index ff96beea3..b86b01b00 100644
+--- a/src/master/allocator/mesos/hierarchical.hpp
++++ b/src/master/allocator/mesos/hierarchical.hpp
+@@ -26,6 +26,7 @@
+ #include <process/id.hpp>
+ #include <process/owned.hpp>
+ 
++#include <stout/boundedhashmap.hpp>
+ #include <stout/duration.hpp>
+ #include <stout/hashmap.hpp>
+ #include <stout/hashset.hpp>
+@@ -87,6 +88,7 @@ public:
+     : initialized(false),
+       paused(true),
+       metrics(*this),
++      completedFrameworkMetrics(0),
+       roleSorter(roleSorterFactory()),
+       quotaRoleSorter(quotaRoleSorterFactory()),
+       frameworkSorterFactory(_frameworkSorterFactory) {}
+@@ -113,7 +115,8 @@ public:
+       bool filterGpuResources = true,
+       const Option<DomainInfo>& domain = None(),
+       const Option<std::vector<Resources>>&
+-        minAllocatableResources = None());
++        minAllocatableResources = None(),
++      const size_t maxCompletedFrameworks = 0);
+ 
+   void recover(
+       const int _expectedAgentCount,
+@@ -356,6 +359,9 @@ protected:
+ 
+   hashmap<FrameworkID, Framework> frameworks;
+ 
++  BoundedHashMap<FrameworkID, process::Owned<FrameworkMetrics>>
++    completedFrameworkMetrics;
++
+   class Slave
+   {
+   public:
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 42fce66ed..9a887ae17 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -810,7 +810,8 @@ void Master::initialize()
+       flags.fair_sharing_excluded_resource_names,
+       flags.filter_gpu_resources,
+       flags.domain,
+-      CHECK_NOTERROR(minAllocatableResources));
++      CHECK_NOTERROR(minAllocatableResources),
++      flags.max_completed_frameworks);
+ 
+   // Parse the whitelist. Passing Allocator::updateWhitelist()
+   // callback is safe because we shut down the whitelistWatcher in
+diff --git a/src/tests/allocator.hpp b/src/tests/allocator.hpp
+index 73fc06043..eef876609 100644
+--- a/src/tests/allocator.hpp
++++ b/src/tests/allocator.hpp
+@@ -45,7 +45,7 @@ namespace tests {
+ 
+ ACTION_P(InvokeInitialize, allocator)
+ {
+-  allocator->real->initialize(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
++  allocator->real->initialize(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+ }
+ 
+ 
+@@ -235,9 +235,9 @@ public:
+     // to get the best of both worlds: the ability to use 'DoDefault'
+     // and no warnings when expectations are not explicit.
+ 
+-    ON_CALL(*this, initialize(_, _, _, _, _, _, _))
++    ON_CALL(*this, initialize(_, _, _, _, _, _, _, _))
+       .WillByDefault(InvokeInitialize(this));
+-    EXPECT_CALL(*this, initialize(_, _, _, _, _, _, _))
++    EXPECT_CALL(*this, initialize(_, _, _, _, _, _, _, _))
+       .WillRepeatedly(DoDefault());
+ 
+     ON_CALL(*this, recover(_, _))
+@@ -368,7 +368,7 @@ public:
+ 
+   virtual ~TestAllocator() {}
+ 
+-  MOCK_METHOD7(initialize, void(
++  MOCK_METHOD8(initialize, void(
+       const Duration&,
+       const lambda::function<
+           void(const FrameworkID&,
+@@ -379,7 +379,8 @@ public:
+       const Option<std::set<std::string>>&,
+       bool,
+       const Option<DomainInfo>&,
+-      const Option<std::vector<Resources>>&));
++      const Option<std::vector<Resources>>&,
++      const size_t maxCompletedFrameworks));
+ 
+   MOCK_METHOD2(recover, void(
+       const int expectedAgentCount,
+diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
+index bc6ca510b..3f62d676a 100644
+--- a/src/tests/api_tests.cpp
++++ b/src/tests/api_tests.cpp
+@@ -1060,7 +1060,7 @@ TEST_P(MasterAPITest, ReserveResources)
+ {
+   TestAllocator<> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -1151,7 +1151,7 @@ TEST_P(MasterAPITest, UnreserveResources)
+ {
+   TestAllocator<> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+diff --git a/src/tests/master_allocator_tests.cpp b/src/tests/master_allocator_tests.cpp
+index 9b73277cc..bece1920c 100644
+--- a/src/tests/master_allocator_tests.cpp
++++ b/src/tests/master_allocator_tests.cpp
+@@ -164,7 +164,7 @@ TYPED_TEST(MasterAllocatorTest, SingleFramework)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -212,7 +212,7 @@ TYPED_TEST(MasterAllocatorTest, ResourcesUnused)
+ 
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -321,7 +321,7 @@ TYPED_TEST(MasterAllocatorTest, OutOfOrderDispatch)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -450,7 +450,7 @@ TYPED_TEST(MasterAllocatorTest, SchedulerFailover)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -576,7 +576,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkExited)
+ 
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.allocation_interval = Milliseconds(50);
+@@ -736,7 +736,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveLost)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -860,7 +860,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveAdded)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.allocation_interval = Milliseconds(50);
+@@ -956,7 +956,7 @@ TYPED_TEST(MasterAllocatorTest, TaskFinished)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.allocation_interval = Milliseconds(50);
+@@ -1060,7 +1060,7 @@ TYPED_TEST(MasterAllocatorTest, CpusOnlyOfferedAndTaskLaunched)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.allocation_interval = Milliseconds(50);
+@@ -1141,7 +1141,7 @@ TYPED_TEST(MasterAllocatorTest, MemoryOnlyOfferedAndTaskLaunched)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.allocation_interval = Milliseconds(50);
+@@ -1235,7 +1235,7 @@ TYPED_TEST(MasterAllocatorTest, Whitelist)
+ 
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Future<Nothing> updateWhitelist1;
+   EXPECT_CALL(allocator, updateWhitelist(Option<hashset<string>>(hosts)))
+@@ -1274,7 +1274,7 @@ TYPED_TEST(MasterAllocatorTest, RoleTest)
+ {
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   masterFlags.roles = Some("role2");
+@@ -1369,7 +1369,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
+   {
+     TestAllocator<TypeParam> allocator;
+ 
+-    EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++    EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+     Try<Owned<cluster::Master>> master = this->StartMaster(
+         &allocator, masterFlags);
+@@ -1427,7 +1427,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
+   {
+     TestAllocator<TypeParam> allocator2;
+ 
+-    EXPECT_CALL(allocator2, initialize(_, _, _, _, _, _, _));
++    EXPECT_CALL(allocator2, initialize(_, _, _, _, _, _, _, _));
+ 
+     Future<Nothing> addFramework;
+     EXPECT_CALL(allocator2, addFramework(_, _, _, _, _))
+@@ -1495,7 +1495,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
+   {
+     TestAllocator<TypeParam> allocator;
+ 
+-    EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++    EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+     Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+     ASSERT_SOME(master);
+@@ -1551,7 +1551,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
+   {
+     TestAllocator<TypeParam> allocator2;
+ 
+-    EXPECT_CALL(allocator2, initialize(_, _, _, _, _, _, _));
++    EXPECT_CALL(allocator2, initialize(_, _, _, _, _, _, _, _));
+ 
+     Future<Nothing> addSlave;
+     EXPECT_CALL(allocator2, addSlave(_, _, _, _, _, _))
+@@ -1618,7 +1618,7 @@ TYPED_TEST(MasterAllocatorTest, RebalancedForUpdatedWeights)
+ 
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   // Start Mesos master.
+   master::Flags masterFlags = this->CreateMasterFlags();
+@@ -1811,7 +1811,7 @@ TYPED_TEST(MasterAllocatorTest, NestedRoles)
+ 
+   TestAllocator<TypeParam> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   master::Flags masterFlags = this->CreateMasterFlags();
+   Try<Owned<cluster::Master>> master =
+diff --git a/src/tests/master_quota_tests.cpp b/src/tests/master_quota_tests.cpp
+index e49e5cccd..320f3db51 100644
+--- a/src/tests/master_quota_tests.cpp
++++ b/src/tests/master_quota_tests.cpp
+@@ -424,7 +424,7 @@ TEST_F(MasterQuotaTest, SetExistingQuota)
+ TEST_F(MasterQuotaTest, RemoveSingleQuota)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -588,7 +588,7 @@ TEST_F(MasterQuotaTest, Status)
+ TEST_F(MasterQuotaTest, InsufficientResourcesSingleAgent)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -648,7 +648,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesSingleAgent)
+ TEST_F(MasterQuotaTest, InsufficientResourcesMultipleAgents)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -723,7 +723,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesMultipleAgents)
+ TEST_F(MasterQuotaTest, AvailableResourcesSingleAgent)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -773,7 +773,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesSingleAgent)
+ TEST_F(MasterQuotaTest, AvailableResourcesMultipleAgents)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -842,7 +842,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesMultipleAgents)
+ TEST_F(MasterQuotaTest, AvailableResourcesAfterRescinding)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+@@ -1077,7 +1077,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
+   }
+ 
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   // Restart the master; configured quota should be recovered from the registry.
+   master->reset();
+@@ -1110,7 +1110,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
+ TEST_F(MasterQuotaTest, NoAuthenticationNoAuthorization)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   // Disable http_readwrite authentication and authorization.
+   // TODO(alexr): Setting master `--acls` flag to `ACLs()` or `None()` seems
+@@ -1216,7 +1216,7 @@ TEST_F(MasterQuotaTest, UnauthenticatedQuotaRequest)
+ TEST_F(MasterQuotaTest, AuthorizeGetUpdateQuotaRequests)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   // Setup ACLs so that only the default principal can modify quotas
+   // for `ROLE1` and read status.
+@@ -1764,7 +1764,7 @@ TEST_F(MasterQuotaTest, DISABLED_ChildRoleDeleteParentQuota)
+ TEST_F(MasterQuotaTest, DISABLED_ClusterCapacityWithNestedRoles)
+ {
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+diff --git a/src/tests/reservation_tests.cpp b/src/tests/reservation_tests.cpp
+index eabcaebff..47c9b4f40 100644
+--- a/src/tests/reservation_tests.cpp
++++ b/src/tests/reservation_tests.cpp
+@@ -655,7 +655,7 @@ TEST_P(ReservationTest, DropReserveTooLarge)
+   masterFlags.allocation_interval = Milliseconds(5);
+   masterFlags.roles = frameworkInfo.roles(0);
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator, masterFlags);
+   ASSERT_SOME(master);
+@@ -2160,7 +2160,7 @@ TEST_P(ReservationTest, DropReserveWithDifferentRole)
+   masterFlags.allocation_interval = Milliseconds(5);
+ 
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator, masterFlags);
+   ASSERT_SOME(master);
+@@ -2261,7 +2261,7 @@ TEST_P(ReservationTest, PreventUnreservingAlienResources)
+   masterFlags.allocation_interval = Milliseconds(5);
+ 
+   TestAllocator<> allocator;
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator, masterFlags);
+   ASSERT_SOME(master);
+diff --git a/src/tests/resource_offers_tests.cpp b/src/tests/resource_offers_tests.cpp
+index 6b1e494aa..b0492af7c 100644
+--- a/src/tests/resource_offers_tests.cpp
++++ b/src/tests/resource_offers_tests.cpp
+@@ -284,7 +284,7 @@ TEST_F(ResourceOffersTest, Request)
+ {
+   TestAllocator<master::allocator::HierarchicalDRFAllocator> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = StartMaster(&allocator);
+   ASSERT_SOME(master);
+diff --git a/src/tests/slave_recovery_tests.cpp b/src/tests/slave_recovery_tests.cpp
+index 60efba54b..036b96c65 100644
+--- a/src/tests/slave_recovery_tests.cpp
++++ b/src/tests/slave_recovery_tests.cpp
+@@ -3707,7 +3707,7 @@ TYPED_TEST(SlaveRecoveryTest, ReconcileTasksMissingFromSlave)
+ {
+   TestAllocator<master::allocator::HierarchicalDRFAllocator> allocator;
+ 
+-  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _));
++  EXPECT_CALL(allocator, initialize(_, _, _, _, _, _, _, _));
+ 
+   Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
+   ASSERT_SOME(master);
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
+++ b/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
@@ -1,0 +1,214 @@
+From 4a4620743f71494bf1fa3e512092681c29b107fe Mon Sep 17 00:00:00 2001
+From: Greg Mann <greg@mesosphere.io>
+Date: Wed, 1 Aug 2018 07:59:04 -0700
+Subject: [PATCH] Added per-framework metrics for suppressed roles.
+
+Review: https://reviews.apache.org/r/66870/
+---
+ src/master/allocator/mesos/hierarchical.cpp | 17 ++++++
+ src/master/allocator/mesos/metrics.cpp      | 66 ++++++++++++++++++++-
+ src/master/allocator/mesos/metrics.hpp      | 12 ++++
+ 3 files changed, 93 insertions(+), 2 deletions(-)
+
+diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
+index c39685bcc..c77cd497f 100644
+--- a/src/master/allocator/mesos/hierarchical.cpp
++++ b/src/master/allocator/mesos/hierarchical.cpp
+@@ -283,8 +283,10 @@ void HierarchicalAllocatorProcess::addFramework(
+ 
+     if (suppressedRoles.count(role)) {
+       frameworkSorters.at(role)->deactivate(frameworkId.value());
++      framework.metrics->suppressRole(role);
+     } else {
+       frameworkSorters.at(role)->activate(frameworkId.value());
++      framework.metrics->reviveRole(role);
+     }
+   }
+ 
+@@ -452,6 +454,10 @@ void HierarchicalAllocatorProcess::updateFramework(
+     return result;
+   }();
+ 
++  foreach (const string& role, newSuppressedRoles) {
++    framework.metrics->suppressRole(role);
++  }
++
+   foreach (const string& role, removedRoles | newSuppressedRoles) {
+     CHECK(frameworkSorters.contains(role));
+     frameworkSorters.at(role)->deactivate(frameworkId.value());
+@@ -467,6 +473,8 @@ void HierarchicalAllocatorProcess::updateFramework(
+     if (framework.offerFilters.contains(role)) {
+       framework.offerFilters.erase(role);
+     }
++
++    framework.metrics->removeSubscribedRole(role);
+   }
+ 
+   const set<string> addedRoles = [&]() {
+@@ -485,7 +493,13 @@ void HierarchicalAllocatorProcess::updateFramework(
+     return result;
+   }();
+ 
++  foreach (const string& role, newRevivedRoles) {
++    framework.metrics->reviveRole(role);
++  }
++
+   foreach (const string& role, addedRoles) {
++    framework.metrics->addSubscribedRole(role);
++
+     // NOTE: It's possible that we're already tracking this framework
+     // under the role because a framework can unsubscribe from a role
+     // while it still has resources allocated to the role.
+@@ -750,6 +764,7 @@ void HierarchicalAllocatorProcess::removeFilters(const SlaveID& slaveId)
+       if (erased) {
+         frameworkSorters.at(role)->activate(id.value());
+         framework.suppressedRoles.erase(role);
++        framework.metrics->reviveRole(role);
+       }
+     }
+   }
+@@ -1314,6 +1329,7 @@ void HierarchicalAllocatorProcess::suppressOffers(
+ 
+     frameworkSorters.at(role)->deactivate(frameworkId.value());
+     framework.suppressedRoles.insert(role);
++    framework.metrics->suppressRole(role);
+   }
+ 
+   LOG(INFO) << "Suppressed offers for roles " << stringify(roles)
+@@ -1342,6 +1358,7 @@ void HierarchicalAllocatorProcess::reviveOffers(
+ 
+     frameworkSorters.at(role)->activate(frameworkId.value());
+     framework.suppressedRoles.erase(role);
++    framework.metrics->reviveRole(role);
+   }
+ 
+   // We delete each actual `OfferFilter` when
+diff --git a/src/master/allocator/mesos/metrics.cpp b/src/master/allocator/mesos/metrics.cpp
+index 7a4b153db..0b5534715 100644
+--- a/src/master/allocator/mesos/metrics.cpp
++++ b/src/master/allocator/mesos/metrics.cpp
+@@ -21,15 +21,21 @@
+ #include <mesos/quota/quota.hpp>
+ 
+ #include <process/metrics/pull_gauge.hpp>
++#include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/metrics.hpp>
+ 
+ #include <stout/hashmap.hpp>
+ 
++#include "common/protobuf_utils.hpp"
++
++#include "master/metrics.hpp"
++
+ #include "master/allocator/mesos/hierarchical.hpp"
+ 
+ using std::string;
+ 
+ using process::metrics::PullGauge;
++using process::metrics::PushGauge;
+ 
+ namespace mesos {
+ namespace internal {
+@@ -203,10 +209,66 @@ void Metrics::removeRole(const string& role)
+ 
+ 
+ FrameworkMetrics::FrameworkMetrics(const FrameworkInfo& _frameworkInfo)
+-  : frameworkInfo(_frameworkInfo) {}
++  : frameworkInfo(_frameworkInfo)
++{
++  // TODO(greggomann): Calling `getRoles` below copies the roles from the
++  // framework info, which could become expensive if the number of roles grows
++  // large. Consider optimizing this.
++  foreach (
++      const string& role,
++      protobuf::framework::getRoles(frameworkInfo)) {
++    addSubscribedRole(role);
++  }
++}
++
++
++FrameworkMetrics::~FrameworkMetrics()
++{
++  foreach (const string& role, suppressed.keys()) {
++    removeSubscribedRole(role);
++  }
++
++  CHECK(suppressed.empty());
++}
++
++
++void FrameworkMetrics::reviveRole(const string& role)
++{
++  auto iter = suppressed.find(role);
++  CHECK(iter != suppressed.end());
++  iter->second = 0;
++}
+ 
+ 
+-FrameworkMetrics::~FrameworkMetrics() {}
++void FrameworkMetrics::suppressRole(const string& role)
++{
++  auto iter = suppressed.find(role);
++  CHECK(iter != suppressed.end());
++  iter->second = 1;
++}
++
++
++void FrameworkMetrics::addSubscribedRole(const string& role)
++{
++  auto result = suppressed.emplace(
++      role,
++      PushGauge(
++          getFrameworkMetricPrefix(frameworkInfo) + "roles/" +
++          role + "/suppressed"));
++
++  CHECK(result.second);
++  process::metrics::add(result.first->second);
++}
++
++
++void FrameworkMetrics::removeSubscribedRole(const string& role)
++{
++  auto iter = suppressed.find(role);
++
++  CHECK(iter != suppressed.end());
++  process::metrics::remove(iter->second);
++  suppressed.erase(iter);
++}
+ 
+ } // namespace internal {
+ } // namespace allocator {
+diff --git a/src/master/allocator/mesos/metrics.hpp b/src/master/allocator/mesos/metrics.hpp
+index daac93f7e..34cc16b3a 100644
+--- a/src/master/allocator/mesos/metrics.hpp
++++ b/src/master/allocator/mesos/metrics.hpp
+@@ -24,6 +24,7 @@
+ 
+ #include <process/metrics/counter.hpp>
+ #include <process/metrics/pull_gauge.hpp>
++#include <process/metrics/push_gauge.hpp>
+ #include <process/metrics/timer.hpp>
+ 
+ #include <process/pid.hpp>
+@@ -97,7 +98,18 @@ struct FrameworkMetrics
+ 
+   ~FrameworkMetrics();
+ 
++  void reviveRole(const std::string& role);
++  void suppressRole(const std::string& role);
++
++  // Since frameworks can update their list of roles,
++  // these methods add/remove per-role metrics.
++  void addSubscribedRole(const std::string& role);
++  void removeSubscribedRole(const std::string& role);
++
+   const FrameworkInfo frameworkInfo;
++
++  // Suppresion state metric (boolean 0 or 1) for each role.
++  hashmap<std::string, process::metrics::PushGauge> suppressed;
+ };
+ 
+ } // namespace internal {
+-- 
+2.17.0
+


### PR DESCRIPTION
#3298 [1.11] Added Mesos patches for per-framework metrics.
#3273 [1.11] Add more information to diagnostics bundle
#3212 [1.11] Add timestamp for dmesg, distro version, timedatectl, systemd unit status and pods endpoint to diag bundle