### PR TITLE
[DCOS_OSS-4491] Tag ZooKeeper metrics

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1405,6 +1405,8 @@ package:
         # tls_key = "/etc/telegraf/key.pem"
         ## If true while TLS is enabled skip chain & host verification
         # insecure_skip_verify = true
+        [inputs.zookeeper.tags]
+          dcos-component-name = "ZooKeeper"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -73,7 +73,7 @@ def test_metrics_masters_mesos(dcos_api_session):
 def test_metrics_masters_zookeeper(dcos_api_session):
     """Assert that ZooKeeper metrics on masters are present."""
     for master in dcos_api_session.masters:
-        get_metrics_prom(dcos_api_session, master, ['zookeeper_'])
+        get_metrics_prom(dcos_api_session, master, ['ZooKeeper', 'zookeeper_avg_latency'])
 
 
 def test_metrics_agents_statsd(dcos_api_session):


### PR DESCRIPTION
## High-level description

This adds consistent tagging among DC/OS components to metrics emitted by the ZooKeeper Telegraf plugin.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4491](https://jira.mesosphere.com/browse/DCOS_OSS-4491) Tag ZooKeeper metrics according to our Documentation.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: No functional change.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)