### PR TITLE
[1.11] Fix panic in metrics agent service when mesos is unavailable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
 
+* DC/OS Metrics: Fixed a bug that was crashing the DC/OS agent metrics service (DCOS-39103)
+
 ### Security Updates
 
 

--- a/packages/dcos-metrics/build
+++ b/packages/dcos-metrics/build
@@ -35,7 +35,7 @@ mkdir -p /pkg/src/github.com/dcos
 mv /pkg/src/dcos-metrics /pkg/src/github.com/dcos/dcos-metrics
 
 pushd /pkg/src/github.com/dcos/dcos-metrics
-make build
+make rawbuild
 popd
 
 mkdir -p $PKG_PATH/bin

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "f7ce9e5a5a8ac4412096c053b9114ffac07a134c",
+    "ref": "7d3be0c9b4a713fa8df33dc3d422877bb3f8a7ca",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "7d3be0c9b4a713fa8df33dc3d422877bb3f8a7ca",
+    "ref": "c7327ad31961e4845ffcfac119352928f1321304",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This fixes a bug that was causing a panic in DC/OS metrics agent service when Mesos was unavailable.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-39103](https://jira.mesosphere.com/browse/DCOS-39103) DC/OS metrics agent service can panic if mesos is unavailable

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
