### PR TITLE
[1.12] Allow user-editable Telegraf configs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Notable changes
 
+* Telegraf: Users can now supply additional Telegraf settings (DCOS-42214)
+
 ### Breaking changes
 
 ### Fixed and improved

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1236,6 +1236,7 @@ package:
     content: |
       TELEGRAF_CONFIG_FILE=/opt/mesosphere/etc/telegraf/telegraf.conf
       TELEGRAF_CONFIG_DIR=/opt/mesosphere/etc/telegraf/telegraf.d/
+      TELEGRAF_EXTRA_CONFIG_DIR=/var/lib/dcos/telegraf/telegraf.d/
       TELEGRAF_CONTAINERS_DIR=/run/dcos/telegraf/dcos_statsd/containers
       LEGACY_CONTAINERS_PARENT_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule
       LEGACY_CONTAINERS_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -24,6 +24,14 @@ mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
 # Migrate old containers dir to new location in case the cluster was upgraded.
 /opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
 
+# Add symlinks to any additional configuration files in the user-editable Telegraf config directory
+shopt -s nullglob
+for file in ${TELEGRAF_EXTRA_CONFIG_DIR}*; do
+	ln -sfn $file ${TELEGRAF_CONFIG_DIR}$(basename "$file")
+done
+# Remove any broken symlinks
+find ${TELEGRAF_CONFIG_DIR} -type l ! -exec test -e {} \; -exec rm {} \;
+
 # Ensure that old socket file is removed, if present
 # TODO(philipnrmn): investigate whether moving to a systemd-managed socket
 # would be a better solution than manually creating and removing this file.


### PR DESCRIPTION
## High-level description

Previously, the only way for a user to supply additional telegraf configuration was to modify/add conf files to the telegraf config directory, which is within `/opt/mesosphere`. Now, users can add additional conf files to the `/var/lib/dcos/telegraf/telegraf.d/` directory, which gets symlinked into the Telegraf config directory.

Will add documentation on this in a docs pr.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-42214](https://jira.mesosphere.com/browse/DCOS-42214) support methods to configure additional settings on dcos-telegraf


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: 
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Mainly a configuration change, not easily testable
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
