### PR TITLE
Collect Admin Router Nginx VTS metrics via Telegraf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
+* Admin Router Nginx Virtual Hosts metrics are now collected by default. An Ningx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
+
 * CockroachDB metrics are now collected by Telegraf (DCOS_OSS-4529).
 
 * ZooKeeper metrics are now collected by Telegraf (DCOS_OSS-4477).

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1446,6 +1446,21 @@ package:
         # insecure_skip_verify = true
         [inputs.prometheus.tags]
           dcos-component-name = "CockroachDB"
+      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      [[inputs.prometheus]]
+        ## An array of urls to scrape metrics from.
+        urls = ["https://localhost/nginx/metrics"]
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
+        ## Optional TLS Config
+        # tls_ca = /path/to/cafile
+        # tls_cert = /path/to/certfile
+        # tls_key = /path/to/keyfile
+        ## Use TLS but skip chain & host verification
+        insecure_skip_verify = true
+        ## Apply DC/OS component name tag according to the documentation.
+        [inputs.prometheus.tags]
+          dcos-component-name = "Admin Router"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"

--- a/packages/adminrouter/build
+++ b/packages/adminrouter/build
@@ -8,7 +8,7 @@ set -u  # Undefined variables
 export CXXFLAGS=-I/opt/mesosphere/include
 export AR_BIN_DIR=$PKG_PATH
 
