### PR TITLE
Add mesos metrics to telegraf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 ### What's new
 
+* Mesos metrics are now available by default. (DCOS_OSS-3815)
+
 
 ### Breaking changes
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1361,8 +1361,6 @@ package:
         cache_expiry = "2m"
         # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
-        # Local Mesos instance's ID.
-        mesos_id = "$DCOS_MESOS_ID"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
   - path: /etc_slave/telegraf/telegraf.d/agent.conf

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1333,15 +1333,6 @@ package:
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters
-      # Expose metrics via the dcos-metrics v0 API.
-      [[outputs.dcos_metrics]]
-        dcos_node_role = "master"
-        # Duration to cache metrics in memory.
-        cache_expiry = "2m"
-        # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
-        dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
-        # Global DC/OS Cluster ID.
-        dcos_cluster_id = "$DCOS_CLUSTER_ID"
       # Telegraf plugin for gathering metrics from mesos
       [[inputs.mesos]]
         # The interval at which to collect metrics
@@ -1363,6 +1354,17 @@ package:
           "registrar",
           "allocator",
        ]
+      # Expose metrics via the dcos-metrics v0 API.
+      [[outputs.dcos_metrics]]
+        dcos_node_role = "master"
+        # Duration to cache metrics in memory.
+        cache_expiry = "2m"
+        # DC/OS node's private IP, as reported by /opt/mesosphere/bin/detect_ip.
+        dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
+        # Local Mesos instance's ID.
+        mesos_id = "$DCOS_MESOS_ID"
+        # Global DC/OS Cluster ID.
+        dcos_cluster_id = "$DCOS_CLUSTER_ID"
   - path: /etc_slave/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
