### PR TITLE
[1.12] Lowercase metrics

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1308,6 +1308,8 @@ package:
       [[inputs.processes]]
       # Read metrics about system load & uptime
       [[inputs.system]]
+      # Coerce all metrics that pass through this filter to lowercase.
+      [[processors.lowercase]]
       # Configuration for the Prometheus client to spawn
       [[outputs.prometheus_client]]
         ## Address to listen on

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -242,7 +242,11 @@ def test_metrics_containers(dcos_api_session):
 def test_metrics_containers_app(dcos_api_session):
     """Assert that app metrics appear in the v0 metrics API."""
     task_name = 'test-metrics-containers-app'
-    metric_name_pfx = 'test_metrics_containers_app'
+    # Mixing case in the metric name allows us to ensure that metrics are
+    # coerced to lowercase: https://jira.mesosphere.com/browse/DCOS-43639
+    metric_name_in_pfx = 'Test_Metrics_Containers_App'
+    metric_name_out_pfx = 'test_metrics_containers_app'
+
     marathon_app = {
         'id': '/' + task_name,
         'instances': 1,
@@ -251,22 +255,22 @@ def test_metrics_containers_app(dcos_api_session):
         'cmd': '\n'.join([
             'echo "Sending metrics to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
             'echo "Sending gauge"',
-            'echo "{}.gauge:100|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.gauge:100|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
 
             'echo "Sending counts"',
-            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
 
             'echo "Sending timings"',
-            'echo "{}.timing:1|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.timing:2|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.timing:3|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.timing:1|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.timing:2|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.timing:3|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
 
             'echo "Sending histograms"',
-            'echo "{}.histogram:1|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:2|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:3|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:4|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
+            'echo "{}.histogram:1|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.histogram:2|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.histogram:3|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
+            'echo "{}.histogram:4|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_in_pfx),
 
             'echo "Done. Sleeping forever."',
             'while true; do',
@@ -281,10 +285,10 @@ def test_metrics_containers_app(dcos_api_session):
     }
     expected_metrics = [
         # metric_name, metric_value
-        ('.'.join([metric_name_pfx, 'gauge']), 100),
-        ('.'.join([metric_name_pfx, 'count']), 2),
-        ('.'.join([metric_name_pfx, 'timing', 'count']), 3),
-        ('.'.join([metric_name_pfx, 'histogram', 'count']), 4),
+        ('.'.join([metric_name_out_pfx, 'gauge']), 100),
+        ('.'.join([metric_name_out_pfx, 'count']), 2),
+        ('.'.join([metric_name_out_pfx, 'timing', 'count']), 3),
+        ('.'.join([metric_name_out_pfx, 'histogram', 'count']), 4),
     ]
 
     with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "7d5cd49f94fe98fa96941e7088c733ff7527d001",
+    "ref": "20ed71519471608c29e6bf0196ffdd5082baec5c",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This change coerces all metrics to lowercase, in order to preserve 1.11 behaviour. 


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43639](https://jira.mesosphere.com/browse/DCOS-43639) Force telegraf metric fields to lowercase


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a change to functionality that was new in 1.12.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/telegraf/compare/7d5cd49f94fe98fa96941e7088c733ff7527d001...20ed71519471608c29e6bf0196ffdd5082baec5c)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/132/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/132/)
