### PR TITLE
[1.11] Add Mesos patches to ensure TEARDOWN is sent in v1 Java shim.

### DIFF
--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,7 +1,7 @@
-From 3949a3e4df361ea9dc1f152de9b8c6f992b31a35 Mon Sep 17 00:00:00 2001
+From 653e5b8de6f4cdb547ca2c39fae0f877918e15c6 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH 01/22] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
@@ -24,5 +24,5 @@ index ef4ef265b..18c8270cc 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,8 +1,8 @@
-From 8fa301f129d89a56c727d03e3ebd32ee55d8063f Mon Sep 17 00:00:00 2001
+From f32bc063f2352e5d342c138fb22a093d87e11933 Mon Sep 17 00:00:00 2001
 From: Gaston Kleiman <gaston.kleiman@gmail.com>
 Date: Mon, 9 Oct 2017 15:19:08 -0700
-Subject: [PATCH 02/22] Mesos UI: updated the URL generation to make it work
- with adminrouter.
+Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
+ adminrouter.
 
 - Use /mesos/agent/{agent_id}/{process_name} as the agent URL prefix.
 - Redirect from Mesos webui location (host:5050) to adminrouter
@@ -47,5 +47,5 @@ index 59665869d..6e0a40f93 100644
              'Mesos Master (' + $scope.$location.host() + ':' + $scope.$location.port() + ')');
        }
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,8 +1,8 @@
-From 9c147b86d5b1fa547aae05c6f23dc97219f41d2a Mon Sep 17 00:00:00 2001
+From 8f7bbe0e138e53613e709a0638c4c7a86ce4927d Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
-Subject: [PATCH 03/22] Revert "Fixed the broken metrics information of master
- in WebUI."
+Subject: [PATCH] Revert "Fixed the broken metrics information of master in
+ WebUI."
 
 This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
 
@@ -69,5 +69,5 @@ index 6e0a40f93..8d9b5f49d 100644
              $timeout(pollMetrics, $scope.delay);
            }
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From a95179580f489c9e6c2a9490ce4f7edfff72d69e Mon Sep 17 00:00:00 2001
+From 3aab21cb77d1cb7df6ef4c1a7db0fc1f0aa32e63 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH 04/22] Updated mesos containerizer to ignore GPU isolator
- creation failure.
+Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
+ failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -19,7 +19,7 @@ This is a decent compromise.
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index ffb6e0225..4ad4eea60 100644
+index 1f7558380..b9a12ee72 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -424,8 +424,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -45,5 +45,5 @@ index ffb6e0225..4ad4eea60 100644
      }
    }
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
+++ b/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
@@ -1,7 +1,7 @@
-From 7b113e8aa1eda41b594acc8f93743e9c1263450d Mon Sep 17 00:00:00 2001
+From cdd835b565e502912bde5536da81861b9eb4ebe3 Mon Sep 17 00:00:00 2001
 From: Benjamin Bannier <benjamin.bannier@mesosphere.io>
 Date: Tue, 20 Mar 2018 10:08:09 +0100
-Subject: [PATCH 05/22] Displayed resource provider resources in
+Subject: [PATCH] Displayed resource provider resources in
  GET_RESOURCE_PROVIDER response.
 
 Review: https://reviews.apache.org/r/65832/
@@ -37,7 +37,7 @@ index 9d90b18f3..0e526fd6a 100644
  
      repeated ResourceProvider resource_providers = 1;
 diff --git a/src/slave/http.cpp b/src/slave/http.cpp
