### PR TITLE
Fix app metric names in v0 API

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -189,7 +189,7 @@ def test_metrics_containers(dcos_api_session):
                     # We expect three datapoints, could be in any order
                     uptime_dp = None
                     for dp in app_metrics['datapoints']:
-                        if dp['name'] == 'statsd_tester_time_uptime':
+                        if dp['name'] == 'statsd_tester.time.uptime':
                             uptime_dp = dp
                             break
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -226,6 +226,62 @@ def test_metrics_containers(dcos_api_session):
         test_containers(endpoints)
 
 
+def test_metrics_containers_app(dcos_api_session):
+    """Assert that app metrics appear in the v0 metrics API."""
+    task_name = 'test-metrics-containers-app'
+    metric_name_pfx = 'test_metrics_containers_app'
+    marathon_app = {
+        'id': '/' + task_name,
+        'instances': 1,
+        'cpus': 0.1,
+        'mem': 128,
+        'cmd': '\n'.join([
+            'echo "Sending metrics to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
+            'echo "Sending gauge"',
+            'echo "{}.gauge:100|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+
+            'echo "Sending counts"',
+            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+
+            'echo "Sending timings"',
+            'echo "{}.timing:1|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.timing:2|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.timing:3|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+
+            'echo "Sending histograms"',
+            'echo "{}.histogram:1|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.histogram:2|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.histogram:3|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.histogram:4|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+
+            'echo "Done. Sleeping forever."',
+            'while true; do',
+            '  sleep 1000',
+            'done',
+        ]),
+        'container': {
+            'type': 'MESOS',
+            'docker': {'image': 'library/alpine'}
+        },
+        'networks': [{'mode': 'host'}],
+    }
+    expected_metrics = [
+        # metric_name, metric_value
+        ('.'.join([metric_name_pfx, 'gauge']), 100),
+        ('.'.join([metric_name_pfx, 'count']), 2),
+        ('.'.join([metric_name_pfx, 'timing', 'count']), 3),
+        ('.'.join([metric_name_pfx, 'histogram', 'count']), 4),
+    ]
+
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
+        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+        node = endpoints[0].host
+        for metric_name, metric_value in expected_metrics:
+            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+
+
 def test_metrics_containers_nan(dcos_api_session):
     """Assert that the metrics API can handle app metric gauges with NaN values."""
     task_name = 'test-metrics-containers-nan'
@@ -249,23 +305,40 @@ def test_metrics_containers_nan(dcos_api_session):
         },
         'networks': [{'mode': 'host'}],
     }
-
-    @retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
-    def _get_app_metric_datapoint_value_for_task(dcos_api_session, node: str, task_name: str, dp_name: str):
-        app_metrics = get_app_metrics_for_task(dcos_api_session, node, task_name)
-        assert app_metrics is not None, "missing metrics for task {}".format(task_name)
-        dps = [dp for dp in app_metrics['datapoints'] if dp['name'] == dp_name]
-        assert len(dps) == 1, 'expected 1 datapoint for metric {}, got {}'.format(dp_name, len(dps))
-        return dps[0]['value']
-
     with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
         endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
         assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
         node = endpoints[0].host
 
         # NaN should be converted to empty string.
-        metric_value = _get_app_metric_datapoint_value_for_task(dcos_api_session, node, task_name, metric_name)
+        metric_value = get_app_metric_for_task(dcos_api_session, node, task_name, metric_name)['value']
         assert metric_value == '', 'unexpected metric value: {}'.format(metric_value)
+
+
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
+def assert_app_metric_value_for_task(dcos_api_session, node: str, task_name: str, metric_name: str, metric_value):
+    """Assert the value of app metric metric_name for container task_name is metric_value.
+
+    Retries on error, non-200 status, missing container metrics, missing app
+    metric, or unexpected app metric value for up to 150 seconds.
+
+    """
+    assert get_app_metric_for_task(dcos_api_session, node, task_name, metric_name)['value'] == metric_value
+
+
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))
+def get_app_metric_for_task(dcos_api_session, node: str, task_name: str, metric_name: str):
+    """Return the app metric metric_name for container task_name.
+
+    Retries on error, non-200 status, or missing container metrics, or missing
+    app metric for up to 150 seconds.
+
+    """
+    app_metrics = get_app_metrics_for_task(dcos_api_session, node, task_name)
+    assert app_metrics is not None, "missing metrics for task {}".format(task_name)
+    dps = [dp for dp in app_metrics['datapoints'] if dp['name'] == metric_name]
+    assert len(dps) == 1, 'expected 1 datapoint for metric {}, got {}'.format(metric_name, len(dps))
+    return dps[0]
 
 
 @retrying.retry(retry_on_result=lambda result: result is None, wait_fixed=(2 * 1000), stop_max_delay=(150 * 1000))

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "071b143b1c93f03e5469378d082ec14dacf41674",
+    "ref": "515b24c921aa4578c2d99b55e2625425580b2a62",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This causes app metric names in the v0 API to use `.` instead of `_` as the name field separator.

Depends on #3436.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4071](https://jira.mesosphere.com/browse/DCOS_OSS-4071) Metrics v0 API changed some metric names

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fixes a regression that has not yet been released.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/ccb5eb8c53842b690ace1af2c40ff6101e0dc93e...515b24c921aa4578c2d99b55e2625425580b2a62
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/42/) (failed due to irrelevant test bug)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/42/)