### PR TITLE
Bump dcos-log

### DIFF
--- a/packages/dcos-log/buildinfo.json
+++ b/packages/dcos-log/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-log.git",
-    "ref": "7ce9b88c2f9854ec75e49fd720ab78dc2d04b57b",
+    "ref": "1ad4746b7359a126244748e32e6af95ca640e5e0",
     "ref_origin": "master"
   },
   "username": "dcos_log",


### PR DESCRIPTION
## High-level description

Fixed file streaming for the Mesos File API in `dcos-log`.

With this PR we address the problems in DCOS-41248.
In order to not overload the Mesos agent with GET requests, we will now
wait one second if we are reading 0 bytes from the Mesos file.

This fix is temporary and not ideal but feels responsive enough to the
enduser and is a better alternative to what we have today.
The right fix here should be a change to the Read semantics so that a
read will block until there is data available.


## Corresponding DC/OS tickets (obligatory)

  - [DCOS_OSS-41248](https://jira.mesosphere.com/browse/DCOS-41248) dcos service log smashes the agent


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: No changes needed.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Test forthcoming. [DCOS-43781](https://jira.mesosphere.com/browse/DCOS-43781)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-log/compare/7ce9b...1ad47
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-log/job/dcos-log-pulls/337/
  - [ ] Code Coverage (if available):