### PR TITLE
Xfailflake date

### DIFF
--- a/packages/dcos-integration-test/extra/common.py
+++ b/packages/dcos-integration-test/extra/common.py
@@ -1,5 +1,0 @@
-import pytest
-
-# Mute Flaky Integration Tests with custom pytest marker.
-# Rationale for doing this is mentioned at DCOS-45308
-xfailflake = pytest.mark.xfail(strict=False)

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 
@@ -39,12 +40,52 @@ def pytest_addoption(parser):
                      help="run only Windows tests")
 
 
+def _add_xfail_markers(item):
+    """
+    Mute flaky Integration Tests with custom pytest marker.
+    Rationale for doing this is mentioned at DCOS-45308.
+    """
+    xfailflake_markers = [
+        marker for marker in item.iter_markers() if marker.name == 'xfailflake'
+    ]
+    for xfailflake_marker in xfailflake_markers:
+        assert 'reason' in xfailflake_marker.kwargs
+        assert 'jira' in xfailflake_marker.kwargs
+        assert xfailflake_marker.kwargs['jira'].startswith('DCOS')
+        # Show the JIRA in the printed reason.
+        xfailflake_marker.kwargs['reason'] = '{jira} - {reason}'.format(
+            jira=xfailflake_marker.kwargs['jira'],
+            reason=xfailflake_marker.kwargs['reason'],
+        )
+        date_text = xfailflake_marker.kwargs['since']
+        try:
+            datetime.datetime.strptime(date_text, '%Y-%m-%d')
+        except ValueError:
+            message = (
+                'Incorrect date format for "since", should be YYYY-MM-DD'
+            )
+            raise ValueError(message)
+
+        # The marker is not "strict" unless that is explicitly stated.
+        # That means that by default, no error is raised if the test passes or
+        # fails.
+        strict = xfailflake_marker.kwargs.get('strict', False)
+        xfailflake_marker.kwargs['strict'] = strict
+        xfail_marker = pytest.mark.xfail(
+            *xfailflake_marker.args,
+            **xfailflake_marker.kwargs,
+        )
+        item.add_marker(xfail_marker)
+
+
 def pytest_runtest_setup(item):
     if pytest.config.getoption('--windows-only'):
         if item.get_marker('supportedwindows') is None:
             pytest.skip("skipping not supported windows test")
     elif item.get_marker('supportedwindowsonly') is not None:
         pytest.skip("skipping windows only test")
+
+    _add_xfail_markers(item)
 
 
 def pytest_configure(config):

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -2,13 +2,17 @@ import logging
 import random
 import uuid
 
-import common
+import pytest
 
 __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
