### PR TITLE
1.10.5.1 with fixes for MESOS-8830

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
-## DC/OS 1.10.5
+## DC/OS 1.10.5.1
+
+* Special Build with Fixes for MESOS-8830
 
 ### Notable changes
 

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -83,7 +83,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.5',
+        'version': '1.10.5.1',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -979,7 +979,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.5',
+        'dcos_version': '1.10.5.1',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -3,6 +3,12 @@ libdir="$PKG_PATH/lib"
 
 # TODO(cmaloney): Check prerequisites installed (glog, protobuf, boost)
 pushd "/pkg/src/mesos"
+
+# Apply patches from packages/mesos/patch directory. All patches are numbered
+for patch in /pkg/extra/patches/*; do
+  git -c user.name="Mesosphere CI" -c user.email="mesosphere-ci@users.noreply.github.com" am $patch
+done
+
 ./bootstrap
 
 mkdir -p build

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -2,9 +2,9 @@
   "requires": ["openssl", "libevent", "curl", "boost-libs"],
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/mesosphere/mesos",
-    "ref": "c8bfe874c68cdf6b9d7e4b7ab0dd81c45b26bc79",
-    "ref_origin" : "dcos-mesos-1.4.x-92d988c"
+    "git": "https://github.com/apache/mesos",
+    "ref": "e7b117e0d9072a50756dd90e12d691af572aed7c",
+    "ref_origin" : "1.4.x"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,0 +1,28 @@
+From 121224d7a6f9d1a3e8b43538327d27a0f110c1de Mon Sep 17 00:00:00 2001
+From: Michael Park <mpark@apache.org>
+Date: Thu, 15 Oct 2015 19:54:02 -0700
+Subject: [PATCH] Set LIBPROCESS_IP into docker container.
+
+---
+ src/docker/docker.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
+index 1dd82337c..40eae2920 100755
+--- a/src/docker/docker.cpp
++++ b/src/docker/docker.cpp
+@@ -638,6 +638,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
+   options.env["MESOS_SANDBOX"] = mappedDirectory;
+   options.env["MESOS_CONTAINER_NAME"] = name;
+ 
++  Option<string> libprocessIP = os::getenv("LIBPROCESS_IP");
++  if (libprocessIP.isSome()) {
++    options.env["LIBPROCESS_IP"] = libprocessIP.get();
++  }
++
+   Option<string> volumeDriver;
+   foreach (const Volume& volume, containerInfo.volumes()) {
+     // The 'container_path' can be either an absolute path or a
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0002-Mesos-UI-Change-paths-pailer-and-logs-to-work-with-a.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-Change-paths-pailer-and-logs-to-work-with-a.patch
@@ -1,0 +1,290 @@
+From 6094ee5e4ce51204e441b6e79888cd67b0754c72 Mon Sep 17 00:00:00 2001
+From: mlunoe <michael.lunoe@gmail.com>
+Date: Thu, 14 May 2015 15:05:23 -0700
+Subject: [PATCH] Mesos UI: Change paths, pailer, and logs to work with a
+ reverse proxy.
+
+Includes using relative paths.
+Includes correcting routes to be /agent/{id}...
+Redirect from old mesos ui location to new dcos mesos ui location.
+Fixed the broken 'Roles' tab of the webui.
+---
+ src/webui/master/static/browse.html       |  2 +-
+ src/webui/master/static/index.html        | 30 +++++++-------
+ src/webui/master/static/js/controllers.js | 49 +++++++++++------------
+ src/webui/master/static/js/services.js    |  2 +-
+ src/webui/master/static/pailer.html       |  6 +--
+ 5 files changed, 44 insertions(+), 45 deletions(-)
+
+diff --git a/src/webui/master/static/browse.html b/src/webui/master/static/browse.html
+index c586b9050..3f55bfc8e 100644
+--- a/src/webui/master/static/browse.html
++++ b/src/webui/master/static/browse.html
+@@ -73,7 +73,7 @@
+             </td>
+             <td>
+               <a data-ng-show="file.mode[0] != 'd'"
+-                 href="//{{agent_host}}/files/download?path={{encodeURIComponent(file.path)}}">
++                 href="{{agent_host}}/files/download?path={{encodeURIComponent(file.path)}}">
+                 <button class="btn btn-xs btn-default" type="button">
+                   Download
+                 </button>
+diff --git a/src/webui/master/static/index.html b/src/webui/master/static/index.html
+index d657eb3b6..0b977f58f 100644
+--- a/src/webui/master/static/index.html
++++ b/src/webui/master/static/index.html
+@@ -7,15 +7,15 @@
+     <meta name="description" content="">
+     <meta name="author" content="">
+ 
+-    <link href="/static/css/bootstrap-3.3.6.min.css" rel="stylesheet">
+-    <link href="/static/css/mesos.css" rel="stylesheet">
++    <link href="static/css/bootstrap-3.3.6.min.css" rel="stylesheet">
++    <link href="static/css/mesos.css" rel="stylesheet">
+ 
+-    <link rel="shortcut icon" href="/static/ico/favicon.ico">
++    <link rel="shortcut icon" href="static/ico/favicon.ico">
+   </head>
+ 
+   <body>
+     <div data-ng-show="doneLoading" style="width: 75px; margin: 0 auto; text-align: center;">
+-      <img src="/static/img/loading.gif" height="64" width="64" alt="">
++      <img src="static/img/loading.gif" height="64" width="64" alt="">
+     </div>
+ 
+     <div ng-controller="MainCtrl">
+@@ -30,7 +30,7 @@
+               <span class="icon-bar"></span>
+             </button>
+             <a class="navbar-brand" href="#/">
+-              <img src="/static/img/mesos_logo.png" alt="Apache Mesos">
++              <img src="static/img/mesos_logo.png" alt="Apache Mesos">
+             </a>
+           </div>
+ 
+@@ -111,16 +111,16 @@
+       </div>
+     </script>
+ 
+-    <script src="/static/js/jquery-1.7.1.min.js"></script>
+-    <script src="/static/js/underscore-1.4.3.min.js"></script>
+-    <script src="/static/js/clipboard-1.5.16.min.js"></script>
+-    <script src="/static/js/angular-1.2.3.min.js"></script>
+-    <script src="/static/js/angular-route-1.2.3.min.js"></script>
+-    <script src="/static/js/ui-bootstrap-tpls-0.9.0.min.js"></script>
+-    <script src="/static/js/relative-date.js"></script>
++    <script src="static/js/jquery-1.7.1.min.js"></script>
++    <script src="static/js/underscore-1.4.3.min.js"></script>
++    <script src="static/js/clipboard-1.5.16.min.js"></script>
++    <script src="static/js/angular-1.2.3.min.js"></script>
++    <script src="static/js/angular-route-1.2.3.min.js"></script>
++    <script src="static/js/ui-bootstrap-tpls-0.9.0.min.js"></script>
++    <script src="static/js/relative-date.js"></script>
+ 
+-    <script src="/static/js/app.js"></script>
+-    <script src="/static/js/services.js"></script>
+-    <script src="/static/js/controllers.js"></script>
++    <script src="static/js/app.js"></script>
++    <script src="static/js/services.js"></script>
++    <script src="static/js/controllers.js"></script>
+   </body>
+ </html>
+diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
+index 339dfc478..ed60f7d40 100644
+--- a/src/webui/master/static/js/controllers.js
++++ b/src/webui/master/static/js/controllers.js
+@@ -14,7 +14,7 @@
+   // Invokes the pailer for the specified host and path using the
+   // specified window_title.
+   function pailer(host, path, window_title) {
+-    var url = '//' + host + '/files/read?path=' + path;
++    var url = host + 'files/read?path=' + path;
+ 
+     // The randomized `storageKey` is removed from `localStorage` once the
+     // pailer window loads the URL into its `sessionStorage`, therefore
+@@ -26,7 +26,7 @@
+     localStorage.setItem(storageKey, url);
+ 
+     var pailer =
+-      window.open('/static/pailer.html', storageKey, 'width=580px, height=700px');
++      window.open('static/pailer.html', storageKey, 'width=580px, height=700px');
+ 
+     // Need to use window.onload instead of document.ready to make
+     // sure the title doesn't get overwritten.
+@@ -287,6 +287,13 @@
+   mesosApp.controller('MainCtrl', [
+       '$scope', '$http', '$location', '$timeout', '$modal',
+       function($scope, $http, $location, $timeout, $modal) {
++
++    // Redirect from old mesos ui location to new dcos mesos ui location
++    if ($location.port() === 5050) {
++      var url = $location.protocol() + "://" + $location.host() + "/mesos";
++      window.location = url;
++    }
++
+     $scope.doneLoading = true;
+ 
+     // Adding bindings into scope so that they can be used from within
+@@ -474,7 +481,7 @@
+         ).open();
+       } else {
+         pailer(
+-            $scope.$location.host() + ':' + $scope.$location.port(),
++            '/mesos/',
+             '/master/log',
+             'Mesos Master');
+       }
+@@ -487,7 +494,7 @@
+     var update = function() {
+       // TODO(haosdent): Send requests to the leading master directly
+       // once `leadingMasterURL` is public.
+-      $http.jsonp('/master/roles?jsonp=JSON_CALLBACK')
++      $http.jsonp('master/roles?jsonp=JSON_CALLBACK')
+       .success(function(response) {
+         $scope.roles = response;
+       })
+@@ -512,7 +519,7 @@
+     var update = function() {
+       // TODO(haosdent): Send requests to the leading master directly
+       // once `leadingMasterURL` is public.
+-      $http.jsonp('/master/maintenance/schedule?jsonp=JSON_CALLBACK')
++      $http.jsonp('master/maintenance/schedule?jsonp=JSON_CALLBACK')
+       .success(function(response) {
+         $scope.maintenance = response;
+       })
+@@ -572,9 +579,8 @@
+       }
+ 
+       var pid = $scope.agents[$routeParams.agent_id].pid;
+-      var hostname = $scope.agents[$routeParams.agent_id].hostname;
+       var id = pid.substring(0, pid.indexOf('@'));
+-      var host = hostname + ":" + pid.substring(pid.lastIndexOf(':') + 1);
++      var host = '/agent/' + $routeParams.agent_id + '/';
+ 
+       $scope.log = function($event) {
+         if (!$scope.state.external_log_file && !$scope.state.log_dir) {
+@@ -593,7 +599,7 @@
+         $top.start(host, id, $scope);
+       }
+ 
+-      $http.jsonp('//' + host + '/' + id + '/state?jsonp=JSON_CALLBACK')
++      $http.jsonp(host + id + '/state?jsonp=JSON_CALLBACK')
+         .success(function (response) {
+           $scope.state = response;
+ 
+@@ -671,7 +677,7 @@
+           $('#alert').show();
+         });
+ 
+-      $http.jsonp('//' + host + '/metrics/snapshot?jsonp=JSON_CALLBACK')
++      $http.jsonp(host + '/metrics/snapshot?jsonp=JSON_CALLBACK')
+         .success(function (response) {
+           $scope.staging_tasks = response['slave/tasks_staging'];
+           $scope.starting_tasks = response['slave/tasks_starting'];
+@@ -711,16 +717,15 @@
+       }
+ 
+       var pid = $scope.agents[$routeParams.agent_id].pid;
+-      var hostname = $scope.agents[$routeParams.agent_id].hostname;
+       var id = pid.substring(0, pid.indexOf('@'));
+-      var host = hostname + ":" + pid.substring(pid.lastIndexOf(':') + 1);
++      var host = '/agent/' + $routeParams.agent_id + '/';
+ 
+       // Set up polling for the monitor if this is the first update.
+       if (!$top.started()) {
+         $top.start(host, id, $scope);
+       }
+ 
+-      $http.jsonp('//' + host + '/' + id + '/state?jsonp=JSON_CALLBACK')
++      $http.jsonp(host + id + '/state?jsonp=JSON_CALLBACK')
+         .success(function (response) {
+           $scope.state = response;
+ 
+@@ -798,16 +803,15 @@
+       }
+ 
+       var pid = $scope.agents[$routeParams.agent_id].pid;
+-      var hostname = $scope.agents[$routeParams.agent_id].hostname;
+       var id = pid.substring(0, pid.indexOf('@'));
+-      var host = hostname + ":" + pid.substring(pid.lastIndexOf(':') + 1);
++      var host = '/agent/' + $routeParams.agent_id + '/';
+ 
+       // Set up polling for the monitor if this is the first update.
+       if (!$top.started()) {
+         $top.start(host, id, $scope);
+       }
+ 
+-      $http.jsonp('//' + host + '/' + id + '/state?jsonp=JSON_CALLBACK')
++      $http.jsonp(host + id + '/state?jsonp=JSON_CALLBACK')
+         .success(function (response) {
+           $scope.state = response;
+ 
+@@ -919,11 +923,11 @@
+       var hostname = $scope.agents[$routeParams.agent_id].hostname;
+       var id = pid.substring(0, pid.indexOf('@'));
+       var port = pid.substring(pid.lastIndexOf(':') + 1);
+-      var host = hostname + ":" + port;
++      var host = '/agent/' + $routeParams.agent_id;
+ 
+       // Request agent details to get access to the route executor's "directory"
+       // to navigate directly to the executor's sandbox.
+-      $http.jsonp('//' + host + '/' + id + '/state?jsonp=JSON_CALLBACK')
++      $http.jsonp(host + '/' + id + '/state?jsonp=JSON_CALLBACK')
+         .success(function(response) {
+ 
+           function matchFramework(framework) {
+@@ -1030,18 +1034,13 @@
+         $scope.agent_id = $routeParams.agent_id;
+         $scope.path = $routeParams.path;
+ 
+-        var pid = $scope.agents[$routeParams.agent_id].pid;
+-        var hostname = $scope.agents[$routeParams.agent_id].hostname;
+-        var id = pid.substring(0, pid.indexOf('@'));
+-        var host = hostname + ":" + pid.substring(pid.lastIndexOf(':') + 1);
+-        var url = '//' + host + '/files/browse?jsonp=JSON_CALLBACK';
+-
+-        $scope.agent_host = host;
++        var url = '/agent/' + $scope.agent_id + '/files/browse?jsonp=JSON_CALLBACK';
+ 
+         $scope.pail = function($event, path) {
+-          pailer(host, path, decodeURIComponent(path));
++          pailer('/agent/' + $scope.agent_id + '/', path, decodeURIComponent(path));
+         };
+ 
++        $scope.agent_host = '/agent/' + $scope.agent_id + '/';
+         // TODO(bmahler): Try to get the error code / body in the error callback.
+         // This wasn't working with the current version of angular.
+         $http.jsonp(url, {params: {path: $routeParams.path}})
+diff --git a/src/webui/master/static/js/services.js b/src/webui/master/static/js/services.js
+index afd254418..3a5191208 100644
+--- a/src/webui/master/static/js/services.js
++++ b/src/webui/master/static/js/services.js
+@@ -271,7 +271,7 @@
+       return;
+     }
+ 
+-    this.endpoint = '//' + host + '/' + id + '/monitor/statistics?jsonp=JSON_CALLBACK';
++    this.endpoint = host + '/' + id + '/monitor/statistics?jsonp=JSON_CALLBACK';
+     this.scope = scope;
+ 
+     // Initial poll is immediate.
+diff --git a/src/webui/master/static/pailer.html b/src/webui/master/static/pailer.html
+index 759b18023..c8ada4b19 100644
+--- a/src/webui/master/static/pailer.html
++++ b/src/webui/master/static/pailer.html
+@@ -24,9 +24,9 @@
+     <pre id="data"></pre>
+     <div class="indicator" id="indicator"></div>
+ 
+-    <script src="/static/js/jquery-1.7.1.min.js"></script>
+-    <script src="/static/js/underscore-1.4.3.min.js"></script>
+-    <script src="/static/js/jquery.pailer.js"></script>
++    <script src="js/jquery-1.7.1.min.js"></script>
++    <script src="js/underscore-1.4.3.min.js"></script>
++    <script src="js/jquery.pailer.js"></script>
+ 
+     <script>
+       var $body = $('body');
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,0 +1,73 @@
+From 0d6997443afed4caf14dc96cadc1ef9b0cd0c093 Mon Sep 17 00:00:00 2001
+From: Joseph Wu <josephwu@apache.org>
+Date: Thu, 10 Nov 2016 11:29:19 -0800
+Subject: [PATCH] Revert "Fixed the broken metrics information of master in
+ WebUI."
+
+This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
+
+In DC/OS, redirection to the leading master is handled by the
+Adminrouter component.
+---
+ src/webui/master/static/js/controllers.js | 24 +++++++----------------
+ 1 file changed, 7 insertions(+), 17 deletions(-)
+
+diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
+index ed60f7d40..d69e92017 100644
+--- a/src/webui/master/static/js/controllers.js
++++ b/src/webui/master/static/js/controllers.js
+@@ -264,7 +264,8 @@
+   }
+ 
+   // Update the outermost scope with the metrics/snapshot endpoint.
+-  function updateMetrics($scope, $timeout, metrics) {
++  function updateMetrics($scope, $timeout, data) {
++    var metrics = JSON.parse(data);
+     $scope.staging_tasks = metrics['master/tasks_staging'];
+     $scope.starting_tasks = metrics['master/tasks_starting'];
+     $scope.running_tasks = metrics['master/tasks_running'];
+@@ -362,18 +363,6 @@
+       if (!matched) $scope.navbarActiveTab = null;
+     });
+ 
+-    var leadingMasterURL = function(path) {
+-      // Use current location as address in case we could not find the
+-      // leading master.
+-      var address = location.hostname + ':' + location.port;
+-      if ($scope.state && $scope.state.leader_info) {
+-          address = $scope.state.leader_info.hostname + ':' +
+-                    $scope.state.leader_info.port;
+-      }
+-
+-      return '//' + address + path;
+-    }
+-
+     var popupErrorModal = function() {
+       if ($scope.delay >= 128000) {
+         $scope.delay = 2000;
+@@ -433,7 +422,7 @@
+       // the leading master automatically. This would cause a CORS error if we
+       // use XMLHttpRequest here. To avoid the CORS error, we use JSONP as a
+       // workaround. Please refer to MESOS-5911 for further details.
+-      $http.jsonp(leadingMasterURL('/master/state?jsonp=JSON_CALLBACK'))
++      $http.jsonp('master/state?jsonp=JSON_CALLBACK')
+         .success(function(response) {
+           if (updateState($scope, $timeout, response)) {
+             $scope.delay = updateInterval(_.size($scope.agents));
+@@ -448,9 +437,10 @@
+     };
+ 
+     var pollMetrics = function() {
+-      $http.jsonp(leadingMasterURL('/metrics/snapshot?jsonp=JSON_CALLBACK'))
+-        .success(function(response) {
+-          if (updateMetrics($scope, $timeout, response)) {
++      $http.get('metrics/snapshot',
++                {transformResponse: function(data) { return data; }})
++        .success(function(data) {
++          if (updateMetrics($scope, $timeout, data)) {
+             $scope.delay = updateInterval(_.size($scope.agents));
+             $timeout(pollMetrics, $scope.delay);
+           }
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,0 +1,49 @@
+From 949808950b35fc775ba3e24691241d2d29f60d96 Mon Sep 17 00:00:00 2001
+From: Kevin Klues <klueska@gmail.com>
+Date: Thu, 9 Feb 2017 19:39:42 -0800
+Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
+ failure.
+
+This cherry-pick will be maintained in DC/OS to avoid the problem of
+requiring NVML to be installed on *every* node in the cluster, even if
+GPUs aren't available on them.
+
+Without this patch, we would need some sort of per-agent configuration
+to only enable the GPU isolator on agents that had NVML intstalled on
+them, and that is currently difficult (or undesirable) to do in DC/OS
+today.
+
+This is a decent compromise.
+---
+ src/slave/containerizer/mesos/containerizer.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
+index 5f29fe183..dfe88909e 100644
+--- a/src/slave/containerizer/mesos/containerizer.cpp
++++ b/src/slave/containerizer/mesos/containerizer.cpp
+@@ -364,8 +364,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+     {"gpu/nvidia",
+       [&nvidia] (const Flags& flags) -> Try<Isolator*> {
+         if (!nvml::isAvailable()) {
+-          return Error("Cannot create the Nvidia GPU isolator:"
+-                       " NVML is not available");
++          LOG(ERROR) << "Cannot create the Nvidia GPU isolator:"
++                        " NVML is not available";
++
++          return nullptr;
+         }
+ 
+         CHECK_SOME(nvidia)
+@@ -433,7 +435,7 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+     // prepared filesystem (e.g., any volume mounts are performed).
+     if (strings::contains(isolation, "filesystem/")) {
+       isolators.insert(isolators.begin(), Owned<Isolator>(isolator.get()));
+-    } else {
++    } else if (isolator.get() != nullptr) {
+       isolators.push_back(Owned<Isolator>(isolator.get()));
+     }
+   }
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0005-Included-nested-command-check-output-in-the-executor.patch
+++ b/packages/mesos/extra/patches/0005-Included-nested-command-check-output-in-the-executor.patch
@@ -1,0 +1,123 @@
+From 26fb989ad0c8097abc93ffaaac1d05151ab04cb1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
+Date: Mon, 21 Aug 2017 15:28:36 -0700
+Subject: [PATCH] Included nested command check output in the executor logs.
+
+This patch updates the checker and health checker to include the output
+of COMMAND checks and health checks in its logs by default. This has
+the effect of including these logs in the executor output for easier
+debugging.
+
+Review: https://reviews.apache.org/r/61697/
+---
+ src/checks/checker_process.cpp | 68 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 68 insertions(+)
+
+diff --git a/src/checks/checker_process.cpp b/src/checks/checker_process.cpp
+index 0b6b85b88..656e9168a 100644
+--- a/src/checks/checker_process.cpp
++++ b/src/checks/checker_process.cpp
+@@ -41,11 +41,13 @@
+ 
+ #include <stout/check.hpp>
+ #include <stout/duration.hpp>
++#include <stout/error.hpp>
+ #include <stout/foreach.hpp>
+ #include <stout/jsonify.hpp>
+ #include <stout/nothing.hpp>
+ #include <stout/option.hpp>
+ #include <stout/protobuf.hpp>
++#include <stout/recordio.hpp>
+ #include <stout/stopwatch.hpp>
+ #include <stout/strings.hpp>
+ #include <stout/try.hpp>
+@@ -138,6 +140,49 @@ static pid_t cloneWithSetns(
+ #endif
+ 
+ 
++// Reads `ProcessIO::Data` records from a string containing "Record-IO"
++// data encoded in protobuf messages, and returns the stdout and stderr.
++//
++// NOTE: This function ignores any `ProcessIO::Control` records.
++//
++// TODO(gkleiman): This function is very similar to one in `api_tests.cpp`, we
++// should refactor them into a common helper when fixing MESOS-7903.
++static Try<tuple<string, string>> decodeProcessIOData(const string& data)
++{
++  string stdoutReceived;
++  string stderrReceived;
++
++  recordio::Decoder<v1::agent::ProcessIO> decoder(
++      lambda::bind(
++          deserialize<v1::agent::ProcessIO>,
++          ContentType::PROTOBUF,
++          lambda::_1));
++
++  Try<std::deque<Try<v1::agent::ProcessIO>>> records = decoder.decode(data);
++
++  if (records.isError()) {
++    return Error(records.error());
++  }
++
++  while (!records->empty()) {
++    Try<v1::agent::ProcessIO> record = records->front();
++    records->pop_front();
++
++    if (record.isError()) {
++      return Error(record.error());
++    }
++
++    if (record->data().type() == v1::agent::ProcessIO::Data::STDOUT) {
++      stdoutReceived += record->data().data();
++    } else if (record->data().type() == v1::agent::ProcessIO::Data::STDERR) {
++      stderrReceived += record->data().data();
++    }
++  }
++
++  return std::make_tuple(stdoutReceived, stderrReceived);
++}
++
++
+ CheckerProcess::CheckerProcess(
+     const CheckInfo& _check,
+     const string& _launcherDir,
+@@ -543,6 +588,10 @@ void CheckerProcess::__nestedCommandCheck(
+   //
+   // This means that this future will not be completed until after the
+   // check command has finished or the connection has been closed.
++  //
++  // TODO(gkleiman): The output of timed-out checks is lost, we'll
++  // probably have to call `Connection::send` with `streamed = true`
++  // to be able to log it. See MESOS-7903.
+   connection.send(request, false)
+     .after(checkTimeout,
+            defer(self(),
+@@ -584,6 +633,25 @@ void CheckerProcess::___nestedCommandCheck(
+     return;
+   }
+ 
++  Try<tuple<string, string>> checkOutput =
++    decodeProcessIOData(launchResponse.body);
++
++  if (checkOutput.isError()) {
++    LOG(WARNING) << "Failed to decode the output of the " << name
++                 << " for task '" << taskId << "': " << checkOutput.error();
++  } else {
++    string stdoutReceived;
++    string stderrReceived;
++
++    tie(stdoutReceived, stderrReceived) = checkOutput.get();
++
++    LOG(INFO) << "Output of the " << name << " for task '" << taskId
++              << "' (stdout):" << std::endl << stdoutReceived;
++
++    LOG(INFO) << "Output of the " << name << " for task '" << taskId
++              << "' (stderr):" << std::endl << stderrReceived;
++  }
++
+   waitNestedContainer(checkContainerId)
+     .onFailed([promise](const string& failure) {
+       promise->fail(
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0006-Made-the-log-output-handling-of-TCP-and-HTTP-checks-.patch
+++ b/packages/mesos/extra/patches/0006-Made-the-log-output-handling-of-TCP-and-HTTP-checks-.patch
@@ -1,0 +1,73 @@
+From d5a84bda184c30d13149ab4e7b9377ae975f62af Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
+Date: Mon, 21 Aug 2017 15:28:37 -0700
+Subject: [PATCH] Made the log output handling of TCP and HTTP checks
+ consistent.
+
+Review: https://reviews.apache.org/r/61766/
+---
+ src/checks/checker_process.cpp | 24 ++++++++++++++----------
+ 1 file changed, 14 insertions(+), 10 deletions(-)
+
+diff --git a/src/checks/checker_process.cpp b/src/checks/checker_process.cpp
+index 656e9168a..d62bdb5d1 100644
+--- a/src/checks/checker_process.cpp
++++ b/src/checks/checker_process.cpp
+@@ -913,32 +913,35 @@ Future<int> CheckerProcess::_httpCheck(
+ 
+   int exitCode = status->get();
+   if (exitCode != 0) {
+-    const Future<string>& error = std::get<2>(t);
+-    if (!error.isReady()) {
++    const Future<string>& commandError = std::get<2>(t);
++    if (!commandError.isReady()) {
+       return Failure(
+           string(HTTP_CHECK_COMMAND) + " " + WSTRINGIFY(exitCode) +
+           "; reading stderr failed: " +
+-          (error.isFailed() ? error.failure() : "discarded"));
++          (commandError.isFailed() ? commandError.failure() : "discarded"));
+     }
+ 
+     return Failure(
+         string(HTTP_CHECK_COMMAND) + " " + WSTRINGIFY(exitCode) + ": " +
+-        error.get());
++        commandError.get());
+   }
+ 
+-  const Future<string>& output = std::get<1>(t);
+-  if (!output.isReady()) {
++  const Future<string>& commandOutput = std::get<1>(t);
++  if (!commandOutput.isReady()) {
+     return Failure(
+         "Failed to read stdout from " + string(HTTP_CHECK_COMMAND) + ": " +
+-        (output.isFailed() ? output.failure() : "discarded"));
++        (commandOutput.isFailed() ? commandOutput.failure() : "discarded"));
+   }
+ 
++  VLOG(1) << "Output of the " << name << " for task '" << taskId
++          << "': " << commandOutput.get();
++
+   // Parse the output and get the HTTP status code.
+-  Try<int> statusCode = numify<int>(output.get());
++  Try<int> statusCode = numify<int>(commandOutput.get());
+   if (statusCode.isError()) {
+     return Failure(
+         "Unexpected output from " + string(HTTP_CHECK_COMMAND) + ": " +
+-        output.get());
++        commandOutput.get());
+   }
+ 
+   return statusCode.get();
+@@ -1067,7 +1070,8 @@ Future<bool> CheckerProcess::_tcpCheck(
+ 
+   const Future<string>& commandOutput = std::get<1>(t);
+   if (commandOutput.isReady()) {
+-    VLOG(1) << string(TCP_CHECK_COMMAND) << ": " << commandOutput.get();
++    VLOG(1) << "Output of the " << name << " for task '" << taskId
++            << "': " << commandOutput.get();
+   }
+ 
+   if (exitCode != 0) {
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0007-Raised-the-logging-level-of-some-check-and-health-ch.patch
+++ b/packages/mesos/extra/patches/0007-Raised-the-logging-level-of-some-check-and-health-ch.patch
@@ -1,0 +1,52 @@
+From a63b7fc20d21e695783306f5927f3368c364ec2e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
+Date: Mon, 21 Aug 2017 15:28:39 -0700
+Subject: [PATCH] Raised the logging level of some check and health check
+ messages.
+
+Some users pointed out that always logging the result of checks and
+health checks makes it easier to debug problems.
+
+Review: https://reviews.apache.org/r/61791/
+---
+ src/checks/checker_process.cpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/checks/checker_process.cpp b/src/checks/checker_process.cpp
+index d62bdb5d1..47eb21a67 100644
+--- a/src/checks/checker_process.cpp
++++ b/src/checks/checker_process.cpp
+@@ -796,7 +796,7 @@ void CheckerProcess::processCommandCheckResult(
+   // see MESOS-7242.
+   if (future.isReady() && WIFEXITED(future.get())) {
+     const int exitCode = WEXITSTATUS(future.get());
+-    VLOG(1) << name << " for task '" << taskId << "' returned: " << exitCode;
++    LOG(INFO) << name << " for task '" << taskId << "' returned: " << exitCode;
+ 
+     CheckStatusInfo checkStatusInfo;
+     checkStatusInfo.set_type(check.type());
+@@ -957,8 +957,8 @@ void CheckerProcess::processHttpCheckResult(
+   Result<CheckStatusInfo> result = None();
+ 
+   if (future.isReady()) {
+-    VLOG(1) << name << " for task '" << taskId << "'"
+-            << " returned: " << future.get();
++    LOG(INFO) << name << " for task '" << taskId << "'"
++              << " returned: " << future.get();
+ 
+     CheckStatusInfo checkStatusInfo;
+     checkStatusInfo.set_type(check.type());
+@@ -1098,8 +1098,8 @@ void CheckerProcess::processTcpCheckResult(
+   Result<CheckStatusInfo> result = None();
+ 
+   if (future.isReady()) {
+-    VLOG(1) << name << " for task '" << taskId << "'"
+-            << " returned: " << future.get();
++    LOG(INFO) << name << " for task '" << taskId << "'"
++              << " returned: " << future.get();
+ 
+     CheckStatusInfo checkStatusInfo;
+     checkStatusInfo.set_type(check.type());
+-- 
+2.17.1
+


### PR DESCRIPTION
## High-level description

1.10.5-sky1 build of DC/OS was created from a unofficial branch of DC/OS - https://github.com/mesosphere/dcos-enterprise/pull/2984/files and shipped to customer.

This patch is to make sure that we capture the changes that were given in 1.10.5.1 patch release and tag them so that it archived properly as a release.

JIRA for this change is:

* DCOS-39387 - 1.10.5.1 - Create a proper branch with changes in.

Other related JIRAs are:

* DCOS-38929 - Provide a 1.10.5.1 DC/OS EE image to customer.
* COPS-3542 - Warrant a clean upgrade from DC/OS 1.10.5-sky1 towards 1.10.8.
* MESOS-8830 - Agent gc on old slave sandboxes could empty persistent volume data
* DCOS-39059 - Support sky1 with 1.10.5.1 release 
