### PR TITLE
Collect Admin Router Nginx metrics from agents

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -113,6 +113,10 @@ minuteman
 Nginx
 - http://nginx.org/LICENSE
 
+nginx-module-vts
+- BSD 2-Clause License
+- https://github.com/vozlt/nginx-module-vts/blob/master/LICENSE
+
 ncurses
 - MIT License
 - http://invisible-island.net/ncurses/ncurses-license.html

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1449,7 +1449,7 @@ package:
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
-        urls = ["https://localhost/nginx/metrics"]
+        urls = ["https://127.0.0.1/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
         response_timeout = "10s"
         ## Optional TLS Config
@@ -1538,6 +1538,21 @@ package:
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
         percentile_limit = 1000
+      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      [[inputs.prometheus]]
+        ## An array of urls to scrape metrics from.
+        urls = ["http://127.0.0.1:61001/nginx/metrics"]
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
+        ## Optional TLS Config
+        # tls_ca = /path/to/cafile
+        # tls_cert = /path/to/certfile
+        # tls_key = /path/to/keyfile
+        ## Use TLS but skip chain & host verification
+        # insecure_skip_verify = true
+        ## Apply DC/OS component name tag according to the documentation.
+        [inputs.prometheus.tags]
+          dcos-component-name = "Admin Router Agent"
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1629,6 +1644,21 @@ package:
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
         percentile_limit = 1000
+      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      [[inputs.prometheus]]
+        ## An array of urls to scrape metrics from.
+        urls = ["http://127.0.0.1:61001/nginx/metrics"]
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
+        ## Optional TLS Config
+        # tls_ca = /path/to/cafile
+        # tls_cert = /path/to/certfile
+        # tls_key = /path/to/keyfile
+        ## Use TLS but skip chain & host verification
+        # insecure_skip_verify = true
+        ## Apply DC/OS component name tag according to the documentation.
+        [inputs.prometheus.tags]
+          dcos-component-name = "Admin Router Agent"
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -594,6 +594,26 @@
         </li>
       </ul>
     </li>
+    <li id="resource-status" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="status" href="#status" aria-hidden="true" class="toggle-route-group" data-id="status">
+            <div class="arrow arrow-right"></div>Status</a>
+        </h2>
+        <span class="options"><a href="#status" class="toggle-route-group" data-id="status">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-status" class="routes">
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/nginx/metrics</code></span>
+            </h3>
+            <span class="route-desc">Virtual host traffic Prometheus output (unauthenticated)</span>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-system" class="resource">
       <div class="heading">
         <h2>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -38,6 +38,11 @@ routes:
       path: 'http://$backend'
       backend: pkgpanda
     path: /pkgpanda/
+  /nginx/metrics:
+    group: Status
+    matcher: path
+    description: Virtual host traffic Prometheus output (unauthenticated)
+    path: /nginx/metrics
   /system/checks/v1:
     group: System
     matcher: path

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -1544,26 +1544,6 @@
         </li>
       </ul>
     </li>
-    <li id="resource-metrics" class="resource">
-      <div class="heading">
-        <h2>
-          <a id="metrics" href="#metrics" aria-hidden="true" class="toggle-route-group" data-id="metrics">
-            <div class="arrow arrow-right"></div>Metrics</a>
-        </h2>
-        <span class="options"><a href="#metrics" class="toggle-route-group" data-id="metrics">Show/Hide</a> </span>
-      </div>
-      <ul id="routes-metrics" class="routes">
-        <li class="route route-type-unknown">
-          <div class="heading">
-            <h3>
-              <span class="route-type">Unknown</span>
-              <span class="route-path"><code>/nginx/status</code></span>
-            </h3>
-            <span class="route-desc">Virtual Host Traffic Module Status</span>
-          </div>
-        </li>
-      </ul>
-    </li>
     <li id="resource-other" class="resource">
       <div class="heading">
         <h2>
@@ -1615,14 +1595,6 @@
                 </td>
               </tr>
             </table>
-          </div>
-        </li>
-        <li class="route route-type-unknown">
-          <div class="heading">
-            <h3>
-              <span class="route-type">Unknown</span>
-              <span class="route-path"><code>/nginx/metrics</code></span>
-            </h3>
           </div>
         </li>
         <li class="route route-type-proxy">
@@ -1796,6 +1768,35 @@
         </li>
       </ul>
     </li>
+    <li id="resource-status" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="status" href="#status" aria-hidden="true" class="toggle-route-group" data-id="status">
+            <div class="arrow arrow-right"></div>Status</a>
+        </h2>
+        <span class="options"><a href="#status" class="toggle-route-group" data-id="status">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-status" class="routes">
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/nginx/metrics</code></span>
+            </h3>
+            <span class="route-desc">Virtual host traffic Prometheus output (unauthenticated)</span>
+          </div>
+        </li>
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/nginx/status</code></span>
+            </h3>
+            <span class="route-desc">Virtual host traffic JavaScript output</span>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-system" class="resource">
       <div class="heading">
         <h2>
@@ -1891,7 +1892,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;url&gt;/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)</code></span>
+              <span class="route-path"><code>/system/v1/agent/(?&lt;agentid&gt;[0-9a-zA-Z-]+)(?&lt;url&gt;/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json|/nginx/metrics)</code></span>
             </h3>
             <span class="route-desc">System proxy to a specific agent node</span>
           </div>
