### PR TITLE
(1.12) Assert system clock is synced before starting dcos-exhibitor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Check system clock is synced before starting Exhibitor (DCOS_OSS-4287)
+
 * Allow dcos-diagnostics bundles location to be configured (DCOS_OSS-4040)
 
 * Add mountinfo to diagnostics bundle (DCOS_OSS_3961)

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -21,6 +21,14 @@ EnvironmentFile=/opt/mesosphere/etc/exhibitor
 EnvironmentFile=-/opt/mesosphere/etc/exhibitor-extras
 # Execute ExecStartPre directives as root
 PermissionsStartOnly=true
+
+# Assert that the system clock is synced. If it isn't, Exhibitor may fail to join the cluster and require a restart.
+# Use the check-time binary instead of the clock_sync check because it no-ops if clock sync checks have been disabled in
+# cluster config.
+# check_time.env defines the env var that check-time uses to determine whether clock sync checks have been disabled.
+EnvironmentFile=/opt/mesosphere/etc/check_time.env
+ExecStartPre=/opt/mesosphere/bin/check-time
+
 # Execute a python script, as root, that sets file permissions to some exact set if those files exist.
 ExecStartPre=$PKG_PATH/bin/set_exhibitor_file_permissions.py
 # Start Exhibitor


### PR DESCRIPTION
## High-level description

This is a 1.12 backport of #3594.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4287](https://jira.mesosphere.com/browse/DCOS_OSS-4287) Check system clock is synced before starting Exhibitor


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This isn't really testable by adding an integration test. We'd need to test this by deploying a cluster on top of hosts that take some time to sync their system clock.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

N/A