### PR TITLE
Marathon 1.6.549 Bump on 1.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## DC/OS 1.11.6
+
+### Notable changes
+
+* Updated to [Marathon 1.6.549](https://github.com/mesosphere/marathon/tree/aabf74302).
+
 ## DC/OS 1.11.5
 
 ### Notable changes

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.544-6b23a51d9/marathon-1.6.544-6b23a51d9.tgz",
-    "sha1": "f30f75e28d550da263e55caed376a43bd4a1dc73"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.549-aabf74302/marathon-1.6.549-aabf74302.tgz",
+    "sha1": "19f685c38328db5928f0e0c225ffd8379eed8642"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-41716](https://jira.mesosphere.com/browse/DCOS-41716) Bump Marathon for 1.11.6.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-37999](https://jira.mesosphere.com/browse/DCOS-37999) Loosen constraint validation during migration.
  - [MARATHON-8095](https://jira.mesosphere.com/browse/MARATHON-8095) PATCH call not proxied correctly to active node.
  - [MARATHON-8381](https://jira.mesosphere.com/browse/MARATHON-8381) Use Different Exit Code for Marathon Suicide.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/6b23a51d9...aabf74302)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.6/20/console)
  - [x] Code Coverage (if available): N/A
