### PR TITLE
[1.10] Merge dependent tests into one big scenario

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import tempfile
-import uuid
 import zipfile
 
 import pytest
@@ -14,18 +13,6 @@ import retrying
 # Expected latency for all dcos-diagnostics units to refresh after postflight plus
 # another minute to allow for check-time to settle. See: DCOS_OSS-988
 LATENCY = 120
-
-
-def check_json(response):
-    response.raise_for_status()
-    try:
-        json_response = response.json()
-        logging.debug('Response: {}'.format(json_response))
-    except ValueError:
-        logging.exception('Could not deserialize response contents:{}'.format(response.content.decode()))
-        raise
-    assert len(json_response) > 0, 'Empty JSON returned from dcos-diagnostics request'
-    return json_response
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
@@ -93,36 +80,19 @@ def test_dcos_diagnostics_health(dcos_api_session):
             assert response[required_field], '{} cannot be empty'.format(required_field)
 
 
-def validate_node(nodes):
-    assert isinstance(nodes, list), 'input argument must be a list'
-    assert len(nodes) > 0, 'input argument cannot be empty'
-    required_fields = ['host_ip', 'health', 'role']
-
-    for node in nodes:
-        assert len(node) == len(required_fields), 'node should have the following fields: {}. Actual: {}'.format(
-            ', '.join(required_fields), node)
-        for required_field in required_fields:
-            assert required_field in node, '{} must be in node. Actual: {}'.format(required_field, node)
-
-        # host_ip, health, role fields cannot be empty
-        assert node['health'] in [0, 1], 'health must be 0 or 1'
-        assert node['host_ip'], 'host_ip cannot be empty'
-        assert node['role'], 'role cannot be empty'
-
-
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_nodes(dcos_api_session):
     """
     test a list of nodes with statuses endpoint /system/health/v1/nodes
     """
     for master in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('nodes', node=master))
+        response = check_json(dcos_api_session.health.get('/nodes', node=master))
         assert len(response) == 1, 'nodes response must have only one field: nodes'
         assert 'nodes' in response
         assert isinstance(response['nodes'], list)
-        assert len(response['nodes']) == len(dcos_api_session.masters + dcos_api_session.all_slaves),\
+        assert len(response['nodes']) == len(dcos_api_session.masters + dcos_api_session.all_slaves), \
             ('a number of nodes in response must be {}'.
-                format(len(dcos_api_session.masters + dcos_api_session.all_slaves)))
+             format(len(dcos_api_session.masters + dcos_api_session.all_slaves)))
 
         # test nodes
         validate_node(response['nodes'])
@@ -140,41 +110,6 @@ def test_dcos_diagnostics_nodes_node(dcos_api_session):
         for node in nodes:
             node_response = check_json(dcos_api_session.health.get('/nodes/{}'.format(node), node=master))
             validate_node([node_response])
-
-
-def validate_units(units):
-    assert isinstance(units, list), 'input argument must be list'
-    assert len(units) > 0, 'input argument cannot be empty'
-    required_fields = ['id', 'name', 'health', 'description']
-
-    for unit in units:
-        assert len(unit) == len(required_fields), 'a unit must have the following fields: {}. Actual: {}'.format(
-            ', '.join(required_fields), unit)
-        for required_field in required_fields:
-            assert required_field in unit, 'unit response must have field: {}. Actual: {}'.format(required_field, unit)
-
-        # a unit must have all 3 fields not empty
-        assert unit['id'], 'id field cannot be empty'
-        assert unit['name'], 'name field cannot be empty'
-        assert unit['health'] in [0, 1], 'health must be 0 or 1'
-        assert unit['description'], 'description field cannot be empty'
-
-
-def validate_unit(unit):
-    assert isinstance(unit, dict), 'input argument must be a dict'
-
-    required_fields = ['id', 'health', 'output', 'description', 'help', 'name']
-    assert len(unit) == len(required_fields), 'unit must have the following fields: {}. Actual: {}'.format(
-        ', '.join(required_fields), unit)
-    for required_field in required_fields:
-        assert required_field in unit, '{} must be in a unit. Actual: {}'.format(required_field, unit)
-
-    # id, name, health, description, help should not be empty
-    assert unit['id'], 'id field cannot be empty'
-    assert unit['name'], 'name field cannot be empty'
-    assert unit['health'] in [0, 1], 'health must be 0 or 1'
-    assert unit['description'], 'description field cannot be empty'
-    assert unit['help'], 'help field cannot be empty'
 
 
 def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