@@ -1382,6 +1384,22 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          "executors",
+          "tasks",
+          "messages",
+        ]
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1399,22 +1417,6 @@ package:
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
-      # Telegraf plugin for gathering metrics from mesos
-      [[inputs.mesos]]
-        # The interval at which to collect metrics
-        interval = "60s"
-        # Timeout, in ms.
-        timeout = 30000
-        ## A list of Mesos slaves
-        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
-        # Slave metrics groups to be collected.
-        slave_collections = [
-          "resources",
-          "agent",
-          "executors",
-          "tasks",
-          "messages",
-        ]
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
@@ -1434,6 +1436,22 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          "executors",
+          "tasks",
+          "messages",
+        ]
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1451,19 +1469,3 @@ package:
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
-      # Telegraf plugin for gathering metrics from mesos
-      [[inputs.mesos]]
-        # The interval at which to collect metrics
-        interval = "60s"
-        # Timeout, in ms.
-        timeout = 30000
-        ## A list of Mesos slaves
-        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
-        # Slave metrics groups to be collected.
-        slave_collections = [
-          "resources",
-          "agent",
-          "executors",
-          "tasks",
-          "messages",
-        ]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1354,7 +1354,6 @@ package:
         master_collections = [
           "resources",
           "master",
-          # "system",
           "agents",
           "frameworks",
           "framework_offers",
@@ -1412,7 +1411,6 @@ package:
         slave_collections = [
           "resources",
           "agent",
-          # "system",
           "executors",
           "tasks",
           "messages",
@@ -1465,7 +1463,6 @@ package:
         slave_collections = [
           "resources",
           "agent",
-          # "system",
           "executors",
           "tasks",
           "messages",

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1342,6 +1342,28 @@ package:
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        # A list of Mesos masters.
+        masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
+        # Master metrics groups to be collected.
+        master_collections = [
+          "resources",
+          "master",
+          # "system",
+          "agents",
+          "frameworks",
+          "framework_offers",
+          "tasks",
+          "messages",
+          "evqueue",
+          "registrar",
+          "allocator",
+       ]
   - path: /etc_slave/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
@@ -1378,6 +1400,23 @@ package:
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          # "system",
+          "executors",
+          "tasks",
+          "messages",
+        ]
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
@@ -1414,3 +1453,20 @@ package:
         dcos_node_private_ip = "$DCOS_NODE_PRIVATE_IP"
         # Global DC/OS Cluster ID.
         dcos_cluster_id = "$DCOS_CLUSTER_ID"
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          # "system",
+          "executors",
+          "tasks",
+          "messages",
+        ]

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -58,7 +58,7 @@ def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
 @pytest.mark.parametrize("prometheus_port", 61091)
 def test_metrics_masters_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on masters are present."""
-    for agent in dcos_api_session.masters:
+    for master in dcos_api_session.masters:
         response = dcos_api_session.session.request('GET', 'http://' + master + ':{}/metrics'.format(prometheus_port))
         assert 'mesos_master_uptime_secs' in response.content
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -47,7 +47,7 @@ def test_metrics_masters_prom(dcos_api_session, prometheus_port):
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
-@pytest.mark.parametrize("prometheus_port", 61091)
+@pytest.mark.parametrize("prometheus_port", [61091])
 def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on agents are present."""
     for agent in dcos_api_session.slaves:
@@ -55,7 +55,7 @@ def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
         assert 'mesos_slave_uptime_secs' in response.content
 
 
-@pytest.mark.parametrize("prometheus_port", 61091)
+@pytest.mark.parametrize("prometheus_port", [61091])
 def test_metrics_masters_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on masters are present."""
     for master in dcos_api_session.masters:

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -52,7 +52,7 @@ def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on agents are present."""
     for agent in dcos_api_session.slaves:
         response = dcos_api_session.session.request('GET', 'http://' + agent + ':{}/metrics'.format(prometheus_port))
-        assert 'mesos_slave_uptime_secs' in response.content
+        assert 'mesos_slave_uptime_secs' in response.text
 
 
 @pytest.mark.parametrize("prometheus_port", [61091])
@@ -60,7 +60,7 @@ def test_metrics_masters_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on masters are present."""
     for master in dcos_api_session.masters:
         response = dcos_api_session.session.request('GET', 'http://' + master + ':{}/metrics'.format(prometheus_port))
-        assert 'mesos_master_uptime_secs' in response.content
+        assert 'mesos_master_uptime_secs' in response.text
 
 
 @pytest.mark.supportedwindows

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -59,7 +59,7 @@ def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
 def test_metrics_masters_mesos(dcos_api_session, prometheus_port):
     """Assert that mesos metrics on masters are present."""
     for agent in dcos_api_session.masters:
-        response = dcos_api_session.session.request('GET', 'http://' + agent + ':{}/metrics'.format(prometheus_port))
+        response = dcos_api_session.session.request('GET', 'http://' + master + ':{}/metrics'.format(prometheus_port))
         assert 'mesos_master_uptime_secs' in response.content
 
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -47,6 +47,22 @@ def test_metrics_masters_prom(dcos_api_session, prometheus_port):
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
+@pytest.mark.parametrize("prometheus_port", 61091)
+def test_metrics_agents_mesos(dcos_api_session, prometheus_port):
+    """Assert that mesos metrics on agents are present."""
+    for agent in dcos_api_session.slaves:
+        response = dcos_api_session.session.request('GET', 'http://' + agent + ':{}/metrics'.format(prometheus_port))
+        assert 'mesos_slave_uptime_secs' in response.content
+
+
+@pytest.mark.parametrize("prometheus_port", 61091)
+def test_metrics_masters_mesos(dcos_api_session, prometheus_port):
+    """Assert that mesos metrics on masters are present."""
+    for agent in dcos_api_session.masters:
+        response = dcos_api_session.session.request('GET', 'http://' + agent + ':{}/metrics'.format(prometheus_port))
+        assert 'mesos_master_uptime_secs' in response.content
+
+
 @pytest.mark.supportedwindows
 def test_metrics_node(dcos_api_session):
     """Test that the '/system/v1/metrics/v0/node' endpoint returns the expected


### PR DESCRIPTION
## High-level description

This adds a mesos input plugin to Telegraf to ensure that it has parity with mesos_exporter. Framework offers and allocator metrics were added. With these changes, there will be no need to run mesos_exporter on a DC/OS cluster.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3815](https://jira.mesosphere.com/browse/DCOS_OSS-3815) Update the Telegraf Mesos input plugin to parity with mesos_exporter

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
