### PR TITLE
[Backport][1.11] bump dcos-net for fix for docker services in bridge/container mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
 
 * Minuteman routes traffic until the first failed health check (DCOS_OSS-1954)
 
+* Docker container unable to curl its own VIP (DCOS-45115)
+
 
 ### Security Updates
 

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "ed7e4e5d7c29fa74eb72ed52f685e31c2756dac9",
+      "ref": "221c50e1e27f1dc5ddbcc1e08bc57f0a29fcd22e",
       "ref_origin": "1.11.x"
     }
   },


### PR DESCRIPTION
## High-level description

In case of docker containerizer if the backend to a VIP is the
actual container ip then the application running in the container
cannot access its own VIP. The only way to make it work is to go
through port mapping. This patch fixes the port mapping such that
the backend is the host IP:port intead of container ip:port

jira: DCOS-45115


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_45115](https://jira.mesosphere.com/browse/DCOS-45115) COPS-4087: Docker container unable to curl its own VIP

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-net/compare/ed7e4e5d7c29fa74eb72ed52f685e31c2756dac9...221c50e1e27f1dc5ddbcc1e08bc57f0a29fcd22e
  - [x] Test Results: https://circleci.com/gh/dcos/dcos-net/767
  - [x] Code Coverage https://codecov.io/gh/dcos/dcos-net/pull/103
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
