### PR TITLE
Assert system clock is synced before starting dcos-exhibitor

### DIFF
--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -21,6 +21,14 @@ EnvironmentFile=/opt/mesosphere/etc/exhibitor
 EnvironmentFile=-/opt/mesosphere/etc/exhibitor-extras
 # Execute ExecStartPre directives as root
 PermissionsStartOnly=true
+
+# Assert that the system clock is synced. If it isn't, Exhibitor may fail to join the cluster and require a restart.
+# Use the check-time binary instead of the clock_sync check because it no-ops if clock sync checks have been disabled in
+# cluster config.
+# check_time.env defines the env var that check-time uses to determine whether clock sync checks have been disabled.
+EnvironmentFile=/opt/mesosphere/etc/check_time.env
+ExecStartPre=/opt/mesosphere/bin/check-time
+
 # Execute a python script, as root, that sets file permissions to some exact set if those files exist.
 ExecStartPre=$PKG_PATH/bin/set_exhibitor_file_permissions.py
 # Start Exhibitor


### PR DESCRIPTION
## High-level description

This updates the `dcos-exhibitor.service` unit file to assert that the system clock is synced before it tries to start Exhibitor. If the system clock is not synced when Exhibitor starts, it may successfully start but fail to join the cluster. Fixing this requires waiting for the system clock to sync, and then manually restarting `dcos-exhibitor.service`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4287](https://jira.mesosphere.com/browse/DCOS_OSS-4287) Check system clock is synced before starting Exhibitor

## Related tickets (optional)

Other tickets related to this change:

 - [COPS-3897](https://jira.mesosphere.com/browse/COPS-3897)

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: The changelog on master is still for 1.12.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This fix can't be covered by a new integration test, since it requires tinkering with cluster nodes. We'd need to test this fix by deploying a cluster where at least one master has their clock jump while dcos-exhibitor is running.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

N/A