### PR TITLE
Add dcos-integration-test/extra/test_users.py

### DIFF
--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -6,7 +6,7 @@ mkdir -p "$LIB_INSTALL_DIR"
 # Install wheels.
 for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
     azure-mgmt-network azure-storage beautifulsoup4 docutils keyring msrest \
-    msrestazure py requests-oauthlib schema webob; do
+    msrestazure requests-oauthlib schema webob; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -111,11 +111,6 @@
       "url": "https://pypi.python.org/packages/a8/11/fb71ced7057b2a8929f51959f4e97bcee9f687aaf896c521984e67118b90/oauthlib-1.1.2.tar.gz",
       "sha1": "68e894d3b41080e14ec3a93ce0858d546617e809"
     },
-    "py": {
-      "kind": "url",
-      "url": "https://pypi.python.org/packages/2.7/p/py/py-1.4.31-py2.py3-none-any.whl",
-      "sha1": "ffcba27ff8391f46904c2762135a383d29a4bf1b"
-    },
     "requests-oauthlib": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/3d/b9/895abf47ce871c80460727ba385d10d246a2d9ded1bc82ba3748d02e5196/requests_oauthlib-0.6.1-py2.py3-none-any.whl",

--- a/packages/dcos-integration-test/extra/test_users.py
+++ b/packages/dcos-integration-test/extra/test_users.py
@@ -1,0 +1,162 @@
+"""
+A collection of tests covering user management in DC/OS.
+
+Assume that access control is activated in Master Admin Router (could be
+disabled with `oauth_enabled`) and therefore authenticate individual HTTP
+requests.
+
+One aspect of DC/OS user management is that once authenticated a user can add
+other users. Unauthenticated HTTP requests are rejected by Master Admin Router
+and user management fails (this is the coarse-grained authorization model of
+(open) DC/OS). Here, test that unauthenticated HTTP requests cannot manage
+users. However, do not test that newly added users can add other users: in this
+test suite we are limited to having authentication state for just a single user
+available. This is why we can test managing other users only from that first
+user's point of view. That is, we can not test that a user (e.g. user2) which
+was added by the first user (user1) can add another user (user3).
+"""
+import logging
+
+import pytest
+
+from test_helpers import expanded_config
+
+
+__maintainer__ = 'jgehrcke'
+__contact__ = 'security-team@mesosphere.io'
+
+
+log = logging.getLogger(__name__)
+
+
+# Skip entire module in downstream integration tests.
+if 'security' in expanded_config:
+    pytest.skip(
+        'Skip upstream-specific user management tests',
+        allow_module_level=True
+    )
+
+
+def get_users(apisession):
+    r = apisession.get('/acs/api/v1/users')
+    r.raise_for_status()
+    users = {u['uid']: u for u in r.json()['array']}
+    return users
+
+
+def delete_user(apisession, uid):
+    r = apisession.delete('/acs/api/v1/users/%s' % (uid, ))
+    r.raise_for_status()
+    assert r.status_code == 204
+
+
+@pytest.fixture()
+def remove_users_added_by_test(dcos_api_session):
+    users_before = set(get_users(dcos_api_session))
+    log.info('remove_users_added_by_test pre test: users are %s', users_before)
+    try:
+        yield
+    finally:
+        users_after = set(get_users(dcos_api_session))
+        new_uids = users_after - users_before
+        for uid in new_uids:
+            log.info('remove_users_added_by_test post test: remove `%s`', uid)
+            delete_user(dcos_api_session, uid)
+
+
+def test_users_get(dcos_api_session):
+    users = get_users(dcos_api_session)
+    assert users
+
+    required_keys = ('uid', 'description')
+    for _, userdict in users.items():
+        for k in required_keys:
+            assert k in userdict
+
+
+def test_user_put_no_email_uid(dcos_api_session):
+    r = dcos_api_session.put('/acs/api/v1/users/user1')
+
+    # This is the current behavior. It does not need to stay in future versions.
+    assert r.status_code == 500
+    assert 'invalid email' in r.text
+
+
+@pytest.mark.usefixtures('remove_users_added_by_test')
+def test_user_put_email_uid(dcos_api_session):
+    # The current behavior is that the request body can be an empty JSON
+    # document. It does not need to stay in future versions.
+    r = dcos_api_session.put('/acs/api/v1/users/user1@email.de', json={})
+    r.raise_for_status()
+    assert r.status_code == 201
+
+    users = get_users(dcos_api_session)
+    assert len(users) > 1
+    assert 'user1@email.de' in users
+
+
+@pytest.mark.usefixtures('remove_users_added_by_test')
+def test_user_put_optional_payload(dcos_api_session):
+    # This is the current behavior. It does not need to stay in future versions.
+
+    r = dcos_api_session.put(
+        '/acs/api/v1/users/user2@email.de',
+        json={'creator_uid': 'any@thing.bla', 'cluster_url': 'foobar'}
+    )
+    assert r.status_code == 201, r.text
+
+    r = dcos_api_session.put(
+        '/acs/api/v1/users/user3@email.de',
+        json={'creator_uid': 'any@thing.bla', 'description': 'barfoo'}
+    )
+    assert r.status_code == 201, r.text
+
+    r = dcos_api_session.put(
+        '/acs/api/v1/users/user4@email.de',
+        json={'is_remote': False}
+    )
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.usefixtures('remove_users_added_by_test')
+def test_user_conflict(dcos_api_session):
+    # This is the current behavior. It does not need to stay in future versions.
+
+    r = dcos_api_session.put(
+        '/acs/api/v1/users/user2@email.de',
+        json={'creator_uid': 'any@thing.bla', 'cluster_url': 'foobar'}
+    )
+    assert r.status_code == 201, r.text
+
+    r = dcos_api_session.put(
+        '/acs/api/v1/users/user2@email.de',
+        json={'creator_uid': 'any@thing.bla', 'cluster_url': 'foobar'}
+    )
+    assert r.status_code == 409, r.text
+
+
+@pytest.mark.usefixtures('remove_users_added_by_test')
+def test_user_delete(dcos_api_session):
+    r = dcos_api_session.put('/acs/api/v1/users/user6@email.de', json={})
+    r.raise_for_status()
+    assert r.status_code == 201
+
+    r = dcos_api_session.delete('/acs/api/v1/users/user6@email.de')
+    r.raise_for_status()
+    assert r.status_code == 204
+
+    users = get_users(dcos_api_session)
+    assert 'user6@email.de' not in users
+
+
+def test_user_put_requires_authentication(noauth_api_session):
+    r = noauth_api_session.put('/acs/api/v1/users/user7@email.de', json={})
+    assert r.status_code == 401, r.text
+
+
+def test_dynamic_ui_config(dcos_api_session):
+    r = dcos_api_session.get('/dcos-metadata/ui-config.json')
+    data = r.json()
+    assert not data['clusterConfiguration']['firstUser']
+    assert 'id' in data['clusterConfiguration']
+    assert 'uiConfiguration' in data

