### PR TITLE
Patched dc/os for sandbox permission change issue from Mesos 1.6.0.

### DIFF
--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,4 +1,4 @@
-From 4a0db79c145c482ad941252b56a8a65653c9bdd3 Mon Sep 17 00:00:00 2001
+From 4f836121f505c803bb478d3eb1c794ee5a46ebc0 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
 Subject: [PATCH] Set LIBPROCESS_IP into docker container.
@@ -8,7 +8,7 @@ Subject: [PATCH] Set LIBPROCESS_IP into docker container.
  1 file changed, 5 insertions(+)
 
 diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
-index 9ebb5f274..3c81d03b6 100644
+index 9ebb5f2..3c81d03 100644
 --- a/src/docker/docker.cpp
 +++ b/src/docker/docker.cpp
 @@ -681,6 +681,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
@@ -24,5 +24,5 @@ index 9ebb5f274..3c81d03b6 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,4 +1,4 @@
-From 437fb8a083f0f83770b4ee3e5f8040f8050c9579 Mon Sep 17 00:00:00 2001
+From 49e7e73427c924804d20bba31039ba70310bcc1e Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
 Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
@@ -23,7 +23,7 @@ by https://reviews.apache.org/r/62472/
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 03a4e0f15..7fc27ba5f 100644
+index a5cf2da..4b2e8a9 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -449,8 +449,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -51,5 +51,5 @@ index 03a4e0f15..7fc27ba5f 100644
  
    // Next, apply any custom isolators in the order given by the flags.
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,4 +1,4 @@
-From bab10ddade663b651dd254c0f15ffc129bf38eb9 Mon Sep 17 00:00:00 2001
+From df7c7325d5d0f7480083fd7354cd927ef99bebd6 Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
 Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
@@ -13,7 +13,7 @@ Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
  1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/src/webui/app/controllers.js b/src/webui/app/controllers.js
-index 8049cf611..74f65f574 100644
+index 8049cf6..74f65f5 100644
 --- a/src/webui/app/controllers.js
 +++ b/src/webui/app/controllers.js
 @@ -51,10 +51,10 @@
@@ -61,5 +61,5 @@ index 8049cf611..74f65f574 100644
  
      // Adding bindings into scope so that they can be used from within
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0004-Revert-Removed-long-ago-deprecated-endpoints.patch
+++ b/packages/mesos/extra/patches/0004-Revert-Removed-long-ago-deprecated-endpoints.patch
@@ -1,4 +1,4 @@
-From 6e0bffb1c1655379da85100e982027258b16612f Mon Sep 17 00:00:00 2001
+From 458f4916a40c311c85ac56f429640a0ad570f6dd Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Tue, 21 Aug 2018 17:59:27 +0200
 Subject: [PATCH] Revert "Removed long ago deprecated endpoints.".
@@ -18,7 +18,7 @@ aka 1.8.0-dev will not have deprecated endpoints.
  3 files changed, 73 insertions(+)
 
 diff --git a/src/files/files.cpp b/src/files/files.cpp
-index f200d5e79..a64613cf6 100644
+index f200d5e..a64613c 100644
 --- a/src/files/files.cpp
 +++ b/src/files/files.cpp
 @@ -222,6 +222,25 @@ FilesProcess::FilesProcess(
@@ -48,10 +48,10 @@ index f200d5e79..a64613cf6 100644
            authenticationRealm,
            FilesProcess::BROWSE_HELP,
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index f88c7c1f0..7b63f4023 100644
+index b4b02d8..1e9ddde 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -947,6 +947,16 @@ void Master::initialize()
+@@ -948,6 +948,16 @@ void Master::initialize()
            logRequest(request);
            return http.reserve(request, principal);
          });
@@ -68,7 +68,7 @@ index f88c7c1f0..7b63f4023 100644
    route("/roles",
          READONLY_HTTP_AUTHENTICATION_REALM,
          Http::ROLES_HELP(),
-@@ -974,6 +984,19 @@ void Master::initialize()
+@@ -975,6 +985,19 @@ void Master::initialize()
                logResponse(request, response);
              });
          });
