### PR TITLE
[master] Fix a metrics module installation bug when overlay network is disabled.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -359,6 +359,8 @@ package:
            }
         ]
       }
+{% case "false" %}
+{% endswitch %}
   - path: /etc/mesos-slave-modules/metrics.json
     content: |
       {
@@ -375,8 +377,6 @@ package:
           } ]
         } ]
       }
-{% case "false" %}
-{% endswitch %}
   - path: /etc/mesos-slave-modules/journal_logger_modules.json
     content: |
       {


### PR DESCRIPTION
## High-level description

This PR fixes an issue in `dcos-config.yaml` which breaks the metrics Mesos module when the overlay network has been disabled at install time.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4521](https://jira.mesosphere.com/browse/DCOS_OSS-4521) Metrics Mesos module fails to load if overlay network is disabled


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
