### PR TITLE
[1.12] Bump Test Utils to get pods cleaned up by marathon.purge

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -66,11 +66,19 @@ def pytest_collection_modifyitems(session, config, items):
     items[:] = new_items + last_items
 
 
+# Note(JP): Attempt to reset Marathon state before and after every
+# test run in this test suite. This is a brute force approach but
+# we found that the problem of side effects as of too careless
+# test isolation and resource cleanup became too large.
 @pytest.fixture(autouse=True)
 def clean_marathon_state(dcos_api_session):
     dcos_api_session.marathon.purge()
-    yield
-    dcos_api_session.marathon.purge()
+    try:
+        yield
+    finally:
+        # This is in `finally:` so that we attempt to clean up
+        # Marathon state especially when the test code failed.
+        dcos_api_session.marathon.purge()
 
 
 @pytest.fixture(scope='session')

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "431c33756ab2959b2fcb658bca861314497f7c0d",
+    "ref": "1286f4b86faadc75a7c4fd9f3bfdab1cf16f041a",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/3833.

The description of that PR is:

```
This bumps dcos-test-utils for a better cleanup of the Marathon state between tests in the DC/OS Integration test suite.

Specifically, this brings this patch: https://github.com/dcos/dcos-test-utils/pull/69/files

To be sure: dcos/dcos-test-utils@713dea0...1286f4b
```

As this was 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


