### PR TITLE
Train 1.12.0 rc1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,8 @@ Format of the entries must be.
 
 * Upgrade OTP version (DCOS_OSS-3655)
 
+* Marathon framework ID generation is now very conservative. [See more](https://github.com/mesosphere/marathon/blob/master/changelog.md#marathon-framework-id-generation-is-now-very-conservative) (MARATHON-8420)
+
 ### Security Updates
 
 

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -86,7 +86,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.12.0-beta2',
+        'version': '1.12.0-rc1',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.12.0-beta2'
+DCOS_VERSION = '1.12.0-rc1'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 

--- a/packages/adminrouter/windows.buildinfo.json
+++ b/packages/adminrouter/windows.buildinfo.json
@@ -3,7 +3,7 @@
         "URLRewrite": {
           "kind": "url",
           "url": "http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi",
-          "sha1": "eff9901ce6c20f94055488e65d3d2748b4e2be8e"
+          "sha1": "d2542e2d398f0e95981ebf4e729f79eaf96e6691"
         },
         "Application-Request-Routing": {
           "kind": "url",

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -54,19 +54,13 @@ def test_pkgpanda_api(dcos_api_session):
 
 # There is no standardized way of getting package requirements from the package description json,
 # e.g. nodes could be called 'brokers' or 'nodes' or something else. This was created by looking at
-# https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/K/kafka/39/config.json
-# 1.1.9-0.10.0.0
-KAFKA_PACKAGE_REQUIREMENTS = {
-    'number_of_nodes': 3,
+# https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/N/nginx/6/config.json
+# Nginx package version 1.10.3
+NGINX_PACKAGE_REQUIREMENTS = {
+    'number_of_nodes': 1,
     'node': {
-        'disk': 5000,
-        'mem': 2304,
-        'cpus': 1
-    },
-    'executor': {
-        'disk': 0,
-        'mem': 256,
-        'cpus': 0.5
+        'cpus': 1,
+        'mem': 1024
     }
 }
 
@@ -86,7 +80,7 @@ def _agent_has_resources(agent, node_requirements):
         node_requirements: dict Resource requirements per agent
     """
     unreserved = agent['unreserved_resources']
-    resources = ['mem', 'disk', 'cpus']
+    resources = ['mem', 'cpus']
     for resource in resources:
         log.debug('{resource}: unreserved {unreserved}, required {required}'.format(
             resource=resource,
@@ -135,14 +129,18 @@ def _skipif_insufficient_resources(dcos_api_session, requirements):
     """Can't access dcos_api_session from through the pytest.mark.skipif decorator, so call this in each test instead
     """
     if not _enough_resources_for_package(_get_cluster_resources(dcos_api_session), requirements):
-        return pytest.skip(msg='Package installation would fail on this cluster due to insufficient resources')
+        pytest.skip(msg='Package installation would fail on this cluster due to insufficient resources')
 
 
 def test_packaging_api(dcos_api_session):
-    """Test the Cosmos API (/package) wrapper
     """
-    _skipif_insufficient_resources(dcos_api_session, KAFKA_PACKAGE_REQUIREMENTS)
-    install_response = dcos_api_session.cosmos.install_package('kafka', package_version='1.1.9-0.10.0.0')
+    Test the Cosmos API (/package) wrapper by installing nginx from
+    https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/N/nginx/6
+    The default configuration of ngnix needs only one agent and no service secrets are
+    required even when running in a strict cluster.
+    """
+    _skipif_insufficient_resources(dcos_api_session, NGINX_PACKAGE_REQUIREMENTS)
+    install_response = dcos_api_session.cosmos.install_package('nginx', package_version='1.10.3')
     data = install_response.json()
 
     dcos_api_session.marathon.wait_for_deployments_complete()
@@ -151,7 +149,7 @@ def test_packaging_api(dcos_api_session):
     packages = list_response.json()['packages']
     assert len(packages) == 1 and packages[0]['appId'] == data['appId']
 
-    dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
+    dcos_api_session.cosmos.uninstall_package('nginx', app_id=data['appId'])
 
     list_response = dcos_api_session.cosmos.list_packages()
     packages = list_response.json()['packages']

--- a/packages/marathon/build
+++ b/packages/marathon/build
@@ -44,7 +44,6 @@ EnvironmentFile=-/opt/mesosphere/etc/marathon-extras
 EnvironmentFile=-/var/lib/dcos/marathon/environment
 Environment=JAVA_HOME=${JAVA_HOME}
 ExecStartPre=/bin/ping -c1 leader.mesos
-ExecStartPre=/bin/ping -c1 zk-1.zk
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-marathon
 ExecStart=/opt/mesosphere/bin/marathon.sh
 EOF

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.149-21b42dbb8/marathon-1.7.149-21b42dbb8.tgz",
-    "sha1": "243f0e070c5ea2dbdee1153a82612c0dbf1fd3dd"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.174-da9365d80/marathon-1.7.174-da9365d80.tgz",
+    "sha1": "cc0c107429cf9a594757e82973edce9b3556ccf2"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

#3529 - Marathon remove precheck on single node 1.12
#3544 - [1.12] Update packaging integration tests to ensure testing on smaller clusters
#3550 - Fix the sha1sum for adminrouter rewrite_amd64_en-US.msi installer
#3551 - Update version to 1.12.0-rc1
#3553 - Bump Marathon to 1.7.174 