@@ -247,7 +182,7 @@ def test_systemd_units_health(dcos_api_session):
     """
     unhealthy_output = []
     assert dcos_api_session.masters, "Must have at least 1 master node"
-    report_response = check_json(dcos_api_session.health.get('report', node=dcos_api_session.masters[0]))
+    report_response = check_json(dcos_api_session.health.get('/report', node=dcos_api_session.masters[0]))
     assert 'Units' in report_response, "Missing `Units` field in response"
     for unit_name, unit_props in report_response['Units'].items():
         assert 'Health' in unit_props, "Unit {} missing `Health` field".format(unit_name)
@@ -282,22 +217,6 @@ def test_dcos_diagnostics_units_unit(dcos_api_session):
             validate_units([unit_response])
 
 
-def make_nodes_ip_map(dcos_api_session):
-    """
-    a helper function to make a map detected_ip -> external_ip
-    """
-    node_private_public_ip_map = {}
-    for node in dcos_api_session.masters:
-        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
-        node_private_public_ip_map[detected_ip] = node
-
-    for node in dcos_api_session.all_slaves:
-        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
-        node_private_public_ip_map[detected_ip] = node
-
-    return node_private_public_ip_map
-
-
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
     """
@@ -328,7 +247,7 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
 
         master_nodes = get_nodes_from_response(master_nodes_response)
 
