### PR TITLE
Bump Marathon dependency on 1.12

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.111-faead2763/marathon-1.7.111-faead2763.tgz",
-    "sha1": "26579af091a4ab5a1015e733f50dde06a2b1a8c5"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.149-21b42dbb8/marathon-1.7.149-21b42dbb8.tgz",
+    "sha1": "243f0e070c5ea2dbdee1153a82612c0dbf1fd3dd"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon dependency for 1.12.0 release. [DCOS-42198](https://jira.mesosphere.com/browse/DCOS-42198)


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
  - [MARATHON-8275](https://jira.mesosphere.com/browse/MARATHON-8275) 
  - [MARATHON-8412](https://jira.mesosphere.com/browse/MARATHON-8412) 
  - [MARATHON-8390](https://jira.mesosphere.com/browse/MARATHON-8390) 
  - [MARATHON-8095](https://jira.mesosphere.com/browse/MARATHON-8095) 
  - [MARATHON-8385](https://jira.mesosphere.com/browse/MARATHON-8385) 
  - [MARATHON-8411](https://jira.mesosphere.com/browse/MARATHON-8411) 
  - [MARATHON-8428](https://jira.mesosphere.com/browse/MARATHON-8428) 
  - [MARATHON-8418](https://jira.mesosphere.com/browse/MARATHON-8418) 
  - [MARATHON-8407](https://jira.mesosphere.com/browse/MARATHON-8407) 
  - [MARATHON-8353](https://jira.mesosphere.com/browse/MARATHON-8353) 
  - [DCOS-41117](https://jira.mesosphere.com/browse/DCOS-41117) 
  - [MARATHON-8430](https://jira.mesosphere.com/browse/MARATHON-8430) 
  - [MARATHON-8315](https://jira.mesosphere.com/browse/MARATHON-8315) 

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]