### PR TITLE
[1.12] Patched dc/os for sandbox permission change issue from Mesos 1.6.0.

### DIFF
--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,14 +1,14 @@
-From ddf0dd12b54acc1c84688825c8edd024315cd2a7 Mon Sep 17 00:00:00 2001
+From 1d42473000a95d0d154dbf06f6a348b7d0a459de Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH 1/4] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
-index 9ebb5f274..3c81d03b6 100644
+index 9ebb5f2..3c81d03 100644
 --- a/src/docker/docker.cpp
 +++ b/src/docker/docker.cpp
 @@ -681,6 +681,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
@@ -24,5 +24,5 @@ index 9ebb5f274..3c81d03b6 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From 6c409dd626f67b64388736257c7289a5166fd998 Mon Sep 17 00:00:00 2001
+From c1cdf772c94a659a25f2cafaf2bb9295e97aaf44 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH 2/4] Updated mesos containerizer to ignore GPU isolator
- creation failure.
+Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
+ failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -23,7 +23,7 @@ by https://reviews.apache.org/r/62472/
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 6c2700053..e938c92b3 100644
+index 2345193..6d45285 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -447,8 +447,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -51,5 +51,5 @@ index 6c2700053..e938c92b3 100644
  
    // Next, apply any custom isolators in the order given by the flags.
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,7 +1,7 @@
-From a3f2f8b2c9c1b646a908d0d366dd12fd1d401471 Mon Sep 17 00:00:00 2001
+From a4b30d59d37dba9fa787403bbdeba9277a1f454c Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
-Subject: [PATCH 3/4] Mesos UI: updated the URL generation to make it work with
+Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
  adminrouter.
 
 - Use /mesos as the leading master URL prefix.
@@ -13,7 +13,7 @@ Subject: [PATCH 3/4] Mesos UI: updated the URL generation to make it work with
  1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/src/webui/app/controllers.js b/src/webui/app/controllers.js
-index 8049cf611..74f65f574 100644
+index 8049cf6..74f65f5 100644
 --- a/src/webui/app/controllers.js
 +++ b/src/webui/app/controllers.js
 @@ -51,10 +51,10 @@
@@ -61,5 +61,5 @@ index 8049cf611..74f65f574 100644
  
      // Adding bindings into scope so that they can be used from within
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,4 +1,4 @@
-From df6b1cae4baedbd592cfb08b072c8b4f4c071403 Mon Sep 17 00:00:00 2001
+From 6cebdf98f9de229e088e0756213b45a95c11b7e7 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Mon, 13 Aug 2018 20:05:26 +0200
 Subject: [PATCH] Added 'received' timestamp into `process::Request`.
@@ -13,7 +13,7 @@ Review: https://reviews.apache.org/r/68992
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/3rdparty/libprocess/include/process/http.hpp b/3rdparty/libprocess/include/process/http.hpp
-index fa66b0fe2..a1b0bb9e3 100644
+index fa66b0f..a1b0bb9 100644
 --- a/3rdparty/libprocess/include/process/http.hpp
 +++ b/3rdparty/libprocess/include/process/http.hpp
 @@ -27,6 +27,7 @@
@@ -43,5 +43,5 @@ index fa66b0fe2..a1b0bb9e3 100644
     * Returns whether the encoding is considered acceptable in the
     * response. See RFC 2616 section 14.3 for details.
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,8 +1,7 @@
-From 30bd18967971f9a4fb87ed5ab2b6dec6cc6f6e79 Mon Sep 17 00:00:00 2001
+From c4c26879fc0e515f424e7103a1976911410d3a9e Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Mon, 29 Oct 2018 11:25:58 -0700
-Subject: [PATCH 4/4] Added task health check definitions to master API
- responses.
+Subject: [PATCH] Added task health check definitions to master API responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified, along with associated
@@ -19,7 +18,7 @@ Review: https://reviews.apache.org/r/69110/
  4 files changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
-index 5a985fca3..81029b885 100644
+index 5a985fc..81029b8 100644
 --- a/include/mesos/mesos.proto
 +++ b/include/mesos/mesos.proto
 @@ -2165,8 +2165,8 @@ message TaskGroupInfo {
@@ -45,7 +44,7 @@ index 5a985fca3..81029b885 100644
    optional string user = 14;
  }
 diff --git a/include/mesos/v1/mesos.proto b/include/mesos/v1/mesos.proto
-index a5ebb786a..637552611 100644
+index a5ebb78..6375526 100644
 --- a/include/mesos/v1/mesos.proto
 +++ b/include/mesos/v1/mesos.proto
 @@ -2158,8 +2158,8 @@ message TaskGroupInfo {
@@ -71,7 +70,7 @@ index a5ebb786a..637552611 100644
    optional string user = 14;
  }
 diff --git a/src/common/http.cpp b/src/common/http.cpp
-index 932111dde..81102d845 100644
+index 932111d..81102d8 100644
 --- a/src/common/http.cpp
 +++ b/src/common/http.cpp
 @@ -733,6 +733,10 @@ void json(JSON::ObjectWriter* writer, const Task& task)
@@ -86,7 +85,7 @@ index 932111dde..81102d845 100644
  
  
 diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
