### PR TITLE
Allow DC/OS installer to work if there is a space in the installer's …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,4 +15,6 @@
 
 * Docker-GC will now log to journald. (COPS-4044)
 
+* Allow the DC/OS installer to be used when there is a space in its path (DCOS_OSS-4429).
+
 ### Notable changes

--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -31,7 +31,7 @@ fi
 # extract payload and load into docker if not extracted
 if [ ! -f "{genconf_tar}" ]; then
     >&2 echo Extracting image from this script and loading into docker daemon, this step can take a few minutes
-    sed '1,/^#EOF#$/d' $0 | tar xv
+    sed '1,/^#EOF#$/d' "$0" | tar xv
     >&2 docker load -i {genconf_tar}
 fi
 trap - INT


### PR DESCRIPTION
…path

## High-level description

Allow the DC/OS installer to be used when there is a space in its path.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4429](https://jira.mesosphere.com/browse/DCOS_OSS-4429) DC/OS installer does not work if there is a space in the installer's path

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I think that this is too much to ask in this case.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)