-        assert len(master_nodes) == len(dcos_api_session.masters),\
+        assert len(master_nodes) == len(dcos_api_session.masters), \
             '{} != {}'.format(master_nodes, dcos_api_session.masters)
         assert set(master_nodes) == set(dcos_api_session.masters), 'a list of difference: {}'.format(
             set(master_nodes).symmetric_difference(set(dcos_api_session.masters))
@@ -372,6 +291,7 @@ def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
                 assert node_response['help'], 'help field cannot be empty'
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_selftest(dcos_api_session):
     """
     test invokes dcos-diagnostics `self test` functionality
@@ -384,12 +304,13 @@ def test_dcos_diagnostics_selftest(dcos_api_session):
             assert attrs['Success'], '{} failed, error message {}'.format(test_name, attrs['ErrorMessage'])
 
 
+@pytest.mark.supportedwindows
 def test_dcos_diagnostics_report(dcos_api_session):
     """
     test dcos-diagnostics report endpoint /system/health/v1/report
     """
     for master in dcos_api_session.masters:
-        report_response = check_json(dcos_api_session.health.get('report', node=master))
+        report_response = check_json(dcos_api_session.health.get('/report', node=master))
         assert 'Units' in report_response
         assert len(report_response['Units']) > 0
 
@@ -397,70 +318,48 @@ def test_dcos_diagnostics_report(dcos_api_session):
         assert len(report_response['Nodes']) > 0
 
 
-def _get_bundle_list(dcos_api_session):
-    response = check_json(dcos_api_session.health.get('report/diagnostics/list/all'))
-    bundles = []
-    for _, bundle_list in response.items():
-        if bundle_list is not None and isinstance(bundle_list, list) and len(bundle_list) > 0:
-            # append bundles and get just the filename.
-            bundles += map(lambda s: os.path.basename(s['file_name']), bundle_list)
-    return bundles
+@pytest.mark.supportedwindows
+def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
+    """
+    test bundle create, read, delete workflow
+    """
+    _create_bundle(dcos_api_session)
+    _check_diagnostics_bundle_status(dcos_api_session)
+    _download_and_extract_bundle(dcos_api_session)
+    _download_and_extract_bundle_from_another_master(dcos_api_session)
+    _delete_bundle(dcos_api_session)
 
 
-def test_dcos_diagnostics_bundle_create(dcos_api_session):
-    """
-    test bundle create functionality
-    """
+def _check_diagnostics_bundle_status(dcos_api_session):
+    # validate diagnostics job status response
+    diagnostics_bundle_status = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
+    required_status_fields = ['is_running', 'status', 'errors', 'last_bundle_dir', 'job_started', 'job_ended',
+                              'job_duration', 'diagnostics_bundle_dir', 'diagnostics_job_timeout_min',
+                              'journald_logs_since_hours', 'diagnostics_job_get_since_url_timeout_min',
+                              'command_exec_timeout_sec', 'diagnostics_partition_disk_usage_percent',
+                              'job_progress_percentage']
+
+    for _, properties in diagnostics_bundle_status.items():
+        assert len(properties) == len(required_status_fields), 'response must have the following fields: {}'.format(
+            required_status_fields
+        )
+        for required_status_field in required_status_fields:
+            assert required_status_field in properties, 'property {} not found'.format(required_status_field)
+
+
+def _create_bundle(dcos_api_session):
     # start the diagnostics bundle job
-    create_response = check_json(dcos_api_session.health.post('report/diagnostics/create', json={"nodes": ["all"]}))
+    create_response = check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
 
     # make sure the job is done, timeout is 5 sec, wait between retying is 1 sec
-
-    class NotCriticalException(Exception):
-        """Exception should be raised to continue retry loop"""
 
     last_datapoint = {
         'time': None,
         'value': 0
     }
 
-    @retrying.retry(wait_fixed=2000, stop_max_delay=120000,
-                    retry_on_exception=lambda e: isinstance(e, NotCriticalException))
-    def wait_for_job():
-        response = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))
-
-        # find if the job is still running
-        job_running = False
-        percent_done = 0
-        for _, attributes in response.items():
-            assert 'is_running' in attributes, '`is_running` field is missing in response'
-            assert 'job_progress_percentage' in attributes, '`job_progress_percentage` field is missing in response'
-
-            if attributes['is_running']:
-                percent_done = attributes['job_progress_percentage']
-                logging.info("Job is running. Progress: {}".format(percent_done))
-                job_running = True
-                break
-
-        # if we ran this bit previously compare the current datapoint with the one we saved
-        if last_datapoint['time'] and last_datapoint['value']:
-            if percent_done <= last_datapoint['value']:
-                assert (datetime.datetime.now() - last_datapoint['time']) < datetime.timedelta(seconds=15), (
-                    "Job is not progressing"
-                )
-        last_datapoint['value'] = percent_done
-        last_datapoint['time'] = datetime.datetime.now()
-
-        if job_running:
-            raise NotCriticalException('Job is still running')
-
-    # sometimes it may take extra few seconds to list bundles after the job is finished.
-    @retrying.retry(stop_max_delay=5000)
-    def wait_for_list():
-        assert _get_bundle_list(dcos_api_session), 'get a list of bundles timeout'
-
-    wait_for_job()
-    wait_for_list()
+    wait_for_diagnostics_job(dcos_api_session, last_datapoint)
+    wait_for_diagnostics_list(dcos_api_session)
 
     # the job should be complete at this point.
     # check the listing for a zip file
@@ -469,29 +368,25 @@ def test_dcos_diagnostics_bundle_create(dcos_api_session):
     assert bundles[0] == create_response['extra']['bundle_name']
 
 
-def verify_unit_response(zip_ext_file, min_lines):
-    assert isinstance(zip_ext_file, zipfile.ZipExtFile)
-    unit_output = gzip.decompress(zip_ext_file.read())
-    assert len(unit_output.decode().split('\n')) >= min_lines, 'Expect at least {} lines. Full unit output {}'.format(
-        min_lines, unit_output)
+def _delete_bundle(dcos_api_session):
+    bundles = _get_bundle_list(dcos_api_session)
+    assert bundles, 'no bundles found'
+    for bundle in bundles:
+        dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
+
+    bundles = _get_bundle_list(dcos_api_session)
+    assert len(bundles) == 0, 'Could not remove bundles {}'.format(bundles)
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
-def test_dcos_diagnostics_bundle_download_and_extract(dcos_api_session):
-    """
-    test bundle download and validate zip file
-    """
+def _download_and_extract_bundle(dcos_api_session):
     _download_bundle_from_master(dcos_api_session, 0)
 
 
-def test_dcos_diagnostics_bundle_download_and_extract_from_another_master(dcos_api_session):
-    """
-    test bundle download and validate zip file
-    """
-    if len(dcos_api_session.masters) < 3:
-        pytest.skip('Test requires at least 3 master nodes')
-
-    _download_bundle_from_master(dcos_api_session, 1)
+@retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
+def _download_and_extract_bundle_from_another_master(dcos_api_session):
+    if len(dcos_api_session.masters) > 1:
+        _download_bundle_from_master(dcos_api_session, 1)
 
 
 def _download_bundle_from_master(dcos_api_session, master_index):
@@ -570,7 +465,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
         for bundle in bundles:
             bundle_full_location = os.path.join(tmp_dir, bundle)
             with open(bundle_full_location, 'wb') as f:
-                r = dcos_api_session.health.get(os.path.join('report/diagnostics/serve', bundle), stream=True,
+                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
                                                 node=dcos_api_session.masters[master_index])
 
                 for chunk in r.iter_content(1024):
@@ -582,6 +477,15 @@ def _download_bundle_from_master(dcos_api_session, master_index):
 
             # get a list of all files in a zip archive.
             archived_items = z.namelist()
+
+            # validate error log is empty
+            if 'summaryErrorsReport.txt' in archived_items:
+                log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
+                raise AssertionError('summaryErrorsReport.txt must be empty. Got {}'.format(log_data))
+
+            # validate all files in zip archive are not empty
+            for item in archived_items:
+                assert z.getinfo(item).file_size, 'item {} is empty'.format(item)
 
             # make sure all required log files for master node are in place.
             for master_ip in dcos_api_session.masters:
@@ -596,9 +500,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(master_folder + 'dcos-mesos-master.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_master_file in expected_master_files:
-                    expected_file = master_folder + expected_master_file
-                    assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
+                verify_archived_items(master_folder, archived_items, expected_master_files)
 
             # make sure all required log files for agent node are in place.
             for slave_ip in dcos_api_session.slaves:
@@ -613,9 +515,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(agent_folder + 'dcos-mesos-slave.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_agent_file in expected_agent_files:
-                    expected_file = agent_folder + expected_agent_file
-                    assert expected_file in archived_items, 'expecting {} in {}'.format(expected_file, archived_items)
+                verify_archived_items(agent_folder, archived_items, expected_agent_files)
 
             # make sure all required log files for public agent node are in place.
             for public_slave_ip in dcos_api_session.public_slaves:
@@ -630,81 +530,142 @@ def _download_bundle_from_master(dcos_api_session, master_index):
                 gzipped_unit_output = z.open(agent_public_folder + 'dcos-mesos-slave-public.service.gz')
                 verify_unit_response(gzipped_unit_output, 100)
 
-                for expected_public_agent_file in expected_public_agent_files:
-                    expected_file = agent_public_folder + expected_public_agent_file
-                    assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+                verify_archived_items(agent_public_folder, archived_items, expected_public_agent_files)
 
 
-def test_bundle_delete(dcos_api_session):
-    bundles = _get_bundle_list(dcos_api_session)
-    assert bundles, 'no bundles found'
-    for bundle in bundles:
-        dcos_api_session.health.post(os.path.join('report/diagnostics/delete', bundle))
-
-    bundles = _get_bundle_list(dcos_api_session)
-    assert len(bundles) == 0, 'Could not remove bundles {}'.format(bundles)
-
-
-def test_diagnostics_bundle_status(dcos_api_session):
-    # validate diagnostics job status response
-    diagnostics_bundle_status = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))
-    required_status_fields = ['is_running', 'status', 'errors', 'last_bundle_dir', 'job_started', 'job_ended',
-                              'job_duration', 'diagnostics_bundle_dir', 'diagnostics_job_timeout_min',
-                              'journald_logs_since_hours', 'diagnostics_job_get_since_url_timeout_min',
-                              'command_exec_timeout_sec', 'diagnostics_partition_disk_usage_percent',
-                              'job_progress_percentage']
-
-    for _, properties in diagnostics_bundle_status.items():
-        assert len(properties) == len(required_status_fields), 'response must have the following fields: {}'.format(
-            required_status_fields
-        )
-        for required_status_field in required_status_fields:
-            assert required_status_field in properties, 'property {} not found'.format(required_status_field)
+def _get_bundle_list(dcos_api_session):
+    response = check_json(dcos_api_session.health.get('/report/diagnostics/list/all'))
+    bundles = []
+    for _, bundle_list in response.items():
+        if bundle_list is not None and isinstance(bundle_list, list) and len(bundle_list) > 0:
+            # append bundles and get just the filename.
+            bundles += map(lambda s: os.path.basename(s['file_name']), bundle_list)
+    return bundles
 
 
-def test_dcos_diagnostics_runner_poststart(dcos_api_session):
-    cmd = [
-        "/opt/mesosphere/bin/dcos-diagnostics",
-        "check",
-        "--check-config",
-        "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json",
-        "node-poststart"
-    ]
-    test_uuid = uuid.uuid4().hex
-    poststart_job = {
-        'id': 'test-dcos-diagnostics-runner-poststart-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(cmd)
-        }
-    }
-
-    dcos_api_session.metronome_one_off(poststart_job)
+def check_json(response):
+    response.raise_for_status()
+    try:
+        json_response = response.json()
+        logging.debug('Response: {}'.format(json_response))
+    except ValueError:
+        logging.exception('Could not deserialize response contents:{}'.format(response.content.decode()))
+        raise
+    assert len(json_response) > 0, 'Empty JSON returned from dcos-diagnostics request'
+    return json_response
 
 
-def test_dcos_diagnostics_runner_cluster(dcos_api_session):
-    cmd = [
-        # Set PATH and LD_LIBRARY_PATH to bad values to assert we're using their values from check config.
-        "env",
-        "PATH=badvalue",
-        "LD_LIBRARY_PATH=badvalue",
-        "/opt/mesosphere/bin/dcos-diagnostics",
-        "check",
-        "--check-config",
-        "/opt/mesosphere/etc/dcos-diagnostics-runner-config.json",
-        "cluster"
-    ]
-    test_uuid = uuid.uuid4().hex
-    job = {
-        'id': 'test-dcos-diagnostics-runner-cluster-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(cmd)
-        }
-    }
+def make_nodes_ip_map(dcos_api_session):
+    """
+    a helper function to make a map detected_ip -> external_ip
+    """
+    node_private_public_ip_map = {}
+    for node in dcos_api_session.masters:
+        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
+        node_private_public_ip_map[detected_ip] = node
 
-    dcos_api_session.metronome_one_off(job)
+    for node in dcos_api_session.all_slaves:
+        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
+        node_private_public_ip_map[detected_ip] = node
+
+    return node_private_public_ip_map
+
+
+@retrying.retry(wait_fixed=2000, stop_max_delay=120000,
+                retry_on_result=lambda x: x is False)
+def wait_for_diagnostics_job(dcos_api_session, last_datapoint):
+    response = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
+    # find if the job is still running
+    job_running = False
+    percent_done = 0
+    for _, attributes in response.items():
+        assert 'is_running' in attributes, '`is_running` field is missing in response'
+        assert 'job_progress_percentage' in attributes, '`job_progress_percentage` field is missing in response'
+
+        if attributes['is_running']:
+            percent_done = attributes['job_progress_percentage']
+            logging.info("Job is running. Progress: {}".format(percent_done))
+            job_running = True
+            break
+
+    # if we ran this bit previously compare the current datapoint with the one we saved
+    if last_datapoint['time'] and last_datapoint['value']:
+        if percent_done <= last_datapoint['value']:
+            assert (datetime.datetime.now() - last_datapoint['time']) < datetime.timedelta(seconds=15), (
+                "Job is not progressing"
+            )
+    last_datapoint['value'] = percent_done
+    last_datapoint['time'] = datetime.datetime.now()
+
+    return not job_running
+
+
+# sometimes it may take extra few seconds to list bundles after the job is finished.
+@retrying.retry(stop_max_delay=5000)
+def wait_for_diagnostics_list(dcos_api_session):
+    assert _get_bundle_list(dcos_api_session), 'get a list of bundles timeout'
+
+
+def validate_node(nodes):
+    assert isinstance(nodes, list), 'input argument must be a list'
+    assert len(nodes) > 0, 'input argument cannot be empty'
+    required_fields = ['host_ip', 'health', 'role']
+
+    for node in nodes:
+        assert len(node) == len(required_fields), 'node should have the following fields: {}. Actual: {}'.format(
+            ', '.join(required_fields), node)
+        for required_field in required_fields:
+            assert required_field in node, '{} must be in node. Actual: {}'.format(required_field, node)
+
+        # host_ip, health, role fields cannot be empty
+        assert node['health'] in [0, 1], 'health must be 0 or 1'
+        assert node['host_ip'], 'host_ip cannot be empty'
+        assert node['role'], 'role cannot be empty'
+
+
+def validate_units(units):
+    assert isinstance(units, list), 'input argument must be list'
+    assert len(units) > 0, 'input argument cannot be empty'
+    required_fields = ['id', 'name', 'health', 'description']
+
+    for unit in units:
+        assert len(unit) == len(required_fields), 'a unit must have the following fields: {}. Actual: {}'.format(
+            ', '.join(required_fields), unit)
+        for required_field in required_fields:
+            assert required_field in unit, 'unit response must have field: {}. Actual: {}'.format(required_field, unit)
+
+        # a unit must have all 3 fields not empty
+        assert unit['id'], 'id field cannot be empty'
+        assert unit['name'], 'name field cannot be empty'
+        assert unit['health'] in [0, 1], 'health must be 0 or 1'
+        assert unit['description'], 'description field cannot be empty'
+
+
+def validate_unit(unit):
+    assert isinstance(unit, dict), 'input argument must be a dict'
+
+    required_fields = ['id', 'health', 'output', 'description', 'help', 'name']
+    assert len(unit) == len(required_fields), 'unit must have the following fields: {}. Actual: {}'.format(
+        ', '.join(required_fields), unit)
+    for required_field in required_fields:
+        assert required_field in unit, '{} must be in a unit. Actual: {}'.format(required_field, unit)
+
+    # id, name, health, description, help should not be empty
+    assert unit['id'], 'id field cannot be empty'
+    assert unit['name'], 'name field cannot be empty'
+    assert unit['health'] in [0, 1], 'health must be 0 or 1'
+    assert unit['description'], 'description field cannot be empty'
+    assert unit['help'], 'help field cannot be empty'
+
+
+def verify_archived_items(folder, archived_items, expected_files):
+    for expected_file in expected_files:
+        expected_file = folder + expected_file
+        assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+
+
+def verify_unit_response(zip_ext_file, min_lines):
+    assert isinstance(zip_ext_file, zipfile.ZipExtFile)
+    unit_output = gzip.decompress(zip_ext_file.read())
+    assert len(unit_output.decode().split('\n')) >= min_lines, 'Expect at least {} lines. Full unit output {}'.format(
+        min_lines, unit_output)


### PR DESCRIPTION
## High-level description

### Backpots: #3438


Currently, we have 4 tests that depend on creating a bundle test. This commit merges them into one big integration test simulation basic use case for diagnostics bundles. This means we will create, check status, download and delete the bundle in a single test. This should prevent tests from failing because due to order.

This commit also rearrange entries in `tests_dcos_diagnostics.py`. All tests are at the top and helper functions were moved to the bottom. This makes code clear and easier to read.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4115](https://jira.mesosphere.com/browse/DCOS_OSS-4115) 

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)