### PR TITLE
dcos-integration-test/test_groups.yaml: rebalance group 3

### DIFF
--- a/packages/dcos-integration-test/extra/test_groups.yaml
+++ b/packages/dcos-integration-test/extra/test_groups.yaml
@@ -65,12 +65,12 @@ groups:
         - test_meta.py
         - test_metrics.py
     group_3:
-        - test_metronome.py
         - test_misc.py
         - test_networking.py
-        - test_packaging.py
         - test_rexray.py
     group_4:
+        - test_metronome.py
+        - test_packaging.py
         - test_rlimit.py
         - test_service_discovery.py
         - test_sysctl.py


### PR DESCRIPTION
*Backport of https://github.com/dcos/dcos/pull/3908*

## High-level description

What features does this change enable? What bugs does this change fix?

Rebalance the test groups to bring Group 3 down somewhat from 17mins and bump Group 4 from 7mins. We aim for something like 14mins vs. 10mins, respectively.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46073](https://jira.mesosphere.com/browse/DCOS-46073) integration tests: rebalance OSS groups


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___