### PR TITLE
[master] Add tests for metrics from standalone containers and pods.

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,5 +1,8 @@
 import contextlib
 
+import logging
+import uuid
+
 import common
 import pytest
 import retrying
@@ -618,3 +621,122 @@ def get_app_metrics(dcos_api_session, node: str, container_id: str):
     assert 'datapoints' in app_metrics, 'got {}'.format(app_metrics)
     assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
     return app_metrics
+
+
+@pytest.mark.skipif(
+    expanded_config.get('security') == 'strict',
+    reason='Only resource providers are authorized to launch standalone containers in strict mode. See DCOS-42325.')
+def test_standalone_container_metrics(dcos_api_session):
+    """
+    An operator should be able to launch a standalone container using the
+    LAUNCH_CONTAINER call of the agent operator API. Additionally, if the
+    process running within the standalone container emits statsd metrics, they
+    should be accessible via the DC/OS metrics API.
+    """
+    # Fetch the mesos master state to get an agent ID
+    master_ip = dcos_api_session.masters[0]
+    r = dcos_api_session.get('/state', host=master_ip, port=5050)
+    assert r.status_code == 200
+    state = r.json()
+
+    # Find hostname and ID of an agent
+    assert len(state['slaves']) > 0, 'No agents found in master state'
+    agent_hostname = state['slaves'][0]['hostname']
+    agent_id = state['slaves'][0]['id']
+    logging.debug('Selected agent %s at %s', agent_id, agent_hostname)
+
+    def _post_agent(json):
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+        }
+
+        r = dcos_api_session.post(
+            '/api/v1',
+            host=agent_hostname,
+            port=5051,
+            headers=headers,
+            json=json,
+            data=None,
+            stream=False)
+        return r
+
+    # Prepare container ID data
+    container_id = {'value': 'test-standalone-%s' % str(uuid.uuid4())}
+
+    # Launch standalone container. The command for this container executes a
+    # binary installed with DC/OS which will emit statsd metrics.
+    launch_data = {
+        'type': 'LAUNCH_CONTAINER',
+        'launch_container': {
+            'command': {
+                'value': './statsd-emitter',
+                'uris': [{
+                    'value': 'https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter',
+                    'executable': True
+                }]
+            },
+            'container_id': container_id,
+            'resources': [
+                {
+                    'name': 'cpus',
+                    'scalar': {'value': 0.2},
+                    'type': 'SCALAR'
+                },
+                {
+                    'name': 'mem',
+                    'scalar': {'value': 64.0},
+                    'type': 'SCALAR'
+                },
+                {
+                    'name': 'disk',
+                    'scalar': {'value': 1024.0},
+                    'type': 'SCALAR'
+                }
+            ],
+            'container': {
+                'type': 'MESOS'
+            }
+        }
+    }
+
+    # There is a short delay between the container starting and metrics becoming
+    # available via the metrics service. Because of this, we wait up to 10
+    # seconds for these metrics to appear before throwing an exception.
+    def _should_retry_metrics_fetch(response):
+        return response.status_code == 204
+
+    @retrying.retry(wait_fixed=1000,
+                    stop_max_delay=10000,
+                    retry_on_result=_should_retry_metrics_fetch,
+                    retry_on_exception=lambda x: False)
+    def _get_metrics():
+        master_response = dcos_api_session.get(
+            '/system/v1/agent/%s/metrics/v0/containers/%s/app' % (agent_id, container_id['value']),
+            host=master_ip)
+        return master_response
+
+    r = _post_agent(launch_data)
+    assert r.status_code == 200, 'Received unexpected status code when launching standalone container'
+
+    try:
+        logging.debug('Successfully created standalone container with container ID %s', container_id['value'])
+
+        # Verify that the standalone container's metrics are being collected
+        r = _get_metrics()
+        assert r.status_code == 200, 'Received unexpected status code when fetching standalone container metrics'
+
+        metrics_response = r.json()
+        metric_keys = [datapoint['name'] for datapoint in metrics_response['datapoints']]
+        assert 'statsd_tester.time.uptime' in metric_keys
+        assert metrics_response['dimensions']['container_id'] == container_id['value']
+    finally:
+        # Clean up the standalone container
+        kill_data = {
+            'type': 'KILL_CONTAINER',
+            'kill_container': {
+                'container_id': container_id
+            }
+        }
+
+        _post_agent(kill_data)


### PR DESCRIPTION
## High-level description

This PR adds an integration test which verifies that statsd metrics emitted by standalone container processes will be collected by the DC/OS metrics service.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-2271](https://jira.mesosphere.com/browse/DCOS_OSS-2271) dcos-metrics should support standalone containers


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-3714](https://jira.mesosphere.com/browse/DCOS_OSS-3714) Adopt Telegraf as the DC/OS metrics pipeline


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a test-only change, so it is not user-facing.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): 
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]