### PR TITLE
[1.12] Update packaging integration tests to ensure testing on smaller clusters

### DIFF
--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -54,19 +54,13 @@ def test_pkgpanda_api(dcos_api_session):
 
 # There is no standardized way of getting package requirements from the package description json,
 # e.g. nodes could be called 'brokers' or 'nodes' or something else. This was created by looking at
-# https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/K/kafka/39/config.json
-# 1.1.9-0.10.0.0
-KAFKA_PACKAGE_REQUIREMENTS = {
-    'number_of_nodes': 3,
+# https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/N/nginx/6/config.json
+# Nginx package version 1.10.3
+NGINX_PACKAGE_REQUIREMENTS = {
+    'number_of_nodes': 1,
     'node': {
-        'disk': 5000,
-        'mem': 2304,
-        'cpus': 1
-    },
-    'executor': {
-        'disk': 0,
-        'mem': 256,
-        'cpus': 0.5
+        'cpus': 1,
+        'mem': 1024
     }
 }
 
@@ -86,7 +80,7 @@ def _agent_has_resources(agent, node_requirements):
         node_requirements: dict Resource requirements per agent
     """
     unreserved = agent['unreserved_resources']
-    resources = ['mem', 'disk', 'cpus']
+    resources = ['mem', 'cpus']
     for resource in resources:
         log.debug('{resource}: unreserved {unreserved}, required {required}'.format(
             resource=resource,
@@ -135,14 +129,18 @@ def _skipif_insufficient_resources(dcos_api_session, requirements):
     """Can't access dcos_api_session from through the pytest.mark.skipif decorator, so call this in each test instead
     """
     if not _enough_resources_for_package(_get_cluster_resources(dcos_api_session), requirements):
-        return pytest.skip(msg='Package installation would fail on this cluster due to insufficient resources')
+        pytest.skip(msg='Package installation would fail on this cluster due to insufficient resources')
 
 
 def test_packaging_api(dcos_api_session):
-    """Test the Cosmos API (/package) wrapper
     """
-    _skipif_insufficient_resources(dcos_api_session, KAFKA_PACKAGE_REQUIREMENTS)
-    install_response = dcos_api_session.cosmos.install_package('kafka', package_version='1.1.9-0.10.0.0')
+    Test the Cosmos API (/package) wrapper by installing nginx from
+    https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/N/nginx/6
+    The default configuration of ngnix needs only one agent and no service secrets are
+    required even when running in a strict cluster.
+    """
+    _skipif_insufficient_resources(dcos_api_session, NGINX_PACKAGE_REQUIREMENTS)
+    install_response = dcos_api_session.cosmos.install_package('nginx', package_version='1.10.3')
     data = install_response.json()
 
     dcos_api_session.marathon.wait_for_deployments_complete()
@@ -151,7 +149,7 @@ def test_packaging_api(dcos_api_session):
     packages = list_response.json()['packages']
     assert len(packages) == 1 and packages[0]['appId'] == data['appId']
 
-    dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
+    dcos_api_session.cosmos.uninstall_package('nginx', app_id=data['appId'])
 
     list_response = dcos_api_session.cosmos.list_packages()
     packages = list_response.json()['packages']


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Currently, in the `test_packaging.py` we are trying to install `kafka` for which i have few concerns:
- It requires 3 agents to run. The intention of this test is to ensure the `/package/install` endpoint works. We should not have to require 3 agent nodes to test this functionality.
- Looking at the [history of this test in teamcity](https://teamcity.mesosphere.io/project.html?tab=testDetails&testNameId=-1224229538779150681&projectId=DcOs), I found out that the test has `0.0%` success rate. (It failed everytime it was ran, and it was ignored most of the time).

Based on above, I decided to install `nginx` instead of `kafka` which requires only one agent node for a successful install.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4221](https://jira.mesosphere.com/browse/DCOS_OSS-4221) Install nginx instead of kafka to ensure the test runs in clusters of smaller sizes.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is only adding an integration tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: No such test
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
