### PR TITLE
Attempt to reduce flakes and gather data on bundle generation.

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -153,9 +153,9 @@ def _dump_diagnostics(request, dcos_api_session):
 
     make_diagnostics_report = os.environ.get('DIAGNOSTICS_DIRECTORY') is not None
     if make_diagnostics_report:
+        creation_start = datetime.datetime.now()
         last_datapoint = {
             'time': None,
-            'start': None,
             'value': 0
         }
 
@@ -177,7 +177,7 @@ def _dump_diagnostics(request, dcos_api_session):
         log.info('\nWait for diagnostics job to complete')
         diagnostics.wait_for_diagnostics_job(last_datapoint=last_datapoint)
 
-        duration = last_datapoint['time'] - last_datapoint['start']
+        duration = last_datapoint['time'] - creation_start
         log.info('\nDiagnostis bundle took {} to generate'.format(duration))
 
         log.info('\nWait for diagnostics report to become available')

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -155,6 +155,7 @@ def _dump_diagnostics(request, dcos_api_session):
     if make_diagnostics_report:
         last_datapoint = {
             'time': None,
+            'start': None,
             'value': 0
         }
 
@@ -175,6 +176,9 @@ def _dump_diagnostics(request, dcos_api_session):
 
         log.info('\nWait for diagnostics job to complete')
         diagnostics.wait_for_diagnostics_job(last_datapoint=last_datapoint)
+
+        duration = last_datapoint['time'] - last_datapoint['start']
+        log.info('\nDiagnostis bundle took {} to generate'.format(duration))
 
         log.info('\nWait for diagnostics report to become available')
         diagnostics.wait_for_diagnostics_reports()


### PR DESCRIPTION
## High-level description

This ups the timeout for bundle generation to 20 minutes instead of 2 to
ensure that the cluster has enough time to generate the bundle which
is the cause of the vast majority of the flakes for this test.

It also adds logging the time taken to generate the bundle to the output
to get a better idea of how much time it really takes to generate the
bundle.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-41819]https://jira.mesosphere.com/browse/DCOS-41819) dcos-e2e/docker/static/strict tests (open_source_tests.test_units.test_socket_files_teardown) failed with "ResourceWarning: unclosed SSL socket"


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a test change
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
