### PR TITLE
maintenance_mode is enabled by default in 1.8 (1.13)

### DIFF
--- a/packages/marathon/extra/marathon.sh
+++ b/packages/marathon/extra/marathon.sh
@@ -11,7 +11,7 @@ export LIBPROCESS_IP=$($MESOS_IP_DISCOVERY_COMMAND)
 : ${MARATHON_TASK_LAUNCH_TIMEOUT=86400000}
 : ${MARATHON_TASK_RESERVATION_TIMEOUT=1800000}
 : ${MARATHON_DECLINE_OFFER_DURATION=300000}
-: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources,maintenance_mode"}
+: ${MARATHON_ENABLE_FEATURES="vips,task_killing,external_volumes,gpu_resources"}
 : ${MARATHON_MESOS_AUTHENTICATION_PRINCIPAL="dcos_marathon"}
 : ${MARATHON_MESOS_USER="root"}
 


### PR DESCRIPTION
## High-level description

In 1.7 we enabled maintenance_mode by default (1.12). So the feature maintenance_mode is not needed anymore. In 1.8 it's even considered an error if that feature is included in the commandline.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8479](https://jira.mesosphere.com/browse/MARATHON-8479) Marathon does not start on 1.13 cluster.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [x] Code Coverage (if available): [link to code coverage report]