### PR TITLE
[1.13] Flaky test_metrics.deploy_and_cleanup_dcos_package

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -219,8 +219,8 @@ def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_vers
     finally:
         dcos_api_session.cosmos.uninstall_package(package_name, app_id=app_id)
 
-        # Retry for 150 seconds for teardown completion
-        @retrying.retry(wait_fixed=5000, stop_max_delay=150 * 1000)
+        # Retry for 15min for teardown completion
+        @retrying.retry(wait_fixed=5000, stop_max_delay=15 * 60 * 1000)
         def wait_for_package_teardown():
             state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
             assert state_response.status_code == 200


### PR DESCRIPTION
## High-level description

Fixes to integration test to avoid flakes. Upped the teardown retry time periods to 15min ([matched timing intervals](https://github.com/mesosphere/dcos-enterprise/blob/master/packages/dcos-integration-test/extra/test_registry_cli.py#L28) in DCOS EE tests that included an [sdk framework install/uninstall test](https://github.com/mesosphere/dcos-enterprise/blob/master/packages/dcos-integration-test/extra/test_registry_cli.py#L415)). 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4568](https://jira.mesosphere.com/browse/DCOS_OSS-4568) test_metrics.deploy_and_cleanup_dcos_package Framework hello-world still running


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: test change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

