### PR TITLE
1.12.0 beta2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,11 @@ Format of the entries must be.
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
 
+* DC/OS Net: Logging improvements (DCOS_OSS-3929)
+
+* DC/OS Net: Get rid of epmd (DCOS_OSS-1751)
+
+* Upgrade OTP version (DCOS_OSS-3655)
 
 ### Security Updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,7 +86,7 @@ Format of the entries must be.
 
 ### Notable changes
 
-* Updated DC/OS UI to master+v2.19.4 [Changelog](https://github.com/dcos/dcos-ui/releases/tag/master+v2.19.4)
+* Updated DC/OS UI to master+v2.21.8 [Changelog](https://github.com/dcos/dcos-ui/releases/tag/master+v2.21.8)
 
 * Updated Metronome to 0.5.0. (DCOS_OSS-2338)
 

--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -9,7 +9,6 @@ The following is a list of ports used by internal DC/OS services, and their corr
  - 53: dcos-net (dns)
  - 61091: telegraf
  - 61092: dcos-metrics
- - 61420: dcos-net (epmd)
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)
 

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -526,7 +526,6 @@ function check_all() {
             "61053 mesos-dns" \
             "61091 telegraf" \
             "61092 dcos-metrics" \
-            "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do
@@ -540,7 +539,6 @@ function check_all() {
             "61001 agent-adminrouter" \
             "61091 telegraf" \
             "61092 dcos-metrics" \
-            "61420 dcos-net" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -156,9 +156,7 @@ package:
       [
         {dcos_net,
           [
-            {dist_port, 62501},
-            {epmd_port, 61420},
-            {enable_killer, false}
+            {dist_port, 62501}
           ]
         },
         {dcos_l4lb,

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -553,6 +553,7 @@ package:
       MESOS_EXECUTOR_REREGISTRATION_TIMEOUT=10secs
       MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-agent.log
       MESOS_GC_DELAY={{ gc_delay }}
+      MESOS_GC_NON_EXECUTOR_CONTAINER_SANDBOXES=true
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_IMAGE_GC_CONFIG=file:///opt/mesosphere/etc/mesos-slave-image-gc-config.json
       MESOS_IMAGE_PROVIDERS=docker

--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -4,7 +4,10 @@
    "test": false,
    "bump-ee": true,
    "merge-it": true,
-   "override-status": true,
+   "override-status": {
+    "enabled": true,
+    "jira_label": "mergebot-override"
+    },
     "label": {
         "enabled": true,
         "default": "Work In Progress",
@@ -30,6 +33,6 @@
             "1.10": "DC/OS 1.10.9",
             "1.9": "DC/OS 1.9.11"
         },
-        "jira_regex": "((?:DCOS|DCOS_OSS|COPS)-\\d+)"
+        "jira_regex": "((?:DCOS|DCOS_OSS|COPS|MARATHON)-\\d+)"
     }
 }

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -264,13 +264,26 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
 
     more_clear_input_headers Accept-Encoding;
     include includes/proxy-headers.conf;
+
     # Non-streaming endpoints don't require HTTP/1.1 but will work as
-    # expected with it enabled. Streaming endpoints require keepalive
+    # expected with it enabled. Streaming endpoints require chunked encoding
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;
     # Disable buffering to support streaming endpoints
     include includes/disable-request-response-buffering.conf;
+
+    # For the reasons stated in
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    # we are setting keepalive timeout to 0, basically
+    # disabling it.
+
+    # ToDo (Arsen) Remove also the 'include includes/http-11.conf;'
+    # directive and deactivate the related harness tests.
+
+    # Disabling keepalive adds 'Connection: close' header to the
+    # response - https://forum.nginx.org/read.php?2,251560,251570
+    keepalive_timeout 0;
     proxy_pass $agentaddr:$agentport;
 }
 
@@ -307,13 +320,25 @@ location /mesos/ {
     }
 
     # Non-streaming endpoints don't require HTTP/1.1 but will work as
-    # expected with it enabled. Streaming endpoints require keepalive
+    # expected with it enabled. Streaming endpoints require chunked encoding
     # functionality added in HTTP/1.1. As such, we enable HTTP/1.1 here
     # while maintaining backwards compatibility.
     include includes/http-11.conf;
     # Disable buffering to support streaming Mesos v1 streaming API:
     proxy_buffering off;
 
+    # For the reasons stated in
+    # https://jira.mesosphere.com/browse/DCOS-42098
+    # we are setting keepalive timeout to 0, basically
+    # disabling it.
+
+    # ToDo (Arsen) Remove also the 'include includes/http-11.conf;'
+    # directive and deactivate the related harness tests.
+
+    # Disabling keepalive adds 'Connection: close' header to the
+    # response - https://forum.nginx.org/read.php?2,251560,251570
+
+    keepalive_timeout 0;
     include includes/proxy-headers.conf;
     rewrite ^/mesos/(.*) /$1 break;
     proxy_pass $upstream_mesos;

--- a/packages/adminrouter/windows.buildinfo.json
+++ b/packages/adminrouter/windows.buildinfo.json
@@ -3,7 +3,7 @@
         "URLRewrite": {
           "kind": "url",
           "url": "http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi",
-          "sha1": "d2542e2d398f0e95981ebf4e729f79eaf96e6691"
+          "sha1": "eff9901ce6c20f94055488e65d3d2748b4e2be8e"
         },
         "Application-Request-Routing": {
           "kind": "url",

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "36de37d5f8087505228cb2cdfc5c30859a302b23",
+      "ref": "1753c7f42cf4577427740e9a23aedb433242b696",
       "ref_origin": "master"
     }
   },

--- a/packages/dcos-ui/buildinfo.json
+++ b/packages/dcos-ui/buildinfo.json
@@ -1,7 +1,7 @@
 {
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.19.4.tar.gz",
-    "sha1": "390b90fcff00f7ab455506f606cc10c5d95203b8"
+    "url": "https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.21.8.tar.gz",
+    "sha1": "a8ddc08b95556d8e57e44a5a6c3a0a3ac32ff4ca"
   }
 }

