### PR TITLE
[1.12] Mesos: logged request processing time.

### DIFF
--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,0 +1,47 @@
+From df6b1cae4baedbd592cfb08b072c8b4f4c071403 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Mon, 13 Aug 2018 20:05:26 +0200
+Subject: [PATCH] Added 'received' timestamp into `process::Request`.
+
+This allows us to note when a request comes in and
+hence calculate request processing time.
+
+Review: https://reviews.apache.org/r/68992
+(cherry picked from commit 6ab80da5b2770a96802f7893ac092d6c8a92a824)
+---
+ 3rdparty/libprocess/include/process/http.hpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/3rdparty/libprocess/include/process/http.hpp b/3rdparty/libprocess/include/process/http.hpp
+index fa66b0fe2..a1b0bb9e3 100644
+--- a/3rdparty/libprocess/include/process/http.hpp
++++ b/3rdparty/libprocess/include/process/http.hpp
+@@ -27,6 +27,7 @@
+ #include <boost/functional/hash.hpp>
+ 
+ #include <process/address.hpp>
++#include <process/clock.hpp>
+ #include <process/future.hpp>
+ #include <process/owned.hpp>
+ #include <process/pid.hpp>
+@@ -517,7 +518,7 @@ public:
+ struct Request
+ {
+   Request()
+-    : keepAlive(false), type(BODY) {}
++    : keepAlive(false), type(BODY), received(Clock::now()) {}
+ 
+   std::string method;
+ 
+@@ -562,6 +563,8 @@ struct Request
+   std::string body;
+   Option<Pipe::Reader> reader;
+ 
++  Time received;
++
+   /**
+    * Returns whether the encoding is considered acceptable in the
+    * response. See RFC 2616 section 14.3 for details.
+-- 
+2.16.3
+

--- a/packages/mesos/extra/patches/0005-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0005-Introduced-logResponse-for-http-handlers.patch
@@ -1,0 +1,78 @@
+From 92ce192274ab8e0670785cc2012e9c56e4bb0ac2 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 11 Oct 2018 15:40:37 +0200
+Subject: [PATCH] Introduced `logResponse` for http handlers.
+
+Currently we use `logRequest` function to log requests to endpoints
+in Mesos `MasterProcess`, `SlaveProcess`, and `FilesProcess`. Each
+request is logged when it is first fetched from the actor mailbox.
+However this obviously does not allow for logging the request
+processing time.
+
+This patch introduces a `logResponse` function which logs the request
+together with the corresponding response status and the time spent
+generating the response.
+
+Review: https://reviews.apache.org/r/68993
+(cherry picked from commit 7df7e4d35ec1c6cce87c629fac0b32149a4830d2)
+---
+ src/common/http.cpp | 15 +++++++++++++++
+ src/common/http.hpp | 11 +++++++++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/src/common/http.cpp b/src/common/http.cpp
+index 932111dde..4d6f5301b 100644
+--- a/src/common/http.cpp
++++ b/src/common/http.cpp
+@@ -32,6 +32,7 @@
+ #include <mesos/quota/quota.hpp>
+ 
+ #include <process/authenticator.hpp>
++#include <process/clock.hpp>
+ #include <process/collect.hpp>
+ #include <process/dispatch.hpp>
+ #include <process/future.hpp>
+@@ -1126,4 +1127,18 @@ void logRequest(const process::http::Request& request)
+                 : "");
+ }
+ 
++
++void logResponse(
++    const process::http::Request& request,
++    const process::http::Response& response)
++{
++  LOG(INFO) << "HTTP " << request.method << " for " << request.url
++            << (request.client.isSome()
++                ? " from " + stringify(request.client.get())
++                : "")
++            << ": '" << response.status << "'"
++            << " after " << (process::Clock::now() - request.received).ms()
++            << Milliseconds::units();
++}
++
+ }  // namespace mesos {
+diff --git a/src/common/http.hpp b/src/common/http.hpp
+index 0901a5528..cc7f747d1 100644
+--- a/src/common/http.hpp
++++ b/src/common/http.hpp
+@@ -338,6 +338,17 @@ Try<Nothing> initializeHttpAuthenticators(
+ // desired request handler to get consistent request logging.
+ void logRequest(const process::http::Request& request);
+ 
++
++// Log the response for the corresponding request together with the request
++// processing time. Route handlers can compose this with the desired request
++// handler to get consistent request/response logging.
++//
++// TODO(alexr): Consider taking `response` as a future to allow logging for
++// cases when response has not been generated.
++void logResponse(
++    const process::http::Request& request,
++    const process::http::Response& response);
++
+ } // namespace mesos {
+ 
+ #endif // __COMMON_HTTP_HPP__
+-- 
+2.16.3
+

--- a/packages/mesos/extra/patches/0006-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0006-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,0 +1,117 @@
+From c142ba1a70f1ad36bfa108bb40d2b8576fd2ae04 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 11 Oct 2018 15:58:41 +0200
+Subject: [PATCH] Logged request processing time for some endpoints.
+
+This patch leverages `logResponse()` function to print response status
+code together with the request processing time for some endpoints on
+the master and agent. Not all endpoints are participating to avoid
+unnecessary log pollution; only these that are know to be "slow" in
+generating the response.
+
+Note that requests are still logged when they are fetched from the
+actor mailbox, i.e., affected endpoints now log twice per request:
+when the processing starts and when the response is ready to be sent.
+
+Review: https://reviews.apache.org/r/68994
+(cherry picked from commit 9203d099da60b3333fa2e2d2a7fcefe8065fa7e1)
+---
+ src/master/master.cpp | 25 ++++++++++++++++++++-----
+ src/slave/slave.cpp   | 10 ++++++++--
+ 2 files changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 6237d9246..84f9db047 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -909,7 +909,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.frameworks(request, principal);
++          return http.frameworks(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/flags",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -969,7 +972,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.slaves(request, principal);
++          return http.slaves(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   // TODO(ijimenez): Remove this endpoint at the end of the
+   // deprecation cycle on 0.26.
+@@ -987,7 +993,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.state(request, principal);
++          return http.state(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/state-summary",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -995,7 +1004,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.stateSummary(request, principal);
++          return http.stateSummary(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   // TODO(ijimenez): Remove this endpoint at the end of the
+   // deprecation cycle.
+@@ -1013,7 +1025,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.tasks(request, principal);
++          return http.tasks(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/maintenance/schedule",
+         READWRITE_HTTP_AUTHENTICATION_REALM,
+diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
+index 7425cfbae..01fd4eedf 100644
+--- a/src/slave/slave.cpp
++++ b/src/slave/slave.cpp
+@@ -809,7 +809,10 @@ void Slave::initialize()
+         [this](const http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.state(request, principal);
++          return http.state(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/flags",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -848,7 +851,10 @@ void Slave::initialize()
+         [this](const http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.containers(request, principal);
++          return http.containers(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+ 
+   const PID<Slave> slavePid = self();
+-- 
+2.16.3
+


### PR DESCRIPTION
## High-level description

Add a series of extra patches that enable logging processing
time for some Mesos master and agent endpoints.

These patches are part of Mesos 1.8 and are tested in Mesos.

## Corresponding DC/OS tickets (obligatory)

## Related tickets (optional)

## Checklist for all PRs

  - [] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
