### PR TITLE
Update dcos-test-utils to use the 1.12 CLI

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["dcos-image-deps"],
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "8f1820f537b0caa4bbb697beaae4d1e4940bfbb6",
-    "ref_origin": "master"
+    "git": "https://github.com/bamarni/dcos-test-utils.git",
+    "ref": "fa7a3e4f89951e87827bb1e211d118ddbfb5c01c",
+    "ref_origin": "DCOS-41483"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/bamarni/dcos-test-utils.git",
-    "ref": "fa7a3e4f89951e87827bb1e211d118ddbfb5c01c",
+    "ref": "0ea9d90b3983138fc481851d09c93fea9771fb9a",
     "ref_origin": "DCOS-41483"
   }
 }


### PR DESCRIPTION
## High-level description

Update dcos-test-utils to use the 1.12 CLI.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS-40541](https://jira.mesosphere.com/browse/DCOS-40541)  Update DC/OS integration tests to pass with the new CLI
