### PR TITLE
dcos-test-utils: bump for better Marathon group cleanup

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -66,11 +66,19 @@ def pytest_collection_modifyitems(session, config, items):
     items[:] = new_items + last_items
 
 
+# Note(JP): Attempt to reset Marathon state before and after every
+# test run in this test suite. This is a brute force approach but
+# we found that the problem of side effects as of too careless
+# test isolation and resource cleanup became too large.
 @pytest.fixture(autouse=True)
 def clean_marathon_state(dcos_api_session):
     dcos_api_session.marathon.purge()
-    yield
-    dcos_api_session.marathon.purge()
+    try:
+        yield
+    finally:
+        # This is in `finally:` so that we attempt to clean up
+        # Marathon state especially when the test code failed.
+        dcos_api_session.marathon.purge()
 
 
 @pytest.fixture(scope='session')

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "713dea062ffddf1a8ec14f95dad84700349c8859",
+    "ref": "1286f4b86faadc75a7c4fd9f3bfdab1cf16f041a",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
This bumps dcos-test-utils for a better cleanup of the Marathon state between tests in the DC/OS Integration test suite.

Specifically, this brings this patch: https://github.com/dcos/dcos-test-utils/pull/69/files

To be sure: https://github.com/dcos/dcos-test-utils/compare/713dea0...1286f4b86faadc75