--- a/packages/pytest/build
+++ b/packages/pytest/build
@@ -3,4 +3,8 @@ source /opt/mesosphere/environment.export
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
-pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME
+pip list
+
+for package in pluggy py attrs moreitertools atomicwrites pytest; do
+  pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
+done

--- a/packages/pytest/buildinfo.json
+++ b/packages/pytest/buildinfo.json
@@ -1,8 +1,35 @@
 {
   "requires": ["python", "teamcity-messages"],
-  "single_source": {
-    "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/50/e2/a28d4c5e4520a0427bc5141703f3296184742e7cb2722ce71fd61020c417/pytest-3.1.0.tar.gz",
-    "sha1": "194bb203353cd907563cce280e946cb3c441d48b"
+  "sources": {
+    "pytest": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/5f/d2/7f77f406ac505abda02ab4afb50d06ebf304f6ea42fca34f8f37529106b2/pytest-3.8.2.tar.gz",
+      "sha1": "6e28889174cfec8ca42bd470fe6168ca19aa58f9"
+    },
+    "pluggy": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/a1/83/ef7d976c12d67a5c7a5bc2a47f0501c926cabae9d9fcfdc26d72abc9ba15/pluggy-0.7.1.tar.gz",
+      "sha1": "a07fa8187288cc4099b91dd59b0df18ba3dc19b1"
+    },
+    "py": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/4f/38/5f427d1eedae73063ce4da680d2bae72014995f9fdeaa57809df61c968cd/py-1.6.0.tar.gz",
+      "sha1": "b7196e40ff311d5f44e3bed2e0d3477f4f19559b"
+    },
+    "attrs": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/0f/9e/26b1d194aab960063b266170e53c39f73ea0d0d3f5ce23313e0ec8ee9bdf/attrs-18.2.0.tar.gz",
+      "sha1": "51a52e1afdd9e8c174ac0b65c2905a8360788dd2"
+    },
+    "moreitertools": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/88/ff/6d485d7362f39880810278bdc906c13300db05485d9c65971dec1142da6a/more-itertools-4.3.0.tar.gz",
+      "sha1": "3655a5e720e7e684730597c72283a4af401a71da"
+    },
+    "atomicwrites": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/ac/ed/a311712ef6b4355035489f665e63e1a73f9eb371929e3c98e5efd451069e/atomicwrites-1.2.1.tar.gz",
+      "sha1": "fec341b1028177784ac97436c479a397ffeb20d7"
+    }
   }
 }

