### PR TITLE
[1.12] Bump Mesos to nightly 1.7.x a6c3804

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git", 
     "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "29561f11a12372752b77839be73418d1d75abe63", 
+    "ref": "bf88ce16e8b868cf5d66e4794db0c55235510fe6", 
     "ref_origin": "1.12"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,28 +1,28 @@
 {
   "requires": [
-    "openssl",
-    "libevent",
-    "curl",
+    "openssl", 
+    "libevent", 
+    "curl", 
     "boost-libs"
-  ],
+  ], 
   "single_source": {
-    "kind": "git",
-    "git": "https://github.com/apache/mesos",
-    "ref": "8419b870c571ac11825c883fa20ea3b7d4348d34",
+    "kind": "git", 
+    "git": "https://github.com/apache/mesos", 
+    "ref": "a6c3804372aaf512145196782c5731f0da58b0e3", 
     "ref_origin": "1.7.x"
-  },
+  }, 
   "environment": {
-    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
+    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib", 
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
-  },
-  "state_directory": true,
+  }, 
+  "state_directory": true, 
   "sysctl": {
     "dcos-mesos-slave": {
-      "vm.max_map_count": 262144,
+      "vm.max_map_count": 262144, 
       "vm.swappiness": 1
-    },
+    }, 
     "dcos-mesos-slave-public": {
-      "vm.max_map_count": 262144,
+      "vm.max_map_count": 262144, 
       "vm.swappiness": 1
     }
   }


### PR DESCRIPTION
## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/8419b870c571ac11825c883fa20ea3b7d4348d34...a6c3804372aaf512145196782c5731f0da58b0e3
    https://github.com/dcos/dcos-mesos-modules/compare/29561f11a12372752b77839be73418d1d75abe63...bf88ce16e8b868cf5d66e4794db0c55235510fe6
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
