### PR TITLE
Admin Router: add 'Connection:close' header to the responses to requests to /mesos and /agent

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -266,7 +266,7 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
     include includes/proxy-headers.conf;
 
     # Non-streaming endpoints don't require HTTP/1.1 but will work as
-    # expected with it enabled. Streaming endpoints require keepalive
+    # expected with it enabled. Streaming endpoints require chunked encoding
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;
@@ -320,7 +320,7 @@ location /mesos/ {
     }
 
     # Non-streaming endpoints don't require HTTP/1.1 but will work as
-    # expected with it enabled. Streaming endpoints require keepalive
+    # expected with it enabled. Streaming endpoints require chunked encoding
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -271,6 +271,11 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
     include includes/http-11.conf;
     # Disable buffering to support streaming endpoints
     include includes/disable-request-response-buffering.conf;
+    # Disabling keepalive adds 'Connection: close' header to the
+    # response - https://forum.nginx.org/read.php?2,251560,251570
+    # For the reasons for this change see
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    keepalive_timeout 0;
     proxy_pass $agentaddr:$agentport;
 }
 
@@ -314,6 +319,11 @@ location /mesos/ {
     # Disable buffering to support streaming Mesos v1 streaming API:
     proxy_buffering off;
 
+    # Disabling keepalive adds 'Connection: close' header to the
+    # response - https://forum.nginx.org/read.php?2,251560,251570
+    # For the reasons for this change see
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    keepalive_timeout 0;
     include includes/proxy-headers.conf;
     rewrite ^/mesos/(.*) /$1 break;
     proxy_pass $upstream_mesos;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -264,17 +264,25 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
 
     more_clear_input_headers Accept-Encoding;
     include includes/proxy-headers.conf;
+
     # Non-streaming endpoints don't require HTTP/1.1 but will work as
     # expected with it enabled. Streaming endpoints require keepalive
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;
-    # Disable buffering to support streaming endpoints
-    include includes/disable-request-response-buffering.conf;
+    # Disable buffering to support streaming Mesos v1 streaming API:
+    proxy_buffering off;
+
+    # For the reasons stated in
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    # we are setting keepalive timeout to 0, basically
+    # disabling it.
+
+    # ToDo (Arsen) Remove also the 'include includes/http-11.conf;'
+    # directive and deactivate the related harness tests.
+
     # Disabling keepalive adds 'Connection: close' header to the
     # response - https://forum.nginx.org/read.php?2,251560,251570
-    # For the reasons for this change see
-    # https://jira.mesosphere.com/browse/DCOS-42098
     keepalive_timeout 0;
     proxy_pass $agentaddr:$agentport;
 }
@@ -319,10 +327,17 @@ location /mesos/ {
     # Disable buffering to support streaming Mesos v1 streaming API:
     proxy_buffering off;
 
+    # For the reasons stated in
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    # we are setting keepalive timeout to 0, basically
+    # disabling it.
+
+    # ToDo (Arsen) Remove also the 'include includes/http-11.conf;'
+    # directive and deactivate the related harness tests.
+
     # Disabling keepalive adds 'Connection: close' header to the
     # response - https://forum.nginx.org/read.php?2,251560,251570
-    # For the reasons for this change see
-    # https://jira.mesosphere.com/browse/DCOS-42098
+
     keepalive_timeout 0;
     include includes/proxy-headers.conf;
     rewrite ^/mesos/(.*) /$1 break;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -270,8 +270,8 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;
-    # Disable buffering to support streaming Mesos v1 streaming API:
-    proxy_buffering off;
+    # Disable buffering to support streaming endpoints
+    include includes/disable-request-response-buffering.conf;
 
     # For the reasons stated in
     # https://jira.mesosphere.com/browse/DCOS-42098


### PR DESCRIPTION
## High-level description

This PR makes Admin Router add "Connection: close" header to the responses 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 https://jira.mesosphere.com/browse/DCOS-42098

## Related tickets (optional)

Other tickets related to this change:

https://jira.mesosphere.com/browse/DCOS-40878

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]