-@common.xfailflake(reason="DCOS-45278 - test_checks_cli _wait_for_run_completion")
+@pytest.mark.xfailflake(
+    jira='DCOS-45278',
+    reason='test_checks_cli _wait_for_run_completion',
+    since='2018-11-20',
+)
 def test_checks_cli(dcos_api_session):
     base_cmd = [
         '/opt/mesosphere/bin/dcos-shell',

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 import zipfile
 
-import common
 import pytest
 import retrying
 
@@ -331,8 +330,11 @@ def test_dcos_diagnostics_report(dcos_api_session):
         assert len(report_response['Nodes']) > 0
 
 
-@common.xfailflake(reason="DCOS-44935 - test_dcos_diagnostics.test_dcos_diagnostics_bundle_create_download_delete is "
-                          "Flaky")
+@pytest.mark.xfailflake(
+    jira='DCOS-45278',
+    reason='test_dcos_diagnostics.test_dcos_diagnostics_bundle_create_download_delete is Flaky',
+    since='2018-11-20',
+)
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
     """
     test bundle create, read, delete workflow

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import uuid
 
-import common
 import pytest
 import retrying
 from test_helpers import expanded_config
@@ -281,7 +280,11 @@ def test_task_metrics_metadata(dcos_api_session):
 
 @pytest.mark.skipif(expanded_config.get('security') == 'strict',
                     reason="Framework disabled for strict mode")
-@common.xfailflake(reason="DCOS_OSS-4568 - Framework hello-world still running")
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4568',
+    reason='Framework hello-world still running',
+    since='2018-12-14',
+)
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'):
@@ -378,7 +381,11 @@ def test_metrics_node(dcos_api_session):
         assert expected_dimension_response(response.json())
 
 
-@common.xfailflake(reason="DCOS_OSS-4486 - test_metrics_containers fails with container metrics response status 204")
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4486',
+    reason='test_metrics_containers fails with container metrics response status 204',
+    since='2018-11-20',
+)
 def test_metrics_containers(dcos_api_session):
     """If there's a deployed container on the slave, iterate through them to check for
     the statsd-emitter executor. When found, query it's /app endpoint to test that

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -1,10 +1,14 @@
-import common
+import pytest
 
 __maintainer__ = 'ichernetsky'
 __contact__ = 'marathon-team@mesosphere.io'
 
 
-@common.xfailflake(reason="DCOS-40611 - test_metronome.test_metronome failed sporadically on Azure ARM platform.")
+@pytest.mark.xfailflake(
+    jira='DCOS-40611',
+    reason="test_metronome.test_metronome failed sporadically on Azure ARM platform.",
+    since='2018-11-20',
+)
 def test_metronome(dcos_api_session):
     job = {
         'description': 'Test Metronome API regressions',

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -9,7 +9,6 @@ import uuid
 from collections import deque
 from subprocess import check_output
 
-import common
 import pytest
 import requests
 import retrying
@@ -227,7 +226,11 @@ def workload_test(dcos_api_session, container, app_net, proxy_net, ipv6, same_ho
     return (hosts, origin_app, proxy_app)
 
 
-@common.xfailflake(reason="DCOS-46146 Upgrade docker to version 17.12.x.")
+@pytest.mark.xfailflake(
+    jira='DCOS-46146',
+    reason='Upgrade docker to version 17.12.x.',
+    since='2018-12-11',
+)
 @pytest.mark.slow
 @pytest.mark.parametrize('same_host', [True, False])
 def test_ipv6(dcos_api_session, same_host):
@@ -278,11 +281,18 @@ def test_vip_ipv6(dcos_api_session):
 @pytest.mark.parametrize(
     'container,vip_net,proxy_net',
     generate_vip_app_permutations())
-@common.xfailflake(
+@pytest.mark.xfailflake(
+    jira='DCOS-46220',
     reason=(
-        "DCOS-46220 Constraints for run spec [xxx] not satisfied / "
-        "DCOS-45799 - container stuck in PROVISIONING"
+        "test_networking.test_vip can fail because Marathon "
+        "says Constraints for run spec [xxx] not satisfied.",
     ),
+    since='2018-12-13',
+)
+@pytest.mark.xfailflake(
+    jira='DCOS-45799',
+    reason='[Container_MESOS-Network_HOST-Network_HOST] (container stuck in PROVISIONING)',
+    since='2018-12-13',
 )
 def test_vip(dcos_api_session,
              container: marathon.Container,
@@ -381,7 +391,11 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, nam
     return (vip, hosts, cmd, origin_app, proxy_app)
 
 
-@common.xfailflake(reason="DCOS-46146 Upgrade docker to version 17.12.x.")
+@pytest.mark.xfailflake(
+    jira='DCOS-46146',
+    reason='Upgrade docker to version 17.12.x.',
+    since='2018-12-11',
+)
 @retrying.retry(wait_fixed=2000,
                 stop_max_delay=120 * 1000,
                 retry_on_exception=lambda x: True)

--- a/packages/dcos-integration-test/extra/test_units.py
+++ b/packages/dcos-integration-test/extra/test_units.py
@@ -5,7 +5,6 @@ import pathlib
 import stat
 import subprocess
 
-import common
 import pytest
 
 
@@ -78,7 +77,11 @@ def test_verify_units():
     _check_units("/etc/systemd/system/dcos-*.socket")
 
 
-@common.xfailflake(reason="DCOS-41819 - Fails on dcos-e2e/docker/static/strict.")
+@pytest.mark.xfailflake(
+    jira='DCOS-41819',
+    reason='Fails on dcos-e2e/docker/static/strict.',
+    since='2018-11-20',
+)
 @pytest.mark.supportedwindows
 def test_socket_units():
     """Test that socket units configure socket files in /run/dcos
@@ -122,8 +125,11 @@ def test_socket_units():
         _check_unit(file)
 
 
-@common.xfailflake(reason="DCOS-45174 test_units.test_socket_files_teardown "
-                          "fails with 503 Server Error:")
+@pytest.mark.xfailflake(
+    jira='DCOS-45174',
+    reason='test_units.test_socket_files_teardown fails with 503 Server Error:',
+    since='2018-11-20',
+)
 @pytest.mark.supportedwindows
 def test_socket_files():
     """Test that all socket files in /run/dcos are owned by 'dcos_adminrouter'."""


### PR DESCRIPTION
## High-level description

This removes ``common.py``.
An alternative could be to extend ``common.py`` with a custom mark as so:

```python
base_xfail = pytest.mark.xfail(strict=False)
MarkDecorator = base_xfail.__class__

class require_date(MarkDecorator):

    mark = pytest.mark.xfail.mark

    def __init__(self, *args, **kwargs):
        #... Date validation goes here

xfailflake = MarkDecorator(base_xfail.mark.combined_with(require_date.mark))
```

I believe that this is more pytest-idiomatic.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).