### PR TITLE
[1.13] Set user-agent configs for telegraf plugins

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1413,7 +1413,9 @@ package:
           "evqueue",
           "registrar",
           "allocator",
-       ]
+        ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
       # Reads 'mntr' health checks from one or many zookeeper servers
       [[inputs.zookeeper]]
         ## An array of addresses to gather stats about. Specify an ip or hostname
@@ -1452,6 +1454,8 @@ package:
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
         timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
         ## The address on which the command API should listen
@@ -1478,6 +1482,8 @@ package:
           "tasks",
           "messages",
         ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1492,6 +1498,8 @@ package:
         ## to each metric as tags; the prefix is stripped from the
         ## label when tagging
         whitelist_prefix = ["DCOS_METRICS_"]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-metadata"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"
@@ -1512,6 +1520,8 @@ package:
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
         timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
         ## The address on which the command API should listen
@@ -1538,6 +1548,8 @@ package:
           "tasks",
           "messages",
         ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1552,6 +1564,8 @@ package:
         ## to each metric as tags; the prefix is stripped from the
         ## label when tagging
         whitelist_prefix = ["DCOS_METRICS_"]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-dcos-metadata"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "agent"

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "c40dce1aca995be7e1beaa5b9f5598d8f78d3695",
+    "ref": "a88d78350c9244336607e37cc808bb76a40e8b89",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This adds unique `user_agent` config values to Telegraf plugins to set the `User-Agent` headers in all outgoing requests.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4522](https://jira.mesosphere.com/browse/DCOS_OSS-4522) [1.13] Add a distinct user-agent for each Telegraf plugin

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: added in 1.12 changelog
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: very difficult to add an integration test for this, and the change is not a risky one
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
