### PR TITLE
Fix unhealthy dcos-telegraf service on Ubuntu-16.04

### DIFF
--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -16,9 +16,9 @@ EnvironmentFile=/opt/mesosphere/etc/telegraf.env
 
 LimitNOFILE=16384
 
-ExecStartPre=/usr/bin/mkdir -p /run/dcos/telegraf
-ExecStartPre=/usr/bin/chmod 775 /run/dcos/telegraf
-ExecStartPre=/usr/bin/chown root:dcos_telegraf /run/dcos/telegraf
+ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}


### PR DESCRIPTION
Previously, the 'dcos-telegraf.service' file was creating and adding
permissions to '/run/dcos/telegraf' using absolute paths to 'mdkir',
'chmod', and 'chown' commands under '/usr/bin'. Unfortunately, these
commands don't exist at this path in Ubunutu 16.04 (they exist under
'/bin' instead). Likewise, these commands don't exist under '/bin'
on CentOS or CoreOS, leaving us in a bit of a conundrum if we want to
have a single service file that works cross-platform.

In order to make this work cross-platform, we now introduce a level of
indirection through '/bin/bash' (which exists on all platforms) and
allow it to access 'mkdir', 'chmod', and 'chown' in its PATH, regardless
of where these commands exist.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4065](https://jira.mesosphere.com/browse/DCOS_OSS-4065) Telegraf fails to start on Ubuntu (DC/OS E2E).
  - [DCOS_OSS-4045](https://jira.mesosphere.com/browse/DCOS_OSS-4045) Telegraf fails to start on clusters running on Azure/Ubuntu.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a bug fix in something not yet released
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Without this change all Azure related tests FAIL because they run Ubuntu 16.04
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)