### PR TITLE
Bump dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,9 @@ Format of the entries must be.
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
 
+* DC/OS Net: Logging improvements (DCOS_OSS-3929)
+
+* DC/OS Net: Get rid of epmd (DCOS_OSS-1751)
 
 ### Security Updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ Format of the entries must be.
 
 * DC/OS Net: Get rid of epmd (DCOS_OSS-1751)
 
+* Upgrade OTP version (DCOS_OSS-3655)
+
 ### Security Updates
 
 * Update cURL to 7.59. (DCOS_OSS-2367)

--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -9,7 +9,6 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 53: dcos-net (dns)
  - 61091: telegraf
  - 61092: dcos-metrics
- - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)
 

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -526,7 +526,6 @@ function check_all() {
             "61053 mesos-dns" \
             "61091 telegraf" \
             "61092 dcos-metrics" \
-            "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do
@@ -540,7 +539,6 @@ function check_all() {
             "61001 agent-adminrouter" \
             "61091 telegraf" \
             "61092 dcos-metrics" \
-            "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -157,8 +157,7 @@ package:
         {dcos_net,
           [
             {dist_port, 62501},
-            {epmd_port, 61420},
-            {enable_killer, false}
+            {killer, {enabled, abort}}
           ]
         },
         {dcos_l4lb,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -156,8 +156,7 @@ package:
       [
         {dcos_net,
           [
-            {dist_port, 62501},
-            {killer, {enabled, abort}}
+            {dist_port, 62501}
           ]
         },
         {dcos_l4lb,

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "36de37d5f8087505228cb2cdfc5c30859a302b23",
+      "ref": "1753c7f42cf4577427740e9a23aedb433242b696",
       "ref_origin": "master"
     }
   },

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -6,6 +6,54 @@ export LDFLAGS="-L/opt/mesosphere/lib -L/opt/mesosphere/active/ncurses/lib -L/op
 export CPPFLAGS=${CFLAGS}
 
 pushd /pkg/src/erlang
+
+# ERL-692
+## erts: Delete fd from poll-set when closing fd_driver port
+git cherry-pick --no-commit 1d1f29eb614ce75012f9136d185f4dbcccc8650b
+# ERL-622
+## ssl: Improve error handling
+git cherry-pick --no-commit a06549fbe59333347232c56093791c0075fcd150
+## ssl: Add new sender process for TLS state machine
+git cherry-pick --no-commit d87ac1c55188f5ba5cdf72384125d94d42118c18
+## ssl: Adopt distribution over TLS to use new sender process
+git cherry-pick --no-commit 0078ebf6c5311edc1a07be71fb7a127a175a60fa
+## ssl: Improve close handling
+git cherry-pick --no-commit a508428df8af14437f1a4766ec68294d1d736915
+## kernel: Fix net_kernel:connect_node/1 to local node
+git cherry-pick --no-commit c4759bc60c8e5db27c070b9e826ddc0f9626b094
+
+## Please see https://bugs.erlang.org/browse/ERL-622
+patch -p1 <<EOF
+diff --git a/lib/ssl/src/tls_connection.erl b/lib/ssl/src/tls_connection.erl
+index 6c7511d2b3..2fde17a0fd 100644
+--- a/lib/ssl/src/tls_connection.erl
++++ b/lib/ssl/src/tls_connection.erl
+@@ -118,6 +118,7 @@ start_link(Role, Sender, Host, Port, Socket, Options, User, CbInfo) ->
+
+ init([Role, Sender, Host, Port, Socket, {SslOpts, _, _} = Options,  User, CbInfo]) ->
+     process_flag(trap_exit, true),
++    link(Sender),
+     case SslOpts#ssl_options.erl_dist of
+         true ->
+             process_flag(priority, max);
+diff --git a/lib/ssl/src/tls_sender.erl b/lib/ssl/src/tls_sender.erl
+index 007fd345dd..db67d7ddff 100644
+--- a/lib/ssl/src/tls_sender.erl
++++ b/lib/ssl/src/tls_sender.erl
+@@ -67,9 +67,9 @@
+ %%  same process is sending and receiving
+ %%--------------------------------------------------------------------
+ start() ->
+-    gen_statem:start_link(?MODULE, [], []).
++    gen_statem:start(?MODULE, [], []).
+ start(SpawnOpts) ->
+-    gen_statem:start_link(?MODULE, [], SpawnOpts).
++    gen_statem:start(?MODULE, [], SpawnOpts).
+
+ %%--------------------------------------------------------------------
+ -spec initialize(pid(), map()) -> ok.
+EOF
+
 ./otp_build setup -a --prefix=$PKG_PATH --with-ssl=/opt/mesosphere/active/openssl --with-termcap=/opt/mesosphere/active/ncurses --disable-hipe --enable-kernel-poll --enable-builtin-zlib
 make -j$NUM_CORES
 make install

--- a/packages/erlang/buildinfo.json
+++ b/packages/erlang/buildinfo.json
@@ -4,8 +4,8 @@
     "erlang": {
       "kind": "git",
       "git": "https://github.com/erlang/otp.git",
-      "ref": "c5ee502e6031986983d3596745cad7fd547fd9c2",
-      "ref_origin": "maint-20"
+      "ref": "333e4c5a1406cdeb9d1d5cf9bf4a4fadb232fca8",
+      "ref_origin": "maint-21"
     }
   }
 }


### PR DESCRIPTION
## High-level description

Bump dcos-net and upgrade OTP version.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3655](https://jira.mesosphere.com/browse/DCOS_OSS-3944) Improve logging in dcos-l4lb
  - [DCOS_OSS-3655](https://jira.mesosphere.com/browse/DCOS_OSS-3945) Improve logging in dcos-overlay
  - [DCOS_OSS-3655](https://jira.mesosphere.com/browse/DCOS_OSS-3655) Upgrade OTP version

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-38600](https://jira.mesosphere.com/browse/DCOS-38600) Deadlock when SSL sockets are simultaneously sending/receiving data and buffers are full
  - [ERL-622](https://bugs.erlang.org/browse/ERL-622) Deadlock when SSL sockets are simultaneously sending/receiving data and buffers are full
  - [ERL-692](https://bugs.erlang.org/browse/ERL-692) open_port/2 is broken with reused file descriptors
  - [DCOS-39517](https://jira.mesosphere.com/browse/DCOS-39517) dcos-net routes can take several minutes to converge after agent is available

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]

https://github.com/erlang/otp/compare/c5ee502e6031986983d3596745cad7fd547fd9c2...333e4c5a1406cdeb9d1d5cf9bf4a4fadb232fca8
https://github.com/dcos/dcos-net/compare/36de37d5f8087505228cb2cdfc5c30859a302b23...1753c7f42cf4577427740e9a23aedb433242b696
https://github.com/dcos/dcos-net/pull/70
https://github.com/dcos/dcos-net/pull/72
https://github.com/dcos/dcos-net/pull/73
https://github.com/dcos/dcos-net/pull/76
https://github.com/dcos/dcos-net/pull/77
https://circleci.com/gh/dcos/dcos-net/642
https://codecov.io/gh/dcos/dcos-net/tree/1753c7f42cf4577427740e9a23aedb433242b696

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).