### PR TITLE
Enabled GC of nested container sandboxes by the Mesos agent.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -555,6 +555,7 @@ package:
       MESOS_EXECUTOR_REREGISTRATION_TIMEOUT=10secs
       MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-agent.log
       MESOS_GC_DELAY={{ gc_delay }}
+      MESOS_GC_NON_EXECUTOR_CONTAINER_SANDBOXES=true
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_IMAGE_GC_CONFIG=file:///opt/mesosphere/etc/mesos-slave-image-gc-config.json
       MESOS_IMAGE_PROVIDERS=docker


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This flips a flag that instructs the Mesos agent to garbage collect
the sandboxes of nested containers, just like the agent currently
GC's executor sandboxes.  Nested containers always run underneath
another active executor, and have in the past been garbage collected
alongside its parent executor.  However, because the default
executor can now potentially run infinite tasks in its lifetime,
the tasks (which are nested containers) can pile up sandboxes.

Note that this flag is technically a breaking change.  A task can
potentially rely on an artifact inside a sibling task's sandbox.
If the sibling task has exited, the sibling's sandbox can now be
garbage collected.  This scenario is however, considered to be
bad practice, as shared artifacts should be placed in the parent's
sandbox or a persistent volume.  The flag can easily be disabled
if this pattern is common in a cluster.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-39879](https://jira.mesosphere.com/browse/DCOS-39879) Enable GC for nested container sandboxes by default


## Related tickets (optional)

Other tickets related to this change:

  - [MESOS-7947](https://issues.apache.org/jira/browse/MESOS-7947) Add GC capability to nested containers
  - [COPS-3238](https://jira.mesosphere.com/browse/COPS-3238) Edge-LB pool task filled up disk on public agent


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:  This change should ideally not affect the user at all, as it deals with a particular way the Mesos default executor works.  As long as the bad practice of accessing sibling sandboxes is not a problem, this change should be transparent to the user.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:  Executing the code enabled by this flag requires the test to either (1) fill up 90% of an agent's disk, (2) wait 2 weeks, or (3) spoof either of the earlier.  These are not practical in an integration test, so the plan is to add a soak test afterwards, instead.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

-If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:-

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
