### PR TITLE
Update dcos-test-utils

### DIFF
--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -3,7 +3,7 @@ DcosApiSession object that will be injected into the pytest 'dcos_api_session' f
 via the make_session_fixture() method
 """
 
-from dcos_test_utils import dcos_api, helpers
+from dcos_test_utils import dcos_api
 from test_helpers import expanded_config
 
 
@@ -15,7 +15,6 @@ def make_session_fixture():
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 
     dcos_api_session = dcos_api.DcosApiSession(
-        auth_user=dcos_api.DcosUser(helpers.CI_CREDENTIALS),
         exhibitor_admin_password=exhibitor_admin_password,
         **args)
     dcos_api_session.wait_for_dcos()

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -67,7 +67,7 @@ def _dump_diagnostics(request, dcos_api_session):
     make_diagnostics_report = os.environ.get('DIAGNOSTICS_DIRECTORY') is not None
     if make_diagnostics_report:
         log.info('Create diagnostics report for all nodes')
-        check_json(dcos_api_session.health.post('report/diagnostics/create', json={"nodes": ["all"]}))
+        check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
 
         last_datapoint = {
             'time': None,
@@ -84,7 +84,7 @@ def _dump_diagnostics(request, dcos_api_session):
         bundles = _get_bundle_list(dcos_api_session)
         for bundle in bundles:
             for master_node in dcos_api_session.masters:
-                r = dcos_api_session.health.get(os.path.join('report/diagnostics/serve', bundle), stream=True,
+                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
                                                 node=master_node)
                 bundle_path = os.path.join(os.path.expanduser('~'), bundle)
                 with open(bundle_path, 'wb') as f:

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -116,7 +116,7 @@ def test_dcos_diagnostics_nodes(dcos_api_session):
     test a list of nodes with statuses endpoint /system/health/v1/nodes
     """
     for master in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('nodes', node=master))
+        response = check_json(dcos_api_session.health.get('/nodes', node=master))
         assert len(response) == 1, 'nodes response must have only one field: nodes'
         assert 'nodes' in response
         assert isinstance(response['nodes'], list)
@@ -247,7 +247,7 @@ def test_systemd_units_health(dcos_api_session):
     """
     unhealthy_output = []
     assert dcos_api_session.masters, "Must have at least 1 master node"
-    report_response = check_json(dcos_api_session.health.get('report', node=dcos_api_session.masters[0]))
+    report_response = check_json(dcos_api_session.health.get('/report', node=dcos_api_session.masters[0]))
     assert 'Units' in report_response, "Missing `Units` field in response"
     for unit_name, unit_props in report_response['Units'].items():
         assert 'Health' in unit_props, "Unit {} missing `Health` field".format(unit_name)
@@ -389,7 +389,7 @@ def test_dcos_diagnostics_report(dcos_api_session):
     test dcos-diagnostics report endpoint /system/health/v1/report
     """
     for master in dcos_api_session.masters:
-        report_response = check_json(dcos_api_session.health.get('report', node=master))
+        report_response = check_json(dcos_api_session.health.get('/report', node=master))
         assert 'Units' in report_response
         assert len(report_response['Units']) > 0
 
@@ -398,7 +398,7 @@ def test_dcos_diagnostics_report(dcos_api_session):
 
 
 def _get_bundle_list(dcos_api_session):
-    response = check_json(dcos_api_session.health.get('report/diagnostics/list/all'))
+    response = check_json(dcos_api_session.health.get('/report/diagnostics/list/all'))
     bundles = []
     for _, bundle_list in response.items():
         if bundle_list is not None and isinstance(bundle_list, list) and len(bundle_list) > 0:
@@ -410,7 +410,7 @@ def _get_bundle_list(dcos_api_session):
 @retrying.retry(wait_fixed=2000, stop_max_delay=120000,
                 retry_on_result=lambda x: x is False)
 def wait_for_diagnostics_job(dcos_api_session, last_datapoint):
-    response = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))
+    response = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
     # find if the job is still running
     job_running = False
     percent_done = 0
