### PR TITLE
Change test_checks to improve its output and reduce the number of irrelevant failures

### DIFF
--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -96,7 +96,10 @@ def test_checks_api(dcos_api_session):
             results = r.json()
             assert isinstance(results, dict)
 
-            logging.info("returned checks: {}".format(checks))
-            logging.info("run checks     : {}".format(results['checks'].keys()))
-            # Make sure we ran all the listed checks.
-            assert set(checks.keys()) == set(results['checks'].keys())
+            # check that the returned statuses of each check is 0
+            expected_status = {c: 0 for c in checks.keys()}
+            response_status = {c: v['status'] for c, v in results['checks'].items()}
+            assert expected_status == response_status
+
+            # check that overall status is also 0
+            assert results['status'] == 0

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -63,7 +63,14 @@ def test_checks_cli(dcos_api_session):
 
 
 def test_checks_api(dcos_api_session):
-    """Test the checks API at /system/checks/"""
+    """
+    Test the checks API at /system/checks/
+    This will only test the checks API can be successfully reached on a real
+    cluster and that the checks it returns when running GET will match those it
+    reports when running the checks with POST. It does not check the results
+    status as `dcos_api_session` will wait while being built for the cluster to
+    be running so we won't expect any checks here to fail anyway.
+    """
     checks_uri = '/system/checks/v1/'
     # Test that we can list and run node and cluster checks on a master, agent, and public agent.
     check_nodes = []
@@ -88,7 +95,8 @@ def test_checks_api(dcos_api_session):
             assert r.status_code == 200
             results = r.json()
             assert isinstance(results, dict)
-            assert results['status'] == 0
 
+            logging.info("returned checks: {}".format(checks))
+            logging.info("run checks     : {}".format(results['checks'].keys()))
             # Make sure we ran all the listed checks.
             assert set(checks.keys()) == set(results['checks'].keys())

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -65,11 +65,9 @@ def test_checks_cli(dcos_api_session):
 def test_checks_api(dcos_api_session):
     """
     Test the checks API at /system/checks/
-    This will only test the checks API can be successfully reached on a real
-    cluster and that the checks it returns when running GET will match those it
-    reports when running the checks with POST. It does not check the results
-    status as `dcos_api_session` will wait while being built for the cluster to
-    be running so we won't expect any checks here to fail anyway.
+    This will test that all checks run on all agents return a normal status. A
+    failure in this test may be an indicator that some unrelated component
+    failed and dcos-checks functioned properly.
     """
     checks_uri = '/system/checks/v1/'
     # Test that we can list and run node and cluster checks on a master, agent, and public agent.


### PR DESCRIPTION

## High-level description
This sort of addresses test flakiness for `test_checks.test_checks_api`. It now no longer checks the result code from the checks API because `dcos_api_session` will essentially wait for and require a healthy cluster in order to continue and run this test. Since we're assuming a healthy cluster I don't think it makes sense to check the status because we thus always expect it to be 0 and if something unexpected goes wrong, it's very likely to be some transient failure in a different component as seen by the issue in the associated ticket.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-42722](https://jira.mesosphere.com/browse/DCOS-42722) test_checks.test_checks_api is flaky

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a change to a test
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a change to a test
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
