### PR TITLE
Fix Telegraf dcos_statsd plugin race condition

### DIFF
--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "7d5cd49f94fe98fa96941e7088c733ff7527d001",
+    "ref": "8b5bdf3411225a198e4fdb978f43066f64ef9fc5",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This bumps the Telegraf package to pull in https://github.com/dcos/telegraf/pull/27.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4096](https://jira.mesosphere.com/browse/DCOS_OSS-4096) Telegraf dcos_statsd input plugin fails go race detector

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fixes a bug in 1.13 that hasn't been released.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This fixes a data race that we haven't seen reproduced on a running cluster, only in CI for this component.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/7d5cd49f94fe98fa96941e7088c733ff7527d001...8b5bdf3411225a198e4fdb978f43066f64ef9fc5
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/52/pipeline)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Ftelegraf%2Ftelegraf-dcos/detail/telegraf-dcos/52/pipeline)
