### PR TITLE
Add xfailflake pytest markers to skip tests.

### DIFF
--- a/packages/dcos-integration-test/extra/common.py
+++ b/packages/dcos-integration-test/extra/common.py
@@ -1,5 +1,4 @@
 import pytest
-
 # Mute Flaky Integration Tests with custom pytest marker.
 # Rationale for doing this is mentioned at DCOS-45308
 xfailflake = pytest.mark.xfail(strict=False)

--- a/packages/dcos-integration-test/extra/common.py
+++ b/packages/dcos-integration-test/extra/common.py
@@ -1,0 +1,5 @@
+import pytest
+
+# Mute Flaky Integration Tests with custom pytest marker.
+# Rationale for doing this is mentioned at DCOS-45308
+xfailflake = pytest.mark.xfail(strict=False)

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -3,9 +3,14 @@ import logging
 import re
 import uuid
 
+import common
 import pytest
 import requests
 import retrying
+
+
+__maintainer__ = 'mnaboka'
+__contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 log = logging.getLogger(__name__)
 

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -43,6 +43,7 @@ def check_response_ok(response: requests.models.Response, headers: dict):
             'Request {} header {} must be {}. All headers {}'.format(response.url, name, value, response.headers))
 
 
+@common.xfailflake(reason="DCOS_OSS-4416 - dcos-log returns more lines than requested limit")
 def test_log_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
         response = dcos_api_session.logs.get('/v1/range/?limit=10', node=node)

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -103,6 +103,7 @@ def test_metrics_node(dcos_api_session):
         assert expected_dimension_response(response.json())
 
 
+@common.xfailflake(reason="DCOS_OSS-4486 - tgest_metrics_containers fails with container metrics response status 204")
 def test_metrics_containers(dcos_api_session):
     """If there's a deployed container on the slave, iterate through them to check for
     the statsd-emitter executor. When found, query it's /app endpoint to test that

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,3 +1,4 @@
+import common
 import retrying
 
 


### PR DESCRIPTION
## High-level description

### DCOS-45308 - Muting flakes using xfailflake custom marker. #3795

Backport of https://github.com/dcos/dcos/pull/3795