### PR TITLE
Remove Kapil from owners.json

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -8,7 +8,6 @@
   "greggomann": {"slack": "greg", "jira": "greg"},
   "jgehrcke": {"slack": "jp", "jira": "jp"},
   "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
-  "karya0": {"slack": "kapil", "jira": "kapil"},
   "klueska": {"slack": "klueska", "jira": "klueska"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
   "nLight": {"slack": "drozhkov", "jira": "drozhkov"},


### PR DESCRIPTION
## High-level description

Noticed this warning in the mergebot logs.

```
2018-10-05 18:49:12,412 mergebot     WARNING  Failed to add kapil as watcher to https://jira.mesosphere.com/rest/api/2/issue/DCOS-42798/watchers. Please check the username and the URL.

```