### PR TITLE
bump metronome 0.4.5 on dcos 1.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Updated to [DC/OS UI 1.11+v1.24.0](https://github.com/dcos/dcos-ui/blob/1.11+v1.24.0/CHANGELOG.md)
 
+* Update to [Metronome 0.4.5](https://github.com/dcos/metronome/tree/8d6c6b9cd7ab6f88d70cfff5f4d10f29b81d0a6b)
+
 ### Fixed and improved
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
@@ -24,6 +26,9 @@
 * dcos-net continously restarting systemd-networkd on a bare-metal server with bond interfaces (DCOS_OSS-4398)
 
 * Minuteman routes traffic until the first failed health check (DCOS_OSS-1954)
+
+* [DCOS_OSS-3616](https://jira.mesosphere.com/browse/DCOS_OSS-3616) Metronome is hoarding offers.
+* [DCOS_OSS-2535](https://jira.mesosphere.com/browse/DCOS_OSS-2535) Info endpoint shows incorrect version of Metronome.
 
 
 ### Security Updates

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.4/metronome-0.4.4.tgz",
-    "sha1": "646ee466175bc5f2a54a9d40c270b1c13d4bcfd4"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.4.5-8d6c6b9/metronome-0.4.5.tgz",
+    "sha1": "c341b338b9c59e192ba03e59f7040225e396a9b3"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45564](https://jira.mesosphere.com/browse/DCOS-45564) Metronome Bump on DCOS 1.11


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-3616](https://jira.mesosphere.com/browse/DCOS_OSS-3616) Metronome is hoarding offers.
- [DCOS_OSS-2535](https://jira.mesosphere.com/browse/DCOS_OSS-2535) Info endpoint shows incorrect version of Metronome.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/3f93ab11e289f76b7f88fff714ed66c8edc32c37...8d6c6b9cd7ab6f88d70cfff5f4d10f29b81d0a6b)
  - [x] Test Results: [test](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/metronome-release/66)
  - [x] Code Coverage (if available): N/A
