### PR TITLE
[1.11] Avoid port conflicts in the networking tests. 

### DIFF
--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -63,16 +63,9 @@ def marathon_test_app(
     Return:
         (dict, str): 2-Tuple of app definition (dict) and app ID (string)
     """
-    if network == marathon.Network.BRIDGE:
-        if container_port is None:
-            # provide a dummy value for the bridged container port if user is indifferent
-            container_port = 8080
-    else:
-        assert container_port is None or container_port == host_port, 'Cannot declare a different host and '\
-            'container port outside of BRIDGE network'
-        container_port = host_port
-    if network == marathon.Network.USER:
-        assert host_port != 0, 'Cannot auto-assign a port on USER network!'
+    if network != marathon.Network.HOST and container_port is None:
+        # provide a dummy value for the bridged container port if user is indifferent
+        container_port = 8080
 
     test_uuid = uuid.uuid4().hex
     app = copy.deepcopy({
@@ -82,9 +75,9 @@ def marathon_test_app(
         'instances': 1,
         'cmd': '/opt/mesosphere/bin/dcos-shell python '
                '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
-                   # If network is host and host port is zero, then the port is auto-assigned
-                   # and the commandline should reference the port with the marathon built-in
-                   '$PORT0' if host_port == 0 and network == marathon.Network.HOST else container_port),
+                   # If container port is not defined, then the port is auto-assigned and
+                   # the commandline should reference the port with the marathon built-in
+                   '$PORT0' if container_port is None else container_port),
         'env': {
             'DCOS_TEST_UUID': test_uuid,
             # required for python_test_server.py to run as nobody
@@ -103,15 +96,16 @@ def marathon_test_app(
             }
         ],
     })
-    if host_port == 0:
+    if container_port is not None and \
+            healthcheck_protocol == marathon.Healthcheck.MESOS_HTTP:
+        app['healthChecks'][0]['port'] = container_port
+    elif host_port == 0:
         # port is being assigned by marathon so refer to this port by index
         app['healthChecks'][0]['portIndex'] = 0
-    elif network == marathon.Network.BRIDGE:
-        app['healthChecks'][0]['port'] = container_port if \
-            healthcheck_protocol == marathon.Healthcheck.MESOS_HTTP else host_port
     else:
         # HOST or USER network with non-zero host port
         app['healthChecks'][0]['port'] = host_port
+
     if container_type != marathon.Container.NONE:
         app['container'] = {
             'type': container_type.value,
@@ -119,46 +113,42 @@ def marathon_test_app(
             'volumes': [{
                 'containerPath': '/opt/mesosphere',
                 'hostPath': '/opt/mesosphere',
-                'mode': 'RO'}]}
-        if container_type == marathon.Container.DOCKER:
-            app['container']['docker']['network'] = network.value
-            if network != marathon.Network.HOST:
-                app['container']['docker']['portMappings'] = [{
-                    'hostPort': host_port,
-                    'containerPort': container_port,
-                    'protocol': 'tcp',
-                    'name': 'test'}]
-                if vip is not None:
-                    app['container']['docker']['portMappings'][0]['labels'] = {'VIP_0': vip}
+                'mode': 'RO'
+            }]
+        }
+    else:
+        app['container'] = {'type': 'MESOS'}
+
+    if host_port != 0:
+        app['requirePorts'] = True
     if network == marathon.Network.HOST:
         app['portDefinitions'] = [{
             'protocol': 'tcp',
             'port': host_port,
-            'name': 'test'}]
+            'name': 'test'
+        }]
         if vip is not None:
             app['portDefinitions'][0]['labels'] = {'VIP_0': vip}
-    elif network == marathon.Network.USER:
-        app['ipAddress'] = {'networkName': network_name}
-        if container_type != marathon.Container.DOCKER:
-            app['ipAddress']['discovery'] = {
-                'ports': [{
-                    'protocol': 'tcp',
-                    'name': 'test',
-                    'number': host_port,
-                }]
-            }
-            if vip is not None:
-                app['ipAddress']['discovery']['ports'][0]['labels'] = {'VIP_0': vip}
-    elif network == marathon.Network.BRIDGE:
-        if container_type == marathon.Container.MESOS:
-            app['networks'] = [{'mode': 'container/bridge'}]
-            app['container']['portMappings'] = [{
-                'hostPort': host_port,
-                'containerPort': container_port,
-                'protocol': 'tcp',
-                'name': 'test'}]
-            if vip is not None:
-                app['container']['portMappings'][0]['labels'] = {'VIP_0': vip}
+    else:
+        app['container']['portMappings'] = [{
+            'hostPort': host_port,
+            'containerPort': container_port,
+            'protocol': 'tcp',
+            'name': 'test'}]
+        if vip is not None:
+            app['container']['portMappings'][0]['labels'] = {'VIP_0': vip}
+        if network == marathon.Network.USER:
+            if host_port == 0:
+                del app['container']['portMappings'][0]['hostPort']
+            app['networks'] = [{
+                'mode': 'container',
+                'name': network_name
+            }]
+        elif network == marathon.Network.BRIDGE:
+            app['networks'] = [{
+                'mode': 'container/bridge'
+            }]
+
     if host_constraint is not None:
         app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
     return app, test_uuid

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -38,7 +38,8 @@ def marathon_test_app(
         healthcheck_protocol: marathon.Healthcheck=marathon.Healthcheck.HTTP,
         vip: str=None,
         host_constraint: str=None,
-        network_name: str='dcos'):
+        network_name: str='dcos',
+        app_name_fmt: str=TEST_APP_NAME_FMT):
     """ Creates an app definition for the python test server which will be
     consistent (i.e. deployable with green health checks and desired network
     routability). To learn more about the test server, see in this repo:
@@ -57,6 +58,7 @@ def marathon_test_app(
         vip: either named or unnamed VIP to be applied to the host port
         host_constraint: string representing a hostname for an agent that this
             app should run on
+        app_name_fmt: format string for unique application identifier
 
     Return:
         (dict, str): 2-Tuple of app definition (dict) and app ID (string)
@@ -74,7 +76,7 @@ def marathon_test_app(
 
     test_uuid = uuid.uuid4().hex
     app = copy.deepcopy({
-        'id': TEST_APP_NAME_FMT.format(test_uuid),
+        'id': app_name_fmt.format(test_uuid),
         'cpus': 0.1,
         'mem': 32,
         'instances': 1,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -20,6 +20,21 @@ log = logging.getLogger(__name__)
 GLOBAL_PORT_POOL = iter(range(10000, 32000))
 
 
+pytestmark = [pytest.mark.usefixtures('marathon_groups_reset')]
+
+
+@pytest.fixture()
+def marathon_groups_reset(dcos_api_session):
+    """
+    After the decorated test is run, remove all Marathon groups.
+    """
+    yield
+    dcos_api_session.marathon.delete(
+        '/v2/groups/',
+        params={'force': True},
+    )
+
+
 class Container(enum.Enum):
     POD = 'POD'
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -413,7 +413,7 @@ def test_ip_per_container(dcos_api_session):
 
     with dcos_api_session.marathon.deploy_and_cleanup(app_definition, check_health=True):
         service_points = dcos_api_session.marathon.get_app_service_endpoints(app_definition['id'])
-        app_port = app_definition['container']['docker']['portMappings'][0]['containerPort']
+        app_port = app_definition['container']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
 
@@ -564,6 +564,7 @@ def test_dcos_cni_l4lb(dcos_api_session):
     # but that doesn't seem to be the case here.
     cni_config_app['cmd'] = 'echo \'{}\' > /opt/mesosphere/etc/dcos/network/cni/spartan.cni && sleep 10000'.format(
         json.dumps(spartan_net))
+    del cni_config_app['healthChecks']
 
     log.info("App for setting CNI config: {}".format(json.dumps(cni_config_app)))
 
@@ -596,50 +597,25 @@ def test_dcos_cni_l4lb(dcos_api_session):
         vip=server_vip)
 
     # Launch the server on the DC/OS overlay
-    server['ipAddress']['networkName'] = 'dcos'
-
-    log.info("Launching server with VIP:{} on network {}".format(server_vip_addr, server['ipAddress']['networkName']))
+    log.info("Launching server with VIP:{} on network {}".format(server_vip_addr, server['networks'][0]['name']))
 
     try:
         dcos_api_session.marathon.deploy_app(server, check_health=False)
     except Exception as ex:
         raise AssertionError(
-            "Couldn't launch server on 'dcos':{}".format(server['ipAddress']['networkName'])) from ex
+            "Couldn't launch server on 'dcos':{}".format(server['networks'][0]['name'])) from ex
 
     # Get the client app on the 'spartan-net' network.
-    #
-    # NOTE: Currently, we are creating the app-def by hand instead of relying
-    # on the harness to create this app-def since the marathon harness does not
-    # allow any port-mapping for CNI networks at this point.
     client_port = 9081
     client, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.MESOS,
         healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         network=marathon.Network.USER,
         host_port=client_port,
+        container_port=client_port,
         vip=server_vip,
-        host_constraint=spartan_net_host)
-
-    client["container"]["portMappings"] = [
-        {
-            'containerPort': client_port,
-            'hostPort': client_port,
-            'protocol': 'tcp',
-            'name': 'http'
-        }
-    ]
-
-    # Remove the `ipAddress` entry for DC/OS overlay.
-    del client["ipAddress"]
-
-    # Attach this container to the `spartan-net` network. We are using the v2
-    # network API here.
-    client["networks"] = [
-        {
-            "mode": "container",
-            "name": "spartan-net"
-        }
-    ]
+        host_constraint=spartan_net_host,
+        network_name='spartan-net')
 
     try:
         dcos_api_session.marathon.deploy_app(client, check_health=False)

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -301,8 +301,6 @@ def test_vip(dcos_api_session,
 
 def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net, ipv6):
     same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
-    if marathon.Network.BRIDGE in [vip_net, proxy_net] and container == marathon.Container.NONE:
-        same_hosts = []
     tests = [vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, named_vip, same_host)
              for named_vip in [True, False]
              for same_host in same_hosts]

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -232,7 +232,6 @@ def test_service_discovery_mesos_host(dcos_api_session):
 def test_service_discovery_mesos_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.MESOS,
-        host_port=9080,
         healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         network=marathon.Network.USER)
 
@@ -258,15 +257,14 @@ def test_service_discovery_docker_bridge(dcos_api_session):
 def test_service_discovery_docker_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
-        network=marathon.Network.USER,
-        host_port=9080)
-    del app_definition['container']['docker']['portMappings'][0]['hostPort']
+        network=marathon.Network.USER)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
+        healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         network=marathon.Network.USER,
         host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay, DNSPortMap])


### PR DESCRIPTION
## High-level description

Marathon randomly assigns host ports. In rare cases it causes port conflicts in the networking integration tests. We shouldn't rely on this feature and have to assign unique port numbers manually.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46220](https://jira.mesosphere.com/browse/DCOS-46220) test_networking.test_vip can fail because Marathon says Constraints for run spec [xxx] not satisfied.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-3736](https://jira.mesosphere.com/browse/DCOS_OSS-3736) Update marathon app configuration to match Marathon 1.5 syntax

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).