### PR TITLE
AR: supporting endpoints for services running in CNI

### DIFF
--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -984,6 +984,42 @@
             </table>
           </div>
         </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/net/</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend/</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>127.0.0.1:62080</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Net
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
       </ul>
     </li>
     <li id="resource-exhibitor" class="resource">

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
@@ -50,28 +50,30 @@ SCHEDULER_APP_TEMPLATE = {
         "volumes": [],
         "docker": {
             "image": "bitnami/nginx:1.10.2-r0",
-            "network": "BRIDGE",
-            "portMappings": [
-                {
-                    "containerPort": 80,
-                    "hostPort": 0,
-                    "servicePort": 10000,
-                    "protocol": "tcp",
-                    "labels": {}
-                },
-                {
-                    "containerPort": 443,
-                    "hostPort": 0,
-                    "servicePort": 10001,
-                    "protocol": "tcp",
-                    "labels": {}
-                }
-            ],
             "privileged": False,
             "parameters": [],
             "forcePullImage": False
-        }
+        },
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                "servicePort": 10000,
+                "protocol": "tcp",
+                "labels": {}
+            },
+            {
+                "containerPort": 443,
+                "hostPort": 0,
+                "servicePort": 10001,
+                "protocol": "tcp",
+                "labels": {}
+            }
+        ],
     },
+    "networks": [
+        {}
+    ],
     "healthChecks": [
         {
             "gracePeriodSeconds": 300,
@@ -103,7 +105,6 @@ SCHEDULER_APP_TEMPLATE = {
         "DCOS_PACKAGE_NAME": "nginx",
         "DCOS_PACKAGE_IS_FRAMEWORK": "false"
     },
-    "ipAddress": None,
     "version": "2017-01-16T15:48:18.007Z",
     "residency": None,
     "secrets": {},


### PR DESCRIPTION
## High-level description
Due to Marathon app description syntax change https://github.com/mesosphere/marathon/blob/master/docs/docs/upgrade/network-api-migration.md#example-definitions AR is not able to expose apps defined with the new syntax. This PR fixes this issue.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS-45468

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)