### PR TITLE
[1.12] Bump telegraf - tcp socket fix

### DIFF
--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "071b143b1c93f03e5469378d082ec14dacf41674",
+    "ref": "59a36b4410388fb4105d678ea0a76f4271d98da5",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This PR fixes an issue which caused hanging TCP connections, which could eventually crash an agent. It also pulls in two small fixes which avoid bulky and uninformative logs. 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-42339](https://jira.mesosphere.com/browse/DCOS-42339) More than 500.000 open TCP connections between mesos agents and dcos telegraf.
 -  [DCOS-41900](https://jira.mesosphere.com/browse/DCOS-41900) Remove duplicate logs from dcos_metadata
 - [DCOS_OSS-4180](https://jira.mesosphere.com/browse/DCOS_OSS-4180) - Downgrade 'empty containers' error to info


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This ticket fixes bugs against a new feature in 1.12
  - [x] Included a test which will fail if code is reverted but test is not. 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/telegraf/compare/071b143b1c93f03e5469378d082ec14dacf41674...59a36b4410388fb4105d678ea0a76f4271d98da5)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos/46/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos/46/)
