### PR TITLE
Change dcos-log text test to expect 10 entries

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -7,6 +7,8 @@ import pytest
 import requests
 import retrying
 
+NEW_ENTRY_PATTERN = "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: "
+
 __maintainer__ = 'mnaboka'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
@@ -51,9 +53,10 @@ def test_log_text(dcos_api_session):
         response = dcos_api_session.logs.get('/v1/range/?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
-        # expect 10 lines
-        lines = list(filter(lambda x: x != '', response.content.decode().split('\n')))
-        assert len(lines) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(len(lines), lines)
+        # expect 10 entries
+        logs = response.content.decode()
+        entries_count = len(re.findall(NEW_ENTRY_PATTERN, logs))
+        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(entries_count, logs)
 
 
 def test_log_json(dcos_api_session):
@@ -256,9 +259,10 @@ def test_log_v2_text(dcos_api_session):
         response = dcos_api_session.logs.get('/v2/component?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
-        # expect 10 lines
-        lines = list(filter(lambda x: x != '', response.content.decode().split('\n')))
-        assert len(lines) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(len(lines), lines)
+        # expect 10 entries
+        logs = response.content.decode()
+        entries_count = len(re.findall(NEW_ENTRY_PATTERN, logs))
+        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(entries_count, logs)
 
 
 def test_log_v2_server_sent_events(dcos_api_session):


### PR DESCRIPTION
**This is a backport, see: https://github.com/dcos/dcos/pull/3754**

Currently test was expecting 10 lines when dcos-log returns 10 entries.
Test failed when multiline entry appered. This change check if retrned
text contains 10 entries by checking if it contains 10 timestapms that
are added by dcos-log.

Refs: DCOS_OSS-4416
(cherry picked from commit 34f4116648c23684b8260e211e61c9e54fc95dd1)