### PR TITLE
[1.12] Add a distinct user-agent for each Telegraf plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,6 @@
 
 ### Notable changes
 
-* Telegraf plugins now send unique User-Agent header values (DCOS_OSS-4168)
-
 ### Breaking changes
 
 ### Fixed and improved

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Notable changes
 
+* Telegraf plugins now send unique User-Agent header values (DCOS_OSS-4168)
+
 ### Breaking changes
 
 ### Fixed and improved

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1346,6 +1346,8 @@ package:
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
         timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
         ## The address on which the command API should listen
@@ -1370,6 +1372,8 @@ package:
         ## to each metric as tags; the prefix is stripped from the
         ## label when tagging
         whitelist_prefix = ["DCOS_METRICS_"]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-metadata"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"
@@ -1390,6 +1394,8 @@ package:
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
         timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
         ## The address on which the command API should listen
@@ -1414,6 +1420,8 @@ package:
         ## to each metric as tags; the prefix is stripped from the
         ## label when tagging
         whitelist_prefix = ["DCOS_METRICS_"]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-metadata"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -114,27 +114,6 @@ def get_task_hostname(dcos_api_session, framework_name, task_name):
 @pytest.mark.skipif(
     test_helpers.expanded_config.get('security') == 'strict',
     reason="MoM disabled for strict mode")
-def test_metrics_metadata(dcos_api_session):
-    """Test that metrics have expected metadata/labels"""
-    with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
-        node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
-
-        @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
-        def check_metrics_metadata():
-            response = get_metrics_prom(dcos_api_session, node)
-            for line in response.text.splitlines():
-                if '#' in line:
-                    continue
-                if 'task_name="marathon-user"' in line:
-                    assert 'service_name="marathon"' in line
-                    # check for whitelisted label
-                    assert 'DCOS_SERVICE_NAME="marathon-user"' in line
-        check_metrics_metadata()
-
-
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('security') == 'strict',
-    reason="MoM disabled for strict mode")
 def test_task_metrics_metadata(dcos_api_session):
     """Test that task metrics have expected metadata/labels"""
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
@@ -148,6 +127,8 @@ def test_task_metrics_metadata(dcos_api_session):
                     continue
                 if 'task_name="marathon-user"' in line:
                     assert 'service_name="marathon"' in line
+                    # check for whitelisted label
+                    assert 'DCOS_SERVICE_NAME="marathon-user"' in line
         check_metrics_metadata()
 
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "c40dce1aca995be7e1beaa5b9f5598d8f78d3695",
+    "ref": "a88d78350c9244336607e37cc808bb76a40e8b89",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This adds unique `user_agent` config values to Telegraf plugins to set the `User-Agent` headers in all outgoing requests.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4544](https://jira.mesosphere.com/browse/DCOS_OSS-4544) [1.12] Add a distinct user-agent for each Telegraf plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: very difficult to add an integration test for this, and the change is not a risky one
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
