### PR TITLE
[1.12] Bump Mesos to nightly 1.7.x c2d2818

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d0186a2cef8da2ba2af54185eee691b8a94cb305",
+    "ref": "c2d2818d7c772cd68d6cf41e708ae85a12bbaf0f",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d0186a2cef8da2ba2af54185eee691b8a94cb305",
+    "ref": "c2d2818d7c772cd68d6cf41e708ae85a12bbaf0f",
     "ref_origin": "1.7.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/d0186a2cef8da2ba2af54185eee691b8a94cb305...c2d2818d7c772cd68d6cf41e708ae85a12bbaf0f
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
