### PR TITLE
Docker gc log fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,6 @@
 
 
 ### Fixed and improved
-
+* Docker-GC will now log to journald. (COPS-4044)
 
 ### Notable changes

--- a/packages/docker-gc/extra/dcos-docker-gc.service
+++ b/packages/docker-gc/extra/dcos-docker-gc.service
@@ -10,5 +10,5 @@ User=dcos_docker_gc
 EnvironmentFile=/opt/mesosphere/environment
 Environment=STATE_DIR=/var/lib/dcos/docker-gc
 Environment=PID_DIR=/var/lib/dcos/docker-gc
-Environment=LOG_TO_SYSLOG=1
+Environment=LOG_TO_SYSLOG=0
 ExecStart=$PKG_PATH/docker-gc


### PR DESCRIPTION
## High-level description

The LOG_TO_SYSLOG envvar here: https://github.com/spotify/docker-gc/blob/master/docker-gc#L53

will write to stdout if it's set to 0, and syslog if it's set to 1.

Our implementation of it as a systemd unit runs it in a container, so with its current setting of 1, it'll write to syslog inside the container which is destroyed after it runs. I'm changing it to 0 so that it will log to journald on the host system.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [COPS-4044](https://jira.mesosphere.com/browse/COPS-4044) Docker-gc isn't configured to log



## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: It's an envvar change to edit the logging behavior of an out-of-the-box script we use. No code changes
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).