### PR TITLE
cockroach: use exhibitor_wait as ExecStartPre

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -109,6 +109,7 @@ bootstrappers = {
     'dcos-mesos-slave': noop,
     'dcos-mesos-slave-public': noop,
     'dcos-cosmos': noop,
+    'dcos-cockroach': noop,
     'dcos-metronome': noop,
     'dcos-history': noop,
     'dcos-mesos-dns': noop,

--- a/packages/cockroach/extra/dcos-cockroach.service
+++ b/packages/cockroach/extra/dcos-cockroach.service
@@ -15,6 +15,10 @@ EnvironmentFile=-/run/dcos/etc/cockroach
 Environment=COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true
 ExecStartPre=/usr/bin/mkdir -p /run/dcos/cockroach
 ExecStartPre=/bin/chown -R dcos_cockroach /run/dcos/cockroach
+# The CockroachDB multi node coordination performed by register.py
+# requires the ZooKeeper cluster to be formed. This is achieved
+# by the noop bootstrapper.
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach
 ExecStartPre=/opt/mesosphere/active/cockroach/bin/register.py
 ExecStart=/opt/mesosphere/active/cockroach/bin/cockroach.sh
 ExecStartPost=-/bin/sleep 15


### PR DESCRIPTION
From the commit message:
```
This fixes DCOS_OSS-4601. Without this step
register.py is highly likely to find the
ZooKeeper cluster in a state where individual
ZooKeeper instances are still in standalone
mode. This on the other hand leads to individual
CockroachDB instances being launched without
being aware of each other.
```

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS_OSS-4601




## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: bug was not yet released
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: there is no multi-master test in our CI
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
