### PR TITLE
[master] Bump Mesos to nightly master 49cab93

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "22fa5aeac19416fd0c7c2284a1e48a5ee15bdd24",
+    "ref": "49cab93b565d250fd7e88cd8bb9cd49abbdd7da4",
     "ref_origin": "master"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "22fa5aeac19416fd0c7c2284a1e48a5ee15bdd24",
+    "ref": "49cab93b565d250fd7e88cd8bb9cd49abbdd7da4",
     "ref_origin": "master"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

[DCOS-43593](https://jira.mesosphere.com/browse/DCOS-43593) - Some Mesos master endpoints do not handle failed authorization properly.

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/22fa5aeac19416fd0c7c2284a1e48a5ee15bdd24...49cab93b565d250fd7e88cd8bb9cd49abbdd7da4
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
