### PR TITLE
DCOS 1.11 Marathon Bump 1.6.567

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ### Notable changes
 
-* Updated to [Marathon 1.6.564](https://github.com/mesosphere/marathon/tree/3fa693b32).
+* Updated to [Marathon 1.6.567](https://github.com/mesosphere/marathon/tree/2d8b3e438ffcc536ccf8b1ea9cb0b39bb3ef4e10).
 
 * Updated to [DC/OS UI 1.11+v1.24.0](https://github.com/dcos/dcos-ui/blob/1.11+v1.24.0/CHANGELOG.md)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.564-3fa693b32/marathon-1.6.564-3fa693b32.tgz",
-    "sha1": "d87fc13bff1f560e76f53b2205d9583566fddb8e"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.6.567-2d8b3e438/marathon-1.6.567-2d8b3e438.tgz",
+    "sha1": "59c2dba8c8b29ffba774bdb75dee8518632b71e6"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8317](https://jira.mesosphere.com/browse/MARATHON-8317) Marathon Bump 1.6 on DCOS 1.11.


## Related tickets (optional)

Other tickets related to this change:

  - [MARATHON-8493](https://jira.mesosphere.com/browse/MARATHON-8493) Incorrect handling of double precision for pods.
 - [MARATHON-8498](https://jira.mesosphere.com/browse/MARATHON-8498) Remove validation for app updates and validate the whole app instead
 - [COPS-3764](https://jira.mesosphere.com/browse/COPS-3764) MarathonUI JSON editor secrets validation fails on an update


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/047f697366fe381efcadc4d5828563fd26bf3fde...2d8b3e438ffcc536ccf8b1ea9cb0b39bb3ef4e10)
  - [x] Test Results: [ci](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/releases%252F1.6/38/)
  - [x] Code Coverage (if available): N/A
