### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 6fd9106

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "9c28b265804269de9411f04cfcccefe3bdd8ef1a",
+    "ref": "6fd91063da7230c2a65bea11ca4c69f241ba0877",
     "ref_origin": "1.5.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
+++ b/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
@@ -1,4 +1,4 @@
-From fea04ca41860fc3713c272d3e8d66a8bae56c247 Mon Sep 17 00:00:00 2001
+From 83950c1f97f5708ed49a99b1a9fde68aae336bdd Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:22 -0700
 Subject: [PATCH] Added per-framework metrics for scheduler events.
@@ -11,7 +11,7 @@ Review: https://reviews.apache.org/r/67809/
  3 files changed, 64 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 332033e9c..5dd1ffa0a 100644
+index f3641936f..05e530cfa 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -349,13 +349,16 @@ public:
@@ -52,8 +52,8 @@ index 332033e9c..5dd1ffa0a 100644
  };
  
  
-@@ -2339,6 +2347,10 @@ struct Framework
-                    << " framework " << *this;
+@@ -2352,6 +2360,10 @@ struct Framework
+       // check that one of `http` or `pid` is set if the framework is connected.
      }
  
 +    // TODO(gilbert): add a helper to transform `SchedulerDriver` API messages
@@ -63,7 +63,7 @@ index 332033e9c..5dd1ffa0a 100644
      if (http.isSome()) {
        if (!http.get().send(message)) {
          LOG(WARNING) << "Unable to send event to framework " << *this << ":"
-@@ -2801,7 +2813,11 @@ struct Framework
+@@ -2816,7 +2828,11 @@ struct Framework
            "framework " + stringify(info.id()),
            event,
            http.get(),
@@ -172,5 +172,5 @@ index 7a7b3a316..fac4440da 100644
  
  
 -- 
-2.17.1
+2.13.6 (Apple Git-96)
 


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/9c28b265804269de9411f04cfcccefe3bdd8ef1a...6fd91063da7230c2a65bea11ca4c69f241ba0877
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
