### PR TITLE
[1.10] Add Mesos patches to ensure TEARDOWN is sent in v1 Java shim.

### DIFF
--- a/packages/mesos/extra/patches/0011-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
+++ b/packages/mesos/extra/patches/0011-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
@@ -1,0 +1,38 @@
+From 1b6cb1822087fb4313b31cd739dd7f0c114a6201 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 27 Sep 2018 15:20:01 +0200
+Subject: [PATCH] Put `TerminateEvent` at the end of the queue in the Mesos
+ library.
+
+This is to ensure all pending dispatches are processed. However
+multistage events, e.g., `Call`, might still be dropped, because
+a continuation (stage) of such event can be dispatched after the
+termination event.
+
+Review: https://reviews.apache.org/r/68865
+(cherry picked from commit 8f400c3e5abe0fa1810a6efd56bc3fecabf1bbd3)
+---
+ src/scheduler/scheduler.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/scheduler/scheduler.cpp b/src/scheduler/scheduler.cpp
+index ce6925802..d805d243e 100644
+--- a/src/scheduler/scheduler.cpp
++++ b/src/scheduler/scheduler.cpp
+@@ -864,7 +864,12 @@ void Mesos::reconnect()
+ void Mesos::stop()
+ {
+   if (process != nullptr) {
+-    terminate(process);
++    // We pass 'false' here to add the termination event at the end of the
++    // `MesosProcess` queue. This is to ensure all pending dispatches are
++    // processed. However multistage events, e.g., `Call`, might still be
++    // dropped, because a continuation (stage) of such event can be dispatched
++    // after the termination event, see MESOS-9274.
++    terminate(process, false);
+     wait(process);
+ 
+     delete process;
+-- 
+2.16.3
+

--- a/packages/mesos/extra/patches/0012-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
+++ b/packages/mesos/extra/patches/0012-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
@@ -1,0 +1,52 @@
+From 37dd033b993b7be6920252ca42d6c3474ef0d872 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Tue, 9 Oct 2018 18:22:16 +0200
+Subject: [PATCH] Waited for TEARDOWN to be sent in v1 Java scheduler shim.
+
+Destruction of the library is not always under our control. For
+example, the JVM can call JNI `finalize()` if the Java scheduler
+nullifies its reference to the V1Mesos library immediately after
+sending `TEARDOWN`. We want to make sure that `TEARDOWN` is sent
+before the Mesos library is destructed.
+---
+ src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
+index 2a5fbd79a..6ec771111 100644
+--- a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
++++ b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
+@@ -28,6 +28,7 @@
+ #include <stout/foreach.hpp>
+ #include <stout/lambda.hpp>
+ #include <stout/option.hpp>
++#include <stout/os.hpp>
+ #include <stout/result.hpp>
+ #include <stout/try.hpp>
+ 
+@@ -286,6 +287,22 @@ JNIEXPORT void JNICALL Java_org_apache_mesos_v1_scheduler_V1Mesos_send
+   }
+ 
+   mesos->mesos->send(call);
++
++  // Destruction of the library is not always under our control. For example,
++  // the JVM can call JNI `finalize()` if the Java scheduler nullifies its
++  // reference to the V1Mesos library immediately after sending `TEARDOWN`,
++  // see MESOS-9274.
++  //
++  // We want to make sure that the `TEARDOWN` message is sent before the
++  // scheduler and the Mesos library are destructed (garbage collected).
++  // Without a flavour of `Mesos::send()` that blocks or returns a future,
++  // there is no better way than a hacky `sleep()`. This approach is foul
++  // because:
++  //   * it does not guarantee that 30s is enough and `TEARDOWN` is sent;
++  //   * it blocks the caller for 30s regardless of how long sending takes.
++  if (call.type() == Call::TEARDOWN) {
++    os::sleep(Seconds(30));
++  }
+ }
+ 
+ 
+-- 
+2.16.3
+


### PR DESCRIPTION
## High-level description

Destruction of the v1 library used in the v1 Java scheduler shim
is not always under our control. For example, the JVM can call JNI
`finalize()` if the Java scheduler nullifies its reference to the
V1Mesos library immediately after sending `TEARDOWN`. We want to make
sure that `TEARDOWN` is sent before the Mesos library is destructed.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:


## Related tickets (optional)

Other tickets related to this change:



## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