@@ -88,7 +88,7 @@ index f88c7c1f0..7b63f4023 100644
    route("/state",
          READONLY_HTTP_AUTHENTICATION_REALM,
          Http::STATE_HELP(),
-@@ -996,6 +1019,16 @@ void Master::initialize()
+@@ -997,6 +1020,16 @@ void Master::initialize()
                logResponse(request, response);
              });
          });
@@ -106,10 +106,10 @@ index f88c7c1f0..7b63f4023 100644
          READONLY_HTTP_AUTHENTICATION_REALM,
          Http::TASKS_HELP(),
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 74f6fb903..523b271e0 100644
+index 858b786..d32f74b 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
-@@ -792,6 +792,17 @@ void Slave::initialize()
+@@ -793,6 +793,17 @@ void Slave::initialize()
  
          return resourceProviderManager->api(request, principal);
        });
@@ -127,7 +127,7 @@ index 74f6fb903..523b271e0 100644
    route("/state",
          READONLY_HTTP_AUTHENTICATION_REALM,
          Http::STATE_HELP(),
-@@ -824,6 +835,16 @@ void Slave::initialize()
+@@ -825,6 +836,16 @@ void Slave::initialize()
            logRequest(request);
            return http.statistics(request, principal);
          });
@@ -145,5 +145,5 @@ index 74f6fb903..523b271e0 100644
          READONLY_HTTP_AUTHENTICATION_REALM,
          Http::CONTAINERS_HELP(),
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0005-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
+++ b/packages/mesos/extra/patches/0005-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
@@ -1,0 +1,45 @@
+From d2ee1b4542232042dd6fa532484f2082f96c0163 Mon Sep 17 00:00:00 2001
+From: Gilbert Song <songzihao1990@gmail.com>
+Date: Fri, 23 Nov 2018 10:54:58 +0800
+Subject: [PATCH] Changed sandbox mode to 0755 in docker containerizer
+ container launch.
+
+Starting from Mesos 1.6.0, sandbox permission was changed from 0755
+to 0750 to narrow access from non-task users. This is a semantic
+change for docker containerizer launched container which honors a
+default user from the docker image. See MESOS-8332 and DCOS_OSS-4415
+for details.
+
+This commit is used to patch DC/OS and allows DC/OS users to have a
+deprecation cycle for this semantic change. This commit should be
+removed in DC/OS 1.15.
+---
+ src/slave/containerizer/docker.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/slave/containerizer/docker.cpp b/src/slave/containerizer/docker.cpp
+index fc29e20..6f52150 100644
+--- a/src/slave/containerizer/docker.cpp
++++ b/src/slave/containerizer/docker.cpp
+@@ -1167,6 +1167,18 @@ Future<Containerizer::LaunchResult> DockerContainerizerProcess::launch(
+     return Containerizer::LaunchResult::NOT_SUPPORTED;
+   }
+ 
++  // TODO(gilbert): This is a patch for DC/OS, in order to work
++  // around the sandbox permission change in Mesos 1.6.0, which
++  // is not backward compatible in DC/OS. Please see MESOS-8332
++  // and DCOS_OSS-4415 for details. Remove this workaround after
++  // a deprecation cycle in DC/OS 1.15.
++  Try<Nothing> chmod = os::chmod(containerConfig.directory(), 0755);
++  if (chmod.isError()) {
++    return Failure(
++        "Failed to chmod directory '" + containerConfig.directory() +
++        "': " + chmod.error());
++  }
++
+   Try<Container*> container = Container::create(
+       containerId,
+       containerConfig,
+-- 
+2.5.1
+


### PR DESCRIPTION
## High-level description

From Mesos 1.6.0, the sandbox mode was changed from 0755 to 0750,
which is not backward compatible in dc/os. Please see DCOS_OSS-4415
for details.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4415](https://jira.mesosphere.com/browse/DCOS_OSS-4415) Container launched by Docker cotnainerizer changed the sandbox mode from 0755 yo 0750 in dc/os 1.12.


## Related tickets (optional)

This issue was caused by:

  - [MESOS-8332](https://issues.apache.org/jira/browse/MESOS-8332) Narrow the container sandbox permissions.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
