### PR TITLE
Bump Bouncer dependencies / Python packages consumes by Bouncer

### DIFF
--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -23,8 +23,8 @@
     },
     "falcon": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/55/3e/9089bad845e1b7cae0707275c36a01353de822710c010f09b8fe07529112/falcon-1.3.0.tar.gz",
-      "sha1": "d3c2b2ac1c535d77e00a5a3c95088c3897f7970c"
+      "url": "https://files.pythonhosted.org/packages/2f/e6/5045da9df509b9259037f065d15608930fd6c997ee930ad230f9fbfecf15/falcon-1.4.1.tar.gz",
+      "sha1": "c29979a1fcb1b3149f1e54cc587d9582a61c947d"
     },
     "python-mimeparse": {
       "kind": "url_extract",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -33,8 +33,8 @@
     },
     "psycopg2": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/dd/47/000b405d73ca22980684fd7bd3318690cc03cfa3b2ae1c5b7fff8050b28a/psycopg2-2.7.3.2.tar.gz",
-      "sha1": "fe5775fe3fe24ca7662f1e1cce31c57cce7c93e9"
+      "url": "https://files.pythonhosted.org/packages/c0/07/93573b97ed61b6fb907c8439bf58f09957564cf7c39612cef36c547e68c6/psycopg2-2.7.6.1.tar.gz",
+      "sha1": "45e359fb2999c9608fea7832cb37a623151274e4"
     },
     "sqlalchemy": {
       "kind": "url_extract",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -58,8 +58,8 @@
     },
     "pyasn1": {
       "kind": "url_extract",
-      "url": "https://github.com/etingof/pyasn1/archive/v0.3.7.tar.gz",
-      "sha1": "b9aae5b8b37273697ad848d2fdec22233f82b185"
+      "url": "https://files.pythonhosted.org/packages/10/46/059775dc8e50f722d205452bced4b3cc965d27e8c3389156acd3b1123ae3/pyasn1-0.4.4.tar.gz",
+      "sha1": "10f67e61e30c064301c826c6e5e461ff7bf5827d"
     },
     "alembic": {
       "kind": "url_extract",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -63,8 +63,8 @@
     },
     "alembic": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/bf/b3/b28ea715824f8455635ece3c12f59d5d205f98cc378858e414e3aa6ebdbc/alembic-0.9.6.tar.gz",
-      "sha1": "be22df78c2c9d49ebd0c6b7451eb6ca78dc12098"
+      "url": "https://files.pythonhosted.org/packages/1c/65/b8e4f5b2f345bb13b5e0a3fddd892b0b3f0e8ad4880e954fdc6a50d00d84/alembic-1.0.5.tar.gz",
+      "sha1": "2eee5fa2bd3ea7c526950e827824397acb24a531"
     },
     "cockroachdb-python": {
       "kind": "url_extract",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -38,8 +38,8 @@
     },
     "sqlalchemy": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/c2/f6/11fcc1ce19a7cb81b1c9377f4e27ce3813265611922e355905e57c44d164/SQLAlchemy-1.1.15.tar.gz",
-      "sha1": "3d6ee06301c4be2d191de182cd169aff23c68107"
+      "url": "https://files.pythonhosted.org/packages/e2/0a/05b7d13618ad41c108a6c2b886af83bf9bb7e35f8951227abb18b1330745/SQLAlchemy-1.2.14.tar.gz",
+      "sha1": "7e7260c3886ff633bbf6ffbcee3a394a7e520145"
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -43,8 +43,8 @@
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/6b/8c/bf6539a85705e845e9f83908cc290dd34c352d90d9a86134124bd4b64acd/SQLAlchemy-Utils-0.32.21.tar.gz",
-      "sha1": "07441982ec43186e7ab5fe79d4057e1a104fbeb1"
+      "url": "https://files.pythonhosted.org/packages/fa/cd/cf58d3a95a619262f0f52eedc707d143b6ada636ed24f6765544c049fdf9/SQLAlchemy-Utils-0.33.8.tar.gz",
+      "sha1": "b1e398f693b81506e64109ccb873a263219fb882"
     },
     "mako": {
       "kind": "url_extract",

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -8,13 +8,13 @@
     },
     "asn1crypto": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/5e/85/d9b46c307ff2b5504432425cd99e2d9f13ab7a9835ba45c93da299cb1ec8/asn1crypto-0.23.0-py2.py3-none-any.whl",
