### PR TITLE
Ensure that statsd socket is cleaned up before launching telegraf

### DIFF
--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -25,5 +25,9 @@ mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
 # Migrate old containers dir to new location in case the cluster was upgraded.
 /opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
 
+# Ensure that old socket file is removed, if present
+# TODO(philipnrmn): investigate whether moving to a systemd-managed socket
+# would be a better solution than manually creating and removing this file.
+rm -f /run/dcos/telegraf/dcos_statsd.sock
 # Start telegraf.
 exec /opt/mesosphere/bin/telegraf "$@"


### PR DESCRIPTION
## High-level description

This PR fixes an issue where telegraf could crash-loop on agents. 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-41747](https://jira.mesosphere.com/browse/DCOS-41747) Telegraf dcos_statsd plugin cannot listen on its assigned socket file, causing a crash-loop


## Related tickets (optional)

Other tickets related to this change:

  - [SOAK-119](https://jira.mesosphere.com/browse/SOAK-119) 


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this is a bugfix, and is covered by a previous entry
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a change in the launch script
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

