### PR TITLE
1.12 train 11/06/2018

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Fixed race condition in Telegraf dcos_statsd input plugin. (DCOS_OSS-4096)
+
 * Check system clock is synced before starting Exhibitor (DCOS_OSS-4287)
 
 * Allow dcos-diagnostics bundles location to be configured (DCOS_OSS-4040)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## DC/OS 1.12-dev
+
+### Notable changes
+
+### Fixed and improved
+
+### Security Updates
+
+* Update Java to 8u192. (DCOS_OSS-4381)
+
+
 ## DC/OS 1.12.0
 
 ```

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# SUMMARY:
+#   Helper script that can fetch all logs for any cluster and outputs them in the current working directory.
+#   Fetched logs are comprised of journald logs, mesos logs, sandbox logs and diagnostics bundles for all nodes.
+#
+# USAGE:
+#   bash fetch_cluster_logs.bash open <ssh-user> <master-public-ip> [--login-token=<token>] [--identity-file=<path>] [--debug]
+#   bash fetch_cluster_logs.bash enterprise <ssh-user> <master-public-ip> [--username=<username>] [--password=<password>] [--identity-file=<path>] [--debug]
+#
+# COMMANDS
+#   open          Fetch the logs for an open cluster.
+#   enterprise    Fetch the logs for an enterprise cluster.
+#
+# REQUIRED ARGUMENTS
+#   <ssh-user>            ssh user to access the nodes of your cluster.
+#   <master-public-ip>    Public ip for the master node of your cluster.
+#
+# OPTIONAL ARGUMENTS
+#   --login-token=<token>     Token used to log in to your open DC/OS cluster. If omitted, you will be prompted for it
+#                             during the DC/OS CLI cluster setup.
+#   --username=<username>     Username to log in to your enterprise DC/OS cluster. If omitted, you will be prompted for
+#                             it during the DC/OS CLI cluster setup.
+#   --password=<password>     Password to log in to your DC/OS enterprise cluster. If omitted, you will be prompted for
+#                             it during the DC/OS CLI cluster setup.
+#   --identity-file=<path>    Path to the private ssh key that will be used to ssh into the nodes. If omitted, that key
+#                             must be added to your ssh-agent.
+#   --debug                   Turn on debug logging for the DC/OS CLI.
+
+set +e
+set -x
+
+dcos_variant=$1
+if [[ -z $dcos_variant ]] || ([[ $dcos_variant != "open" ]] && [[ $dcos_variant != "enterprise" ]]); then
+  echo "ERROR: You must specify either the 'open' or 'enterprise' command depending on your cluster type."
+  exit 0
+fi
+shift
+
+ssh_user=$1
+if [[ -z $ssh_user ]]; then
+  echo "ERROR: Required argument 'ssh_user' was either not specified or null."
+  exit 0
+fi
+shift
+
+master_public_ip=$1
+if [[ -z $master_public_ip ]]; then
+  echo "ERROR: Required argument 'master_public_ip' was either not specified or null."
+  exit 0
+fi
+shift
+
+if [[ $dcos_variant == "open" ]]; then
+  for i in "$@"
+  do
+  case $i in
+    --debug)
+      debug_options="--debug --log-level=debug"
+      shift
+    ;;
+    --login-token=*)
+      dcos_login_token_input="<<< ${i#*=}"
+      shift
+    ;;
+      --identity-file=*)
+      identity_file="${i#*=}"
+    shift
+    ;;
+    *)
+      echo "ERROR: Unrecognized argument '$i' for command '$dcos_variant'"
+      exit 0
+    ;;
+  esac
+  done
+else
+  for i in "$@"
+  do
+  case $i in
+    --debug)
+      debug_options="--debug --log-level=debug"
+      shift
+    ;;
+    --username=*)
+      dcos_username=$i
+      shift
+    ;;
+    --password=*)
+      dcos_password=$i
+      shift
+    ;;
+    --identity-file=*)
+      identity_file="${i#*=}"
+      shift
+    ;;
+    *)
+      echo "ERROR: Unrecognized argument '$i' for command '$dcos_variant'"
+      exit 0
+    ;;
+  esac
+  done
+fi
+
+ssh_options="-A -T -l $ssh_user -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+if [[ ! -z $identity_file ]]; then
+  ssh_options="-i $identity_file ${ssh_options}"
+fi
+
+# download the DC/OS CLI
+if [ ! -f dcos-cli ]; then
+  wget https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos --output-document=dcos-cli
+  chmod +x dcos-cli
+fi
+
+# link the CLI with the cluster
+if [[ $dcos_variant == "open" ]]; then
+  bash -c "./dcos-cli $debug_options cluster setup $master_public_ip --insecure $dcos_login_token_input"
+else
+  ./dcos-cli $debug_options cluster setup $master_public_ip $dcos_username $dcos_password --insecure
+fi
+
+# generate diagnostics bundle
+bundle_name=$(./dcos-cli $debug_options node diagnostics create all | grep -o bundle-.*)
+echo "diagnostics bundle name: ${bundle_name}"
+
+# wait for the diagnostics job to complete
+status_output="$(./dcos-cli $debug_options node diagnostics --status)"
+while [[ $status_output =~ "is_running: True" ]]; do
+    echo "Diagnostics job still running. Retrying in 5 seconds."
+    sleep 5
+    status_output="$(./dcos-cli $debug_options node diagnostics --status)"
+done
+
+# get diagnostics bundle
+./dcos-cli $debug_options node diagnostics download $bundle_name
+
+# copy the identity file to the master node so we don't need the ssh-agent when agent forwarding
+if [[ ! -z $identity_file ]]; then
+  scp -i $identity_file -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $identity_file ${ssh_user}@${master_public_ip}:~/$identity_file
+fi
+
+nodes_info_json=$(./dcos-cli $debug_options node --json)
+for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
+  _jq() {
+   echo "$node_info" | base64 --decode | jq -r ${1}
+  }
+
+  id=$(_jq '.id')
+  pid=$(_jq '.pid')
+  ip=$(_jq '.hostname')
+  # converting the dots to underscores in the ip for log file names
+  ip_underscores=${ip//./_}
+
+  if [[ $pid == *"master"* ]]; then
+    # get journald logs
+    ssh $ssh_options $master_public_ip -- journalctl -x -b --no-pager > master_journald.log
+
+    # get mesos logs
+    ./dcos-cli $debug_options node log --leader > mesos_master.log
+  else
+    # get sandbox logs
+    ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo tar --exclude=provisioner -zc /var/lib/mesos/slave > sandbox_${ip_underscores}.tar.gz
+
+    # get journald logs
+    ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- journalctl -x -b --no-pager > agent_${ip_underscores}_journald.log
+
+    # get mesos logs
+    ./dcos-cli $debug_options node log --mesos-id=$id > mesos_agent_${ip_underscores}.log
+  fi
+done

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -693,6 +693,20 @@ package:
     content: |
         {
           "HTTPEndpoints": [
+{% switch dcos_overlay_enable %}
+{% case "true" %}
+              {
+                  "Port": 5050,
+                  "Uri": "/overlay-master/state",
+                  "Role": ["master"]
+              },
+              {
+                  "Port": 5051,
+                  "Uri": "/overlay-agent/overlay",
+                  "Role": ["agent", "agent_public"]
+              },
+{% case "false" %}
+{% endswitch %}
               {
                   "Port": 5050,
                   "Uri": "/__processes__",
@@ -872,16 +886,6 @@ package:
                   "Port": 8123,
                   "Uri": "/v1/version",
                   "Role": ["master"]
-              },
-              {
-                  "Port": 5050,
-                  "Uri": "/overlay-master/state",
-                  "Role": ["master"]
-              },
-              {
-                  "Port": 5051,
-                  "Uri": "/overlay-agent/overlay",
-                  "Role": ["agent", "agent_public"]
               },
               {
                   "Port": 5051,

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "f612504f524c74f10b48c0e1a2cdb06820529e50",
+    "ref": "2ec443d7227940345bcedc7a4f352f0f9df031dc",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -418,10 +418,11 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
 
     # these files are expected to be in archive for a master host
     expected_master_files = ['dcos-mesos-master.service.gz', 'var/lib/dcos/exhibitor/zookeeper/snapshot/myid.gz',
-                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz', '5050-quota.json'
+                             'var/lib/dcos/exhibitor/conf/zoo.cfg.gz', '5050-quota.json',
+                             '5050-overlay-master_state.json.gz'
                              ] + expected_common_files
 
-    expected_agent_common_files = ['5051-containers.json']
+    expected_agent_common_files = ['5051-containers.json', '5051-overlay-agent_overlay.json']
 
     # for agent host
     expected_agent_files = ['dcos-mesos-slave.service.gz'

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -154,7 +154,6 @@ def test_metrics_containers(dcos_api_session):
             for c in get_container_ids(dcos_api_session, agent.host):
                 # Test that /containers/<id> responds with expected data
                 container_metrics = get_container_metrics(dcos_api_session, agent.host, c)
-                assert 'datapoints' in container_metrics, 'got {}'.format(container_metrics)
 
                 cid_registry = []
                 for dp in container_metrics['datapoints']:
@@ -176,9 +175,6 @@ def test_metrics_containers(dcos_api_session):
                     cid_registry.append(dp['tags']['container_id'])
                     assert(check_cid(cid_registry))
 
-                assert 'dimensions' in container_metrics, 'got {}'.format(container_metrics)
-                assert 'task_name' in container_metrics['dimensions'], 'got {}'.format(
-                    container_metrics['dimensions'])
                 assert container_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(
                     container_metrics['dimensions'])
 
@@ -368,7 +364,7 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     """
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
-        if container_metrics['dimensions'].get('task_name') == task_name:
+        if container_metrics['dimensions']['task_name'] == task_name:
             return get_app_metrics(dcos_api_session, node, cid)
     return None
 
@@ -389,19 +385,34 @@ def get_container_ids(dcos_api_session, node: str):
     return container_ids
 
 
-@retrying.retry(stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(30 * 1000))
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
-    Retries on error or non-200 status for up to 30 seconds.
+    Retries on error, non-200 status, or missing response fields for up
+    to 30 seconds.
 
     """
     response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
     assert response.status_code == 200
-    return response.json()
+    container_metrics = response.json()
+
+    assert 'datapoints' in container_metrics, (
+        'container metrics must include datapoints. Got: {}'.format(container_metrics)
+    )
+    assert 'dimensions' in container_metrics, (
+        'container metrics must include dimensions. Got: {}'.format(container_metrics)
+    )
+    # task_name is an important dimension for identifying metrics, but it may take some time to appear in the container
+    # metrics response.
+    assert 'task_name' in container_metrics['dimensions'], (
+        'task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions'])
+    )
+
+    return container_metrics
 
 
-@retrying.retry(stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=(2 * 1000), stop_max_delay=(30 * 1000))
 def get_app_metrics(dcos_api_session, node: str, container_id: str):
     """Return app metrics for container_id from the metrics API on node.
 

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "8f1820f537b0caa4bbb697beaae4d1e4940bfbb6",
+    "ref": "431c33756ab2959b2fcb658bca861314497f7c0d",
     "ref_origin": "master"
   }
 }

--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.io/java/jdk-8u181-linux-x64.tar.gz",
-      "sha1": "35e4a57f20cfa06a9731674810731d442641cf1e"
+      "url": "https://downloads.mesosphere.io/java/jdk-8u192-linux-x64.tar.gz",
+      "sha1": "9e482a7ded535f14916f91510b78904eace28e49"
     }
   },
   "environment": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d0186a2cef8da2ba2af54185eee691b8a94cb305",
+    "ref": "cb07b697d4fbd8143136b39dd48a64dd634c2c4f",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,0 +1,47 @@
+From df6b1cae4baedbd592cfb08b072c8b4f4c071403 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Mon, 13 Aug 2018 20:05:26 +0200
+Subject: [PATCH] Added 'received' timestamp into `process::Request`.
+
+This allows us to note when a request comes in and
+hence calculate request processing time.
+
+Review: https://reviews.apache.org/r/68992
+(cherry picked from commit 6ab80da5b2770a96802f7893ac092d6c8a92a824)
+---
+ 3rdparty/libprocess/include/process/http.hpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/3rdparty/libprocess/include/process/http.hpp b/3rdparty/libprocess/include/process/http.hpp
+index fa66b0fe2..a1b0bb9e3 100644
+--- a/3rdparty/libprocess/include/process/http.hpp
++++ b/3rdparty/libprocess/include/process/http.hpp
+@@ -27,6 +27,7 @@
+ #include <boost/functional/hash.hpp>
+ 
+ #include <process/address.hpp>
++#include <process/clock.hpp>
+ #include <process/future.hpp>
+ #include <process/owned.hpp>
+ #include <process/pid.hpp>
+@@ -517,7 +518,7 @@ public:
+ struct Request
+ {
+   Request()
+-    : keepAlive(false), type(BODY) {}
++    : keepAlive(false), type(BODY), received(Clock::now()) {}
+ 
+   std::string method;
+ 
+@@ -562,6 +563,8 @@ struct Request
+   std::string body;
+   Option<Pipe::Reader> reader;
+ 
++  Time received;
++
+   /**
+    * Returns whether the encoding is considered acceptable in the
+    * response. See RFC 2616 section 14.3 for details.
+-- 
+2.16.3
+

--- a/packages/mesos/extra/patches/0005-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0005-Introduced-logResponse-for-http-handlers.patch
@@ -1,0 +1,78 @@
+From 92ce192274ab8e0670785cc2012e9c56e4bb0ac2 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 11 Oct 2018 15:40:37 +0200
+Subject: [PATCH] Introduced `logResponse` for http handlers.
+
+Currently we use `logRequest` function to log requests to endpoints
+in Mesos `MasterProcess`, `SlaveProcess`, and `FilesProcess`. Each
+request is logged when it is first fetched from the actor mailbox.
+However this obviously does not allow for logging the request
+processing time.
+
+This patch introduces a `logResponse` function which logs the request
+together with the corresponding response status and the time spent
+generating the response.
+
+Review: https://reviews.apache.org/r/68993
+(cherry picked from commit 7df7e4d35ec1c6cce87c629fac0b32149a4830d2)
+---
+ src/common/http.cpp | 15 +++++++++++++++
+ src/common/http.hpp | 11 +++++++++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/src/common/http.cpp b/src/common/http.cpp
+index 932111dde..4d6f5301b 100644
+--- a/src/common/http.cpp
++++ b/src/common/http.cpp
+@@ -32,6 +32,7 @@
+ #include <mesos/quota/quota.hpp>
+ 
+ #include <process/authenticator.hpp>
++#include <process/clock.hpp>
+ #include <process/collect.hpp>
+ #include <process/dispatch.hpp>
+ #include <process/future.hpp>
+@@ -1126,4 +1127,18 @@ void logRequest(const process::http::Request& request)
+                 : "");
+ }
+ 
++
++void logResponse(
++    const process::http::Request& request,
++    const process::http::Response& response)
++{
++  LOG(INFO) << "HTTP " << request.method << " for " << request.url
++            << (request.client.isSome()
++                ? " from " + stringify(request.client.get())
++                : "")
++            << ": '" << response.status << "'"
++            << " after " << (process::Clock::now() - request.received).ms()
++            << Milliseconds::units();
++}
++
+ }  // namespace mesos {
+diff --git a/src/common/http.hpp b/src/common/http.hpp
+index 0901a5528..cc7f747d1 100644
+--- a/src/common/http.hpp
++++ b/src/common/http.hpp
+@@ -338,6 +338,17 @@ Try<Nothing> initializeHttpAuthenticators(
+ // desired request handler to get consistent request logging.
+ void logRequest(const process::http::Request& request);
+ 
++
++// Log the response for the corresponding request together with the request
++// processing time. Route handlers can compose this with the desired request
++// handler to get consistent request/response logging.
++//
++// TODO(alexr): Consider taking `response` as a future to allow logging for
++// cases when response has not been generated.
++void logResponse(
++    const process::http::Request& request,
++    const process::http::Response& response);
++
+ } // namespace mesos {
+ 
+ #endif // __COMMON_HTTP_HPP__
+-- 
+2.16.3
+

--- a/packages/mesos/extra/patches/0006-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0006-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,0 +1,117 @@
+From c142ba1a70f1ad36bfa108bb40d2b8576fd2ae04 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 11 Oct 2018 15:58:41 +0200
+Subject: [PATCH] Logged request processing time for some endpoints.
+
+This patch leverages `logResponse()` function to print response status
+code together with the request processing time for some endpoints on
+the master and agent. Not all endpoints are participating to avoid
+unnecessary log pollution; only these that are know to be "slow" in
+generating the response.
+
+Note that requests are still logged when they are fetched from the
+actor mailbox, i.e., affected endpoints now log twice per request:
+when the processing starts and when the response is ready to be sent.
+
+Review: https://reviews.apache.org/r/68994
+(cherry picked from commit 9203d099da60b3333fa2e2d2a7fcefe8065fa7e1)
+---
+ src/master/master.cpp | 25 ++++++++++++++++++++-----
+ src/slave/slave.cpp   | 10 ++++++++--
+ 2 files changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 6237d9246..84f9db047 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -909,7 +909,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.frameworks(request, principal);
++          return http.frameworks(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/flags",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -969,7 +972,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.slaves(request, principal);
++          return http.slaves(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   // TODO(ijimenez): Remove this endpoint at the end of the
+   // deprecation cycle on 0.26.
+@@ -987,7 +993,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.state(request, principal);
++          return http.state(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/state-summary",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -995,7 +1004,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.stateSummary(request, principal);
++          return http.stateSummary(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   // TODO(ijimenez): Remove this endpoint at the end of the
+   // deprecation cycle.
+@@ -1013,7 +1025,10 @@ void Master::initialize()
+         [this](const process::http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.tasks(request, principal);
++          return http.tasks(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/maintenance/schedule",
+         READWRITE_HTTP_AUTHENTICATION_REALM,
+diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
+index 7425cfbae..01fd4eedf 100644
+--- a/src/slave/slave.cpp
++++ b/src/slave/slave.cpp
+@@ -809,7 +809,10 @@ void Slave::initialize()
+         [this](const http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.state(request, principal);
++          return http.state(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+   route("/flags",
+         READONLY_HTTP_AUTHENTICATION_REALM,
+@@ -848,7 +851,10 @@ void Slave::initialize()
+         [this](const http::Request& request,
+                const Option<Principal>& principal) {
+           logRequest(request);
+-          return http.containers(request, principal);
++          return http.containers(request, principal)
++            .onReady([request](const process::http::Response& response) {
++              logResponse(request, response);
++            });
+         });
+ 
+   const PID<Slave> slavePid = self();
+-- 
+2.16.3
+

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d0186a2cef8da2ba2af54185eee691b8a94cb305",
+    "ref": "cb07b697d4fbd8143136b39dd48a64dd634c2c4f",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "20ed71519471608c29e6bf0196ffdd5082baec5c",
+    "ref": "8b5bdf3411225a198e4fdb978f43066f64ef9fc5",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
#3727 Update dcos-test-utils
#3709 (1.12) Improve reliability of metrics tests
#3702 (1.12) Fix Telegraf dcos_statsd plugin race condition
#3698 [1.12] Bump Mesos to nightly 1.7.x cb07b69
#3695 Add fetch_cluster_logs.bash
#3682 [1.12] packages/java: Update to 8u192
#3631 [1.12] Mesos: logged request processing time.
#3626 [1.12] Update dcos-diagnostics
#3577 [1.12] Do not pull overlay data when overlay is disable