### PR TITLE
[1.11] packages/java: Update to 8u192

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@
 
 ### Security Updates
 
+* Update Java to 8u192. (DCOS_OSS-4382)
+
 
 ## DC/OS 1.11.6
 

--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.io/java/jdk-8u181-linux-x64.tar.gz",
-      "sha1": "35e4a57f20cfa06a9731674810731d442641cf1e"
+      "url": "https://downloads.mesosphere.io/java/jdk-8u192-linux-x64.tar.gz",
+      "sha1": "9e482a7ded535f14916f91510b78904eace28e49"
     }
   },
   "environment": {


### PR DESCRIPTION
## High-level description

Update Java to `8u192`.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4382](https://jira.mesosphere.com/browse/DCOS_OSS-4382) Update DC/OS Java JDK 8 to 8u192

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://www.java.com/en/download/faq/release_changes.xml
  - [ ] Test Results: n/a - external package
  - [ ] Code Coverage (if available): n/a - external package