### PR TITLE
[1.10] Bump Mesos to nightly 1.4.x 1a59ec6

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -1,12 +1,12 @@
 {
   "requires": [
-    "mesos", 
+    "mesos",
     "boost-libs"
-  ], 
+  ],
   "single_source": {
-    "kind": "git", 
-    "git": "https://github.com/dcos/dcos-mesos-modules.git", 
-    "ref": "5b3577ec734c866c71c70018b9d0fad67ba8aba0",
+    "kind": "git",
+    "git": "https://github.com/dcos/dcos-mesos-modules.git",
+    "ref": "8adedeeba73805c0e6884bac517aacca7623eace",
     "ref_origin": "1.10"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -1,28 +1,28 @@
 {
   "requires": [
-    "openssl", 
-    "libevent", 
-    "curl", 
+    "openssl",
+    "libevent",
+    "curl",
     "boost-libs"
-  ], 
+  ],
   "single_source": {
-    "kind": "git", 
-    "git": "https://github.com/apache/mesos", 
-    "ref": "5f6d4cdc79e1b28bc2d157d4b5b4aaf941a26d91", 
+    "kind": "git",
+    "git": "https://github.com/apache/mesos",
+    "ref": "1a59ec62b0aec0db4e5ee8ba4a468aba4141ff90",
     "ref_origin": "1.4.x"
-  }, 
+  },
   "environment": {
-    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib", 
+    "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",
     "MESOS_NATIVE_JAVA_LIBRARY": "/opt/mesosphere/lib/libmesos.so"
-  }, 
-  "state_directory": true, 
+  },
+  "state_directory": true,
   "sysctl": {
     "dcos-mesos-slave": {
-      "vm.max_map_count": 262144, 
+      "vm.max_map_count": 262144,
       "vm.swappiness": 1
-    }, 
+    },
     "dcos-mesos-slave-public": {
-      "vm.max_map_count": 262144, 
+      "vm.max_map_count": 262144,
       "vm.swappiness": 1
     }
   }


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/5f6d4cdc79e1b28bc2d157d4b5b4aaf941a26d91...1a59ec62b0aec0db4e5ee8ba4a468aba4141ff90
    https://github.com/dcos/dcos-mesos-modules/compare/5b3577ec734c866c71c70018b9d0fad67ba8aba0...8adedeeba73805c0e6884bac517aacca7623eace
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
