### PR TITLE
[master] Bump Mesos to nightly master 7aaef19

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "78b54e46bf2024e8438c7394c78d9b38fe728395",
+    "ref": "f70ab812954ee1b3fd81428fd0a53f8ec6f94bab",
     "ref_origin": "master"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d34ded8b8d8d1a1b5e4fcda3dd596ede0d1ff037",
+    "ref": "7aaef1979a10de5e11548123d1985474b143854b",
     "ref_origin": "master"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -1,9 +1,9 @@
 {
-  "single_source" : {
+  "single_source": {
     "kind": "git",
-    "git": "https://github.com/apache/mesos", 
-    "ref": "84749967a1c1384f75c3c017bda45a85eea67787",
-    "ref_origin" : "master"
+    "git": "https://github.com/apache/mesos",
+    "ref": "7aaef1979a10de5e11548123d1985474b143854b",
+    "ref_origin": "master"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/d34ded8b8d8d1a1b5e4fcda3dd596ede0d1ff037...7aaef1979a10de5e11548123d1985474b143854b
    https://github.com/dcos/dcos-mesos-modules/compare/78b54e46bf2024e8438c7394c78d9b38fe728395...f70ab812954ee1b3fd81428fd0a53f8ec6f94bab
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
