### PR TITLE
(1.11) Fix dcos-metrics Prometheus producer omitting some metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ### Fixed and improved
 
+* Fixed a bug that caused the Prometheus exporter to omit some metrics. (DCOS_OSS-3863)
+
 * Docker-GC will now log to journald. (COPS-4044)
 
 * Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,8 +3,9 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "c7327ad31961e4845ffcfac119352928f1321304",
+    "ref": "033c3f4c51b06c14a3e204274b3ffc06c0edad38",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"
 }
+


### PR DESCRIPTION
## High-level description

This fixes a bug in dcos-metrics that could cause its Prometheus producer (exporter) to omit some metric data in responses. See the upstream PR at https://github.com/dcos/dcos-metrics/pull/168 for more information on the bug and its fix.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3863](https://jira.mesosphere.com/browse/DCOS_OSS-3863) agent metrics prometheus endpoint does not show all containers running on this agent


## Related tickets (optional)

Other tickets related to this change:

N/A


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This bug is internal to dcos-metrics; its cause isn't related to other DC/OS components or configuration. The fix is covered by a Prometheus producer test added in the upstream dcos-metrics PR. See https://github.com/dcos/dcos-metrics/pull/168/files#diff-2caadd9cf74f55ff0ae58fa5d34872e7R97.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-metrics/compare/c7327ad31961e4845ffcfac119352928f1321304...033c3f4c51b06c14a3e204274b3ffc06c0edad38
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/14/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/dcos-metrics/job/dcos-metrics-branch/14/)