### PR TITLE
(1.12) Remove mesos_id dimension from v0 metrics API

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1329,8 +1329,6 @@ package:
         cache_expiry = "2m"
         # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
-        # Local Mesos instance's ID.
-        mesos_id = "$DCOS_MESOS_ID"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
   - path: /etc_slave/telegraf/telegraf.d/agent.conf
@@ -1367,8 +1365,6 @@ package:
         cache_expiry = "2m"
         # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
-        # Local Mesos instance's ID.
-        mesos_id = "$DCOS_MESOS_ID"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
@@ -1405,7 +1401,5 @@ package:
         cache_expiry = "2m"
         # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
-        # Local Mesos instance's ID.
-        mesos_id = "$DCOS_MESOS_ID"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -80,6 +80,8 @@ def test_metrics_node(dcos_api_session):
 
         assert response['dimensions']['cluster_id'] != "", 'expected cluster to contain a value'
 
+        assert response['dimensions']['mesos_id'] == '', 'expected dimensions to include empty "mesos_id"'
+
         return True
 
     # Retry for 30 seconds for for the node metrics content to appear.
@@ -174,6 +176,8 @@ def test_metrics_containers(dcos_api_session):
                 assert 'dimensions' in container_metrics, 'got {}'.format(container_metrics)
                 assert 'task_name' in container_metrics['dimensions'], 'got {}'.format(
                     container_metrics['dimensions'])
+                assert container_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(
+                    container_metrics['dimensions'])
 
                 debug_task_name.append(container_metrics['dimensions']['task_name'])
 
@@ -205,6 +209,9 @@ def test_metrics_containers(dcos_api_session):
                     }
                     check_tags(uptime_dp['tags'], expected_tag_names)
                     assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+
+                    assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
+                    assert app_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(app_metrics)
 
                     return True
 

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -18,7 +18,6 @@ node_private_ip=$(/opt/mesosphere/bin/detect_ip)
 # Export values to env vars so Telegraf config can reference them.
 export DCOS_CLUSTER_ID="${cluster_id}"
 export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
-export DCOS_MESOS_ID="fake_mesos_id" # TODO(branden)
 
 # Create containers dir for dcos_statsd input.
 mkdir -p "${TELEGRAF_CONTAINERS_DIR}"


### PR DESCRIPTION
## High-level description

This is a 1.12 backport of #3465.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4144](https://jira.mesosphere.com/browse/DCOS_OSS-4144) Remove mesos_id tag from v0 metrics API

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: The field being removed is unimplemented and unused.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]