### PR TITLE
Add mergebot to owners.

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -12,6 +12,7 @@
   "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
   "klueska": {"slack": "klueska", "jira": "klueska"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
+  "mesosphere-mergebot": {"slack": "mergebot", "jira": "svc.mergebot"},
   "nLight": {"slack": "drozhkov", "jira": "drozhkov"},
   "philipnrmn": {"slack": "philip", "jira": "philip"},
   "orlandohohmeier": {"slack": "orlando", "jira": "orlando"},


### PR DESCRIPTION
## High-level description

Mergebot should be in owners.json to issue a `merge-it` command and auto-merge PRs.
We plan to use this for auto-merging Train PRs.

https://jira.mesosphere.com/browse/DCOS-46116 

