### PR TITLE
Fix 500 responses from v0 metrics API

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -146,34 +146,13 @@ def test_metrics_containers(dcos_api_session):
         debug_task_name = []
 
         for agent in app_endpoints:
-
-            # Retry for two and a half minutes since the collector collects
-            # state every 2 minutes to propogate containers to the API
-            @retrying.retry(wait_fixed=2000, stop_max_delay=150000)
-            def wait_for_container_propogation():
-                response = dcos_api_session.metrics.get('/containers', node=agent.host)
-                assert response.status_code == 200
-                assert len(response.json()) > 0, 'must have at least 1 container'
-
-            wait_for_container_propogation()
-
-            response = dcos_api_session.metrics.get('/containers', node=agent.host)
-            for c in response.json():
+            for c in get_container_ids(dcos_api_session, agent.host):
                 # Test that /containers/<id> responds with expected data
-                container_id_path = '/containers/{}'.format(c)
-
-                # Retry for 30 seconds for each container to present its content.
-                @retrying.retry(stop_max_delay=30000)
-                def wait_for_container_response():
-                    response = dcos_api_session.metrics.get(container_id_path, node=agent.host)
-                    assert response.status_code == 200
-                    return response
-
-                container_response = wait_for_container_response()
-                assert 'datapoints' in container_response.json(), 'got {}'.format(container_response.json())
+                container_metrics = get_container_metrics(dcos_api_session, agent.host, c)
+                assert 'datapoints' in container_metrics, 'got {}'.format(container_metrics)
 
                 cid_registry = []
-                for dp in container_response.json()['datapoints']:
+                for dp in container_metrics['datapoints']:
                     # Verify expected tags are present.
                     assert 'tags' in dp, 'got {}'.format(dp)
                     expected_tag_names = {
@@ -192,31 +171,27 @@ def test_metrics_containers(dcos_api_session):
                     cid_registry.append(dp['tags']['container_id'])
                     assert(check_cid(cid_registry))
 
-                assert 'dimensions' in container_response.json(), 'got {}'.format(container_response.json())
-                assert 'task_name' in container_response.json()['dimensions'], 'got {}'.format(
-                    container_response.json()['dimensions'])
+                assert 'dimensions' in container_metrics, 'got {}'.format(container_metrics)
+                assert 'task_name' in container_metrics['dimensions'], 'got {}'.format(
+                    container_metrics['dimensions'])
 
-                debug_task_name.append(container_response.json()['dimensions']['task_name'])
+                debug_task_name.append(container_metrics['dimensions']['task_name'])
 
                 # looking for "statsd-emitter"
-                if 'statsd-emitter' == container_response.json()['dimensions']['task_name']:
+                if 'statsd-emitter' == container_metrics['dimensions']['task_name']:
                     # Test that /app response is responding with expected data
-                    app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(c), node=agent.host)
-                    assert app_response.status_code == 200
-                    'got {}'.format(app_response.status_code)
+                    app_metrics = get_app_metrics(dcos_api_session, agent.host, c)
 
                     # Ensure all /container/<id>/app data is correct
-                    assert 'datapoints' in app_response.json(), 'got {}'.format(app_response.json())
-
                     # We expect three datapoints, could be in any order
                     uptime_dp = None
-                    for dp in app_response.json()['datapoints']:
+                    for dp in app_metrics['datapoints']:
                         if dp['name'] == 'statsd_tester_time_uptime':
                             uptime_dp = dp
                             break
 
                     # If this metric is missing, statsd-emitter's metrics were not received
-                    assert uptime_dp is not None, 'got {}'.format(app_response.json())
+                    assert uptime_dp is not None, 'got {}'.format(app_metrics)
 
                     datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
                     for k in datapoint_keys:
@@ -230,8 +205,6 @@ def test_metrics_containers(dcos_api_session):
                     }
                     check_tags(uptime_dp['tags'], expected_tag_names)
                     assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
-
-                    assert 'dimensions' in app_response.json(), 'got {}'.format(app_response.json())
 
                     return True
 
@@ -248,3 +221,103 @@ def test_metrics_containers(dcos_api_session):
         endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_config['id'])
         assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
         test_containers(endpoints)