-index 677958fb0..0b8858dc6 100644
+index 4f791f24b..f0e92df8e 100644
 --- a/src/slave/http.cpp
 +++ b/src/slave/http.cpp
 @@ -1895,6 +1895,9 @@ Future<Response> Http::getResourceProviders(
@@ -87,5 +87,5 @@ index 01440330f..5985070f8 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,7 +1,7 @@
-From 65c357d036712a1f3ce9ba4d0abd39e2944c948c Mon Sep 17 00:00:00 2001
+From 1ec1824b7ecb472e0f5d72d1398985c164e6bc2b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Tue, 10 Jul 2018 08:06:32 -0700
-Subject: [PATCH 06/22] Improved logging for offers and inverse offers.
+Subject: [PATCH] Improved logging for offers and inverse offers.
 
 Log offer IDs and inverse offer IDs when sending out offers and
 inverse offers so it is easier to match them to their ACCEPT or DECLINE
@@ -19,10 +19,10 @@ Review: https://reviews.apache.org/r/67817/
  1 file changed, 18 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 5fcdd632f..2e676155f 100644
+index 0229d1bca..73a0102c4 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -8739,6 +8739,9 @@ void Master::offer(
+@@ -8699,6 +8699,9 @@ void Master::offer(
    // and a single allocation role.
    ResourceOffersMessage message;
  
@@ -32,7 +32,7 @@ index 5fcdd632f..2e676155f 100644
    foreachkey (const string& role, resources) {
      foreachpair (const SlaveID& slaveId,
                   const Resources& offered,
-@@ -8883,6 +8886,13 @@ void Master::offer(
+@@ -8843,6 +8846,13 @@ void Master::offer(
        // Add the offer *AND* the corresponding slave's PID.
        message.add_offers()->MergeFrom(offer_);
        message.add_pids(slave->pid);
@@ -46,7 +46,7 @@ index 5fcdd632f..2e676155f 100644
      }
    }
  
-@@ -8890,8 +8900,7 @@ void Master::offer(
+@@ -8850,8 +8860,7 @@ void Master::offer(
      return;
    }
  
@@ -56,7 +56,7 @@ index 5fcdd632f..2e676155f 100644
  
    framework->send(message);
  }
-@@ -8979,8 +8988,13 @@ void Master::inverseOffer(
+@@ -8939,8 +8948,13 @@ void Master::inverseOffer(
      return;
    }
  
@@ -73,5 +73,5 @@ index 5fcdd632f..2e676155f 100644
    framework->send(message);
  }
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
+++ b/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
@@ -1,7 +1,7 @@
-From b5a9836855b75ae10a3de4ccf05c316167520d2b Mon Sep 17 00:00:00 2001
+From e285b706666a65752098cef0feb59546ebfcb2c8 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:53 -0700
-Subject: [PATCH 07/22] Introduced a push-based gauge metric.
+Subject: [PATCH] Introduced a push-based gauge metric.
 
 A push-based gauge differs from a pull-based gauge in that the
 client is responsible for pushing the latest value into the gauge
@@ -144,5 +144,5 @@ index 000000000..5c3984617
 +
 +#endif // __PROCESS_METRICS_PUSH_GAUGE_HPP__
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
+++ b/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
@@ -1,7 +1,7 @@
-From 0eb86c2ddab984e689f29a5f29bd1e32caf27dbb Mon Sep 17 00:00:00 2001
+From 57971fa7f9e26f1615489c0eaee904dd641c3b6f Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:58 -0700
-Subject: [PATCH 08/22] Added a test for PushGauge.
+Subject: [PATCH] Added a test for PushGauge.
 
 Review: https://reviews.apache.org/r/66830/
 ---
@@ -66,5 +66,5 @@ index bb7c9e37e..d394a42bf 100644
  {
    Counter counter("test/counter", process::TIME_SERIES_WINDOW);
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
+++ b/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
@@ -1,8 +1,8 @@
-From 79638159612d8b10d2451251613eb278cd33b5bf Mon Sep 17 00:00:00 2001
+From 3174722a7896f06a87334ef24b582a80e273cd27 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:01 -0700
-Subject: [PATCH 09/22] Renamed Gauge to PullGauge and documented differences
- to PushGauge.
+Subject: [PATCH] Renamed Gauge to PullGauge and documented differences to
+ PushGauge.
 
 Given `PushGauge`, it makes sense to explicitly distinguish the two
 gauge types and document the the caveats of `PullGauge`.
@@ -353,5 +353,5 @@ index 6beb973e0..4a193d778 100644
  // endpoint. This has been observed specifically for the memory
  // metrics. If in the future we put the error message from the Failure
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
+++ b/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
@@ -1,7 +1,7 @@
-From f88598b7a157ef012052247a4e29ad09783505f5 Mon Sep 17 00:00:00 2001
+From eab69da63d2b20ad28e0e508dfc9fdc0ed38427f Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:05 -0700
-Subject: [PATCH 10/22] Updated mesos source for Gauge -> PullGauge renaming.
+Subject: [PATCH] Updated mesos source for Gauge -> PullGauge renaming.
 
 Review: https://reviews.apache.org/r/66832/
 ---
@@ -404,10 +404,10 @@ index 61568cb52..1ff7489ee 100644
  
  } // namespace allocator {
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 43676bd55..61809de88 100644
+index c1db276b4..282925da5 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -2094,7 +2094,7 @@ private:
+@@ -2097,7 +2097,7 @@ private:
    // copyable metric types only.
    std::shared_ptr<Metrics> metrics;
  
@@ -697,7 +697,7 @@ index 07d2b37e0..c04cfbc42 100644
  
    double _event_queue_messages()
 diff --git a/src/slave/containerizer/fetcher_process.hpp b/src/slave/containerizer/fetcher_process.hpp
-index 034fe34fe..56fecf237 100644
+index 5b7c1b5a3..faa5ac858 100644
 --- a/src/slave/containerizer/fetcher_process.hpp
 +++ b/src/slave/containerizer/fetcher_process.hpp
 @@ -28,7 +28,7 @@
@@ -709,7 +709,7 @@ index 034fe34fe..56fecf237 100644
  
  #include <stout/hashmap.hpp>
  
-@@ -258,8 +258,8 @@ private:
+@@ -261,8 +261,8 @@ private:
      process::metrics::Counter task_fetches_succeeded;
      process::metrics::Counter task_fetches_failed;
  
@@ -954,5 +954,5 @@ index d638b8806..8d42011be 100644
    {
      return static_cast<double>(frameworks.size());
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
+++ b/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
@@ -1,7 +1,7 @@
-From 06509932f2c3e844bacf06fa774e24f81f95fc32 Mon Sep 17 00:00:00 2001
+From e687b38ee1045d14b59ca84e8c850126119149a8 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:57:56 -0700
-Subject: [PATCH 11/22] Enabled per-framework metrics in the master.
+Subject: [PATCH] Enabled per-framework metrics in the master.
 
 The `FrameworkMetrics` struct will be used to track per-framework
 metrics in the master.
@@ -14,10 +14,10 @@ Review: https://reviews.apache.org/r/67962/
  3 files changed, 36 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 61809de88..367060738 100644
+index 282925da5..c8a4b7621 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -2894,6 +2894,9 @@ struct Framework
+@@ -2909,6 +2909,9 @@ struct Framework
    Option<process::Owned<Heartbeater<scheduler::Event, v1::scheduler::Event>>>
      heartbeater;
  
@@ -27,7 +27,7 @@ index 61809de88..367060738 100644
  private:
    Framework(Master* const _master,
              const Flags& masterFlags,
-@@ -2908,8 +2911,11 @@ private:
+@@ -2923,8 +2926,11 @@ private:
        registeredTime(time),
        reregisteredTime(time),
        completedTasks(masterFlags.max_completed_tasks_per_framework),
@@ -99,5 +99,5 @@ index 1ef74dedf..9f10aecba 100644
  } // namespace internal {
  } // namespace mesos {
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
+++ b/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
@@ -1,7 +1,7 @@
-From a069435be5c5f4b05cb26581ead4dbde5e263308 Mon Sep 17 00:00:00 2001
+From db5ba69852d66320243de6b884119938c89f55cb Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Wed, 1 Aug 2018 07:58:06 -0700
-Subject: [PATCH 12/22] Added per-framework 'subscribed' metric and helpers.
+Subject: [PATCH] Added per-framework 'subscribed' metric and helpers.
 
 Review: https://reviews.apache.org/r/66820/
 ---
@@ -12,7 +12,7 @@ Review: https://reviews.apache.org/r/66820/
  4 files changed, 30 insertions(+), 8 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 2e676155f..c22ca3405 100644
+index 73a0102c4..13a0af995 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -452,6 +452,13 @@ void Framework::untrackUnderRole(const string& role)
@@ -56,7 +56,7 @@ index 2e676155f..c22ca3405 100644
  
    // Tell the allocator to stop allocating resources to this framework.
    allocator->deactivateFramework(framework->id());
-@@ -9422,7 +9429,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -9382,7 +9389,7 @@ Try<Nothing> Master::activateRecoveredFramework(
    }
  
    // Activate the framework.
@@ -65,7 +65,7 @@ index 2e676155f..c22ca3405 100644
    allocator->activateFramework(framework->id());
  
    // Export framework metrics if a principal is specified in `FrameworkInfo`.
-@@ -9572,7 +9579,7 @@ void Master::_failoverFramework(Framework* framework)
+@@ -9532,7 +9539,7 @@ void Master::_failoverFramework(Framework* framework)
    // NOTE: We do this after recovering resources (above) so that
    // the allocator has the correct view of the framework's share.
    if (!framework->active()) {
@@ -75,10 +75,10 @@ index 2e676155f..c22ca3405 100644
    }
  
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 367060738..6352f7e28 100644
+index c8a4b7621..332033e9c 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -1737,6 +1737,7 @@ private:
+@@ -1740,6 +1740,7 @@ private:
    Master& operator=(const Master&); // No assigning.
  
    friend struct Framework;
@@ -86,7 +86,7 @@ index 367060738..6352f7e28 100644
    friend struct Metrics;
    friend struct Slave;
    friend struct SlavesWriter;
-@@ -2798,6 +2799,8 @@ struct Framework
+@@ -2813,6 +2814,8 @@ struct Framework
    void trackUnderRole(const std::string& role);
    void untrackUnderRole(const std::string& role);
  
@@ -95,7 +95,7 @@ index 367060738..6352f7e28 100644
    Master* const master;
  
    FrameworkInfo info;
-@@ -2907,7 +2910,6 @@ private:
+@@ -2922,7 +2925,6 @@ private:
        info(_info),
        roles(protobuf::framework::getRoles(_info)),
        capabilities(_info.capabilities()),
@@ -103,7 +103,7 @@ index 367060738..6352f7e28 100644
        registeredTime(time),
        reregisteredTime(time),
        completedTasks(masterFlags.max_completed_tasks_per_framework),
-@@ -2916,6 +2918,8 @@ private:
+@@ -2931,6 +2933,8 @@ private:
    {
      CHECK(_info.has_id());
  
@@ -159,5 +159,5 @@ index 9f10aecba..d3f093f9d 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
+++ b/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
@@ -1,7 +1,7 @@
-From c8e084b4afe2d8de38433fe46a76cea62db68905 Mon Sep 17 00:00:00 2001
+From 1f73ece29f37ac29610945bec2b5145d0e7cc87f Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:14 -0700
-Subject: [PATCH 13/22] Added per-framework metrics for scheduler calls.
+Subject: [PATCH] Added per-framework metrics for scheduler calls.
 
 Review: https://reviews.apache.org/r/67776/
 ---
@@ -25,7 +25,7 @@ index 1f9aac44f..f4cd2dc68 100644
    // into the authorizer. See MESOS-7399.
    if (principal.isSome() && principal != framework->info.principal()) {
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index c22ca3405..2244701e1 100644
+index 13a0af995..bf1e61eb5 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -2487,6 +2487,8 @@ void Master::receive(
@@ -153,5 +153,5 @@ index d3f093f9d..7a7b3a316 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
+++ b/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
@@ -1,7 +1,7 @@
-From 891d74044602feb93b5d87194a3ee33fe8b4e8dd Mon Sep 17 00:00:00 2001
+From fea04ca41860fc3713c272d3e8d66a8bae56c247 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:22 -0700
-Subject: [PATCH 14/22] Added per-framework metrics for scheduler events.
+Subject: [PATCH] Added per-framework metrics for scheduler events.
 
 Review: https://reviews.apache.org/r/67809/
 ---
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67809/
  3 files changed, 64 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 6352f7e28..431e8732c 100644
+index 332033e9c..5dd1ffa0a 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -346,13 +346,16 @@ public:
+@@ -349,13 +349,16 @@ public:
                const Message& _heartbeatMessage,
                const HttpConnection& _http,
                const Duration& _interval,
@@ -33,7 +33,7 @@ index 6352f7e28..431e8732c 100644
  
  protected:
    virtual void initialize() override
-@@ -374,6 +377,10 @@ private:
+@@ -377,6 +380,10 @@ private:
      if (http.closed().isPending()) {
        VLOG(2) << "Sending heartbeat to " << logMessage;
  
@@ -44,7 +44,7 @@ index 6352f7e28..431e8732c 100644
        Message message(heartbeatMessage);
        http.send<Message, Event>(message);
      }
-@@ -386,6 +393,7 @@ private:
+@@ -389,6 +396,7 @@ private:
    HttpConnection http;
    const Duration interval;
    const Option<Duration> delay;
@@ -52,7 +52,7 @@ index 6352f7e28..431e8732c 100644
  };
  
  
-@@ -2324,6 +2332,10 @@ struct Framework
+@@ -2339,6 +2347,10 @@ struct Framework
                     << " framework " << *this;
      }
  
@@ -63,7 +63,7 @@ index 6352f7e28..431e8732c 100644
      if (http.isSome()) {
        if (!http.get().send(message)) {
          LOG(WARNING) << "Unable to send event to framework " << *this << ":"
-@@ -2786,7 +2798,11 @@ struct Framework
+@@ -2801,7 +2813,11 @@ struct Framework
            "framework " + stringify(info.id()),
            event,
            http.get(),
@@ -172,5 +172,5 @@ index 7a7b3a316..fac4440da 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
+++ b/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
@@ -1,7 +1,7 @@
-From 6f1ac264e41ee80ea968c7ab898e89017bb18834 Mon Sep 17 00:00:00 2001
+From f914709f1f1d881bdab02a1826c3d51912fe0f2b Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:25 -0700
-Subject: [PATCH 15/22] Added per-framework offer metrics.
+Subject: [PATCH] Added per-framework offer metrics.
 
 Review: https://reviews.apache.org/r/67812/
 ---
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67812/
  3 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 2244701e1..3a337e7b4 100644
+index bf1e61eb5..a743a6c9c 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -4029,6 +4029,8 @@ void Master::accept(
+@@ -3989,6 +3989,8 @@ void Master::accept(
      // Validate the offers.
      error = validation::offer::validate(accept.offer_ids(), this, framework);
  
@@ -23,7 +23,7 @@ index 2244701e1..3a337e7b4 100644
      // Compute offered resources and remove the offers. If the
      // validation failed, return resources to the allocator.
      foreach (const OfferID& offerId, accept.offer_ids()) {
-@@ -4046,6 +4048,8 @@ void Master::accept(
+@@ -4006,6 +4008,8 @@ void Master::accept(
            slaveId = offer->slave_id();
            allocationInfo = offer->allocation_info();
            offeredResources += offer->resources();
@@ -32,7 +32,7 @@ index 2244701e1..3a337e7b4 100644
          }
  
          removeOffer(offer);
-@@ -4057,6 +4061,8 @@ void Master::accept(
+@@ -4017,6 +4021,8 @@ void Master::accept(
        LOG(WARNING) << "Ignoring accept of offer " << offerId
                     << " since it is no longer valid";
      }
@@ -41,7 +41,7 @@ index 2244701e1..3a337e7b4 100644
    }
  
    // If invalid, send TASK_DROPPED for the launch attempts. If the
-@@ -5570,6 +5576,8 @@ void Master::decline(
+@@ -5530,6 +5536,8 @@ void Master::decline(
  
    ++metrics->messages_decline_offers;
  
@@ -50,7 +50,7 @@ index 2244701e1..3a337e7b4 100644
    //  Return resources to the allocator.
    foreach (const OfferID& offerId, decline.offer_ids()) {
      Offer* offer = getOffer(offerId);
-@@ -5581,6 +5589,8 @@ void Master::decline(
+@@ -5541,6 +5549,8 @@ void Master::decline(
            decline.filters());
  
        removeOffer(offer);
@@ -59,7 +59,7 @@ index 2244701e1..3a337e7b4 100644
        continue;
      }
  
-@@ -5589,6 +5599,8 @@ void Master::decline(
+@@ -5549,6 +5559,8 @@ void Master::decline(
      LOG(WARNING) << "Ignoring decline of offer " << offerId
                   << " since it is no longer valid";
    }
@@ -68,7 +68,7 @@ index 2244701e1..3a337e7b4 100644
  }
  
  
-@@ -8915,6 +8927,7 @@ void Master::offer(
+@@ -8875,6 +8887,7 @@ void Master::offer(
  
    LOG(INFO) << "Sending offers " << offerIds << " to framework " << *framework;
  
@@ -76,7 +76,7 @@ index 2244701e1..3a337e7b4 100644
    framework->send(message);
  }
  
-@@ -10843,6 +10856,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
+@@ -10803,6 +10816,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
    if (rescind) {
      RescindResourceOfferMessage message;
      message.mutable_offer_id()->MergeFrom(offer->id());
@@ -142,5 +142,5 @@ index fac4440da..b6fe20fb5 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
+++ b/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
@@ -1,7 +1,7 @@
-From 3eb7b20437636bb49d322d800e77040dd4959f96 Mon Sep 17 00:00:00 2001
+From 4a2be618a885210742ec0d6df27a6c02b9c28bbb Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:31 -0700
-Subject: [PATCH 16/22] Added per-framework metrics for task states.
+Subject: [PATCH] Added per-framework metrics for task states.
 
 Review: https://reviews.apache.org/r/67813/
 ---
@@ -12,10 +12,10 @@ Review: https://reviews.apache.org/r/67813/
  4 files changed, 79 insertions(+), 2 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 3a337e7b4..fcbfecd42 100644
+index a743a6c9c..40f8bec29 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -10283,6 +10283,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10243,6 +10243,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
    // task transitioned to a new state.
    bool sendSubscribersUpdate = false;
  
@@ -24,7 +24,7 @@ index 3a337e7b4..fcbfecd42 100644
    // Set 'removable' to true if this is the first time the task
    // transitioned to a removable state. Also set the latest state.
    bool removable;
-@@ -10296,6 +10298,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10256,6 +10258,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -38,7 +38,7 @@ index 3a337e7b4..fcbfecd42 100644
        task->set_state(latestState.get());
      }
    } else {
-@@ -10309,6 +10318,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10269,6 +10278,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -52,7 +52,7 @@ index 3a337e7b4..fcbfecd42 100644
        task->set_state(status.state());
      }
    }
-@@ -10340,7 +10356,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10300,7 +10316,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
      // transitioned to `TASK_KILLED` by `removeFramework()`, thus
      // `sendSubscribersUpdate` shouldn't have been set to true.
      // TODO(chhsiao): This may be changed after MESOS-6608 is resolved.
@@ -60,7 +60,7 @@ index 3a337e7b4..fcbfecd42 100644
      CHECK_NOTNULL(framework);
  
      subscribers.send(
-@@ -10369,7 +10384,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10329,7 +10344,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
  
      slave->recoverResources(task);
  
@@ -69,10 +69,10 @@ index 3a337e7b4..fcbfecd42 100644
        framework->recoverResources(task);
      }
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 431e8732c..40df26b81 100644
+index 5dd1ffa0a..536e4fe7c 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -2280,6 +2280,8 @@ struct Framework
+@@ -2295,6 +2295,8 @@ struct Framework
        }
      }
  
@@ -200,5 +200,5 @@ index b6fe20fb5..071246b71 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
+++ b/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
@@ -1,7 +1,7 @@
-From 2f7b5f705423f12d8dd2867a54d5b7f60187cd69 Mon Sep 17 00:00:00 2001
+From 759cb104e9b4406239cc6815774f934e8d485048 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:39 -0700
-Subject: [PATCH 17/22] Added per-framework metrics for offer operations.
+Subject: [PATCH] Added per-framework metrics for offer operations.
 
 Review: https://reviews.apache.org/r/67814/
 ---
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67814/
  3 files changed, 59 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index fcbfecd42..184c9e01c 100644
+index 40f8bec29..7bb2062fc 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -5112,6 +5112,10 @@ void Master::_accept(
+@@ -5072,6 +5072,10 @@ void Master::_accept(
                        << (launchExecutor ?
                            " new executor" : " existing executor");
  
@@ -25,7 +25,7 @@ index fcbfecd42..184c9e01c 100644
              send(slave->pid, message);
            }
          }
-@@ -5319,6 +5323,10 @@ void Master::_accept(
+@@ -5279,6 +5283,10 @@ void Master::_accept(
                    << *slave << " on "
                    << (launchExecutor ? " new executor" : " existing executor");
  
@@ -36,7 +36,7 @@ index fcbfecd42..184c9e01c 100644
          send(slave->pid, message);
  
          break;
-@@ -10832,6 +10840,12 @@ void Master::_apply(
+@@ -10792,6 +10800,12 @@ void Master::_apply(
  
      send(slave->pid, message);
    }
@@ -146,5 +146,5 @@ index 071246b71..7ce3941b2 100644
  
  
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
@@ -1,7 +1,7 @@
-From c50b9f341918834f8186755e6143575df04979e3 Mon Sep 17 00:00:00 2001
+From 2615a4c21e95657250cf7494c9743245777943c1 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:45 -0700
-Subject: [PATCH 18/22] Enabled per-framework metrics in the allocator.
+Subject: [PATCH] Enabled per-framework metrics in the allocator.
 
 The `FrameworkMetrics` struct will hold per-framework metrics tracked
 by the allocator.
@@ -81,5 +81,5 @@ index 6d386225c..daac93f7e 100644
  } // namespace allocator {
  } // namespace master {
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
+++ b/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
@@ -1,7 +1,7 @@
-From c492e746eb95613fa6898d12b9e158972edf26de Mon Sep 17 00:00:00 2001
+From da74108a1a691b805c5c65033c08d95f7e5a6b16 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:48 -0700
-Subject: [PATCH 19/22] Changed the 'capacity_' member of 'BoundedHashMap' to
+Subject: [PATCH] Changed the 'capacity_' member of 'BoundedHashMap' to
  non-const.
 
 This prevents the assignment operator from being implicitly deleted.
@@ -25,5 +25,5 @@ index 09a9b96f0..f73ec6b66 100644
    map keys_; // Map from key to "pointer" to key's location in list.
  };
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
@@ -1,7 +1,7 @@
-From 4c75ceaf1a8f42b9cbd6e634feb6426fc282972a Mon Sep 17 00:00:00 2001
+From 35eb904c028dfe50a49e5b1a46617a444117965d Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:49 -0700
-Subject: [PATCH 20/22] Tracked completed framework metrics in the allocator.
+Subject: [PATCH] Tracked completed framework metrics in the allocator.
 
 This ensures that per-framework metrics which are tracked in the
 allocator will be retained as long as the per-framework metrics
@@ -169,7 +169,7 @@ index ff96beea3..b86b01b00 100644
    {
    public:
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 184c9e01c..62a248cc7 100644
+index 7bb2062fc..8761cf0a5 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -810,7 +810,8 @@ void Master::initialize()
@@ -566,5 +566,5 @@ index 60efba54b..036b96c65 100644
    Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
    ASSERT_SOME(master);
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
+++ b/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
@@ -1,7 +1,7 @@
-From e4d3d99534b513190e29906cc4b9d0b5851ce67b Mon Sep 17 00:00:00 2001
+From 3a4d8a406830260ed29b763053e82de58f5e533f Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:59:04 -0700
-Subject: [PATCH 21/22] Added per-framework metrics for suppressed roles.
+Subject: [PATCH] Added per-framework metrics for suppressed roles.
 
 Review: https://reviews.apache.org/r/66870/
 ---
@@ -210,5 +210,5 @@ index daac93f7e..34cc16b3a 100644
  
  } // namespace internal {
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,8 +1,7 @@
-From 7972a847165e59d82662474bfb68f30470882c74 Mon Sep 17 00:00:00 2001
+From 99703756b4dad1d55b0649f874dce152b8f0543c Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Fri, 2 Nov 2018 16:13:01 -0700
-Subject: [PATCH 22/22] Added task health check definitions to master API
- responses.
+Subject: [PATCH] Added task health check definitions to master API responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified. Associated helpers are
@@ -102,5 +101,5 @@ index fda130727..5f3c2ae61 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.17.0
+2.17.1
 

--- a/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
+++ b/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
@@ -1,0 +1,38 @@
+From 5e56ee627019b035e736ffa166a8473eeabdc5f0 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Thu, 27 Sep 2018 15:20:01 +0200
+Subject: [PATCH] Put `TerminateEvent` at the end of the queue in the Mesos
+ library.
+
+This is to ensure all pending dispatches are processed. However
+multistage events, e.g., `Call`, might still be dropped, because
+a continuation (stage) of such event can be dispatched after the
+termination event.
+
+Review: https://reviews.apache.org/r/68865
+(cherry picked from commit 8f400c3e5abe0fa1810a6efd56bc3fecabf1bbd3)
+---
+ src/scheduler/scheduler.cpp | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/scheduler/scheduler.cpp b/src/scheduler/scheduler.cpp
+index c04cfbc42..7ca306702 100644
+--- a/src/scheduler/scheduler.cpp
++++ b/src/scheduler/scheduler.cpp
+@@ -927,7 +927,12 @@ void Mesos::reconnect()
+ void Mesos::stop()
+ {
+   if (process != nullptr) {
+-    terminate(process);
++    // We pass 'false' here to add the termination event at the end of the
++    // `MesosProcess` queue. This is to ensure all pending dispatches are
++    // processed. However multistage events, e.g., `Call`, might still be
++    // dropped, because a continuation (stage) of such event can be dispatched
++    // after the termination event, see MESOS-9274.
++    terminate(process, false);
+     wait(process);
+ 
+     delete process;
+-- 
+2.17.1
+

--- a/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
+++ b/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
@@ -1,0 +1,52 @@
+From dc0477937b92439f7ac2594589db8cbf08685e78 Mon Sep 17 00:00:00 2001
+From: Alexander Rukletsov <alexr@apache.org>
+Date: Tue, 9 Oct 2018 18:22:16 +0200
+Subject: [PATCH] Waited for TEARDOWN to be sent in v1 Java scheduler shim.
+
+Destruction of the library is not always under our control. For
+example, the JVM can call JNI `finalize()` if the Java scheduler
+nullifies its reference to the V1Mesos library immediately after
+sending `TEARDOWN`. We want to make sure that `TEARDOWN` is sent
+before the Mesos library is destructed.
+---
+ .../org_apache_mesos_v1_scheduler_V1Mesos.cpp   | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
+index 2a5fbd79a..6ec771111 100644
+--- a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
++++ b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
+@@ -28,6 +28,7 @@
+ #include <stout/foreach.hpp>
+ #include <stout/lambda.hpp>
+ #include <stout/option.hpp>
++#include <stout/os.hpp>
+ #include <stout/result.hpp>
+ #include <stout/try.hpp>
+ 
+@@ -286,6 +287,22 @@ JNIEXPORT void JNICALL Java_org_apache_mesos_v1_scheduler_V1Mesos_send
+   }
+ 
+   mesos->mesos->send(call);
++
++  // Destruction of the library is not always under our control. For example,
++  // the JVM can call JNI `finalize()` if the Java scheduler nullifies its
++  // reference to the V1Mesos library immediately after sending `TEARDOWN`,
++  // see MESOS-9274.
++  //
++  // We want to make sure that the `TEARDOWN` message is sent before the
++  // scheduler and the Mesos library are destructed (garbage collected).
++  // Without a flavour of `Mesos::send()` that blocks or returns a future,
++  // there is no better way than a hacky `sleep()`. This approach is foul
++  // because:
++  //   * it does not guarantee that 30s is enough and `TEARDOWN` is sent;
++  //   * it blocks the caller for 30s regardless of how long sending takes.
++  if (call.type() == Call::TEARDOWN) {
++    os::sleep(Seconds(30));
++  }
+ }
+ 
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
## High-level description

Add Mesos patches to ensure TEARDOWN is sent in v1 Java shim.

Destruction of the v1 library used in the v1 Java scheduler shim
is not always under our control. For example, the JVM can call JNI
`finalize()` if the Java scheduler nullifies its reference to the
V1Mesos library immediately after sending `TEARDOWN`. We want to make
sure that `TEARDOWN` is sent before the Mesos library is destructed.

## Corresponding DC/OS tickets (obligatory)


## Related tickets (optional)


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
