### PR TITLE
[1.12] Add whitelist for including labels in telegraf metrics metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,6 @@
 
 ### Breaking changes
 
-* DCOS_METRICS_-prefixed labels are now configured to be included in metrics (DCOS-43591)
-
 ### Fixed and improved
 
 * dcos-net ignores some tcp/udp discovery ports for tasks on host network (DCOS_OSS-4395)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### Notable changes
 
+### Breaking changes
+
+* DCOS_METRICS_-prefixed labels are now configured to be included in metrics (DCOS-43591)
+
 ### Fixed and improved
 
 * dcos-net ignores some tcp/udp discovery ports for tasks on host network (DCOS_OSS-4395)
@@ -11,6 +15,8 @@
 * dcos-net continously restarting systemd-networkd on a bare-metal server with bond interfaces (DCOS_OSS-4398)
 
 * Lots of CRASH messages in dcos-net logs (DCOS-45161)
+
+* Telegraf: Added configurable whitelists for labels to include in metrics (DCOS-43591)
 
 * Make push_ops_timeout configurable through config.yaml (DCOS-45196)
 
@@ -63,8 +69,6 @@ Format of the entries must be.
 
 * Replaced dcos-metrics with Telegraf (DCOS_OSS-3714)
 
-* DCOS_METRICS_-prefixed labels are no longer included in metrics metadata by default, but are now configured to be (DCOS-43591)
-
 
 ### Fixed and improved
 
@@ -109,10 +113,6 @@ Format of the entries must be.
 * Upgrade OTP version (DCOS_OSS-3655)
 
 * Marathon framework ID generation is now very conservative. [See more](https://github.com/mesosphere/marathon/blob/master/changelog.md#marathon-framework-id-generation-is-now-very-conservative) (MARATHON-8420)
-
-* Task health check definitions are now included in Mesos master/agent API outputs. [See more](https://issues.apache.org/jira/browse/MESOS-8780) (MESOS-8780)
-
-* Telegraf: Added configurable whitelists for labels to include in metrics metadata (DCOS-43591)
 
 
 ### Security Updates

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@ Format of the entries must be.
 
 * Replaced dcos-metrics with Telegraf (DCOS_OSS-3714)
 
+* DCOS_METRICS_-prefixed labels are no longer included in metrics metadata by default, but are now configured to be (DCOS-43591)
+
 
 ### Fixed and improved
 
@@ -109,6 +111,9 @@ Format of the entries must be.
 * Marathon framework ID generation is now very conservative. [See more](https://github.com/mesosphere/marathon/blob/master/changelog.md#marathon-framework-id-generation-is-now-very-conservative) (MARATHON-8420)
 
 * Task health check definitions are now included in Mesos master/agent API outputs. [See more](https://issues.apache.org/jira/browse/MESOS-8780) (MESOS-8780)
+
+* Telegraf: Added configurable whitelists for labels to include in metrics metadata (DCOS-43591)
+
 
 ### Security Updates
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1364,6 +1364,12 @@ package:
         timeout = "10s"
         ## The minimum period between requests to the mesos agent
         rate_limit = "5s"
+        ## List of labels to always add to each metric as tags
+        whitelist = ["DCOS_SERVICE_NAME"]
+        ## List of prefixes a label should have in order to be added
+        ## to each metric as tags; the prefix is stripped from the
+        ## label when tagging
+        whitelist_prefix = ["DCOS_METRICS_"]
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"
@@ -1402,6 +1408,12 @@ package:
         timeout = "10s"
         ## The minimum period between requests to the mesos agent
         rate_limit = "5s"
+        ## List of labels to always add to each metric as tags
+        whitelist = ["DCOS_SERVICE_NAME"]
+        ## List of prefixes a label should have in order to be added
+        ## to each metric as tags; the prefix is stripped from the
+        ## label when tagging
+        whitelist_prefix = ["DCOS_METRICS_"]
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -110,6 +110,9 @@ def get_task_hostname(dcos_api_session, framework_name, task_name):
     return node
 
 
+@pytest.mark.skipif(
+    test_helpers.expanded_config.get('security') == 'strict',
+    reason="MoM disabled for strict mode")
 def test_metrics_metadata(dcos_api_session):
     """Test that metrics have expected metadata/labels"""
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "8b5bdf3411225a198e4fdb978f43066f64ef9fc5",
+    "ref": "c40dce1aca995be7e1beaa5b9f5598d8f78d3695",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This adds a whitelist in telegraf config to add certain task labels (that are not prefixed with `DCOS_METRICS_` which are automatically pulled in to tags on the metric) to metrics metadata. For now, we would like to add the `DCOS_SERVICE_NAME` labels, which has been added to the whitelist.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43591](https://jira.mesosphere.com/browse/DCOS-43591) Add DCOS_SERVICE_NAME label to dcos-telegraf metrics to allow grouping of scheduler tasks


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
