### PR TITLE
packages/bouncer: add dcos-oauth user migration service

### DIFF
--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -12,6 +12,7 @@
     "python-pyyaml",
     "python-cryptography",
     "python-gunicorn",
+    "python-kazoo",
     "six",
     "libpq"
   ],

--- a/packages/bouncer/build
+++ b/packages/bouncer/build
@@ -26,3 +26,9 @@ SERVICE_FILE_NAME="dcos-bouncer.service"
 SERVICE_FILE_PATH="$PKG_PATH/dcos.target.wants_master/${SERVICE_FILE_NAME}"
 mkdir -p "$(dirname "$SERVICE_FILE_PATH")"
 envsubst '$PKG_PATH' < "/pkg/extra/${SERVICE_FILE_NAME}" > "${SERVICE_FILE_PATH}"
+
+# Copy the IAM users migration script to the package bin directory.
+mkdir -p $PKG_PATH/bin
+install -m 755 /pkg/extra/iam-migrate-users-from-1.12.py $PKG_PATH/bin/iam-migrate-users-from-1.12.py
+
+cp /pkg/extra/dcos-bouncer-migrate-users.service "$PKG_PATH/dcos.target.wants_master/dcos-bouncer-migrate-users.service"

--- a/packages/bouncer/build
+++ b/packages/bouncer/build
@@ -29,6 +29,6 @@ envsubst '$PKG_PATH' < "/pkg/extra/${SERVICE_FILE_NAME}" > "${SERVICE_FILE_PATH}
 
 # Copy the IAM users migration script to the package bin directory.
 mkdir -p $PKG_PATH/bin
-install -m 755 /pkg/extra/iam-migrate-users-from-1.12.py $PKG_PATH/bin/iam-migrate-users-from-1.12.py
+install -m 755 /pkg/extra/iam-migrate-users-from-zk.py $PKG_PATH/bin/iam-migrate-users-from-zk.py
 
 cp /pkg/extra/dcos-bouncer-migrate-users.service "$PKG_PATH/dcos.target.wants_master/dcos-bouncer-migrate-users.service"

--- a/packages/bouncer/extra/dcos-bouncer-migrate-users.service
+++ b/packages/bouncer/extra/dcos-bouncer-migrate-users.service
@@ -11,7 +11,6 @@ RestartSec=30
 LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=/opt/mesosphere/active/bouncer/bin/iam-migrate-users-from-1.12.py
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/bouncer/extra/dcos-bouncer-migrate-users.service
+++ b/packages/bouncer/extra/dcos-bouncer-migrate-users.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=DC/OS Identity and Access users migration: Migrate users from dcos-oauth service.
+Documentation=https://docs.mesosphere.com
+
+[Service]
+Type=simple
+User=dcos_bouncer
+StartLimitInterval=0
+Restart=on-failure
+RestartSec=30
+LimitNOFILE=16384
+EnvironmentFile=/opt/mesosphere/environment
+ExecStart=/opt/mesosphere/active/bouncer/bin/iam-migrate-users-from-1.12.py
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/bouncer/extra/dcos-bouncer-migrate-users.service
+++ b/packages/bouncer/extra/dcos-bouncer-migrate-users.service
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=30
 LimitNOFILE=16384
 EnvironmentFile=/opt/mesosphere/environment