--- a/packages/erlang/build
+++ b/packages/erlang/build
@@ -6,6 +6,54 @@ export LDFLAGS="-L/opt/mesosphere/lib -L/opt/mesosphere/active/ncurses/lib -L/op
 export CPPFLAGS=${CFLAGS}
 
 pushd /pkg/src/erlang
+
+# ERL-692
+## erts: Delete fd from poll-set when closing fd_driver port
+git cherry-pick --no-commit 1d1f29eb614ce75012f9136d185f4dbcccc8650b
+# ERL-622
+## ssl: Improve error handling
+git cherry-pick --no-commit a06549fbe59333347232c56093791c0075fcd150
+## ssl: Add new sender process for TLS state machine
+git cherry-pick --no-commit d87ac1c55188f5ba5cdf72384125d94d42118c18
+## ssl: Adopt distribution over TLS to use new sender process
+git cherry-pick --no-commit 0078ebf6c5311edc1a07be71fb7a127a175a60fa
+## ssl: Improve close handling
+git cherry-pick --no-commit a508428df8af14437f1a4766ec68294d1d736915
+## kernel: Fix net_kernel:connect_node/1 to local node
+git cherry-pick --no-commit c4759bc60c8e5db27c070b9e826ddc0f9626b094
+
+## Please see https://bugs.erlang.org/browse/ERL-622
+patch -p1 <<EOF
+diff --git a/lib/ssl/src/tls_connection.erl b/lib/ssl/src/tls_connection.erl
+index 6c7511d2b3..2fde17a0fd 100644
+--- a/lib/ssl/src/tls_connection.erl
++++ b/lib/ssl/src/tls_connection.erl
+@@ -118,6 +118,7 @@ start_link(Role, Sender, Host, Port, Socket, Options, User, CbInfo) ->
+
+ init([Role, Sender, Host, Port, Socket, {SslOpts, _, _} = Options,  User, CbInfo]) ->
+     process_flag(trap_exit, true),
++    link(Sender),
+     case SslOpts#ssl_options.erl_dist of
+         true ->
+             process_flag(priority, max);
+diff --git a/lib/ssl/src/tls_sender.erl b/lib/ssl/src/tls_sender.erl
+index 007fd345dd..db67d7ddff 100644
+--- a/lib/ssl/src/tls_sender.erl
++++ b/lib/ssl/src/tls_sender.erl
+@@ -67,9 +67,9 @@
+ %%  same process is sending and receiving
+ %%--------------------------------------------------------------------
+ start() ->
+-    gen_statem:start_link(?MODULE, [], []).
++    gen_statem:start(?MODULE, [], []).
+ start(SpawnOpts) ->
+-    gen_statem:start_link(?MODULE, [], SpawnOpts).
++    gen_statem:start(?MODULE, [], SpawnOpts).
+
+ %%--------------------------------------------------------------------
+ -spec initialize(pid(), map()) -> ok.
+EOF
+
 ./otp_build setup -a --prefix=$PKG_PATH --with-ssl=/opt/mesosphere/active/openssl --with-termcap=/opt/mesosphere/active/ncurses --disable-hipe --enable-kernel-poll --enable-builtin-zlib
 make -j$NUM_CORES
 make install

