### PR TITLE
Improve reliability of metrics tests

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -170,7 +170,6 @@ def test_metrics_containers(dcos_api_session):
             for c in get_container_ids(dcos_api_session, agent.host):
                 # Test that /containers/<id> responds with expected data
                 container_metrics = get_container_metrics(dcos_api_session, agent.host, c)
-                assert 'datapoints' in container_metrics, 'got {}'.format(container_metrics)
 
                 cid_registry = []
                 for dp in container_metrics['datapoints']:
@@ -191,10 +190,6 @@ def test_metrics_containers(dcos_api_session):
                     # the same.
                     cid_registry.append(dp['tags']['container_id'])
                     assert(check_cid(cid_registry))
-
-                assert 'dimensions' in container_metrics, 'got {}'.format(container_metrics)
-                assert 'task_name' in container_metrics['dimensions'], 'got {}'.format(
-                    container_metrics['dimensions'])
 
                 debug_task_name.append(container_metrics['dimensions']['task_name'])
 
@@ -369,7 +364,7 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     """
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
-        if container_metrics['dimensions'].get('task_name') == task_name:
+        if container_metrics['dimensions']['task_name'] == task_name:
             return get_app_metrics(dcos_api_session, node, cid)
     return None
 
@@ -394,12 +389,27 @@ def get_container_ids(dcos_api_session, node: str):
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
-    Retries on error or non-200 status for up to 30 seconds.
+    Retries on error, non-200 status, or missing response fields for up
+    to 30 seconds.
 
     """
     response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
     assert response.status_code == 200
-    return response.json()
+    container_metrics = response.json()
+
+    assert 'datapoints' in container_metrics, (
+        'container metrics must include datapoints. Got: {}'.format(container_metrics)
+    )
+    assert 'dimensions' in container_metrics, (
+        'container metrics must include dimensions. Got: {}'.format(container_metrics)
+    )
+    # task_name is an important dimension for identifying metrics, but it may take some time to appear in the container
+    # metrics response.
+    assert 'task_name' in container_metrics['dimensions'], (
+        'task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions'])
+    )
+
+    return container_metrics
 
 
 @retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(30 * 1000))

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -390,7 +390,7 @@ def get_container_ids(dcos_api_session, node: str):
     return container_ids
 
 
-@retrying.retry(stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(30 * 1000))
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
@@ -402,7 +402,7 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     return response.json()
 
 
-@retrying.retry(stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(30 * 1000))
 def get_app_metrics(dcos_api_session, node: str, container_id: str):
     """Return app metrics for container_id from the metrics API on node.
 


### PR DESCRIPTION
## High-level description

This changes `get_container_metrics()` to verify that the container metrics response contains expected fields before returning it. This improves the reliability of `test_metrics_containers()` by retrying an individual container metrics request if its response is missing the `task_name` dimension, instead of retrying the entire test.

This also extends the retry interval of some helper functions, in order to prevent integration tests from unnecessarily hammering the v0 metrics API.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4342](https://jira.mesosphere.com/browse/DCOS_OSS-4342) test_metrics.test_metrics_containers fails with AssertionError

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This improves tests, which aren't user-facing.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This improves tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]