### PR TITLE
exhibitor package: bump ZooKeeper to 3.4.13 release

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,8 +9,8 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz",
-      "sha1": "eb2145498c5f7a0d23650d3e0102318363206fba"
+      "url": "http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
+      "sha1": "a989b527f3f990d471e6d47ee410e57d8be7620b"
     },
     "log4j": {
         "kind": "url",


### PR DESCRIPTION
## High-level description

Bump ZooKeeper for bugixes / reliability improvements.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS_OSS-4104



## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: will include in 1.11.6/7
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: difficult
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]

