### PR TITLE
(1.10) Assert system clock is synced before starting dcos-exhibitor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Check system clock is synced before starting Exhibitor (DCOS_OSS-4287)
+
 * Updated to [DC/OS UI v1.10.9-rc3](https://github.com/dcos/dcos-ui/releases/tag/v1.10+v1.10.9-rc3)
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861) 

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -19,4 +19,12 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dns_config
 EnvironmentFile=/opt/mesosphere/etc/exhibitor
 EnvironmentFile=-/opt/mesosphere/etc/exhibitor-extras
+
+# Assert that the system clock is synced. If it isn't, Exhibitor may fail to join the cluster and require a restart.
+# Use the check-time binary instead of the clock_sync check because it no-ops if clock sync checks have been disabled in
+# cluster config.
+# check_time.env defines the env var that check-time uses to determine whether clock sync checks have been disabled.
+EnvironmentFile=/opt/mesosphere/etc/check_time.env
+ExecStartPre=/opt/mesosphere/bin/check-time
+
 ExecStart=$PKG_PATH/usr/exhibitor/start_exhibitor.py


### PR DESCRIPTION
## High-level description

This is a 1.10 backport of #3594.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4287](https://jira.mesosphere.com/browse/DCOS_OSS-4287) Check system clock is synced before starting Exhibitor


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This isn't really testable by adding an integration test. We'd need to test this by deploying a cluster on top of hosts that take some time to sync their system clock.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

N/A