### PR TITLE
Point DC/OS 1.13-dev to Mesos master.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,12 +1,12 @@
 {
   "requires": [
-    "mesos", 
+    "mesos",
     "boost-libs"
-  ], 
+  ],
   "single_source": {
-    "kind": "git", 
-    "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "29561f11a12372752b77839be73418d1d75abe63", 
-    "ref_origin": "1.12"
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "78b54e46bf2024e8438c7394c78d9b38fe728395",
+    "ref_origin": "master"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,8 +8,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "8419b870c571ac11825c883fa20ea3b7d4348d34",
-    "ref_origin": "1.7.x"
+    "ref": "d34ded8b8d8d1a1b5e4fcda3dd596ede0d1ff037",
+    "ref_origin": "master"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/extra/patches/0004-Revert-Removed-long-ago-deprecated-endpoints.patch
+++ b/packages/mesos/extra/patches/0004-Revert-Removed-long-ago-deprecated-endpoints.patch
@@ -1,0 +1,146 @@
+From b1a3c04f557daeb0bfb8a21a8a8a1f80c7a9fbf6 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Tue, 21 Aug 2018 17:59:27 +0200
+Subject: [PATCH] Revert "Removed long ago deprecated endpoints.".
+
+This reverts commit 42551cb5290b7b04101f7d800b4b8fd573e47b91.
+
+Even though the endpoints have been deprecated long ago and should
+have already been removed, doing this so close to the release might
+prevent people from adjusting their tooling on time.
+
+The deprecated endpoints are restored in 1.7.x only, Mesos master
+aka 1.8.0-dev will not have deprecated endpoints.
+---
+ src/files/files.cpp   | 19 +++++++++++++++++++
+ src/master/master.cpp | 30 ++++++++++++++++++++++++++++++
+ src/slave/slave.cpp   | 21 +++++++++++++++++++++
+ 3 files changed, 70 insertions(+)
+
+diff --git a/src/files/files.cpp b/src/files/files.cpp
+index f200d5e79..a64613cf6 100644
+--- a/src/files/files.cpp
++++ b/src/files/files.cpp
+@@ -222,6 +222,25 @@ FilesProcess::FilesProcess(
+ 
+ void FilesProcess::initialize()
+ {
++    // TODO(ijimenez): Remove these endpoints at the end of the
++    // deprecation cycle on 0.26.
++    route("/browse.json",
++          authenticationRealm,
++          FilesProcess::BROWSE_HELP,
++          &FilesProcess::loggedBrowse);
++    route("/read.json",
++          authenticationRealm,
++          FilesProcess::READ_HELP,
++          &FilesProcess::loggedRead);
++    route("/download.json",
++          authenticationRealm,
++          FilesProcess::DOWNLOAD_HELP,
++          &FilesProcess::loggedDownload);
++    route("/debug.json",
++          authenticationRealm,
++          FilesProcess::DEBUG_HELP,
++          &FilesProcess::loggedDebug);
++
+     route("/browse",
+           authenticationRealm,
+           FilesProcess::BROWSE_HELP,
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index cec20419c..ba71c6bdc 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -937,6 +937,16 @@ void Master::initialize()
+           logRequest(request);
+           return http.reserve(request, principal);
+         });
++  // TODO(ijimenez): Remove this endpoint at the end of the
++  // deprecation cycle on 0.26.
++  route("/roles.json",
++        READONLY_HTTP_AUTHENTICATION_REALM,
++        Http::ROLES_HELP(),
++        [this](const process::http::Request& request,
++               const Option<Principal>& principal) {
++          logRequest(request);
++          return http.roles(request, principal);
++        });
+   route("/roles",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+         Http::ROLES_HELP(),
+@@ -961,6 +971,16 @@ void Master::initialize()
+           logRequest(request);
+           return http.slaves(request, principal);
+         });
++  // TODO(ijimenez): Remove this endpoint at the end of the
++  // deprecation cycle on 0.26.
++  route("/state.json",
++        READONLY_HTTP_AUTHENTICATION_REALM,
++        Http::STATE_HELP(),
++        [this](const process::http::Request& request,
++               const Option<Principal>& principal) {
++          logRequest(request);
++          return http.state(request, principal);
++        });
+   route("/state",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+         Http::STATE_HELP(),
+@@ -977,6 +997,16 @@ void Master::initialize()
+           logRequest(request);
+           return http.stateSummary(request, principal);
+         });
++  // TODO(ijimenez): Remove this endpoint at the end of the
++  // deprecation cycle.
++  route("/tasks.json",
++        READONLY_HTTP_AUTHENTICATION_REALM,
++        Http::TASKS_HELP(),
++        [this](const process::http::Request& request,
++               const Option<Principal>& principal) {
++          logRequest(request);
++          return http.tasks(request, principal);
++        });
+   route("/tasks",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+         Http::TASKS_HELP(),
+diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
+index e6c7e686f..b5199124d 100644
+--- a/src/slave/slave.cpp
++++ b/src/slave/slave.cpp
+@@ -792,6 +792,17 @@ void Slave::initialize()
+ 
+         return resourceProviderManager->api(request, principal);
+       });
++
++  // TODO(ijimenez): Remove this endpoint at the end of the
++  // deprecation cycle on 0.26.
++  route("/state.json",
++        READONLY_HTTP_AUTHENTICATION_REALM,
++        Http::STATE_HELP(),
++        [this](const http::Request& request,
++               const Option<Principal>& principal) {
++          logRequest(request);
++          return http.state(request, principal);
++        });
+   route("/state",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+         Http::STATE_HELP(),
+@@ -821,6 +832,16 @@ void Slave::initialize()
+           logRequest(request);
+           return http.statistics(request, principal);
+         });
++  // TODO(ijimenez): Remove this endpoint at the end of the
++  // deprecation cycle on 0.26.
++  route("/monitor/statistics.json",
++        READONLY_HTTP_AUTHENTICATION_REALM,
++        Http::STATISTICS_HELP(),
++        [this](const http::Request& request,
++               const Option<Principal>& principal) {
++          logRequest(request);
++          return http.statistics(request, principal);
++        });
+   route("/containers",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+         Http::CONTAINERS_HELP(),
+-- 
+2.16.3
+


### PR DESCRIPTION
## High-level description

This change switches DC/OS `master` (= `1.13-dev`) to Mesos `master` (= `1.8-dev`).

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
