### PR TITLE
bump marathon to 1.5.12

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.11/marathon-1.5.11.tgz",
-    "sha1" : "61d4bb2c30740b021abbc7345c459cb4745f6771"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.12/marathon-1.5.12.tgz",
+    "sha1" : "89e5ede385019c0d854b3e8427dd7b90c92bfee0"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## Changes from 1.5.11 to 1.5.12

### Default for "kill_retry_timeout" was increased to 30 seconds

Sending frequent kill requests to an agent can in certain cases lead to overloading the Docker daemon (if the tasks are docker containers run by the Docker containerizer). Thirty seconds seems to be a more sensible default here. 

### Marathon framework ID generation is now very conservative

Previously, Marathon would automatically request a new framework ID from Mesos if the old one was marked as torn down in Mesos, or if the framework ID record was removed from Zookeeper. This has led to more trouble than it has helped. The new behavior is:

* If Marathon's framework ID has been torn down in Mesos, or if the failover timeout has been exceeded, Marathon will crash, on launch, with a clear message.

* If Marathon's framework ID record was deleted from Zookeeper or is otherwise inaccessible, and there are instances defined, Marathon will refuse to create a new Framework ID and crash.

For more information, refer to the [framework id docs page](https://mesosphere.github.io/marathon/docs/framework-id.html).


### Docker image now allows user `nobody`

Previously, the Marathon Docker container would only run as user root. The packaging has been updated so that the container can be run as the user `nobody`. The default user for running the container (and, subsequently, the default value for `--mesos_user`) has not been changed.

### Docker image upgraded to Debian Stretch

The Docker image for Marathon now uses Debian Stretch as a base OS, since Debian Jessie is no longer receiving security updates.

### Native Packages

We have stopped publishing native packages for operating system versions that are past their end-of-life:

- Ubuntu Yakkety
- Ubuntu Wily
- Ubuntu Vivid

Additionally, we have added support for Debian Stretch.

### Fixed Issues

- [MARATHON-7568](https://jira.mesosphere.com/browse/MARATHON-7568) We now redact any Zookeeper credentials from the /v2/info response endpoint.
- [MARATHON-8413](https://jira.mesosphere.com/browse/MARATHON-8413) Fixed a bug where versions feature did not work if Marathon was launched using Java 9.
- [MARATHON-8095](https://jira.mesosphere.com/browse/MARATHON-8095) Fixed a bug where proxying the PATCH call was impossible due to Java limitations.
- [MARATHON-8430](https://jira.mesosphere.com/browse/MARATHON-8430) Readiness checks now work with self-signed certificates.
- Updated version of [Marathon UI to 1.3.1](https://github.com/mesosphere/marathon-ui/blob/master/CHANGELOG.md#131---2018-06-07):
    - [MARATHON-8255](https://jira.mesosphere.com/browse/MARATHON-8255) Marathon UI properly shows fetch URLs in the edit dialog, now.
- [MARATHON-7941](https://jira.mesosphere.com/browse/MARATHON-7941) Default for unreachable strategy on PUT /apps now matches POST requests.
- [MARATHON-8084](https://jira.mesosphere.com/browse/MARATHON-8084) Fix issue in which `POST /v2/apps/{app_id}/restart` would not proxy properly.
- [MARATHON-7390](https://jira.mesosphere.com/browse/MARATHON-7390) Fix issue in which Marathon would become unresponsive for a long time if Zookeeper DNS cannot be resolved at launch.
- Fixed a data migration issue in which UNIQUE constraint value was stripped when empty.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/mesosphere/marathon/compare/v1.5.11...v1.5.12
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/90/console
  - [x] Code Coverage (if available): N/A
