### PR TITLE
Handle Azure Exception During Copy and Upload.

### DIFF
--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -35,7 +35,7 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
         resp = None
         try:
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
-        except azure.common.AzureConflictHttpError:
+        except (azure.common.AzureConflictHttpError, azure.common.AzureException):
             # Cancel the past copy, make a new copy
             properties = self.blob_service.get_blob_properties(self.container, destination_path)
             assert properties.id
@@ -48,7 +48,7 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
         # synchronous and successful.
         assert resp.status == 'success'
 
-    @retry(stop_max_attempt_number=3)
+    @retry(stop_max_attempt_number=5)
     def upload(self,
                destination_path: str,
                blob: Optional[bytes]=None,


### PR DESCRIPTION
## High-level description

* (DCOS-40442) AzureException during storage upload

### Background.

It is was important to note that problem was not neccessarily due to large file size on Azure platform.

This can be seen on this failure.

```
[15:21:26]Store to azure artifact testing/master/ee.bootstrap.latest by method copy
```

Where ee.bootstrap.latest is not a generate_config.sh that is the largest artifact file.

The failure was in the copy operation, the copy operation was handling only one kind of error `AzureConflictHttpError` and we can simply expand the scope to `AzureException` that was frequently observed.

* More over, instead of retry, we are doing a `abort copy` and copy again. 

(This is same the existing code, but little more stringent).

---- 

Another change was to retry upload 5 times instead of 3

```
-    @retry(stop_max_attempt_number=3)
+    @retry(stop_max_attempt_number=5)
     def upload(self,
```