-ExecStart=/opt/mesosphere/active/bouncer/bin/iam-migrate-users-from-1.12.py
+ExecStart=/opt/mesosphere/active/bouncer/bin/iam-migrate-users-from-zk.py
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/bouncer/extra/iam-migrate-users-from-1.12.py
+++ b/packages/bouncer/extra/iam-migrate-users-from-1.12.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+"""
+This is a users migration script from DC/OS Open 1.12 where users were stored
+in ZK database.
+
+The migration scripts creates an IAM user for each legacy user and deletes
+the legacy user from ZK. After the migration is completed the /dcos/users
+path is deleted completely.
+
+Notes:
+This script should be removed from future versions of DC/OS Open.
+When removing this script also remove `python-kazoo` dependency from the
+`bouncer-deps` DC/OS package.
+"""
+
+import logging
+from typing import List
+
+
+import kazoo.exceptions
+import requests
+from kazoo.client import KazooClient
+from kazoo.retry import KazooRetry
+
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
+
+
+# This script will run on a master server after the IAM service has been running.
+ZK_HOSTS = 'zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181'
+ZK_USERS_PATH = '/dcos/users'
+# To keep this script simple and avoid authentication and authorization this
+# script uses local IAM address instead of going through Admin Router
+IAM_BASE_URL = 'http://127.0.0.1:8101'
+
+
+def create_zk_client(zk_hosts: str) -> KazooClient:
+    conn_retry_policy = KazooRetry(max_tries=-1, delay=0.1, max_delay=0.1)
+    cmd_retry_policy = KazooRetry(
+        max_tries=3, delay=0.3, backoff=1, max_delay=1, ignore_expire=False)
+    return KazooClient(
+        hosts=zk_hosts,
+        connection_retry=conn_retry_policy,
+        command_retry=cmd_retry_policy,
+    )
+
+
+def get_legacy_uids_from_zk(zk: KazooClient) -> List:
+    """
+    Loads users from legacy datastore
+
+    https://github.com/dcos/dcos-oauth/blob/ac186bf48f21166c3bb935fdc1922bbace75b6a4/dcos-oauth/users.go
+    """
+    return zk.get_children(ZK_USERS_PATH)
+
+
+def migrate_user(uid: str) -> None:
+    """
+    Create a user in IAM service:
+
+    https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
+    """
+    url = '{iam}/acs/api/v1/users/{uid}'.format(
+        iam=IAM_BASE_URL,
+        uid=uid,
+    )
+    r = requests.put(url, json={})
+
+    # The 409 response code means that user already exists in the DC/OS IAM
+    # service
+    if r.status_code != 409:
+        r.raise_for_status()
+
+    log.info('Created IAM user `%s`', uid)
+
+
+def main() -> None:
+    log.info('Initialize ZK client')
+    zk = create_zk_client(zk_hosts=ZK_HOSTS)
+    zk.start()
+
+    # If a cluster is not being upgraded or a migration has been already
+    # performed fail fast
+    if not zk.exists(ZK_USERS_PATH):
+        log.info(
+            'Path `%s` does not exits in ZK. Nothing to migrate.', ZK_USERS_PATH)
+        return
+
+    # Check that the IAM service is up and running with a simple health check
+    r = requests.get('{iam}/acs/api/v1/auth/jwks'.format(
+        iam=IAM_BASE_URL,
+    ))
+    assert r.status_code == 200
+
+    uids = get_legacy_uids_from_zk(zk=zk)
+    log.info('Found `%d` users for migration.', len(uids))
+
+    for uid in uids:
+        log.info('Migrating uid `%s`', uid)
+        migrate_user(uid=uid)
+
+        zk_uid_path = '{base_path}/{uid}'.format(
+            base_path=ZK_USERS_PATH,
+            uid=uid
+        )
+        try:
+            log.info('Deleting ZK path `%s`', zk_uid_path)
+            zk.delete(zk_uid_path)
+        except kazoo.exceptions.NoNodeError:
+            # Is it possible that it was migrated in other instance of this
+            # script.
+            log.warn('ZK node `%s` no loger exists.', zk_uid_path)
+            pass
+
+    # Finally we can remove /dcos/users which should be empty at this point
+    try:
+        log.info('Removing legacy ZK path `%s`.', ZK_USERS_PATH)
+        zk.delete(ZK_USERS_PATH)
+    except kazoo.exceptions.NoNodeError:
+        # Is it possible that it was migrated in other instance of this
+        # script.
+        log.warn('ZK node `%s` no loger exists.', zk_uid_path)
+
+    zk.stop()
+    log.info('Migration completed.')
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/dcos-integration-test/buildinfo.json
+++ b/packages/dcos-integration-test/buildinfo.json
@@ -4,5 +4,6 @@
       "dcos-test-utils",
       "pytest",
       "python",
+      "python-kazoo",
       "python-requests"]
 }

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -129,6 +129,7 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
         'dcos-metronome.service',
         'dcos-signal.service',
         'dcos-bouncer.service',
