### PR TITLE
Fix the release create stage.

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -45,4 +45,4 @@ python3.5 -m venv /tmp/dcos_build_venv
 ./prep_local
 
 # Build a release of DC/OS
-release create --noop --local `whoami` local_build $tree_variants
+release --noop --local create `whoami` local_build $tree_variants


### PR DESCRIPTION
## High-level description

Fix the release create step

**Before this change**

```
[10:26:03]	+ release create --noop --local root local_build default installer
[10:26:04]	usage: release [-h] [--noop] [--local] [-c CONFIG]
[10:26:04]	               {promote,create,create-installer} ...
[10:26:04]	release: error: unrecognized arguments: --noop --local
[10:26:04]	Process exited with code 2
[10:26:04]	Process exited with code 2
[10:26:04]	Step build_teamcity (Command Line) failed
```

**After this change**

```
Successfully installed dcos-image
++ whoami
+ release --noop --local create senthil local_build default installer
starting: Building packages
starting: dcos/dcos-builder (adminrouter)
```