### PR TITLE
Gather Prometheus metrics from tasks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,15 +13,18 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
-* Admin Router Nginx Virtual Hosts metrics are now collected by default. An Ningx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
+* Admin Router Nginx Virtual Hosts metrics are now collected by default. An Nginx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
 
 * CockroachDB metrics are now collected by Telegraf (DCOS_OSS-4529).
 
 * ZooKeeper metrics are now collected by Telegraf (DCOS_OSS-4477).
 
 * Mesos metrics are now available by default. (DCOS_OSS-3815)
+
 * Metronome supports UCR
+
 * Metronome supports file based secrets
+
 * Metronome supports hybrid cloud
 
 * Expose Public IP (DCOS_OSS-4514)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Prometheus-format metrics can be gathered from tasks (DCOS_OSS-3717)
 
+
 ### Breaking changes
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Expose Public IP (DCOS_OSS-4514)
 
+* Prometheus-format metrics can be gathered from tasks (DCOS_OSS-3717)
+
 ### Breaking changes
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1572,6 +1572,12 @@ package:
         percentile_limit = 1000
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
+        ## The URL of the local mesos agent
+		mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        ## The period after which requests to mesos agent should time out
+	    mesos_timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "telegraf-prometheus"
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
@@ -1684,6 +1690,13 @@ package:
         percentile_limit = 1000
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
+        ## The URL of the local mesos agent
+		mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        ## The period after which requests to mesos agent should time out
+	    mesos_timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "telegraf-prometheus"
+
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1577,7 +1577,7 @@ package:
         ## The period after which requests to mesos agent should time out
         mesos_timeout = "10s"
         ## The user agent to send with requests
-        user_agent = "telegraf-prometheus"
+        user_agent = "Telegraf-prometheus"
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
@@ -1695,7 +1695,7 @@ package:
         ## The period after which requests to mesos agent should time out
         mesos_timeout = "10s"
         ## The user agent to send with requests
-        user_agent = "telegraf-prometheus"
+        user_agent = "Telegraf-prometheus"
 
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1573,9 +1573,9 @@ package:
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
         ## The URL of the local mesos agent
-		mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
-	    mesos_timeout = "10s"
+        mesos_timeout = "10s"
         ## The user agent to send with requests
         user_agent = "telegraf-prometheus"
         ## An array of urls to scrape metrics from.
@@ -1691,9 +1691,9 @@ package:
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
         ## The URL of the local mesos agent
-		mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
         ## The period after which requests to mesos agent should time out
-	    mesos_timeout = "10s"
+        mesos_timeout = "10s"
         ## The user agent to send with requests
         user_agent = "telegraf-prometheus"
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -559,8 +559,8 @@ def test_prom_metrics_containers_app(dcos_api_session):
 
             'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_bucket{{le=\"+Inf\"}} 4" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_sum 4" >> metrics"'.format(metric_name_pfx),
-            'echo "{}_histogram_seconds_count 4" >> metrics"'.format(metric_name_pfx),
+            'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
 
             'echo "Serving prometheus metrics on http://localhost:$PORT0"',
             'python3 -m http.server $PORT0',

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -579,9 +579,9 @@ def test_prom_metrics_containers_app(dcos_api_session):
     logging.debug('Starting marathon app with config: %s', marathon_app)
     expected_metrics = [
         # metric_name, metric_value
-        ('_'.join([metric_name_pfx, 'gauge']), 100),
-        ('_'.join([metric_name_pfx, 'count']), 2),
-        ('_'.join([metric_name_pfx, 'histogram', 'count']), 4),
+        ('_'.join([metric_name_pfx, 'gauge.gauge']), 100),
+        ('_'.join([metric_name_pfx, 'count.counter']), 2),
+        ('_'.join([metric_name_pfx, 'histogram_seconds', 'count']), 4),
     ]
 
     with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -558,7 +558,7 @@ def test_prom_metrics_containers_app(dcos_api_session):
             'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
 
             'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_bucket{le="+Inf"} 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_bucket{{le="+Inf"}} 4" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_sum 4" >> metrics"'.format(metric_name_pfx),
             'echo "{}_histogram_seconds_count 4" >> metrics"'.format(metric_name_pfx),
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -569,12 +569,14 @@ def test_prom_metrics_containers_app(dcos_api_session):
             'type': 'MESOS',
             'docker': {'image': 'library/python:3'}
         },
-        'portDefinitions': {
+        'portDefinitions': [{
             'protocol': 'tcp',
             'port': 0,
             'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
-        },
+        }],
     }
+
+    logging.debug('Starting marathon app with config: %s', marathon_app)
     expected_metrics = [
         # metric_name, metric_value
         ('_'.join([metric_name_pfx, 'gauge']), 100),

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -558,7 +558,7 @@ def test_prom_metrics_containers_app(dcos_api_session):
             'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
 
             'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_bucket{{le="+Inf"}} 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_bucket{{le=\"+Inf\"}} 4" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_sum 4" >> metrics"'.format(metric_name_pfx),
             'echo "{}_histogram_seconds_count 4" >> metrics"'.format(metric_name_pfx),
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -482,10 +482,10 @@ def test_metrics_containers(dcos_api_session):
         test_containers(endpoints)
 
 
-def test_metrics_containers_app(dcos_api_session):
-    """Assert that app metrics appear in the v0 metrics API."""
-    task_name = 'test-metrics-containers-app'
-    metric_name_pfx = 'test_metrics_containers_app'
+def test_statsd_metrics_containers_app(dcos_api_session):
+    """Assert that statsd app metrics appear in the v0 metrics API."""
+    task_name = 'test-statsd-metrics-containers-app'
+    metric_name_pfx = 'test_statsd_metrics_containers_app'
     marathon_app = {
         'id': '/' + task_name,
         'instances': 1,

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -558,7 +558,7 @@ def test_prom_metrics_containers_app(dcos_api_session):
             'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
 
             'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_bucket{{le=\"+Inf\"}} 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "590e7f862df5adb00976838979fff6bdf27960a3",
+    "ref": "644970f36a64f412576550ed2b7707cdde364efa",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "4d195ab4ea296d9a34dfc8560f376d24cac4f4ce",
+    "ref": "590e7f862df5adb00976838979fff6bdf27960a3",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This PR enables Prometheus metrics collection from ports on tasks which specify `DCOS_METRICS_FORMAT=prometheus` in their labels.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3717](https://jira.mesosphere.com/browse/DCOS_OSS-3717) Add Mesos service discovery to the Telegraf prometheus metrics input plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/telegraf/compare/a88d78350c9244336607e37cc808bb76a40e8b89...ba18887f5d6358e3eb73d5df7e16a2c19c3cbfda)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/161/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/161/)