-      "sha1": "664233097c6bee3d9ae1802a411ba4f629116406"
+      "url": "https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl",
+      "sha1": "fff0f73e555ae1b230a95beae1604ce3fbc22646"
     },
     "cffi": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/a1/32/e3d6c3a8b5461b903651dd6ce958ed03c093d2e00128e3f33ea69f1d7965/cffi-1.9.1.tar.gz",
-      "sha1": "16265a4b305d433fb9089b19278502e904b0cb43"
+      "url": "https://files.pythonhosted.org/packages/e7/a7/4cd50e57cc6f436f1cc3a7e8fa700ff9b8b4d471620629074913e3735fb2/cffi-1.11.5.tar.gz",
+      "sha1": "1686e6689a691414d3d22626c837adeee3996dd9"
     }
   }
 }

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -3,8 +3,8 @@
   "sources": {
     "cryptography": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/f3/7c/ec4f94489719803cb14d35e9625d1f5a613b9c4b8d01ee52a4c77485e681/cryptography-2.1.3.tar.gz",
-      "sha1": "066acf8315cab631eb735188e20bef37c5848582"
+      "url": "https://files.pythonhosted.org/packages/f3/39/d3904df7c56f8654691c4ae1bdb270c1c9220d6da79bd3b1fbad91afd0e1/cryptography-2.4.2.tar.gz",
+      "sha1": "dbebf76a5e10eeb3c251bd1a243e0d1dacfda765"
     },
     "asn1crypto": {
       "kind": "url",

--- a/packages/python-gunicorn/buildinfo.json
+++ b/packages/python-gunicorn/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/30/3a/10bb213cede0cc4d13ac2263316c872a64bf4c819000c8ccd801f1d5f822/gunicorn-19.7.1.tar.gz",
-    "sha1": "e4d9f55744bf4198f71d29f61f9eeaf9d216ecac"
+    "url": "https://files.pythonhosted.org/packages/47/52/68ba8e5e8ba251e54006a49441f7ccabca83b6bef5aedacb4890596c7911/gunicorn-19.9.0.tar.gz",
+    "sha1": "4fa8b5a57c8be192b761ed2d76bcafe29b379aed"
   }
 }

--- a/packages/python-jwt/buildinfo.json
+++ b/packages/python-jwt/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://pypi.python.org/packages/8a/a6/4d931a2c77a224d27c78382f4ce8ec07542d4426ea2793bea77a689273c2/PyJWT-1.5.3-py2.py3-none-any.whl",
-    "sha1": "b1985b2c7b78d768c078f03987a919ddb2b98435"
+    "url": "https://files.pythonhosted.org/packages/93/d1/3378cc8184a6524dc92993090ee8b4c03847c567e298305d6cf86987e005/PyJWT-1.6.4-py2.py3-none-any.whl",
+    "sha1": "4a7a127bda251d12e10a89226a2d84bcab5f9dc4"
   }
 }

--- a/packages/python-passlib/buildinfo.json
+++ b/packages/python-passlib/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://pypi.python.org/packages/02/2b/02b66a8417918654afb8e129fb5a03dbb07ef73b66aea628f60bd60c7596/passlib-1.7.0-py2.py3-none-any.whl",
-    "sha1": "c58455c2d55843259cf2c3197b1b2ecbe8b991d4"
+    "url": "https://files.pythonhosted.org/packages/ee/a7/d6d238d927df355d4e4e000670342ca4705a72f0bf694027cf67d9bcf5af/passlib-1.7.1-py2.py3-none-any.whl",
+    "sha1": "bc8fca38c407eb01ee55ec199538734c1d35ff8c"
   }
 }

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -12,8 +12,8 @@
     },
     "cython": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/ee/2a/c4d2cdd19c84c32d978d18e9355d1ba9982a383de87d0fcb5928553d37f4/Cython-0.27.3.tar.gz",
-      "sha1": "688aa815301dd9e710cd847528de31099f3b52c4"
+      "url": "https://files.pythonhosted.org/packages/f0/f8/7f406aac4c6919d5a4ce16509bbe059cd256e9ad94bae5ccac14094b7c51/Cython-0.29.1.tar.gz",
+      "sha1": "afbb57c0c4a194dcd32167bcca5ee02257b8fbab"
     },
     "setuptools": {
       "kind": "url",


### PR DESCRIPTION
## High-level description

This is a maintenance patch for including security/bugfix/maintenance releases of Bouncer dependencies; and for generally syncing Bouncer dependencies in DC/OS to those used for Bouncer development/CI.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-45578


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: does not change Bouncer behavior
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
