### PR TITLE
[[--testing,WIP--]] AR: opt-in long-polling support for dc/os services

### DIFF
--- a/packages/adminrouter/extra/src/includes/longpoll.conf
+++ b/packages/adminrouter/extra/src/includes/longpoll.conf
@@ -1,0 +1,5 @@
+keepalive_timeout 160s;
+keepalive_requests 100000;
+proxy_read_timeout 900s;
+proxy_send_timeout 600s;
+proxy_ignore_client_abort off;

--- a/packages/adminrouter/extra/src/includes/longpoll.conf
+++ b/packages/adminrouter/extra/src/includes/longpoll.conf
@@ -3,3 +3,4 @@ keepalive_requests 100000;
 proxy_read_timeout 900s;
 proxy_send_timeout 600s;
 proxy_ignore_client_abort off;
+send_timeout 600s;

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -221,20 +221,39 @@ location ~ ^/service/(?<service_path>.+) {
         -- labels. The proxy_request_buffering directive by itself is unable to
         -- parse lua variables directly.
         if service.request_buffering_required(service_name, marathon_cache) == false then
-            -- Do an internal redirect; proceed handling this request in the
-            -- @service_requnbuffered location block below.
-            return ngx.exec("@service_requnbuffered");
+            if service.long_poll_enabled(service_name, marathon_cache) == false then
+                -- Do an internal redirect; proceed handling this request in the
+                -- @service_requnbuffered location block below.
+                return ngx.exec("@service_requnbuffered");
+            end
+            -- No request buffering w/ long-polling enabled.
+            return ngx.exec("@service_requnbuffered_longpoll");
         end
-
+        if service.long_poll_enabled(service_name, marathon_cache) == false then
             -- Do an internal redirect; proceed handling this request in the
             -- @service_default location block below.
-        return ngx.exec("@service_default");
+            return ngx.exec("@service_default");
+        end
+        -- Default request buffering w/ long-polling enabled.
+        return ngx.exec("@service_reqlongpoll");
     }
 }
 
 location @service_requnbuffered {
     proxy_request_buffering off;
 
+    include includes/service-location.common.conf;
+}
+
+location @service_requnbuffered_longpoll {
+    proxy_request_buffering off;
+
+    include includes/longpoll.conf;
+    include includes/service-location.common.conf;
+}
+
+location @service_reqlongpoll {
+    include includes/longpoll.conf;
     include includes/service-location.common.conf;
 }
 

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -291,12 +291,24 @@ local function fetch_and_store_marathon_apps(auth_token)
           do_request_buffering = true
        end
 
+       local long_poll_enabled = labels["DCOS_SERVICE_LONGPOLL_ENABLED"]
+       if long_poll_enabled == 'false' or not long_poll_enabled then
+          long_poll_enabled = false
+       else
+          ngx.log(ngx.INFO, "DCOS_SERVICE_LONGPOLL_ENABLED for app '" .. appId .. "' set to 'true'")
+          -- Treat everything else as true, i.e.:
+          -- * label is set to "true" (string) or true (bool)
+          -- * label is set to some random string
+          long_poll_enabled = true
+       end
+
        local url = scheme .. "://" .. host_or_ip .. ":" .. port
        svcApps[svcId] = {
          scheme=scheme,
          url=url,
          do_rewrite_req_url=do_rewrite_req_url,
          do_request_buffering=do_request_buffering,
+         long_poll_enabled=long_poll_enabled,
          }
 
        ::continue::

--- a/packages/adminrouter/extra/src/lib/service.lua
+++ b/packages/adminrouter/extra/src/lib/service.lua
@@ -163,6 +163,28 @@ local function request_buffering_required(service_name, marathon_cache)
     return marathon_cache[service_name]['do_request_buffering']
 end
 
+local function long_poll_enabled(service_name, marathon_cache)
+    -- Determine if long-polling is enabled for this service.
+    --
+    -- Arguments:
+    --   service_name (string): service name that should be resolved
+    --   marathon_cache (table): cached root Marathon's apps state
+    --
+    -- Returns:
+    --   duration that nginx should allow the request to proceed.
+    --
+    if service_name == 'marathon' or service_name == 'metronome' then
+      -- These two services should always use the default.
+      return false
+    end
+
+    if marathon_cache[service_name] == nil then
+        return false
+    end
+
+    return marathon_cache[service_name]['long_poll_enabled']
+end
+
 local function resolve_via_mesos_dns(service_name)
     -- Try to resolve upstream for given service name basing on
     -- MesosDNS SRV entries
@@ -375,6 +397,7 @@ function _M.init()
 
     res.recursive_resolve = recursive_resolve
     res.request_buffering_required = request_buffering_required
+    res.long_poll_enabled = long_poll_enabled
 
     return res
 end


### PR DESCRIPTION
## High-level description

The default proxy read/write timeouts are 60s, which is too small for some services deployed on DC/OS. This change set proposes a label `DCOS_SERVICE_LONGPOLL_ENABLED` that will enable larger timeouts for apps w/ such requirements.

This is complementary to the already-existing websockets support available in the standard AR config.

TODO:
* [ ] update AR docs w/ description of new service label

Related to https://jira.mesosphere.com/browse/DCOS-25375

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4558](https://jira.mesosphere.com/browse/DCOS_OSS-4558) AR: introduce DCOS_SERVICE_LONGPOLL_ENABLED.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
