### PR TITLE
[1.13] Cache executor container metadata in metrics

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -136,6 +136,81 @@ def test_metrics_agents_statsd(dcos_api_session):
             get_metrics_prom(dcos_api_session, agent, expected_metrics)
 
 
+@retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
+def check_metrics_prom(dcos_api_session, prometheus_port, node, check_func):
+    """Get metrics from prometheus port on node and run check_func function,
+    asserting that it returns True.
+
+    Retries on non-200 status or failed assertions
+    for up to 150 seconds.
+
+    """
+    response = dcos_api_session.session.request(
+        'GET', 'http://{}:{}/metrics'.format(node, prometheus_port))
+    assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
+    assert check_func(response) is True
+
+
+@pytest.mark.parametrize("prometheus_port", [61091])
+def test_metrics_metadata(dcos_api_session, prometheus_port):
+    # install framework
+    install_response = dcos_api_session.cosmos.install_package('kafka')
+    data = install_response.json()
+
+    dcos_api_session.marathon.wait_for_deployments_complete()
+
+    wait = True
+    executor_mesos_id = task_mesos_id = ''
+    while wait:
+        master = dcos_api_session.masters[0]
+        state_response = dcos_api_session.get('/state', host=master, port=5050)
+        assert state_response.status_code == 200
+        state = state_response.json()
+        for framework in state['frameworks']:
+            if framework['name'] == 'marathon':
+                for task in framework['tasks']:
+                    if task['name'] == 'kafka':
+                        executor_mesos_id = task['slave_id']
+            if framework['name'] == 'kafka' and len(framework['tasks']) > 0 and executor_mesos_id:
+                task_mesos_id = framework['tasks'][0]['slave_id']
+                wait = False
+                break
+
+    for agent in state['slaves']:
+        if agent['id'] == executor_mesos_id:
+            executor_node = agent['hostname']
+        if agent['id'] == task_mesos_id:
+            task_node = agent['hostname']
+
+    def executor_checks(response):
+        # check executor metric metadata
+        for line in response.text.splitlines():
+            if '#' in line:
+                continue
+            if 'cpus_nr_periods' in line and 'marathon' in line:
+                assert 'service_name="marathon"' in line
+                assert 'task_name="kafka"' in line
+                return True
+        return False
+    check_metrics_prom(dcos_api_session, prometheus_port, executor_node, executor_checks)
+
+    def task_checks(response):
+        # check kafka task metric metadata
+        for line in response.text.splitlines():
+            if '#' in line:
+                continue
+            if 'cpus_nr_periods' in line and 'marathon' not in line:
+                assert 'service_name="kafka"' in line
+                assert 'task_name=""' in line
+                assert 'executor_name="kafka"' in line
+                return True
+        return False
+    check_metrics_prom(dcos_api_session, prometheus_port, task_node, task_checks)
+
+    # uninstall and cleanup framework
+    dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
+
+
 @pytest.mark.supportedwindows
 def test_metrics_node(dcos_api_session):
     """Test that the '/system/v1/metrics/v0/node' endpoint returns the expected

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -3,6 +3,7 @@ import contextlib
 import common
 import pytest
 import retrying
+from test_helpers import expanded_config
 
 
 __maintainer__ = 'mnaboka'
@@ -207,6 +208,8 @@ def get_task_hostname(dcos_api_session, framework_name, task_name):
     return node
 
 
+@pytest.mark.skipif(expanded_config.get('security') == 'strict',
+                    reason="MoM disabled for strict mode")
 def test_task_metrics_metadata(dcos_api_session):
     """Test that task metrics have expected metadata/labels"""
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
@@ -223,6 +226,8 @@ def test_task_metrics_metadata(dcos_api_session):
         check_metrics_metadata()
 
 
+@pytest.mark.skipif(expanded_config.get('security') == 'strict',
+                    reason="Framework disabled for strict mode")
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'):

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -153,7 +153,14 @@ def check_metrics_prom(dcos_api_session, prometheus_port, node, check_func):
 
 @pytest.mark.parametrize("prometheus_port", [61091])
 def test_metrics_metadata(dcos_api_session, prometheus_port):
-    # install framework
+    num_containers = 0
+    # get count of all running containers to check against later for complete teardown of kafka
+    for agent_ip in dcos_api_session.slaves:
+        response = dcos_api_session.metrics.get('/containers', node=agent_ip)
+        assert response.status_code == 200
+        num_containers += len(response.json())
+
+    # install kafka framework
     install_response = dcos_api_session.cosmos.install_package('kafka')
     data = install_response.json()
 
@@ -209,6 +216,18 @@ def test_metrics_metadata(dcos_api_session, prometheus_port):
 
     # uninstall and cleanup framework
     dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
+
+    # Retry for 150 seconds for kafka teardown completion
+    @retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
+    def wait_for_framework_teardown():
+        num_containers_check = 0
+        for agent_ip in dcos_api_session.slaves:
+            response = dcos_api_session.metrics.get('/containers', node=agent_ip)
+            assert response.status_code == 200
+            num_containers_check += len(response.json())
+        assert num_containers_check <= num_containers
+
+    wait_for_framework_teardown()
 
 
 @pytest.mark.supportedwindows

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import common
 import pytest
 import retrying
@@ -46,7 +48,7 @@ def test_metrics_masters_prom(dcos_api_session):
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
-@retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+@retrying.retry(wait_fixed=5000, stop_max_delay=300 * 1000)
 def get_metrics_prom(dcos_api_session, node):
     """Gets metrics from prometheus port on node and returns the response.
 
