### PR TITLE
Collect ZooKeeper Metrics using DC/OS Telegraf

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1381,6 +1381,22 @@ package:
           "registrar",
           "allocator",
        ]
+      # Reads 'mntr' health checks from one or many zookeeper servers
+      [[inputs.zookeeper]]
+        ## An array of addresses to gather stats about. Specify an ip or hostname
+        ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+        ## If no hosts are specified, then localhost is used as the host.
+        ## If no port is specified, 2181 is used
+        servers = [":2181"]
+        ## Timeout for metric collections from all servers.  Minimum timeout is "1s".
+        timeout = "10s"
+        ## Optional TLS Config
+        # enable_tls = true
+        # tls_ca = "/etc/telegraf/ca.pem"
+        # tls_cert = "/etc/telegraf/cert.pem"
+        # tls_key = "/etc/telegraf/key.pem"
+        ## If true while TLS is enabled skip chain & host verification
+        # insecure_skip_verify = true
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -70,6 +70,12 @@ def test_metrics_masters_mesos(dcos_api_session):
         get_metrics_prom(dcos_api_session, master, ['mesos_master_uptime_secs'])
 
 
+def test_metrics_masters_zookeeper(dcos_api_session):
+    """Assert that ZooKeeper metrics on masters are present."""
+    for master in dcos_api_session.masters:
+        get_metrics_prom(dcos_api_session, master, ['zookeeper_'])
+
+
 def test_metrics_agents_statsd(dcos_api_session):
     """Assert that statsd metrics on agent are present."""
     if len(dcos_api_session.slaves) > 0:


### PR DESCRIPTION
## High-level description

This PR adds metrics collection from ZooKeeper instance on master nodes by the `dcos-telegraf` service. The collected logs correspond to the output from the `mntr` command:
https://zookeeper.apache.org/doc/r3.4.8/zookeeperAdmin.html#sc_zkCommands

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4477](https://jira.mesosphere.com/browse/DCOS_OSS-4477) Instrument and Transmit ZooKeeper Metrics to dcos-telegraf service.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)