### PR TITLE
[1.12] Added a Mesos patch for health check definitions in master API outputs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,8 @@ Format of the entries must be.
 
 * Marathon framework ID generation is now very conservative. [See more](https://github.com/mesosphere/marathon/blob/master/changelog.md#marathon-framework-id-generation-is-now-very-conservative) (MARATHON-8420)
 
+* Task health check definitions are now included in Mesos master/agent API outputs. [See more](https://issues.apache.org/jira/browse/MESOS-8780) (MESOS-8780)
+
 ### Security Updates
 
 

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,14 +1,14 @@
-From c572e2468545c00ba518ca8f1d773d58a4ba5fca Mon Sep 17 00:00:00 2001
+From ddf0dd12b54acc1c84688825c8edd024315cd2a7 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH 1/4] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
-index baac70f25..c61dbae70 100644
+index 9ebb5f274..3c81d03b6 100644
 --- a/src/docker/docker.cpp
 +++ b/src/docker/docker.cpp
 @@ -681,6 +681,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
@@ -24,5 +24,5 @@ index baac70f25..c61dbae70 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From e9d8be82eac88c2585550cc2b860ecc026c032c2 Mon Sep 17 00:00:00 2001
+From 6c409dd626f67b64388736257c7289a5166fd998 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
- failure.
+Subject: [PATCH 2/4] Updated mesos containerizer to ignore GPU isolator
+ creation failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -23,10 +23,10 @@ by https://reviews.apache.org/r/62472/
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index c38bfacef..ec08818c4 100644
+index 6c2700053..e938c92b3 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
-@@ -443,8 +443,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -447,8 +447,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
      {"gpu/nvidia",
        [&nvidia] (const Flags& flags) -> Try<Isolator*> {
          if (!nvml::isAvailable()) {
@@ -39,7 +39,7 @@ index c38bfacef..ec08818c4 100644
          }
  
          CHECK_SOME(nvidia)
-@@ -504,7 +506,9 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -508,7 +510,9 @@ Try<MesosContainerizer*> MesosContainerizer::create(
                     isolator.error());
      }
  
@@ -51,5 +51,5 @@ index c38bfacef..ec08818c4 100644
  
    // Next, apply any custom isolators in the order given by the flags.
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,7 +1,7 @@
-From 11a5b919e9aa68d2df2bc158498bd8413ae9e8e8 Mon Sep 17 00:00:00 2001
+From a3f2f8b2c9c1b646a908d0d366dd12fd1d401471 Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
-Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
+Subject: [PATCH 3/4] Mesos UI: updated the URL generation to make it work with
  adminrouter.
 
 - Use /mesos as the leading master URL prefix.
@@ -61,5 +61,5 @@ index 8049cf611..74f65f574 100644
  
      // Adding bindings into scope so that they can be used from within
 -- 
-2.16.3
+2.17.0
 

--- a/packages/mesos/extra/patches/0004-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0004-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,0 +1,105 @@
+From 30bd18967971f9a4fb87ed5ab2b6dec6cc6f6e79 Mon Sep 17 00:00:00 2001
+From: Greg Mann <gregorywmann@gmail.com>
+Date: Mon, 29 Oct 2018 11:25:58 -0700
+Subject: [PATCH 4/4] Added task health check definitions to master API
+ responses.
+
+The `Task` protobuf message is updated to include the health check
+definition of a task when it is specified, along with associated
+helper functions.
+
+(cherry-picked from commit d8466a8a0a7d84d997f4c20b5631fadee7110b94)
+
+Review: https://reviews.apache.org/r/69110/
+---
+ include/mesos/mesos.proto     | 8 ++++++--
+ include/mesos/v1/mesos.proto  | 8 ++++++--
+ src/common/http.cpp           | 4 ++++
+ src/common/protobuf_utils.cpp | 4 ++++
+ 4 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
+index 5a985fca3..81029b885 100644
+--- a/include/mesos/mesos.proto
++++ b/include/mesos/mesos.proto
+@@ -2165,8 +2165,8 @@ message TaskGroupInfo {
+  *   1) we need additional IDs, such as a specific
+  *      framework, executor, or agent; or
+  *   2) we do not need the additional data, such as the command run by the
+- *      task or the health checks.  These additional fields may be large and
+- *      unnecessary for some Mesos messages.
++ *      task. These additional fields may be large and unnecessary for some
++ *      Mesos messages.
+  *
+  * `Task` is generally constructed from a `TaskInfo`.  See protobuf::createTask.
+  */
+@@ -2197,6 +2197,10 @@ message Task {
+   // Container information for the task.
+   optional ContainerInfo container = 13;
+ 
++  optional HealthCheck health_check = 15;
++
++  // TODO(greggomann): Add the task's `CheckInfo`. See MESOS-8780.
++
+   // Specific user under which task is running.
+   optional string user = 14;
+ }
+diff --git a/include/mesos/v1/mesos.proto b/include/mesos/v1/mesos.proto
+index a5ebb786a..637552611 100644
+--- a/include/mesos/v1/mesos.proto
++++ b/include/mesos/v1/mesos.proto
+@@ -2158,8 +2158,8 @@ message TaskGroupInfo {
+  *   1) we need additional IDs, such as a specific
+  *      framework, executor, or agent; or
+  *   2) we do not need the additional data, such as the command run by the
+- *      task or the health checks.  These additional fields may be large and
+- *      unnecessary for some Mesos messages.
++ *      task. These additional fields may be large and unnecessary for some
++ *      Mesos messages.
+  *
+  * `Task` is generally constructed from a `TaskInfo`.  See protobuf::createTask.
+  */
+@@ -2190,6 +2190,10 @@ message Task {
+   // Container information for the task.
+   optional ContainerInfo container = 13;
+ 
++  optional HealthCheck health_check = 15;
++
++  // TODO(greggomann): Add the task's `CheckInfo`. See MESOS-8780.
++
+   // Specific user under which task is running.
+   optional string user = 14;
+ }
+diff --git a/src/common/http.cpp b/src/common/http.cpp
+index 932111dde..81102d845 100644
+--- a/src/common/http.cpp
++++ b/src/common/http.cpp
+@@ -733,6 +733,10 @@ void json(JSON::ObjectWriter* writer, const Task& task)
+   if (task.has_container()) {
+     writer->field("container", JSON::Protobuf(task.container()));
+   }
++
++  if (task.has_health_check()) {
++    writer->field("health_check", JSON::Protobuf(task.health_check()));
++  }
+ }
+ 
+ 
+diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
+index 77139d8a3..2ae37ac61 100644
+--- a/src/common/protobuf_utils.cpp
++++ b/src/common/protobuf_utils.cpp
+@@ -341,6 +341,10 @@ Task createTask(
+     t.mutable_container()->CopyFrom(task.container());
+   }
+ 
++  if (task.has_health_check()) {
++    t.mutable_health_check()->CopyFrom(task.health_check());
++  }
++
+   // Copy `user` if set.
+   if (task.has_command() && task.command().has_user()) {
+     t.set_user(task.command().user());
+-- 
+2.17.0
+


### PR DESCRIPTION
## High-level description

This PR adds a patch on top of OSS Mesos which includes task health check definitions in Mesos master/agent API outputs.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

The related ticket for this PR exists in OSS Mesos JIRA:
  - [MESOS-8780](https://issues.apache.org/jira/browse/MESOS-8780) Expose Check and HealthCheck information on Mesos HTTP endpoints.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The relevant tests are included in the Mesos test suite - see [this patch](https://reviews.apache.org/r/69110/).
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]