@@ -148,15 +150,40 @@ def test_metrics_agents_statsd(dcos_api_session):
             assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
 
             @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
-            def check_statsd_metrics(response):
+            def check_statsd_metrics():
                 response = get_metrics_prom(dcos_api_session, agent)
                 for metric_name in expected_metrics:
                     assert metric_name in response.text
             check_statsd_metrics()
 
 
+@contextlib.contextmanager
+def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_version, framework_name):
+    """Deploys dcos package and waits for package teardown once the context is left"""
+    app_id = dcos_api_session.cosmos.install_package(package_name, package_version=package_version).json()['appId']
+    dcos_api_session.marathon.wait_for_deployments_complete()
+
+    try:
+        yield
+    finally:
+        dcos_api_session.cosmos.uninstall_package(package_name, app_id=app_id)
+
+        # Retry for 150 seconds for teardown completion
+        @retrying.retry(wait_fixed=5000, stop_max_delay=150 * 1000)
+        def wait_for_package_teardown():
+            state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+            assert state_response.status_code == 200
+            state = state_response.json()
+
+            for framework in state['frameworks']:
+                if framework['name'] == framework_name:
+                    raise Exception('Framework {} still running'.format(framework_name))
+        wait_for_package_teardown()
+
+
 @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
 def get_task_hostname(dcos_api_session, framework_name, task_name):
+    # helper func that gets a framework's task's hostname
     mesos_id = node = ''
     state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
     assert state_response.status_code == 200
@@ -182,42 +209,23 @@ def get_task_hostname(dcos_api_session, framework_name, task_name):
 
 def test_task_metrics_metadata(dcos_api_session):
     """Test that task metrics have expected metadata/labels"""
-    install_response = dcos_api_session.cosmos.install_package('marathon')
-    data = install_response.json()
-    dcos_api_session.marathon.wait_for_deployments_complete()
+    with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
+        node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
 
