### PR TITLE
Enable Mergebot Sync in dcos/dcos.

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -4,6 +4,7 @@
    "test": false,
    "bump-ee": true,
    "merge-it": true,
+   "sync": true,
    "override-status": {
     "enabled": true,
     "jira_label": "mergebot-override"


### PR DESCRIPTION
## High-level description

Mergebot sync will prevent flakiness with mergebot and will help synchronize the mergebot actions. 

It addresses this flaky issue

* DCOS-39073 - Mergebot shows `aggregate` as red, although downstream has all CI checks green