--- a/packages/python/build
+++ b/packages/python/build
@@ -30,16 +30,17 @@ export LD_LIBRARY_PATH=$PKG_PATH/lib
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/setuptools/*.whl
 
-# Install pip from git checkout, because we need the fix for
+# Upgrade pip. With CPython 3.6.6 comes pip 9.0.3 which contains
+# a bug which was fixed only in pip 10.0.0 and beyond. The bug is
 # https://github.com/pypa/pip/issues/373 i.e. we need the patch
 # https://github.com/pypa/pip/pull/4495 for subsequent pip
 # invocations. For _this_ pip invocation here (for upgrading pip...),
 # however, the bug pip/issues/373 is present and needs to be worked
-# around by manually creating the egg directory as a _relative_ path
-# `opt/mesosphere/active.....pip-10.0.0.dev0-py3.6.egg-info`.
-ABSDIR="$PKG_PATH/lib/python3.6/site-packages/pip-10.0.0.dev0-py3.6.egg-info"
-RELDIR="${ABSDIR:1}"
-mkdir -p $RELDIR
+# around by manually creating the dist directory as a _relative_ path
+# `opt/mesosphere/active.....pip-18.1.dist-info`.
+#ABSDIR="$PKG_PATH/lib/python3.6/site-packages/pip-18.1.dist-info"
+#RELDIR="${ABSDIR:1}"
+#mkdir -p $RELDIR
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip
 echo "pip version: $($PKG_PATH/bin/pip3 --version)"
 

--- a/packages/python/build
+++ b/packages/python/build
@@ -13,7 +13,7 @@ export CPPFLAGS=-I/opt/mesosphere/include
 make -j$NUM_CORES
 make install
 
-# Install the build specific gdb helper artefact
+# Install the build-specific gdb helper artifact
 cp python-gdb.py "$PKG_PATH/share/"
 
 # Remove some big things we don't use at all
@@ -30,17 +30,6 @@ export LD_LIBRARY_PATH=$PKG_PATH/lib
 export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/setuptools/*.whl
 
-# Upgrade pip. With CPython 3.6.6 comes pip 9.0.3 which contains
-# a bug which was fixed only in pip 10.0.0 and beyond. The bug is
-# https://github.com/pypa/pip/issues/373 i.e. we need the patch
-# https://github.com/pypa/pip/pull/4495 for subsequent pip
-# invocations. For _this_ pip invocation here (for upgrading pip...),
-# however, the bug pip/issues/373 is present and needs to be worked
-# around by manually creating the dist directory as a _relative_ path
-# `opt/mesosphere/active.....pip-18.1.dist-info`.
-#ABSDIR="$PKG_PATH/lib/python3.6/site-packages/pip-18.1.dist-info"
-#RELDIR="${ABSDIR:1}"
-#mkdir -p $RELDIR
 $PKG_PATH/bin/python3 -m pip install --upgrade --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/pip
 echo "pip version: $($PKG_PATH/bin/pip3 --version)"
 
@@ -54,11 +43,10 @@ ln -fs "$PKG_PATH/bin/python3-config" "$PKG_PATH/bin/python-config"
 ln -fs "$PKG_PATH/bin/idle3" "$PKG_PATH/bin/idle"
 ln -fs "$PKG_PATH/bin/pydoc3"  "$PKG_PATH/bin/pydoc"
 
-# Install Cython as part of the pgkpanda python package so that
-# it is available as a build dependency for all other pkgpanda
-# packages that pull in this package here as a dependency.
-# The Cython installation via pip actually suffers from pip/issues/373
-# which is one reason why we install the unreleased pip-10.0.0.dev0
-# above.
+# Install Cython as part of the pgkpanda `python` package so that
+# pkgpanda packages that declare the `python` package as a dependency
+# will find Cython to be installed. During some Python package
+# installations this will result in special build variants with
+# performance improvements.
 $PKG_PATH/bin/python3 -m pip install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/cython
 

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -7,8 +7,8 @@
   "sources": {
     "python": {
       "kind": "url_extract",
-      "url": "https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz",
-      "sha1": "6c71b14bdbc4d8aa0cfd59d4b6dc356d46abfdf5"
+      "url": "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz",
+      "sha1": "5731cf379838023fc8c55491b4068c4404d0e34f"
     },
     "cython": {
       "kind": "url_extract",

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -17,8 +17,8 @@
     },
     "setuptools": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/0f/40/b3c98aa32bc91d3d8c573443a29aa482d77268d77132b63f09d8385b21ff/setuptools-37.0.0-py2.py3-none-any.whl",
-      "sha1": "da26335ea77a8680a983a3cfb57f304447c26df5"
+      "url": "https://files.pythonhosted.org/packages/96/06/c8ee69628191285ddddffb277bd5abdf769166e7a14b867c2a172f0175b1/setuptools-40.4.3-py2.py3-none-any.whl",
+      "sha1": "40410299ab3c7b091f9dff4dd7bda7f874c4d1b6"
     },
     "pip": {
       "kind": "url_extract",

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -21,10 +21,9 @@
       "sha1": "da26335ea77a8680a983a3cfb57f304447c26df5"
     },
     "pip": {
-      "kind": "git",
-      "git": "https://github.com/pypa/pip.git",
-      "ref": "8ed4ac1fe6e2a05db41585c10a7b46f16bc60666",
-      "ref_origin": "master"
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/45/ae/8a0ad77defb7cc903f09e551d88b443304a9bd6e6f124e75c0fbbf6de8f7/pip-18.1.tar.gz",
+      "sha1": "1226368a8d39bd8b945517b6f7cb9802b279564e"
     }
   }
 }


### PR DESCRIPTION
## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS_OSS-3995 (Bump platform CPython to 3.6.6 (or 3.6 latest)
  - https://jira.mesosphere.com/browse/DCOS-43029 (Write basic integration tests for (open) DC/OS user management)


This pull request updates pytest for supporting the `allow_module_level` argument.