-    node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
-
-    @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
-    def check_metrics_metadata(response):
-        response = get_metrics_prom(dcos_api_session, node)
-        for line in response.text.splitlines():
-            if '#' in line:
-                continue
-            if 'task_name="marathon-user"' in line:
-                assert 'service_name="marathon"' in line
-    check_metrics_metadata()
-
-    # uninstall and cleanup framework
-    dcos_api_session.cosmos.uninstall_package('marathon', app_id=data['appId'])
+        @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+        def check_metrics_metadata():
+            response = get_metrics_prom(dcos_api_session, node)
+            for line in response.text.splitlines():
+                if '#' in line:
+                    continue
+                if 'task_name="marathon-user"' in line:
+                    assert 'service_name="marathon"' in line
+        check_metrics_metadata()
 
 
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
-    # get count of all running containers to check against later for complete teardown
-    num_containers = 0
-    for agent_ip in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('/containers', node=agent_ip)
-        assert response.status_code == 200
-        num_containers += len(response.json())
-
-    try:
-        # install hello-world framework
-        install_response = dcos_api_session.cosmos.install_package('hello-world', package_version='2.2.0-0.42.2')
-        data = install_response.json()
-
-        dcos_api_session.marathon.wait_for_deployments_complete()
-
+    with deploy_and_cleanup_dcos_package(dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'):
         node = get_task_hostname(dcos_api_session, 'marathon', 'hello-world')
 
         @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
@@ -234,21 +242,6 @@ def test_executor_metrics_metadata(dcos_api_session):
                     # hello-world executors can be named "hello" or "world"
                     assert ('executor_name="hello"' in line or 'executor_name="world"' in line)
         check_executor_metrics_metadata()
-    finally:
-        # uninstall and cleanup framework
-        dcos_api_session.cosmos.uninstall_package('hello-world', app_id=data['appId'])
-
-        # Retry for 150 seconds for teardown completion
-        @retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
-        def wait_for_framework_teardown():
-            num_containers_check = 0
-            for agent_ip in dcos_api_session.slaves:
-                response = dcos_api_session.metrics.get('/containers', node=agent_ip)
-                assert response.status_code == 200
-                num_containers_check += len(response.json())
-            assert num_containers_check <= num_containers
-
-        wait_for_framework_teardown()
 
 
 @pytest.mark.supportedwindows

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -136,98 +136,102 @@ def test_metrics_agents_statsd(dcos_api_session):
             get_metrics_prom(dcos_api_session, agent, expected_metrics)
 
 
-@retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
-def check_metrics_prom(dcos_api_session, prometheus_port, node, check_func):
+@retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+def check_metrics_prom(dcos_api_session, node, check_func):
     """Get metrics from prometheus port on node and run check_func function,
     asserting that it returns True.
 
     Retries on non-200 status or failed assertions
-    for up to 150 seconds.
+    for up to 300 seconds.
 
     """
     response = dcos_api_session.session.request(
-        'GET', 'http://{}:{}/metrics'.format(node, prometheus_port))
+        'GET', 'http://{}:61091/metrics'.format(node))
     assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
     assert check_func(response) is True
 
 
-@pytest.mark.parametrize("prometheus_port", [61091])
-def test_metrics_metadata(dcos_api_session, prometheus_port):
-    num_containers = 0
+def test_metrics_metadata(dcos_api_session):
     # get count of all running containers to check against later for complete teardown of kafka
+    num_containers = 0
     for agent_ip in dcos_api_session.slaves:
         response = dcos_api_session.metrics.get('/containers', node=agent_ip)
         assert response.status_code == 200
         num_containers += len(response.json())
 
-    # install kafka framework
-    install_response = dcos_api_session.cosmos.install_package('kafka')
-    data = install_response.json()
+    try:
+        # install kafka framework
+        install_response = dcos_api_session.cosmos.install_package('kafka', package_version='2.3.0-1.1.0')
+        data = install_response.json()
 
-    dcos_api_session.marathon.wait_for_deployments_complete()
+        dcos_api_session.marathon.wait_for_deployments_complete()
 
-    wait = True
-    executor_mesos_id = task_mesos_id = ''
-    while wait:
-        master = dcos_api_session.masters[0]
-        state_response = dcos_api_session.get('/state', host=master, port=5050)
-        assert state_response.status_code == 200
-        state = state_response.json()
-        for framework in state['frameworks']:
-            if framework['name'] == 'marathon':
-                for task in framework['tasks']:
-                    if task['name'] == 'kafka':
-                        executor_mesos_id = task['slave_id']
-            if framework['name'] == 'kafka' and len(framework['tasks']) > 0 and executor_mesos_id:
-                task_mesos_id = framework['tasks'][0]['slave_id']
-                wait = False
-                break
+        wait = True
+        executor_mesos_id = task_mesos_id = kafka_task_name = ''
+        while wait:
+            master = dcos_api_session.masters[0]
+            state_response = dcos_api_session.get('/state', host=master, port=5050)
+            assert state_response.status_code == 200
+            state = state_response.json()
+            for framework in state['frameworks']:
+                if framework['name'] == 'marathon':
+                    for task in framework['tasks']:
+                        if task['name'] == 'kafka':
+                            executor_mesos_id = task['slave_id']
+                            break
+                elif framework['name'] == 'kafka' and len(framework['tasks']) > 0 and executor_mesos_id:
+                    task_mesos_id = framework['tasks'][0]['slave_id']
+                    kafka_task_name = framework['tasks'][0]['name']
+                    wait = False
+                    break
 
