### PR TITLE
Collect Vault metrics via Telegraf

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1355,6 +1355,34 @@ package:
       [[inputs.processes]]
       # Read metrics about system load & uptime
       [[inputs.system]]
+      # Configuration for the Prometheus client to spawn
+      [[outputs.prometheus_client]]
+        ## Address to listen on
+        listen = ":61091"
+  - path: /etc_master/telegraf/telegraf.d/master.conf
+    content: |
+      # Additional Telegraf config for masters
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        # A list of Mesos masters.
+        masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
+        # Master metrics groups to be collected.
+        master_collections = [
+          "resources",
+          "master",
+          "agents",
+          "frameworks",
+          "framework_offers",
+          "tasks",
+          "messages",
+          "evqueue",
+          "registrar",
+          "allocator",
+       ]
       # Statsd UDP/TCP Server
       [[inputs.statsd]]
         ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
@@ -1386,34 +1414,6 @@ package:
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
         percentile_limit = 1000
-      # Configuration for the Prometheus client to spawn
-      [[outputs.prometheus_client]]
-        ## Address to listen on
-        listen = ":61091"
-  - path: /etc_master/telegraf/telegraf.d/master.conf
-    content: |
-      # Additional Telegraf config for masters
-      # Telegraf plugin for gathering metrics from mesos
-      [[inputs.mesos]]
-        # The interval at which to collect metrics
-        interval = "60s"
-        # Timeout, in ms.
-        timeout = 30000
-        # A list of Mesos masters.
-        masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
-        # Master metrics groups to be collected.
-        master_collections = [
-          "resources",
-          "master",
-          "agents",
-          "frameworks",
-          "framework_offers",
-          "tasks",
-          "messages",
-          "evqueue",
-          "registrar",
-          "allocator",
-       ]
       # Reads 'mntr' health checks from one or many zookeeper servers
       [[inputs.zookeeper]]
         ## An array of addresses to gather stats about. Specify an ip or hostname
@@ -1478,6 +1478,37 @@ package:
           "tasks",
           "messages",
         ]
+      # Statsd UDP/TCP Server
+      [[inputs.statsd]]
+        ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
+        protocol = "udp"
+        ## Address and port to host UDP listener on
+        service_address = "localhost:61825"
+        ## The following configuration options control when telegraf clears it's cache
+        ## of previous values. If set to false, then telegraf will only clear it's
+        ## cache when the daemon is restarted.
+        ## Reset gauges every interval (default=true)
+        delete_gauges = true
+        ## Reset counters every interval (default=true)
+        delete_counters = true
+        ## Reset sets every interval (default=true)
+        delete_sets = true
+        ## Reset timings & histograms every interval (default=true)
+        delete_timings = true
+        ## Percentiles to calculate for timing & histogram stats
+        percentiles = [90]
+        ## separator to use between elements of a statsd metric
+        metric_separator = "_"
+        ## Parses tags in the datadog statsd format
+        ## http://docs.datadoghq.com/guides/dogstatsd/
+        parse_data_dog_tags = false
+        ## Number of UDP messages allowed to queue up, once filled,
+        ## the statsd server will start dropping packets
+        allowed_pending_messages = 10000
+        ## Number of timing/histogram values to track per-measurement in the
+        ## calculation of percentiles. Raising this limit increases the accuracy
+        ## of percentiles but also increases the memory usage and cpu time.
+        percentile_limit = 1000
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1532,6 +1563,37 @@ package:
           "tasks",
           "messages",
         ]
+      # Statsd UDP/TCP Server
+      [[inputs.statsd]]
+        ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
+        protocol = "udp"
+        ## Address and port to host UDP listener on
+        service_address = "localhost:61825"
+        ## The following configuration options control when telegraf clears it's cache
+        ## of previous values. If set to false, then telegraf will only clear it's
+        ## cache when the daemon is restarted.
+        ## Reset gauges every interval (default=true)
+        delete_gauges = true
+        ## Reset counters every interval (default=true)
+        delete_counters = true
+        ## Reset sets every interval (default=true)
+        delete_sets = true
+        ## Reset timings & histograms every interval (default=true)
+        delete_timings = true
+        ## Percentiles to calculate for timing & histogram stats
+        percentiles = [90]
+        ## separator to use between elements of a statsd metric
+        metric_separator = "_"
+        ## Parses tags in the datadog statsd format
+        ## http://docs.datadoghq.com/guides/dogstatsd/
+        parse_data_dog_tags = false
+        ## Number of UDP messages allowed to queue up, once filled,
+        ## the statsd server will start dropping packets
+        allowed_pending_messages = 10000
+        ## Number of timing/histogram values to track per-measurement in the
+        ## calculation of percentiles. Raising this limit increases the accuracy
+        ## of percentiles but also increases the memory usage and cpu time.
+        percentile_limit = 1000
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent


### PR DESCRIPTION
## High-level description

This PR prepares DC/OS and adds metrics collection for Vault via Telegraf.
The OSS part duplicates the DC/OS Telegraf StatsD config into master.conf and agent.conf so that they can be overridden separately in DC/OS Enterprise.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-44592](https://jira.mesosphere.com/browse/DCOS-44592) Instrument and Transmit Vault Metrics to dcos-telegraf.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: No change of functionality for OSS.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: No change of functionality for OSS. Same tests apply.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)