### PR TITLE
[1.12] Telegraf config updates

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1226,7 +1226,8 @@ package:
   - path: /etc/telegraf.env
     content: |
       TELEGRAF_CONFIG_FILE=/opt/mesosphere/etc/telegraf/telegraf.conf
-      TELEGRAF_CONFIG_DIR=/opt/mesosphere/etc/telegraf/telegraf.d/
+      TELEGRAF_CONFIG_TPL=/opt/mesosphere/etc/telegraf/telegraf.d/
+      TELEGRAF_CONFIG_DIR=/var/lib/dcos/telegraf/telegraf.d/
       TELEGRAF_CONTAINERS_DIR=/run/dcos/telegraf/dcos_statsd/containers
       LEGACY_CONTAINERS_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers
   - path: /etc/telegraf/telegraf.conf

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1328,6 +1328,8 @@ package:
       # Additional Telegraf config for agents
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
+        ## The interval at which to collect metrics
+        interval = "60s"
         ## The URL of the local mesos agent
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
@@ -1364,6 +1366,8 @@ package:
       # Additional Telegraf config for agents
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
+        ## The interval at which to collect metrics
+        interval = "60s"
         ## The URL of the local mesos agent
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1229,6 +1229,7 @@ package:
       TELEGRAF_CONFIG_TPL=/opt/mesosphere/etc/telegraf/telegraf.d/
       TELEGRAF_CONFIG_DIR=/var/lib/dcos/telegraf/telegraf.d/
       TELEGRAF_CONTAINERS_DIR=/run/dcos/telegraf/dcos_statsd/containers
+      LEGACY_CONTAINERS_PARENT_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule
       LEGACY_CONTAINERS_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers
   - path: /etc/telegraf/telegraf.conf
     content: |

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -6,5 +6,6 @@
     "ref": "59a36b4410388fb4105d678ea0a76f4271d98da5",
     "ref_origin": "1.7.2-dcos"
   },
-  "username": "dcos_telegraf"
+  "username": "dcos_telegraf",
+  "state_directory": true
 }

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -19,6 +19,8 @@ LimitNOFILE=16384
 ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
+# Ensure that start_telegraf.sh can move the legacy container
+ExecStartPre=/bin/bash -c "chown -R root:dcos_telegraf ${LEGACY_CONTAINERS_PARENT_DIR}
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -18,9 +18,9 @@ LimitNOFILE=16384
 
 ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
-ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "chown dcos_telegraf:dcos_telegraf /run/dcos/telegraf"
 # Ensure that start_telegraf.sh can move the legacy container
-ExecStartPre=/bin/bash -c "chown -R root:dcos_telegraf ${LEGACY_CONTAINERS_PARENT_DIR}
+ExecStartPre=/bin/bash -c "chown -R dcos_telegraf:dcos_telegraf ${LEGACY_CONTAINERS_PARENT_DIR}
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -24,6 +24,10 @@ mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
 # Migrate old containers dir to new location in case the cluster was upgraded.
 /opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
 
+mkdir -p "${TELEGRAF_CONFIG_DIR}"
+# Copy the contents of the telegraf.d template files to the config directory
+cp "${TELEGRAF_CONFIG_TPL}/*" "${TELEGRAF_CONFIG_DIR}"
+
 # Ensure that old socket file is removed, if present
 # TODO(philipnrmn): investigate whether moving to a systemd-managed socket
 # would be a better solution than manually creating and removing this file.


### PR DESCRIPTION
## High-level description

This PR adds two configuration updates to telegraf, increasing the poll interval against get_containers to 60s and moving the configuration to /var/lib/dcos


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4228](https://jira.mesosphere.com/browse/DCOS_OSS-4228) Decrease the poll frequency of dcos_containers to 60s
  - [DCOS-42214](https://jira.mesosphere.com/browse/DCOS-42214) [dcos-telegraf] support methods to configure additional settings on dcos-telegraf
 - [DCOS-42964](https://jira.mesosphere.com/browse/DCOS-42964) Telegraf fails to come up during upgrade due to permissions issue


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this polishes a new feature in 1.12, there is no user-facing change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