-$OPENRESTY_COMPILE_SCRIPT --with-cc-opt="-I /opt/mesosphere/include" --with-ld-opt="-L /opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
+$OPENRESTY_COMPILE_SCRIPT --with-cc-opt="-I /opt/mesosphere/include" --with-ld-opt="-L /opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib" --add-module=$VTS_MODULE_DIR
 
 # Incorporate Admin Router components.
 rm -vfR $PKG_PATH/nginx/conf/*

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -8,6 +8,9 @@ ENV OPENRESTY_VERSION=1.13.6.1 \
     OPENRESTY_COMPILE_OPTS="" \
     VENV_DIR=/usr/local/venv \
     AR_BIN_DIR=/usr/local/adminrouter/ \
+    VTS_MODULE_DIR=/usr/local/src/nginx-vts-module-v0.1.18 \
+    VTS_MODULE_DOWNLOAD_SHASUM=8887748e0ef76e459aa2c86244baf382d4f7d4e5 \
+    VTS_MODULE_DOWNLOAD_URL=https://github.com/vozlt/nginx-module-vts/archive/v0.1.18.tar.gz \
     VEGETA_DOWNLOAD_SHA256=2f0a69d0ae6f0bf268b7f655bd37c0104d5568d5b2bc45bbb2c405266f74e33d \
     VEGETA_DOWNLOAD_URL=https://github.com/tsenart/vegeta/releases/download/v6.1.1/vegeta-v6.1.1-linux-amd64.tar.gz \
     IAM_PUBKEY_FILE_PATH=/usr/local/iam.jwt-key.pub \
@@ -91,6 +94,13 @@ RUN curl -fsSL "$VEGETA_DOWNLOAD_URL" -o vegeta.tar.gz \
     && echo "$VEGETA_DOWNLOAD_SHA256  vegeta.tar.gz" | sha256sum -c - \
         && tar -C /usr/local/bin -xzf vegeta.tar.gz \
         && rm vegeta.tar.gz
+
+# Download VTS module for metrics
+RUN curl -fsSL "$VTS_MODULE_DOWNLOAD_URL" -o vts-module.tar.gz \
+    && echo "$VTS_MODULE_DOWNLOAD_SHASUM  vts-module.tar.gz" | shasum -c - \
+    && mkdir -pv $VTS_MODULE_DIR \
+    && tar --strip-components=1 -C $VTS_MODULE_DIR -xzf vts-module.tar.gz \
+    && rm vts-module.tar.gz
 
 # Prepare Openresty. Compilation is done in Makefile itself so that
 # this container can be reused during DC/OS build.

--- a/packages/adminrouter/extra/src/Makefile.common
+++ b/packages/adminrouter/extra/src/Makefile.common
@@ -69,7 +69,7 @@ update-devkit: clean-devkit-container
 	@docker run \
 		$(DEVKIT_BASE_DOCKER_OPTS) \
 		mesosphere/$(DEVKIT_NAME):noresty \
-			/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT" && \
+			/bin/bash -c "\$$OPENRESTY_COMPILE_SCRIPT --add-module=\$$VTS_MODULE_DIR" && \
 	docker commit $$(docker ps -a -q -f name=$(DEVKIT_NAME)) \
 		mesosphere/$(DEVKIT_NAME):full
 	@docker rm -f $(DEVKIT_NAME)

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -1491,7 +1491,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>http://$backend/dcos-metadata/ui-config.json</code>
+                  <code>http://$backend/acs/api/v1/uiconfig/</code>
                 </td>
               </tr>
               <tr>
@@ -1540,6 +1540,26 @@
                 </td>
               </tr>
             </table>
+          </div>
+        </li>
+      </ul>
+    </li>
+    <li id="resource-metrics" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="metrics" href="#metrics" aria-hidden="true" class="toggle-route-group" data-id="metrics">
+            <div class="arrow arrow-right"></div>Metrics</a>
+        </h2>
+        <span class="options"><a href="#metrics" class="toggle-route-group" data-id="metrics">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-metrics" class="routes">
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/nginx/status</code></span>
+            </h3>
+            <span class="route-desc">Virtual Host Traffic Module Status</span>
           </div>
         </li>
       </ul>
@@ -1595,6 +1615,14 @@
                 </td>
               </tr>
             </table>
+          </div>
+        </li>
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/nginx/metrics</code></span>
+            </h3>
           </div>
         </li>
         <li class="route route-type-proxy">

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -245,7 +245,7 @@ routes:
     matcher: path
     description: DC/OS GUI configuration (unauthenticated)
     proxy:
-      path: 'http://$backend/dcos-metadata/ui-config.json'
+      path: 'http://$backend/acs/api/v1/uiconfig/'
       backend: iam
     path: /dcos-metadata/ui-config.json
   /metadata:
@@ -255,6 +255,11 @@ routes:
     lua:
       file: conf/lib/metadata.lua
     path: /metadata
+  /nginx/status:
+    group: Metrics
+    matcher: path
+    description: Virtual Host Traffic Module Status
+    path: /nginx/status
   /internal/mesos_dns/:
     group: Other
     matcher: path
@@ -262,6 +267,10 @@ routes:
       path: 'http://$backend/'
       backend: mesos_dns
     path: /internal/mesos_dns/
+  /nginx/metrics:
+    group: Other
+    matcher: path
+    path: /nginx/metrics
   '@service_default':
     group: Other
     matcher: path

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -1,3 +1,10 @@
+# Enable VTS module for metrics
+# Set the shared memory zone size to 32MB to be sure to
+# contain all metrics in the VTS module configuration.
+# If the VTS module configuration enables dynamic metric
+# keys this needs to be increased to accommodate for that.
+vhost_traffic_status_zone shared:vhost_traffic_status:32m;
+
 client_max_body_size 1024M;
 
 # Define custom log format. Use the default 'combined'
@@ -27,6 +34,7 @@ keepalive_timeout 65;
 server_tokens off;
 
 lua_package_path '$prefix/conf/lib/?.lua;;';
+
 
 # Name: DC/OS Component Package Manager (Pkgpanda)
 # Reference: https://dcos.io/docs/1.10/administering-clusters/component-management/

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -1,3 +1,14 @@
+# Group: Metrics
+# Description: Virtual Host Traffic Module Status
+location /nginx/status {
+    vhost_traffic_status_display;
+    vhost_traffic_status_display_format html;
+}
+location /nginx/metrics {
+    vhost_traffic_status_display;
+    vhost_traffic_status_display_format prometheus;
+}
+
 # Group: Pkgpanda
 # Description: List the active Pkgpanda packages
 location /pkgpanda/active.buildinfo.full.json {

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -1,4 +1,18 @@
 endpoint_tests:
+######### /nginx endpoint
+  - tests:
+      is_response_correct:
+        expect_http_status: 200
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /nginx/status
+          - /nginx/metrics
+      is_unauthed_access_permitted:
+        locations:
+          - /nginx/status
+          - /nginx/metrics
+    type:
+      - master
 ######### /exhibitor endpoint
   - tests:
       is_response_correct:

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -113,6 +113,22 @@ def test_metrics_masters_cockroachdb(dcos_api_session):
         check_cockroachdb_metrics()
 
 
+def test_metrics_masters_adminrouter(dcos_api_session):
+    """Assert that Admin Router metrics on masters are present."""
+    for master in dcos_api_session.masters:
+        expected_metrics = [
+            'dcos_component_name="Admin Router"',
+            'nginx_vts',
+        ]
+
+        @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+        def check_adminrouter_metrics():
+            response = get_metrics_prom(dcos_api_session, master)
+            for metric_name in expected_metrics:
+                assert metric_name in response.text
+        check_adminrouter_metrics()
+
+
 def test_metrics_agents_statsd(dcos_api_session):
     """Assert that statsd metrics on agent are present."""
     if len(dcos_api_session.slaves) > 0:


### PR DESCRIPTION
## High-level description

This PR adds basic Nginx metrics display on `/nginx/status` for masters and metrics scraping of Nginx by Telegraf via the `/nginx/metrics` endpoint on masters. The underlying module added is 3rd-party module: https://github.com/vozlt/nginx-module-vts

The module seems to be fairly popular, however only developed by one person.
Regarding the issues on the module automatic testing is not a priority there.
I still think this is our best option right now to get metrics in for the MWT.

The module provides basic HTTP metrics for each `upstream` and `proxy_pass` directive individually.

We use the base configuration with an extra large shared memory area size of 32MB.
We expect the minimal performance impact with this configuration, but will probably expand on this in the future.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4562](https://jira.mesosphere.com/browse/DCOS_OSS-4562) .

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: I'll add this on the mini-train.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)