### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 742471c

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "2f1fb59b0c20959c0dbd4f0b98b13cee08b56633",
+    "ref": "9d5cc18a2065864350c23ad56f1c4caa2ae308c5",
     "ref_origin": "1.11"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "6008868c715733b7d798279e9b39ae3483f7d955",
+    "ref": "742471c575f9959f3ea9ffe7b6a317a033bfb42d",
     "ref_origin": "1.5.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/6008868c715733b7d798279e9b39ae3483f7d955...742471c575f9959f3ea9ffe7b6a317a033bfb42d
    https://github.com/dcos/dcos-mesos-modules/compare/2f1fb59b0c20959c0dbd4f0b98b13cee08b56633...9d5cc18a2065864350c23ad56f1c4caa2ae308c5
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
