### PR TITLE
New config.yaml to support Windows Build Artifacts in Separate S3 Bucket

### DIFF
--- a/config/dcos-release-windows.config.yaml
+++ b/config/dcos-release-windows.config.yaml
@@ -1,0 +1,15 @@
+storage:
+  aws:
+    kind: aws_s3
+    bucket: downloads.dcos.io
+    object_prefix: dcos/dcos-windows
+    download_url: https://downloads.dcos.io/dcos/dcos-windows
+  azure:
+    kind: azure_block_blob
+    account_name: $AZURE_PROD_STORAGE_ACCOUNT
+    account_key: $AZURE_PROD_STORAGE_ACCESS_KEY
+    container: dcos
+    download_url: https://dcosio.azureedge.net/dcos/
+options:
+  preferred: aws
+  cloudformation_s3_url: https://s3-us-west-2.amazonaws.com/downloads.dcos.io/dcos/dcos-windows


### PR DESCRIPTION
We needed to create a new S3 bucket to store Windows build artificats. Otherwise we would overwrite the linux build artifacts witth the same PR that builds Linux and Windows builds.

## High-level description

What features does this change enable? What bugs does this change fix?
This enables the ability to store Windows build artifacts into its own S3 bucket

## Checklist for all PRs

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)