### PR TITLE
Fix Telegraf build

### DIFF
--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "071b143b1c93f03e5469378d082ec14dacf41674",
+    "ref": "7d5cd49f94fe98fa96941e7088c733ff7527d001",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This bumps Telegraf to pull in a build fix. Without this fix, Telegraf will fail to build. See https://github.com/dcos/telegraf/pull/24.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43554](https://jira.mesosphere.com/browse/DCOS-43554) DC/OS Uncached Build fails to build telegraf package

## Related tickets (optional)

Other tickets related to this change:

  - N/A


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fixes the DC/OS build without making any user-facing changes.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Build works now!
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/071b143b1c93f03e5469378d082ec14dacf41674...7d5cd49f94fe98fa96941e7088c733ff7527d001
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos/49/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos/49/)