-index 77139d8a3..2ae37ac61 100644
+index 77139d8..2ae37ac 100644
 --- a/src/common/protobuf_utils.cpp
 +++ b/src/common/protobuf_utils.cpp
 @@ -341,6 +341,10 @@ Task createTask(
@@ -101,5 +100,5 @@ index 77139d8a3..2ae37ac61 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
@@ -1,4 +1,4 @@
-From 92ce192274ab8e0670785cc2012e9c56e4bb0ac2 Mon Sep 17 00:00:00 2001
+From 1d6f506f13f9b111b31ecef23c98556a0e78373e Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:40:37 +0200
 Subject: [PATCH] Introduced `logResponse` for http handlers.
@@ -21,7 +21,7 @@ Review: https://reviews.apache.org/r/68993
  2 files changed, 26 insertions(+)
 
 diff --git a/src/common/http.cpp b/src/common/http.cpp
-index 932111dde..4d6f5301b 100644
+index 81102d8..50c9b55 100644
 --- a/src/common/http.cpp
 +++ b/src/common/http.cpp
 @@ -32,6 +32,7 @@
@@ -32,7 +32,7 @@ index 932111dde..4d6f5301b 100644
  #include <process/collect.hpp>
  #include <process/dispatch.hpp>
  #include <process/future.hpp>
-@@ -1126,4 +1127,18 @@ void logRequest(const process::http::Request& request)
+@@ -1130,4 +1131,18 @@ void logRequest(const process::http::Request& request)
                  : "");
  }
  
@@ -52,7 +52,7 @@ index 932111dde..4d6f5301b 100644
 +
  }  // namespace mesos {
 diff --git a/src/common/http.hpp b/src/common/http.hpp
-index 0901a5528..cc7f747d1 100644
+index 0901a55..cc7f747 100644
 --- a/src/common/http.hpp
 +++ b/src/common/http.hpp
 @@ -338,6 +338,17 @@ Try<Nothing> initializeHttpAuthenticators(
@@ -74,5 +74,5 @@ index 0901a5528..cc7f747d1 100644
  
  #endif // __COMMON_HTTP_HPP__
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,4 +1,4 @@
-From c142ba1a70f1ad36bfa108bb40d2b8576fd2ae04 Mon Sep 17 00:00:00 2001
+From e6093638d6db2bd478d1c574b5a8c150fce69de6 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:58:41 +0200
 Subject: [PATCH] Logged request processing time for some endpoints.
@@ -21,7 +21,7 @@ Review: https://reviews.apache.org/r/68994
  2 files changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 6237d9246..84f9db047 100644
+index 84add3e..5d13d89 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -909,7 +909,10 @@ void Master::initialize()
@@ -85,7 +85,7 @@ index 6237d9246..84f9db047 100644
    route("/maintenance/schedule",
          READWRITE_HTTP_AUTHENTICATION_REALM,
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 7425cfbae..01fd4eedf 100644
+index 7425cfb..01fd4ee 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -809,7 +809,10 @@ void Slave::initialize()
@@ -113,5 +113,5 @@ index 7425cfbae..01fd4eedf 100644
  
    const PID<Slave> slavePid = self();
 -- 
-2.16.3
+2.5.1
 

--- a/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
+++ b/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
@@ -1,0 +1,47 @@
+From 3a4a769488a8e6c01dffcc1dc897266f7b204950 Mon Sep 17 00:00:00 2001
+From: Gilbert Song <songzihao1990@gmail.com>
+Date: Fri, 23 Nov 2018 10:54:58 +0800
+Subject: [PATCH] Changed sandbox mode to 0755 in docker containerizer
+ container launch.
+
+Starting from Mesos 1.6.0, sandbox permission was changed from 0755
+to 0750 to narrow access from non-task users. This is a semantic
+change for docker containerizer launched container which honors a
+default user from the docker image. See MESOS-8332 and DCOS_OSS-4415
+for details.
+
+This commit is used to patch DC/OS and allows DC/OS users to have a
+deprecation cycle for this semantic change. This commit should be
+removed in DC/OS 1.15.
+
+(cherry picked from commit d2ee1b4542232042dd6fa532484f2082f96c0163)
+---
+ src/slave/containerizer/docker.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/slave/containerizer/docker.cpp b/src/slave/containerizer/docker.cpp
+index 192dc29..7c3575a 100644
+--- a/src/slave/containerizer/docker.cpp
++++ b/src/slave/containerizer/docker.cpp
+@@ -1176,6 +1176,18 @@ Future<Containerizer::LaunchResult> DockerContainerizerProcess::launch(
+     return Containerizer::LaunchResult::NOT_SUPPORTED;
+   }
+ 
++  // TODO(gilbert): This is a patch for DC/OS, in order to work
++  // around the sandbox permission change in Mesos 1.6.0, which
++  // is not backward compatible in DC/OS. Please see MESOS-8332
++  // and DCOS_OSS-4415 for details. Remove this workaround after
++  // a deprecation cycle in DC/OS 1.15.
++  Try<Nothing> chmod = os::chmod(containerConfig.directory(), 0755);
++  if (chmod.isError()) {
++    return Failure(
++        "Failed to chmod directory '" + containerConfig.directory() +
++        "': " + chmod.error());
++  }
++
+   Try<Container*> container = Container::create(
+       containerId,
+       containerConfig,
+-- 
+2.5.1
+


### PR DESCRIPTION
## High-level description

From Mesos 1.6.0, the sandbox mode was changed from 0755 to 0750,
which is not backward compatible in dc/os. Please see DCOS_OSS-4415
for details.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4415](https://jira.mesosphere.com/browse/DCOS_OSS-4415) Container launched by Docker cotnainerizer changed the sandbox mode from 0755 yo 0750 in dc/os 1.12.

## Related tickets (optional)

This issue was caused by:
  - [MESOS-8332](https://issues.apache.org/jira/browse/MESOS-8332) Narrow the container sandbox permissions.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [CI test](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Mesos_CI-build/4980/)
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
