### PR TITLE
dcos-integration-test/conftest.py: clean_marathon_state cleans groups

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -69,8 +69,16 @@ def pytest_collection_modifyitems(session, config, items):
 @pytest.fixture(autouse=True)
 def clean_marathon_state(dcos_api_session):
     dcos_api_session.marathon.purge()
+    dcos_api_session.marathon.delete(
+        '/v2/groups/',
+        params={'force': True},
+    )
     yield
     dcos_api_session.marathon.purge()
+    dcos_api_session.marathon.delete(
+        '/v2/groups/',
+        params={'force': True},
+    )
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Clean marathon groups as part of `clean_marathon_state`. Some tests, notably `test_vip`, does not remove marathon groups after running.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: The integration tests in group2 fail without this due to some tests asserting that the environment is clean.
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___