@@ -1950,6 +1951,39 @@
                       </td>
                       <td>
                         <code>/dcos-metadata/dcos-version.json</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Type:
+                      </td>
+                      <td>
+                        <code>break</code>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Rewrite:
+                </td>
+                <td>
+                  <table>
+                    <tr>
+                      <td>
+                        Regex:
+                      </td>
+                      <td>
+                        <code>^/system/v1/agent/[0-9a-zA-Z-]+/nginx/metrics</code>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        Replacement:
+                      </td>
+                      <td>
+                        <code>/nginx/metrics</code>
                       </td>
                     </tr>
                     <tr>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -255,11 +255,6 @@ routes:
     lua:
       file: conf/lib/metadata.lua
     path: /metadata
-  /nginx/status:
-    group: Metrics
-    matcher: path
-    description: Virtual Host Traffic Module Status
-    path: /nginx/status
   /internal/mesos_dns/:
     group: Other
     matcher: path
@@ -267,10 +262,6 @@ routes:
       path: 'http://$backend/'
       backend: mesos_dns
     path: /internal/mesos_dns/
-  /nginx/metrics:
-    group: Other
-    matcher: path
-    path: /nginx/metrics
   '@service_default':
     group: Other
     matcher: path
@@ -319,6 +310,16 @@ routes:
         replacement: /service/$1/
         type: permanent
     path: '/service/(?<serviceid>[0-9a-zA-Z-.]+)'
+  /nginx/metrics:
+    group: Status
+    matcher: path
+    description: Virtual host traffic Prometheus output (unauthenticated)
+    path: /nginx/metrics
+  /nginx/status:
+    group: Status
+    matcher: path
+    description: Virtual host traffic JavaScript output
+    path: /nginx/status
   /system/checks/v1:
     group: System
     matcher: path
@@ -335,7 +336,7 @@ routes:
       path: 'http://$backend/system/health/v1'
       backend: dcos_diagnostics
     path: /system/health/v1
-  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)':
+  '/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json|/nginx/metrics)':
     group: System
     matcher: regex
     description: System proxy to a specific agent node
@@ -348,8 +349,11 @@ routes:
       - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json'
         replacement: /dcos-metadata/dcos-version.json
         type: break
+      - regex: '^/system/v1/agent/[0-9a-zA-Z-]+/nginx/metrics'
+        replacement: /nginx/metrics
+        type: break
     path: >-
-      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)
+      /system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json|/nginx/metrics)
   /system/v1/leader/marathon(?<url>.*):
     group: System
     matcher: regex