--- a/packages/erlang/buildinfo.json
+++ b/packages/erlang/buildinfo.json
@@ -4,8 +4,8 @@
     "erlang": {
       "kind": "git",
       "git": "https://github.com/erlang/otp.git",
-      "ref": "c5ee502e6031986983d3596745cad7fd547fd9c2",
-      "ref_origin": "maint-20"
+      "ref": "333e4c5a1406cdeb9d1d5cf9bf4a4fadb232fca8",
+      "ref_origin": "maint-21"
     }
   }
 }

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.111-faead2763/marathon-1.7.111-faead2763.tgz",
-    "sha1": "26579af091a4ab5a1015e733f50dde06a2b1a8c5"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.149-21b42dbb8/marathon-1.7.149-21b42dbb8.tgz",
+    "sha1": "243f0e070c5ea2dbdee1153a82612c0dbf1fd3dd"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,12 +1,12 @@
 {
   "requires": [
-    "mesos", 
+    "mesos",
     "boost-libs"
-  ], 
+  ],
   "single_source": {
-    "kind": "git", 
-    "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "29561f11a12372752b77839be73418d1d75abe63", 
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "545c3ff25e8bf5dcff166b83ee419584db22a5c4",
     "ref_origin": "1.12"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "8419b870c571ac11825c883fa20ea3b7d4348d34",
+    "ref": "06eb5bad486236ac557927a50386e4587034206c",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -1,9 +1,9 @@
 {
-  "single_source" : {
+  "single_source": {
     "kind": "git",
-    "git": "https://github.com/apache/mesos", 
-    "ref": "84749967a1c1384f75c3c017bda45a85eea67787",
-    "ref_origin" : "master"
+    "git": "https://github.com/apache/mesos",
+    "ref": "06eb5bad486236ac557927a50386e4587034206c",
+    "ref_origin": "1.7.x"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description


* #3375 - [1.12] Bump dcos-net 
* #3458 - Admin Router: add 'Connection:close' header to the responses to requests to /mesos and /agent
* #3461 - Bump DC/OS UI to v2.21.8
* #3477 - [1.12] Bump Mesos to nightly 1.7.x 06eb5ba
* #3484 - Bump Marathon dependency on 1.12

Included

* [1.12] Enabled GC of nested container sandboxes by the Mesos agent #3490