+
+
+def test_metrics_containers_nan(dcos_api_session):
+    """Assert that the metrics API can handle app metric gauges with NaN values."""
+    task_name = 'test-metrics-containers-nan'
+    metric_name = 'test_metrics_containers_nan'
+    marathon_app = {
+        'id': '/' + task_name,
+        'instances': 1,
+        'cpus': 0.1,
+        'mem': 128,
+        'cmd': '\n'.join([
+            'echo "Sending gauge with NaN value to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
+            'echo "{}:NaN|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name),
+            'echo "Done. Sleeping forever."',
+            'while true; do',
+            '  sleep 1000',
+            'done',
+        ]),
+        'container': {
+            'type': 'MESOS',
+            'docker': {'image': 'library/alpine'}
+        },
+        'networks': [{'mode': 'host'}],
+    }
+
+    @retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
+    def _get_app_metric_datapoint_value_for_task(dcos_api_session, node: str, task_name: str, dp_name: str):
+        app_metrics = get_app_metrics_for_task(dcos_api_session, node, task_name)
+        assert app_metrics is not None, "missing metrics for task {}".format(task_name)
+        dps = [dp for dp in app_metrics['datapoints'] if dp['name'] == dp_name]
+        assert len(dps) == 1, 'expected 1 datapoint for metric {}, got {}'.format(dp_name, len(dps))
+        return dps[0]['value']
+
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
+        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+        node = endpoints[0].host
+
+        # NaN should be converted to empty string.
+        metric_value = _get_app_metric_datapoint_value_for_task(dcos_api_session, node, task_name, metric_name)
+        assert metric_value == '', 'unexpected metric value: {}'.format(metric_value)
+
+
+@retrying.retry(retry_on_result=lambda result: result is None, wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
+def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
+    """Return container metrics for task_name.
+
+    Returns None if container metrics for task_name can't be found. Retries on
+    error, non-200 status, or missing container metrics for up to 150 seconds.
+
+    """
+    for cid in get_container_ids(dcos_api_session, node):
+        container_metrics = get_container_metrics(dcos_api_session, node, cid)
+        if container_metrics['dimensions'].get('task_name') == task_name:
+            return get_app_metrics(dcos_api_session, node, cid)
+    return None
+
+
+# Retry for two and a half minutes since the collector collects
+# state every 2 minutes to propogate containers to the API
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
+def get_container_ids(dcos_api_session, node: str):
+    """Return container IDs reported by the metrics API on node.
+
+    Retries on error, non-200 status, or empty response for up to 150 seconds.
+
+    """
+    response = dcos_api_session.metrics.get('/containers', node=node)
+    assert response.status_code == 200
+    container_ids = response.json()
+    assert len(container_ids) > 0, 'must have at least 1 container'
+    return container_ids
+
+
+@retrying.retry(stop_max_delay=(30 * 1000))
+def get_container_metrics(dcos_api_session, node: str, container_id: str):
+    """Return container_id's metrics from the metrics API on node.
+
+    Retries on error or non-200 status for up to 30 seconds.
+
+    """
+    response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
+    assert response.status_code == 200
+    return response.json()
+
+
+@retrying.retry(stop_max_delay=(30 * 1000))
+def get_app_metrics(dcos_api_session, node: str, container_id: str):
+    """Return app metrics for container_id from the metrics API on node.
+
+    Retries on error or non-200 status for up to 30 seconds.
+
+    """
+    resp = dcos_api_session.metrics.get('/containers/' + container_id + '/app', node=node)
+    assert resp.status_code == 200, 'got {}'.format(resp.status_code)
+    app_metrics = resp.json()
+    assert 'datapoints' in app_metrics, 'got {}'.format(app_metrics)
+    assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
+    return app_metrics

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "ccb5eb8c53842b690ace1af2c40ff6101e0dc93e",
+    "ref": "071b143b1c93f03e5469378d082ec14dacf41674",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This PR bumps the Telegraf package to pull in a fix for an issue that causes some requests to the v0 metrics API to get 500 responses due to a JSON serialization error.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4088](https://jira.mesosphere.com/browse/DCOS_OSS-4088) metrics v0 API 500 error: "Failed to encode value to JSON"

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fixes a regression that hasn't yet been released.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/ccb5eb8c53842b690ace1af2c40ff6101e0dc93e...071b143b1c93f03e5469378d082ec14dacf41674
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/40/pipeline)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/40/pipeline)