--- a/packages/adminrouter/extra/src/includes/server/common.conf
+++ b/packages/adminrouter/extra/src/includes/server/common.conf
@@ -1,3 +1,10 @@
+# Group: Status
+# Description: Virtual host traffic Prometheus output (unauthenticated)
+location /nginx/metrics {
+    vhost_traffic_status_display;
+    vhost_traffic_status_display_format prometheus;
+}
+
 # Group: Metadata
 # Description: DC/OS version (unauthenticated)
 location /dcos-metadata/dcos-version.json {

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -1,12 +1,8 @@
-# Group: Metrics
-# Description: Virtual Host Traffic Module Status
+# Group: Status
+# Description: Virtual host traffic JavaScript output
 location /nginx/status {
     vhost_traffic_status_display;
     vhost_traffic_status_display_format html;
-}
-location /nginx/metrics {
-    vhost_traffic_status_display;
-    vhost_traffic_status_display_format prometheus;
 }
 
 # Group: Pkgpanda
@@ -61,7 +57,7 @@ location ~ ^/system/v1/leader/marathon(?<url>.*)$ {
 
 # Group: System
 # Description: System proxy to a specific agent node
-location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json)$ {
+location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0.*|/dcos-metadata/dcos-version.json|/nginx/metrics)$ {
     set $agentaddr '';
     rewrite_by_lua_block {
         auth.access_system_agent_endpoint();
@@ -70,6 +66,7 @@ location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0
     }
     rewrite ^/system/v1/agent/[0-9a-zA-Z-]+/(logs.*|metrics/v0.*) /system/v1$url break;
     rewrite ^/system/v1/agent/[0-9a-zA-Z-]+/dcos-metadata/dcos-version.json /dcos-metadata/dcos-version.json break;
+    rewrite ^/system/v1/agent/[0-9a-zA-Z-]+/nginx/metrics /nginx/metrics break;
 
     more_clear_input_headers Accept-Encoding;
     include includes/http-11.conf;

--- a/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_generic.config.yml
@@ -5,12 +5,22 @@ endpoint_tests:
         expect_http_status: 200
         nocaching_headers_are_sent: skip
         test_paths:
-          - /nginx/status
           - /nginx/metrics
       is_unauthed_access_permitted:
         locations:
-          - /nginx/status
           - /nginx/metrics
+    type:
+      - master
+      - agent
+  - tests:
+      is_response_correct:
+        expect_http_status: 200
+        nocaching_headers_are_sent: skip
+        test_paths:
+          - /nginx/status
+      is_unauthed_access_permitted:
+        locations:
+          - /nginx/status
     type:
       - master
 ######### /exhibitor endpoint
@@ -354,6 +364,8 @@ endpoint_tests:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0/
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/logs
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/dcos-metadata/dcos-version.json
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/nginx/metrics
         upstream: http://127.0.0.2:61001
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.1
@@ -372,6 +384,8 @@ endpoint_tests:
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/metrics/v0
           - expected: /dcos-metadata/dcos-version.json
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/dcos-metadata/dcos-version.json
+          - expected: /nginx/metrics
+            sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S1/nginx/metrics
     type:
       - master
 # Agent B
@@ -390,6 +404,8 @@ endpoint_tests:
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0/
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/logs
           - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/dcos-metadata/dcos-version.json
+          - /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/nginx/metrics
         upstream: http://127.0.0.3:61001
       is_upstream_req_ok:
         expected_http_ver: HTTP/1.1
@@ -408,6 +424,8 @@ endpoint_tests:
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/metrics/v0
           - expected: /dcos-metadata/dcos-version.json
             sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/dcos-metadata/dcos-version.json
+          - expected: /nginx/metrics
+            sent: /system/v1/agent/de1baf83-c36c-4d23-9cb0-f89f596cd6ab-S0/nginx/metrics
     type:
       - master
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -129,6 +129,22 @@ def test_metrics_masters_adminrouter(dcos_api_session):
         check_adminrouter_metrics()
 
 
+def test_metrics_agents_adminrouter(dcos_api_session):
+    """Assert that Admin Router metrics on agents are present."""
+    for master in dcos_api_session.slaves:
+        expected_metrics = [
+            'dcos_component_name="Admin Router Agent"',
+            'nginx_vts',
+        ]
+
+        @retrying.retry(wait_fixed=2000, stop_max_delay=300 * 1000)
+        def check_adminrouter_metrics():
+            response = get_metrics_prom(dcos_api_session, master)
+            for metric_name in expected_metrics:
+                assert metric_name in response.text
+        check_adminrouter_metrics()
+
+
 def test_metrics_agents_statsd(dcos_api_session):
     """Assert that statsd metrics on agent are present."""
     if len(dcos_api_session.slaves) > 0:


### PR DESCRIPTION
## High-level description

This PR adds Admin Router metric scraping to agents. The `/nginx/metrics` Prometheus endpoint is added for that purpose. The endpoint can also be queried via the master Admin Router proxy as in:
`/system/v1/agent/<agent-id>/nginx/metrics`

Some missing Admin Router tests were also added in this PR. The Admin Router docs were re-generated for the new endpoint.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4569](https://jira.mesosphere.com/browse/DCOS_OSS-4569) Add Admin Router metrics scraping to agents.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This has already been done for Admin Router when metrics for masters were added.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)