### PR TITLE
Collect CockroachDB metrics via Telegraf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
+* CockroachDB metrics are now collected by Telegraf (DCOS_OSS-4529).
+
+* ZooKeeper metrics are now collected by Telegraf (DCOS_OSS-4477).
+
 * Mesos metrics are now available by default. (DCOS_OSS-3815)
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1432,6 +1432,20 @@ package:
         # insecure_skip_verify = true
         [inputs.zookeeper.tags]
           dcos-component-name = "ZooKeeper"
+      # Reads metrics from CockroachDB's prometheus client
+      [[inputs.prometheus]]
+        ## An array of urls to scrape metrics from.
+        urls = ["http://localhost:8090/_status/vars"]
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
+        ## Optional TLS Config
+        # tls_ca = /path/to/cafile
+        # tls_cert = /path/to/certfile
+        # tls_key = /path/to/keyfile
+        ## Use TLS but skip chain & host verification
+        # insecure_skip_verify = true
+        [inputs.prometheus.tags]
+          dcos-component-name = "CockroachDB"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"

--- a/packages/dcos-integration-test/buildinfo.json
+++ b/packages/dcos-integration-test/buildinfo.json
@@ -3,5 +3,6 @@
       "dcos-image-deps",
       "dcos-test-utils",
       "pytest",
-      "python"]
+      "python",
+      "python-requests"]
 }

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -6,7 +6,7 @@ import retrying
 from test_helpers import expanded_config
 
 
-__maintainer__ = 'mnaboka'
+__maintainer__ = 'philipnrmn'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
@@ -38,12 +38,14 @@ def test_metrics_masters_ping(dcos_api_session):
 
 
 def test_metrics_agents_prom(dcos_api_session):
+    """Telegraf Prometheus endpoint is reachable on all agents."""
     for agent in dcos_api_session.slaves:
         response = dcos_api_session.session.request('GET', 'http://' + agent + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
 
 
 def test_metrics_masters_prom(dcos_api_session):
+    """Telegraf Prometheus endpoint is reachable on all masters."""
     for master in dcos_api_session.masters:
         response = dcos_api_session.session.request('GET', 'http://' + master + ':61091/metrics')
         assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
@@ -92,6 +94,19 @@ def test_metrics_masters_zookeeper(dcos_api_session):
             for metric_name in expected_metrics:
                 assert metric_name in response.text
         check_zookeeper_metrics()
+
+
+def test_metrics_masters_cockroachdb(dcos_api_session):
+    """Assert that CockroachDB metrics on masters are present."""
+    for master in dcos_api_session.masters:
+        expected_metrics = ['CockroachDB', 'ranges_underreplicated']
+
+        @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+        def check_cockroachdb_metrics():
+            response = get_metrics_prom(dcos_api_session, master)
+            for metric_name in expected_metrics:
+                assert metric_name in response.text
+        check_cockroachdb_metrics()
 
 
 def test_metrics_agents_statsd(dcos_api_session):


### PR DESCRIPTION
## High-level description

This PR adds collection of CockroachDB metrics to DC/OS OSS. It also refactors and moves corresponding metrics tests over from Enterprise.

It also adds back the changelog entry for ZooKeeper metrics being collected which was swallowed by force-pushing over the corresponding PR back when it was added.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4529](https://jira.mesosphere.com/browse/DCOS_OSS-4529) Collect CockroachDB metrics via Telegraf.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)