### PR TITLE
Add integration test for pod application metrics.

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -321,3 +321,206 @@ def get_app_metrics(dcos_api_session, node: str, container_id: str):
     assert 'datapoints' in app_metrics, 'got {}'.format(app_metrics)
     assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
     return app_metrics
+
+
+def test_pod_application_metrics(dcos_api_session):
+    """Launch a pod, wait for its containers to be added to the metrics service,
+    and then verify that:
+    1) Container statistics metrics are provided for the executor container
+    2) Application metrics are exposed for the task container
+    """
+    # Helper func to check for non-unique CID's in a given /containers/id endpoint
+    def check_cid(registry):
+        if len(registry) <= 1:
+            return True
+
+        cid1 = registry[len(registry) - 1]
+        cid2 = registry[len(registry) - 2]
+        if cid1 != cid2:
+            raise ValueError('{} != {}'.format(cid1, cid2))
+
+        return True
+
+    @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
+    def test_application_metrics(agent_ip, agent_id, task_name, num_containers):
+        debug_task_name = []
+
+        # Retry for two and a half minutes since the collector collects
+        # state every 2 minutes to propogate containers to the API
+        @retrying.retry(wait_fixed=2000, stop_max_delay=150000)
+        def wait_for_container_metrics_propogation():
+            response = dcos_api_session.metrics.get('/containers', node=agent_ip)
+            assert response.status_code == 200
+            assert len(response.json()) == num_containers, 'Test should create {} containers'.format(num_containers)
+
+        wait_for_container_metrics_propogation()
+
+        get_containers = {
+            "type": "GET_CONTAINERS",
+            "get_containers": {
+                "show_nested": True,
+                "show_standalone": True
+            }
+        }
+
+        r = dcos_api_session.post('/agent/{}/api/v1'.format(agent_id), json=get_containers)
+        r.raise_for_status()
+        mesos_agent_containers = r.json()['get_containers']['containers']
+
+        assert len(mesos_agent_containers) == num_containers, 'Agent operator API should report '\
+            'exactly {} running containers'.format(num_containers)
+
+        def is_nested_container(container):
+            """Helper to check whether or not a container returned in the
+            GET_CONTAINERS response is a nested container.
+            """
+            return 'parent' in container['container_status']['container_id']
+
+        def check_tags(tags: dict, expected_tag_names: set):
+            """Assert that tags contain only expected keys with nonempty values."""
+            assert set(tags.keys()) == expected_tag_names
+            for tag_name, tag_val in tags.items():
+                assert tag_val != '', 'Value for tag "%s" must not be empty'.format(tag_name)
+
+        for container in mesos_agent_containers:
+            container_id = container['container_id']['value']
+
+            # Test that /containers/<id> responds with expected data.
+            container_id_path = '/containers/{}'.format(container_id)
+
+            if (is_nested_container(container)):
+                # Retry for 30 seconds for each nested container to appear.
+                # Since nested containers do not report resource statistics, we
+                # expect the response code to be 204.
+                @retrying.retry(stop_max_delay=30000)
+                def wait_for_container_response():
+                    response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
+                    assert response.status_code == 204
+                    return response
+
+                # For the nested container, we do not expect any container-level
+                # resource statistics, so this response should be empty.
+                assert not wait_for_container_response().json()
+
+                # Test that expected application metrics are present.
+                app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(container_id), node=agent_ip)
+                assert app_response.status_code == 200, 'got {}'.format(app_response.status_code)
+
+                # Ensure all /container/<id>/app data is correct
+                assert 'datapoints' in app_response.json(), 'got {}'.format(app_response.json())
+
+                # We expect three datapoints, could be in any order
+                uptime_dp = None
+                for dp in app_response.json()['datapoints']:
+                    if dp['name'] == 'statsd_tester_time_uptime':
+                        uptime_dp = dp
+                        break
+
+                # If this metric is missing, statsd-emitter's metrics were not received
+                assert uptime_dp is not None, 'got {}'.format(app_response.json())
+
+                datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
+                for k in datapoint_keys:
+                    assert k in uptime_dp, 'got {}'.format(uptime_dp)
+
+                expected_tag_names = {
+                    'dcos_cluster_id',
+                    'test_tag_key',
+                    'dcos_cluster_name',
+                    'host'
+                }
+                check_tags(uptime_dp['tags'], expected_tag_names)
+                assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+
+                assert 'dimensions' in app_response.json(), 'got {}'.format(app_response.json())
+            else:
+                # Retry for 30 seconds for each parent container to present its
+                # content.
+                @retrying.retry(stop_max_delay=30000)
+                def wait_for_container_response():
+                    response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
+                    assert response.status_code == 200
+                    return response
+
+                container_response = wait_for_container_response()
+                assert 'datapoints' in container_response.json(), 'got {}'.format(container_response.json())
+
+                cid_registry = []
+                for dp in container_response.json()['datapoints']:
+                    # Verify expected tags are present.
+                    assert 'tags' in dp, 'got {}'.format(dp)
+                    expected_tag_names = {
+                        'container_id',
+                    }
+                    if 'executor_name' in dp['tags']:
+                        # If present, we want to make sure it has a valid value.
+                        expected_tag_names.add('executor_name')
+                    if dp['name'].startswith('blkio.'):
+                        # blkio stats have 'blkio_device' tags.
+                        expected_tag_names.add('blkio_device')
+                    check_tags(dp['tags'], expected_tag_names)
+
+                    # Ensure all container IDs in the response from the
+                    # containers/<id> endpoint are the same.
+                    cid_registry.append(dp['tags']['container_id'])
+                    assert(check_cid(cid_registry))
+
+                assert 'dimensions' in container_response.json(), 'got {}'.format(container_response.json())
+                assert 'task_name' in container_response.json()['dimensions'], 'got {}'.format(
+                    container_response.json()['dimensions'])
+
+                debug_task_name.append(container_response.json()['dimensions']['task_name'])
+
+                # Look for the specified task name.
+                assert task_name.strip('/') == container_response.json()['dimensions']['task_name'],\
+                    'Parent container was not tagged with the correct task name'
+
+                # The executor container shouldn't expose application metrics.
+                app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(container_id), node=agent_ip)
+                assert app_response.status_code == 204, 'got {}'.format(app_response.status_code)
+
+                return True
+
+    marathon_pod_config = {
+        "id": "/statsd-emitter-task-group10",
+        "containers": [{
+            "name": "statsd-emitter-task",
+            "resources": {
+                "cpus": 0.5,
+                "mem": 128.0,
+                "disk": 1024.0
+            },
+            "image": {
+                "kind": "DOCKER",
+                "id": "alpine"
+            },
+            "exec": {
+                "command": {
+                    "shell": "/mnt/mesos/sandbox/metrics_bin_dir/statsd-emitter"
+                }
+            },
+            "volumeMounts": [{
+                "name": "metricsbindir",
+                "mountPath": "metrics_bin_dir"
+            }]
+        }],
+        "volumes": [{
+            "name": "metricsbindir",
+            "host": "/opt/mesosphere/active/dcos-metrics/bin"
+        }],
+        "scheduling": {
+            "instances": 1
+        }
+    }
+
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(marathon_pod_config):
+        r = dcos_api_session.marathon.get('/v2/pods/{}::status'.format(marathon_pod_config['id']))
+        r.raise_for_status()
+        data = r.json()
+
+        assert len(data['instances']) == 1, 'The marathon pod should have been deployed exactly once.'
+
+        test_application_metrics(
+            data['instances'][0]['agentHostname'],
+            data['instances'][0]['agentId'],
+            marathon_pod_config['containers'][0]['name'], 2)


### PR DESCRIPTION
## High-level description

This PR adds an integration test which verifies that application metrics from services running as DC/OS pods (aka Mesos "task groups") are available as expected via the DC/OS metrics API.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4183](https://jira.mesosphere.com/browse/DCOS_OSS-4183) Mesos Metrics 2.0: integration tests


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a test-only change.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): 
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