+        'dcos-bouncer-migrate-users.service',
     ]
     all_node_units = [
         'dcos-checks-api.service',

--- a/packages/dcos-integration-test/extra/test_groups.yaml
+++ b/packages/dcos-integration-test/extra/test_groups.yaml
@@ -77,4 +77,5 @@ groups:
         - test_ucr.py
         - test_units.py
         - test_iam.py
+        - test_iam_migration.py
         - test_legacy_user_management.py

--- a/packages/dcos-integration-test/extra/test_iam_migration.py
+++ b/packages/dcos-integration-test/extra/test_iam_migration.py
@@ -1,0 +1,80 @@
+"""
+Tests automated migration script for users stored by dcos-oauth service
+"""
+
+import logging
+import time
+from subprocess import check_call
+
+import kazoo.exceptions
+import pytest
+from dcos_test_utils.dcos_api import DcosApiSession
+from kazoo.client import KazooClient
+from kazoo.retry import KazooRetry
+
+
+__maintainer__ = 'mhrabovcin'
+__contact__ = 'security-team@mesosphere.io'
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope='module')
+def zk() -> KazooClient:
+    conn_retry_policy = KazooRetry(max_tries=-1, delay=0.1, max_delay=0.1)
+    cmd_retry_policy = KazooRetry(
+        max_tries=3, delay=0.3, backoff=1, max_delay=1, ignore_expire=False)
+    zk = KazooClient(
+        hosts='zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181',
+        connection_retry=conn_retry_policy,
+        command_retry=cmd_retry_policy,
+    )
+    zk.start()
+    yield zk
+    zk.stop()
+
+
+@pytest.fixture()
+def create_dcos_oauth_users(zk: KazooClient) -> None:
+
+    def _create_dcos_oauth_user(uid):
+        log.info('Creating user `%s`', uid)
+        zk.create('/dcos/users/{uid}'.format(uid=uid), makepath=True)
+
+    def _delete_dcos_oauth_user(uid):
+        try:
+            zk.delete('/dcos/users/{uid}'.format(uid=uid))
+        except kazoo.exceptions.NoNodeError:
+            pass
+
+    _create_dcos_oauth_user('user1@example.com')
+    _create_dcos_oauth_user('user2@example.com')
+
+    yield
+
+    _delete_dcos_oauth_user('user1@example.com')
+    _delete_dcos_oauth_user('user2@example.com')
+
+
+@pytest.mark.usefixtures('create_dcos_oauth_users')
+def test_iam_migration(zk: KazooClient, dcos_api_session: DcosApiSession) -> None:
+    check_call(['sudo', 'systemctl', 'stop', 'dcos-bouncer-migrate-users.service'])
+
+    def _filter_test_uids(r):
+        return [
+            u['uid'] for u in r.json()['array'] if '@example.com' in u['uid']]
+
+    r = dcos_api_session.get('/acs/api/v1/users')
+    test_uids = _filter_test_uids(r)
+    assert len(test_uids) == 0
+
+    check_call(['sudo', 'systemctl', 'start', 'dcos-bouncer-migrate-users.service'])
+    # Sleep for 5 seconds and let the migration script run
+    time.sleep(5)
+
+    r = dcos_api_session.get('/acs/api/v1/users')
+    test_uids = _filter_test_uids(r)
+    assert len(test_uids) == 2
+    assert 'user1@example.com' in test_uids
+    assert 'user2@example.com' in test_uids

--- a/packages/dcos-integration-test/extra/test_iam_migration.py
+++ b/packages/dcos-integration-test/extra/test_iam_migration.py
@@ -58,7 +58,7 @@ def create_dcos_oauth_users(zk: KazooClient) -> None:
 
 
 @pytest.mark.usefixtures('create_dcos_oauth_users')
-def test_iam_migration(zk: KazooClient, dcos_api_session: DcosApiSession) -> None:
+def test_iam_migration(dcos_api_session: DcosApiSession) -> None:
     check_call(['sudo', 'systemctl', 'stop', 'dcos-bouncer-migrate-users.service'])
 
     def _filter_test_uids(r):


### PR DESCRIPTION
## High-level description

Add a migration script that will convert DC/OS Open users from version `1.12` and beyond from Zookeeper database to the new IAM service datastore.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45632](https://jira.mesosphere.com/browse/DCOS-45632) Write Basic Migration Script

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: service accounts alignment is already documented in `CHANGES.md` file
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)