-    for agent in state['slaves']:
-        if agent['id'] == executor_mesos_id:
-            executor_node = agent['hostname']
-        if agent['id'] == task_mesos_id:
-            task_node = agent['hostname']
+        for agent in state['slaves']:
+            if agent['id'] == executor_mesos_id:
+                executor_node = agent['hostname']
+            if agent['id'] == task_mesos_id:
+                task_node = agent['hostname']
 
-    def executor_checks(response):
-        # check executor metric metadata
-        for line in response.text.splitlines():
-            if '#' in line:
-                continue
-            if 'cpus_nr_periods' in line and 'marathon' in line:
-                assert 'service_name="marathon"' in line
-                assert 'task_name="kafka"' in line
-                return True
-        return False
-    check_metrics_prom(dcos_api_session, prometheus_port, executor_node, executor_checks)
+        def task_checks(response):
+            # check kafka task metric metadata
+            for line in response.text.splitlines():
+                if '#' in line:
+                    continue
+                # check that a kafka task's metric is appropriately tagged
+                if kafka_task_name in line:
+                    return ('service_name="kafka"' in line and
+                            'task_name="{}"'.format(kafka_task_name) in line and
+                            'executor_name="kafka"' in line)
+            return False
+        check_metrics_prom(dcos_api_session, task_node, task_checks)
 
-    def task_checks(response):
-        # check kafka task metric metadata
-        for line in response.text.splitlines():
-            if '#' in line:
-                continue
-            if 'cpus_nr_periods' in line and 'marathon' not in line:
-                assert 'service_name="kafka"' in line
-                assert 'task_name=""' in line
-                assert 'executor_name="kafka"' in line
-                return True
-        return False
-    check_metrics_prom(dcos_api_session, prometheus_port, task_node, task_checks)
+        def executor_checks(response):
+            # check kafka executor metric metadata
+            for line in response.text.splitlines():
+                if '#' in line:
+                    continue
+                # ignore metrics from kafka task started by marathon by checking
+                # for absence of 'marathon' string.
+                if 'cpus_nr_periods' in line and 'marathon' not in line:
+                    return ('service_name="kafka"' in line and
+                            'task_name=""' in line and  # this is an executor, not a task
+                            'executor_name="kafka"' in line)
+            return False
+        check_metrics_prom(dcos_api_session, executor_node, executor_checks)
+    finally:
+        # uninstall and cleanup framework
+        dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
 
-    # uninstall and cleanup framework
-    dcos_api_session.cosmos.uninstall_package('kafka', app_id=data['appId'])
+        # Retry for 150 seconds for kafka teardown completion
+        @retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
+        def wait_for_framework_teardown():
+            num_containers_check = 0
+            for agent_ip in dcos_api_session.slaves:
+                response = dcos_api_session.metrics.get('/containers', node=agent_ip)
+                assert response.status_code == 200
+                num_containers_check += len(response.json())
+            assert num_containers_check <= num_containers
 
-    # Retry for 150 seconds for kafka teardown completion
-    @retrying.retry(wait_fixed=2000, stop_max_delay=150 * 1000)
-    def wait_for_framework_teardown():
-        num_containers_check = 0
-        for agent_ip in dcos_api_session.slaves:
-            response = dcos_api_session.metrics.get('/containers', node=agent_ip)
-            assert response.status_code == 200
-            num_containers_check += len(response.json())
-        assert num_containers_check <= num_containers
-
-    wait_for_framework_teardown()
+        wait_for_framework_teardown()
 
 
 @pytest.mark.supportedwindows

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -73,7 +73,7 @@ def _get_cluster_resources(dcos_api_session):
 
 
 def _agent_has_resources(agent, node_requirements):
-    """Check that an agent has at least as much resources as required for one node
+    """Check that an agent has at least as much resources as requried for one node
 
     Args:
         agent: dict Info for one 'slave' from the mesos state summary

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -73,7 +73,7 @@ def _get_cluster_resources(dcos_api_session):
 
 
 def _agent_has_resources(agent, node_requirements):
-    """Check that an agent has at least as much resources as requried for one node
+    """Check that an agent has at least as much resources as required for one node
 
     Args:
         agent: dict Info for one 'slave' from the mesos state summary


### PR DESCRIPTION
## High-level description

This fixes a bug in the dcos-metadata plugin in telegraf where executor containers were not being cached. This caused repeated hits on Mesos due to constant cache misses and missing information in the metrics output.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4181](https://jira.mesosphere.com/browse/DCOS_OSS-4181) Telegraf does not retrieve executor metadata from Mesos


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: will be added to 1.12 changelog
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]