@@ -447,7 +447,7 @@ def test_dcos_diagnostics_bundle_create(dcos_api_session):
     test bundle create functionality
     """
     # start the diagnostics bundle job
-    create_response = check_json(dcos_api_session.health.post('report/diagnostics/create', json={"nodes": ["all"]}))
+    create_response = check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
 
     # make sure the job is done, timeout is 5 sec, wait between retying is 1 sec
 
@@ -568,7 +568,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
         for bundle in bundles:
             bundle_full_location = os.path.join(tmp_dir, bundle)
             with open(bundle_full_location, 'wb') as f:
-                r = dcos_api_session.health.get(os.path.join('report/diagnostics/serve', bundle), stream=True,
+                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
                                                 node=dcos_api_session.masters[master_index])
 
                 for chunk in r.iter_content(1024):
@@ -646,7 +646,7 @@ def test_bundle_delete(dcos_api_session):
     bundles = _get_bundle_list(dcos_api_session)
     assert bundles, 'no bundles found'
     for bundle in bundles:
-        dcos_api_session.health.post(os.path.join('report/diagnostics/delete', bundle))
+        dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 
     bundles = _get_bundle_list(dcos_api_session)
     assert len(bundles) == 0, 'Could not remove bundles {}'.format(bundles)
@@ -654,7 +654,7 @@ def test_bundle_delete(dcos_api_session):
 
 def test_diagnostics_bundle_status(dcos_api_session):
     # validate diagnostics job status response
-    diagnostics_bundle_status = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))
+    diagnostics_bundle_status = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
     required_status_fields = ['is_running', 'status', 'errors', 'last_bundle_dir', 'job_started', 'job_ended',
                               'job_duration', 'diagnostics_bundle_dir', 'diagnostics_job_timeout_min',
                               'journald_logs_since_hours', 'diagnostics_job_get_since_url_timeout_min',

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -45,7 +45,7 @@ def check_response_ok(response: requests.models.Response, headers: dict):
 
 def test_log_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=10', node=node)
+        response = dcos_api_session.logs.get('/v1/range/?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 lines
@@ -55,21 +55,21 @@ def test_log_text(dcos_api_session):
 
 def test_log_json(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
         check_response_ok(response, {'Content-Type': 'application/json'})
         validate_json_entry(response.json())
 
 
 def test_log_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         validate_sse_entry(response.text)
 
 
 def test_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/stream/?skip_prev=1', node=node, stream=True,
+        response = dcos_api_session.logs.get('/v1/stream/?skip_prev=1', node=node, stream=True,
                                              headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
@@ -250,7 +250,7 @@ def validate_journald_cursor(c: str, cursor_regexp=None):
 
 def test_log_v2_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?limit=10', node=node)
+        response = dcos_api_session.logs.get('/v2/component?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 lines
@@ -260,8 +260,8 @@ def test_log_v2_text(dcos_api_session):
 
 def test_log_v2_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?limit=1', node=node, headers={'Accept': 'text/event-stream'},
-                                             stream=True)
+        response = dcos_api_session.logs.get(
+            '/v2/component?limit=1', node=node, headers={'Accept': 'text/event-stream'}, stream=True)
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
         sse_id = next(lines)
@@ -272,7 +272,7 @@ def test_log_v2_server_sent_events(dcos_api_session):
 
 def test_log_v2_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v2/component?skip=-1', node=node, stream=True,
+        response = dcos_api_session.logs.get('/v2/component?skip=-1', node=node, stream=True,
                                              headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()
@@ -318,11 +318,11 @@ def test_log_v2_task_logs(dcos_api_session):
     }
 
     with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
-        response = dcos_api_session.logs.get('v2/task/{}/file/stdout'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/stdout'.format(task_id))
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
 
-        response = dcos_api_session.logs.get('v2/task/{}/file/stderr'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/stderr'.format(task_id))
         check_response_ok(response, {})
         assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
 
@@ -351,11 +351,11 @@ def test_log_v2_pod_logs(dcos_api_session):
     }
 
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
-        response = dcos_api_session.logs.get('v2/task/sleep1')
+        response = dcos_api_session.logs.get('/v2/task/sleep1')
         check_response_ok(response, {})
         assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
 
-        response = dcos_api_session.logs.get('v2/task/sleep1/file/stderr')
+        response = dcos_api_session.logs.get('/v2/task/sleep1/file/stderr')
         check_response_ok(response, {})
         assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
 
@@ -386,32 +386,32 @@ def test_log_v2_api(dcos_api_session):
 
     with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
         # skip 2 entries from the beggining
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=2'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=2'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "three\nfour\nfive\n"
 
         # move to the end of file and read 2 last LINE_SIZE
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # move three lines from the top and limit to one entry
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?skip=3&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=3&limit=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\n"
 
         # set cursor to 7 (bytes) which the second word and skip 1 lines
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=7&skip=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # set cursor to 7 (bytes) which the second word and skip -1 lines and limit 1
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "two\n"
 
         # validate the bug is fixed https://jira.mesosphere.com/browse/DCOS_OSS-1995
-        response = dcos_api_session.logs.get('v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id))
         check_response_ok(response, {})
         assert response.text == "one\ntwo\nthree\nfour\nfive\n"
 
@@ -425,7 +425,7 @@ def test_log_v2_api(dcos_api_session):
 
 
 def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
-    response = dcos_api_session.logs.get('v2/task/{}/browse'.format(task))
+    response = dcos_api_session.logs.get('/v2/task/{}/browse'.format(task))
     check_response_ok(response, {})
 
     expected_fields = ['gid', 'mode', 'mtime', 'nlink', 'path', 'size', 'uid']
@@ -443,7 +443,7 @@ def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
 
 def _assert_can_download_files(dcos_api_session, task, expected_files):
     for expected_file in expected_files:
-        response = dcos_api_session.logs.get('v2/task/{}/file/{}/download'.format(task, expected_file))
+        response = dcos_api_session.logs.get('/v2/task/{}/file/{}/download'.format(task, expected_file))
         check_response_ok(response, {
             'Content-Type': 'application/octet-stream',
             'Content-Disposition': 'attachment; filename={}'.format(expected_file)})

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -8,20 +8,20 @@ def test_metrics_agents_ping(dcos_api_session):
     """ Test that the metrics service is up on masters.
     """
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
         'agent.'
 
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
 def test_metrics_masters_ping(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('ping', node=master)
+        response = dcos_api_session.metrics.get('/ping', node=master)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
@@ -77,7 +77,7 @@ def test_metrics_node(dcos_api_session):
 
     # private agents
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -86,7 +86,7 @@ def test_metrics_node(dcos_api_session):
 
     # public agents
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -95,7 +95,7 @@ def test_metrics_node(dcos_api_session):
 
     # masters
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('node', node=master)
+        response = dcos_api_session.metrics.get('/node', node=master)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -131,16 +131,16 @@ def test_metrics_containers(dcos_api_session):
             # state every 2 minutes to propogate containers to the API
             @retrying.retry(wait_fixed=2000, stop_max_delay=150000)
             def wait_for_container_propogation():
-                response = dcos_api_session.metrics.get('containers', node=agent.host)
+                response = dcos_api_session.metrics.get('/containers', node=agent.host)
                 assert response.status_code == 200
                 assert len(response.json()) > 0, 'must have at least 1 container'
 
             wait_for_container_propogation()
 
-            response = dcos_api_session.metrics.get('containers', node=agent.host)
+            response = dcos_api_session.metrics.get('/containers', node=agent.host)
             for c in response.json():
                 # Test that /containers/<id> responds with expected data
-                container_id_path = 'containers/{}'.format(c)
+                container_id_path = '/containers/{}'.format(c)
                 container_response = dcos_api_session.metrics.get(container_id_path, node=agent.host)
 
                 # /containers/<container_id> should always respond succesfully
@@ -173,7 +173,7 @@ def test_metrics_containers(dcos_api_session):
                 # looking for "statsd-emitter.<some_uuid>"
                 if 'statsd-emitter' in container_response.json()['dimensions']['executor_id'].split('.'):
                     # Test that /app response is responding with expected data
-                    app_response = dcos_api_session.metrics.get('containers/{}/app'.format(c), node=agent.host)
+                    app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(c), node=agent.host)
                     assert app_response.status_code == 200
                     'got {}'.format(app_response.status_code)
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -54,13 +54,13 @@ class MarathonApp:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/apps', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/apps', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/apps/{}'.format(self.id))
         assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
         self._info = r.json()
@@ -69,8 +69,8 @@ class MarathonApp:
     def info(self, dcos_api_session):
         try:
             if self._info['app']['tasksHealthy'] != self.app['instances']:
-                raise
-        except:
+                raise Exception("Number of Healthy Tasks not equal to number of instances.")
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -90,7 +90,7 @@ class MarathonApp:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/apps/{}'.format(self.id))
 
 
 class MarathonPod:
@@ -143,14 +143,14 @@ class MarathonPod:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/pods', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/pods', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/pods/{}::status'.format(self.id))
         assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
         self._info = r.json()
@@ -160,8 +160,8 @@ class MarathonPod:
     def info(self, dcos_api_session):
         try:
             if self._info['status'] != 'STABLE':
-                raise
-        except:
+                raise Exception("The status information is not Stable!")
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -176,7 +176,7 @@ class MarathonPod:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/pods/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/pods/{}'.format(self.id))
 
 
 def unused_port():
@@ -360,7 +360,7 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, nam
                 retry_on_exception=lambda x: True)
 def test_if_overlay_ok(dcos_api_session):
     def _check_overlay(hostname, port):
-        overlays = dcos_api_session.get('overlay-agent/overlay', host=hostname, port=port).json()['overlays']
+        overlays = dcos_api_session.get('/overlay-agent/overlay', host=hostname, port=port).json()['overlays']
         assert len(overlays) > 0
         for overlay in overlays:
             assert overlay['state']['status'] == 'STATUS_OK'

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -41,8 +41,8 @@ def test_pkgpanda_api(dcos_api_session):
                 assert package == buildinfo_package
 
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        package_ids = get_and_validate_package_ids('pkgpanda/repository/', node)
-        active_package_ids = get_and_validate_package_ids('pkgpanda/active/', node)
+        package_ids = get_and_validate_package_ids('/pkgpanda/repository/', node)
+        active_package_ids = get_and_validate_package_ids('/pkgpanda/active/', node)
 
         assert set(active_package_ids) <= set(package_ids)
         assert_packages_match_active_buildinfo(active_package_ids)
@@ -64,7 +64,7 @@ NGINX_PACKAGE_REQUIREMENTS = {
 def _get_cluster_resources(dcos_api_session):
     """Return the mesos state summary
     """
-    r = dcos_api_session.get('mesos/state-summary')
+    r = dcos_api_session.get('/mesos/state-summary')
     return r.json()
 
 

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "caf020d4c247bd0286fdfee8f361b7569dd92947",
+    "ref": "c1608590e010ca08c418f8bd9d9ebd764d511d57",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

Update dcos-test-utils to the version with modified fixtures to prevent CLI timeouts. This is required to fix problems in Enterprise integration tests.

This enables a backport of DCOS-38213 in order to resolve DCOS-43687. DCOS-13496 is also applied, as it is required by the updated dcos-test-utils.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43687](https://jira.mesosphere.com/browse/DCOS-43687) DC/OS Enterprise - Test flake retry failing to download CLI.
 - [DCOS-38213](https://jira.mesosphere.com/browse/DCOS-38213) dcoscli fixture times-out while downloading CLI
  - [DCOS-13496](https://jira.mesosphere.com/browse/DCOS-13496) Enforce that paths in test handle leading slash consistently

## Related tickets (optional)

Other tickets related to this change:


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: test framework only
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
test framework only
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-test-utils](https://github.com/dcos/dcos-test-utils/compare/caf020d4c247bd0286fdfee8f361b7569dd92947...c1608590e010ca08c418f8bd9d9ebd764d511d57)
  - [x] Test Results: [https://teamcity.mesosphere.io/viewLog.html?buildId=1281183&buildTypeId=DcosIo_DcosTestUtils_ToxIntegrationTest]
  - [ ] Code Coverage (if available): [link to code coverage report]
