### PR TITLE
Removed marathon start precondition which challenges HA of marathon based on 1 node failure

### DIFF
--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -44,7 +44,6 @@ EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment
 Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
-ExecStartPre=/bin/ping -c1 zk-1.zk
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStart=/opt/mesosphere/bin/marathon.sh
 EOF


### PR DESCRIPTION
## High-level description
What features does this change enable? What bugs does this change fix?

## Corresponding DC/OS tickets (obligatory)
These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

* [DCOS_OSS-4193](https://jira.mesosphere.com/browse/DCOS_OSS-4193) Marathon bootstrap relies on zk-1.zk node to be available.

## Checklist for all PRs
* [ ]  Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
* [ ]  Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
* [x]  Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
* [x]  Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:
If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

* [ ]  Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A -Configuration change only
* [ ]  Test Results: N/A
* [ ]  Code Coverage (if available): N/A
