### PR TITLE
[1.10] Avoid port conflicts in the networking tests.

### DIFF
--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -61,8 +61,6 @@ def marathon_test_app(
         (dict, str): 2-Tuple of app definition (dict) and app ID (string)
     """
     if network == marathon.Network.BRIDGE:
-        assert container_type == marathon.Container.DOCKER, \
-            'BRIDGE network mode only supported for DOCKER container type'
         if container_port is None:
             # provide a dummy value for the bridged container port if user is indifferent
             container_port = 8080
@@ -148,6 +146,16 @@ def marathon_test_app(
             }
             if vip is not None:
                 app['ipAddress']['discovery']['ports'][0]['labels'] = {'VIP_0': vip}
+    elif network == marathon.Network.BRIDGE:
+        if container_type == marathon.Container.MESOS:
+            app['networks'] = [{'mode': 'container/bridge'}]
+            app['container']['portMappings'] = [{
+                'hostPort': host_port,
+                'containerPort': container_port,
+                'protocol': 'tcp',
+                'name': 'test'}]
+            if vip is not None:
+                app['container']['portMappings'][0]['labels'] = {'VIP_0': vip}
     if host_constraint is not None:
         app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
     return app, test_uuid

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -37,7 +37,8 @@ def marathon_test_app(
         network: marathon.Network=marathon.Network.HOST,
         healthcheck_protocol: marathon.Healthcheck=marathon.Healthcheck.HTTP,
         vip: str=None,
-        host_constraint: str=None):
+        host_constraint: str=None,
+        network_name: str='dcos'):
     """ Creates an app definition for the python test server which will be
     consistent (i.e. deployable with green health checks and desired network
     routability). To learn more about the test server, see in this repo:
@@ -135,7 +136,7 @@ def marathon_test_app(
         if vip is not None:
             app['portDefinitions'][0]['labels'] = {'VIP_0': vip}
     elif network == marathon.Network.USER:
-        app['ipAddress'] = {'networkName': 'dcos'}
+        app['ipAddress'] = {'networkName': network_name}
         if container_type != marathon.Container.DOCKER:
             app['ipAddress']['discovery'] = {
                 'ports': [{

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -63,16 +63,9 @@ def marathon_test_app(
     Return:
         (dict, str): 2-Tuple of app definition (dict) and app ID (string)
     """
-    if network == marathon.Network.BRIDGE:
-        if container_port is None:
-            # provide a dummy value for the bridged container port if user is indifferent
-            container_port = 8080
-    else:
-        assert container_port is None or container_port == host_port, 'Cannot declare a different host and '\
-            'container port outside of BRIDGE network'
-        container_port = host_port
-    if network == marathon.Network.USER:
-        assert host_port != 0, 'Cannot auto-assign a port on USER network!'
+    if network != marathon.Network.HOST and container_port is None:
+        # provide a dummy value for the bridged container port if user is indifferent
+        container_port = 8080
 
     test_uuid = uuid.uuid4().hex
     app = copy.deepcopy({
@@ -82,9 +75,9 @@ def marathon_test_app(
         'instances': 1,
         'cmd': '/opt/mesosphere/bin/dcos-shell python '
                '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
-                   # If network is host and host port is zero, then the port is auto-assigned
-                   # and the commandline should reference the port with the marathon built-in
-                   '$PORT0' if host_port == 0 and network == marathon.Network.HOST else container_port),
+                   # If container port is not defined, then the port is auto-assigned and
+                   # the commandline should reference the port with the marathon built-in
+                   '$PORT0' if container_port is None else container_port),
         'env': {
             'DCOS_TEST_UUID': test_uuid,
             # required for python_test_server.py to run as nobody
@@ -103,15 +96,16 @@ def marathon_test_app(
             }
         ],
     })
-    if host_port == 0:
+    if container_port is not None and \
+            healthcheck_protocol == marathon.Healthcheck.MESOS_HTTP:
+        app['healthChecks'][0]['port'] = container_port
+    elif host_port == 0:
         # port is being assigned by marathon so refer to this port by index
         app['healthChecks'][0]['portIndex'] = 0
-    elif network == marathon.Network.BRIDGE:
-        app['healthChecks'][0]['port'] = container_port if \
-            healthcheck_protocol == marathon.Healthcheck.MESOS_HTTP else host_port
     else:
         # HOST or USER network with non-zero host port
         app['healthChecks'][0]['port'] = host_port
+
     if container_type != marathon.Container.NONE:
         app['container'] = {
             'type': container_type.value,
@@ -119,46 +113,42 @@ def marathon_test_app(
             'volumes': [{
                 'containerPath': '/opt/mesosphere',
                 'hostPath': '/opt/mesosphere',
-                'mode': 'RO'}]}
-        if container_type == marathon.Container.DOCKER:
-            app['container']['docker']['network'] = network.value
-            if network != marathon.Network.HOST:
-                app['container']['docker']['portMappings'] = [{
-                    'hostPort': host_port,
-                    'containerPort': container_port,
-                    'protocol': 'tcp',
-                    'name': 'test'}]
-                if vip is not None:
-                    app['container']['docker']['portMappings'][0]['labels'] = {'VIP_0': vip}
+                'mode': 'RO'
+            }]
+        }
+    else:
+        app['container'] = {'type': 'MESOS'}
+
+    if host_port != 0:
+        app['requirePorts'] = True
     if network == marathon.Network.HOST:
         app['portDefinitions'] = [{
             'protocol': 'tcp',
             'port': host_port,
-            'name': 'test'}]
+            'name': 'test'
+        }]
         if vip is not None:
             app['portDefinitions'][0]['labels'] = {'VIP_0': vip}
-    elif network == marathon.Network.USER:
-        app['ipAddress'] = {'networkName': network_name}
-        if container_type != marathon.Container.DOCKER:
-            app['ipAddress']['discovery'] = {
-                'ports': [{
-                    'protocol': 'tcp',
-                    'name': 'test',
-                    'number': host_port,
-                }]
-            }
-            if vip is not None:
-                app['ipAddress']['discovery']['ports'][0]['labels'] = {'VIP_0': vip}
-    elif network == marathon.Network.BRIDGE:
-        if container_type == marathon.Container.MESOS:
-            app['networks'] = [{'mode': 'container/bridge'}]
-            app['container']['portMappings'] = [{
-                'hostPort': host_port,
-                'containerPort': container_port,
-                'protocol': 'tcp',
-                'name': 'test'}]
-            if vip is not None:
-                app['container']['portMappings'][0]['labels'] = {'VIP_0': vip}
+    else:
+        app['container']['portMappings'] = [{
+            'hostPort': host_port,
+            'containerPort': container_port,
+            'protocol': 'tcp',
+            'name': 'test'}]
+        if vip is not None:
+            app['container']['portMappings'][0]['labels'] = {'VIP_0': vip}
+        if network == marathon.Network.USER:
+            if host_port == 0:
+                del app['container']['portMappings'][0]['hostPort']
+            app['networks'] = [{
+                'mode': 'container',
+                'name': network_name
+            }]
+        elif network == marathon.Network.BRIDGE:
+            app['networks'] = [{
+                'mode': 'container/bridge'
+            }]
+
     if host_constraint is not None:
         app['constraints'] = [['hostname', 'CLUSTER', host_constraint]]
     return app, test_uuid

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -38,7 +38,8 @@ def marathon_test_app(
         healthcheck_protocol: marathon.Healthcheck=marathon.Healthcheck.HTTP,
         vip: str=None,
         host_constraint: str=None,
-        network_name: str='dcos'):
+        network_name: str='dcos',
+        app_name_fmt: str=TEST_APP_NAME_FMT):
     """ Creates an app definition for the python test server which will be
     consistent (i.e. deployable with green health checks and desired network
     routability). To learn more about the test server, see in this repo:
@@ -57,6 +58,7 @@ def marathon_test_app(
         vip: either named or unnamed VIP to be applied to the host port
         host_constraint: string representing a hostname for an agent that this
             app should run on
+        app_name_fmt: format string for unique application identifier
 
     Return:
         (dict, str): 2-Tuple of app definition (dict) and app ID (string)
@@ -74,7 +76,7 @@ def marathon_test_app(
 
     test_uuid = uuid.uuid4().hex
     app = copy.deepcopy({
-        'id': TEST_APP_NAME_FMT.format(test_uuid),
+        'id': app_name_fmt.format(test_uuid),
         'cpus': 0.1,
         'mem': 32,
         'instances': 1,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -231,7 +231,7 @@ def test_vip(dcos_api_session,
     proxy container that will ping the origin container VIP and then assert
     that the expected origin app UUID was returned
     '''
-    errors = 0
+    errors = []
     tests = setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net)
     for vip, hosts, cmd, origin_app, proxy_app in tests:
         log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
@@ -241,13 +241,13 @@ def test_vip(dcos_api_session,
             ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app.uuid
         except Exception as e:
             log.error('Exception: {}'.format(e))
-            errors = errors + 1
+            errors.append(e)
         finally:
             log.info('Purging application: {}'.format(origin_app.id))
             origin_app.purge(dcos_api_session)
             log.info('Purging application: {}'.format(proxy_app.id))
             proxy_app.purge(dcos_api_session)
-    assert errors == 0
+    assert not errors
 
 
 def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -26,28 +26,20 @@ class Container(enum.Enum):
 
 class MarathonApp:
     def __init__(self, container, network, host, vip=None, app_name_fmt=None):
-        self._network = network
-        self._container = container
-        if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
-            # both of these cases will rely on marathon to assign ports
-            self.app, self.uuid = test_helpers.marathon_test_app(
-                network=network,
-                host_constraint=host,
-                vip=vip,
-                container_type=container,
-                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
-                app_name_fmt=app_name_fmt)
-        elif network == marathon.Network.USER:
-            self.app, self.uuid = test_helpers.marathon_test_app(
-                network=marathon.Network.USER,
-                host_port=unused_port(),
-                host_constraint=host,
-                vip=vip,
-                container_type=container,
-                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
-                app_name_fmt=app_name_fmt)
-            if vip is not None and container == marathon.Container.DOCKER:
-                del self.app['container']['docker']['portMappings'][0]['hostPort']
+        args = {
+            'app_name_fmt': app_name_fmt,
+            'network': network,
+            'host_port': unused_port(),
+            'host_constraint': host,
+            'vip': vip,
+            'container_type': container,
+            'healthcheck_protocol': marathon.Healthcheck.MESOS_HTTP
+        }
+        if network == marathon.Network.USER:
+            args['container_port'] = unused_port()
+            if vip is not None:
+                del args['host_port']
+        self.app, self.uuid = test_helpers.marathon_test_app(**args)
         # allow this app to run on public slaves
         self.app['acceptedResourceRoles'] = ['*', 'slave_public']
         self.id = self.app['id']
@@ -79,12 +71,10 @@ class MarathonApp:
     def hostport(self, dcos_api_session):
         info = self.info(dcos_api_session)
         task = info['app']['tasks'][0]
-        if self._network == marathon.Network.USER:
+        if 'networks' in self.app and \
+                self.app['networks'][0]['mode'] == 'container':
             host = task['ipAddresses'][0]['ipAddress']
-            if self._container == marathon.Container.DOCKER:
-                port = task['ports'][0]
-            else:
-                port = self.app['ipAddress']['discovery']['ports'][0]['number']
+            port = self.app['container']['portMappings'][0]['containerPort']
         else:
             host = task['host']
             port = task['ports'][0]
@@ -120,7 +110,7 @@ class MarathonPod:
                              '{}'.format(port)
                 }},
                 'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
-                'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
+                'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': unused_port()}],
                 'environment': {'DCOS_TEST_UUID': self.uuid, 'HOME': '/'}
             }],
             'networks': [{'mode': 'host'}],

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -2,6 +2,7 @@ import contextlib
 import json
 import logging
 import threading
+import uuid
 from collections import deque
 from subprocess import check_output
 
@@ -168,10 +169,145 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
     return (vip, hosts, cmd, origin_app, proxy_app)
 
 
-@retrying.retry(wait_fixed=5000, stop_max_delay=20 * 60 * 1000)
+def pod_vip_app(network: marathon.Network, host: str, vip: str):
+    ''' Creates a single app in docker container in pod
+    '''
+    container_port = 0
+    if network is not marathon.Network.HOST:
+        container_port = unused_port(network)
+    test_uuid = uuid.uuid4().hex
+    app = {
+        'id': '/integration-test-{}'.format(test_uuid),
+        'placement': {'acceptedResourceRoles': ['*', 'slave_public']},
+        'containers': [{
+            'name': 'app-{}'.format(test_uuid),
+            'resources': {'cpus': 0.01, 'mem': 32},
+            'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
+            'exec': {'command': {
+                'shell': '/opt/mesosphere/bin/dcos-shell python '
+                         '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
+                             '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port)
+            }},
+            'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
+            'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
+            'environment': {'DCOS_TEST_UUID': test_uuid, 'HOME': '/'}
+        }],
+        'networks': [{'mode': 'host'}],
+        'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
+    }
+    if host is not None:
+        app['placement']['constraints'] = [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+    if vip is not None:
+        app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
+    if network == marathon.Network.USER:
+        del app['containers'][0]['endpoints'][0]['hostPort']
+        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+        app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
+    elif network == marathon.Network.BRIDGE:
+        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+        app['networks'] = [{'mode': 'container/bridge'}]
+    return app, test_uuid
+
+
+def generate_pod_vip_app_permutations():
+    """ Generate all possible network interface permutations for applying vips
+    """
+    return [(vip_net, proxy_net)
+            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]]
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
+@pytest.mark.parametrize('vip_net,proxy_net', generate_pod_vip_app_permutations())
+def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: marathon.Network):
+    """ Same as test_vip but for pods
+        * containers: UCR
+        * networks: USER, HOST
+        * vips: named and unnamed vip
+    """
+    errors = 0
+    tests = setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net)
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info("Remote command: {}".format(cmd))
+        proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(proxy_app['id'])).json()
+        log.info(proxy_info)
+        if proxy_net == marathon.Network.USER:
+            proxy_host = proxy_info['instances'][0]['networks'][0]['addresses'][0]
+            proxy_port = proxy_app['containers'][0]['endpoints'][0]['containerPort']
+        else:
+            proxy_host = proxy_info['instances'][0]['agentHostname']
+            proxy_port = proxy_info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
+        try:
+            assert ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == \
+                origin_app['containers'][0]['environment']['DCOS_TEST_UUID']
+        except Exception as ex:
+            log.error('Exception: {}'.format(ex))
+            errors = errors + 1
+        finally:
+            log.info('Purging application: {}'.format(origin_app['id']))
+            dcos_api_session.marathon.delete('v2/pods/{}'.format(origin_app['id']))
+            log.info('Purging application: {}'.format(proxy_app['id']))
+            dcos_api_session.marathon.delete('v2/pods/{}'.format(proxy_app['id']))
+    assert errors == 0
+
+
+def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
+    same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
+             for named_vip in [True, False]
+             for same_host in same_hosts]
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
+        log.info("Origin app: {}".format(origin_app))
+        dcos_api_session.marathon.post('v2/pods', json=origin_app).raise_for_status()
+        log.info("Proxy app: {}".format(proxy_app))
+        dcos_api_session.marathon.post('v2/pods', json=proxy_app).raise_for_status()
+    for vip, hosts, cmd, origin_app, proxy_app in tests:
+        log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
+        log.info('Deploying origin app: {}'.format(origin_app['id']))
+        wait_for_pod_tasks_healthy(dcos_api_session, origin_app)
+        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
+        wait_for_pod_tasks_healthy(dcos_api_session, proxy_app)
+        log.info('Apps are ready')
+    return tests
+
+
+def pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host):
+    origin_host = dcos_api_session.all_slaves[0]
+    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
+    if named_vip:
+        vip_port = unused_port('namedvip')
+        vip = '/namedvip:{}'.format(vip_port)
+        vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
+    else:
+        vip_port = unused_port('1.1.1.7')
+        vip = '1.1.1.7:{}'.format(vip_port)
+        vipaddr = vip
+    cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
+    origin_app, origin_app_uuid = pod_vip_app(vip_net, origin_host, vip)
+    proxy_app, proxy_app_uuid = pod_vip_app(proxy_net, proxy_host, None)
+    hosts = list(set([origin_host, proxy_host]))
+    return (vip, hosts, cmd, origin_app, proxy_app)
+
+
+@retrying.retry(
+    wait_fixed=5000,
+    stop_max_delay=20 * 60 * 1000,
+    retry_on_result=lambda res: res is False)
 def wait_for_tasks_healthy(dcos_api_session, app_definition):
     info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
-    assert info['app']['tasksHealthy'] == app_definition['instances']
+    return info['app']['tasksHealthy'] == app_definition['instances']
+
+
+@retrying.retry(
+    wait_fixed=5000,
+    stop_max_delay=20 * 60 * 1000,
+    retry_on_result=lambda res: res is False)
+def wait_for_pod_tasks_healthy(dcos_api_session, pod_definition):
+    proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(pod_definition['id'])).json()
+    return 'status' in proxy_info and proxy_info['status'] == 'STABLE'
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -1,4 +1,5 @@
 import contextlib
+import enum
 import json
 import logging
 import threading
@@ -17,6 +18,163 @@ from dcos_test_utils import marathon
 log = logging.getLogger(__name__)
 
 GLOBAL_PORT_POOL = iter(range(10000, 32000))
+
+
+class Container(enum.Enum):
+    POD = 'POD'
+
+
+class MarathonApp():
+    def __init__(self, container, network, host, vip):
+        if container == Container.POD:
+            self.__class__ = MarathonPod
+            return MarathonPod.__init__(self, network, host, vip)
+        self._network = network
+        self._container = container
+        if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
+            # both of these cases will rely on marathon to assign ports
+            self.app, self.uuid = test_helpers.marathon_test_app(
+                network=network,
+                host_constraint=host,
+                vip=vip,
+                container_type=container,
+                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
+        elif network == marathon.Network.USER:
+            self.app, self.uuid = test_helpers.marathon_test_app(
+                network=network,
+                host_port=unused_port(),
+                host_constraint=host,
+                vip=vip,
+                container_type=container,
+                healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
+        # allow this app to run on public slaves
+        self.app['acceptedResourceRoles'] = ['*', 'slave_public']
+        self.id = self.app['id']
+
+    def __str__(self):
+        return str(self.app)
+
+    def deploy(self, dcos_api_session):
+        return dcos_api_session.marathon.post('v2/apps', json=self.app).raise_for_status()
+
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=20 * 60 * 1000,
+        retry_on_result=lambda res: res is False)
+    def wait(self, dcos_api_session):
+        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        r.raise_for_status()
+        self._info = r.json()
+        return self._info['app']['tasksHealthy'] == self.app['instances']
+
+    def info(self, dcos_api_session):
+        try:
+            if self._info['app']['tasksHealthy'] != self.app['instances']:
+                raise
+        except:
+            self.wait(dcos_api_session)
+        return self._info
+
+    def hostport(self, dcos_api_session):
+        info = self.info(dcos_api_session)
+        task = info['app']['tasks'][0]
+        if self._network == marathon.Network.USER:
+            host = task['ipAddresses'][0]['ipAddress']
+            if self._container == marathon.Container.DOCKER:
+                port = task['ports'][0]
+            else:
+                port = self.app['ipAddress']['discovery']['ports'][0]['number']
+        else:
+            host = task['host']
+            port = task['ports'][0]
+        return host, port
+
+    def purge(self, dcos_api_session):
+        return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
+
+
+class MarathonPod():
+    def __init__(self, network, host, vip):
+        self._network = network
+        container_port = 0
+        if network is not marathon.Network.HOST:
+            container_port = unused_port()
+        # ENDPOINT_TEST will be computed from the `endpoints` definition. See [1], [2]
+        # [1] https://dcos.io/docs/1.9/deploying-services/pods/technical-overview/#environment-variables
+        # [2] https://github.com/mesosphere/marathon/blob/v1.5.0/
+        #     src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala#L420-L443
+        port = '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port
+        self.uuid = uuid.uuid4().hex
+        self.id = '/integration-test-{}'.format(self.uuid)
+        self.app = {
+            'id': self.id,
+            'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
+            'containers': [{
+                'name': 'app-{}'.format(self.uuid),
+                'resources': {'cpus': 0.01, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
+                'exec': {'command': {
+                    'shell': '/opt/mesosphere/bin/dcos-shell python '
+                             '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py '
+                             '{}'.format(port)
+                }},
+                'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
+                'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
+                'environment': {'DCOS_TEST_UUID': self.uuid, 'HOME': '/'}
+            }],
+            'networks': [{'mode': 'host'}],
+            'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
+        }
+        if host is not None:
+            self.app['scheduling']['placement']['constraints'] = \
+                [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+        if vip is not None:
+            self.app['containers'][0]['endpoints'][0]['labels'] = \
+                {'VIP_0': vip}
+        if network == marathon.Network.USER:
+            del self.app['containers'][0]['endpoints'][0]['hostPort']
+            self.app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+            self.app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
+        elif network == marathon.Network.BRIDGE:
+            self.app['containers'][0]['endpoints'][0]['containerPort'] = container_port
+            self.app['networks'] = [{'mode': 'container/bridge'}]
+
+    def __str__(self):
+        return str(self.app)
+
+    def deploy(self, dcos_api_session):
+        return dcos_api_session.marathon.post('v2/pods', json=self.app).raise_for_status()
+
+    @retrying.retry(
+        wait_fixed=5000,
+        stop_max_delay=20 * 60 * 1000,
+        retry_on_result=lambda res: res is False)
+    def wait(self, dcos_api_session):
+        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        r.raise_for_status()
+        self._info = r.json()
+        return self._info['status'] == 'STABLE'
+
+    def info(self, dcos_api_session):
+        try:
+            if self._info['status'] != 'STABLE':
+                raise
+        except:
+            self.wait(dcos_api_session)
+        return self._info
+
+    def hostport(self, dcos_api_session):
+        info = self.info(dcos_api_session)
+        if self._network == marathon.Network.USER:
+            host = info['instances'][0]['networks'][0]['addresses'][0]
+            port = self.app['containers'][0]['endpoints'][0]['containerPort']
+        else:
+            host = info['instances'][0]['agentHostname']
+            port = info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
+        return host, port
+
+    def purge(self, dcos_api_session):
+        return dcos_api_session.marathon.delete('v2/pods/{}'.format(self.id))
 
 
 def unused_port():
@@ -41,38 +199,21 @@ def ensure_routable(cmd, host, port):
     return json.loads(response['output'])
 
 
-def vip_app(container: marathon.Container, network: marathon.Network, host: str, vip: str):
-    # user_net_port is only actually used for USER network because this cannot be assigned
-    # by marathon
-    if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
-        # both of these cases will rely on marathon to assign ports
-        return test_helpers.marathon_test_app(
-            network=network,
-            host_constraint=host,
-            vip=vip,
-            container_type=container,
-            healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
-    elif network == marathon.Network.USER:
-        return test_helpers.marathon_test_app(
-            network=network,
-            host_port=unused_port(),
-            host_constraint=host,
-            vip=vip,
-            container_type=container,
-            healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
-    else:
-        raise AssertionError('Unexpected network: {}'.format(network.value))
-
-
 def generate_vip_app_permutations():
     """ Generate all possible network interface permutations for applying vips
     """
+    containers = \
+        [marathon.Container.NONE, marathon.Container.MESOS,
+         marathon.Container.DOCKER, Container.POD]
+    networks = \
+        [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
     return [(container, vip_net, proxy_net)
-            for container in [marathon.Container.NONE, marathon.Container.MESOS, marathon.Container.DOCKER]
-            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
-            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+            for container in containers
+            for vip_net in networks
+            for proxy_net in networks
             # only DOCKER containers support BRIDGE network
-            if marathon.Network.BRIDGE not in (vip_net, proxy_net) or container == marathon.Container.DOCKER]
+            if marathon.Network.BRIDGE not in (vip_net, proxy_net) \
+            or container == marathon.Container.DOCKER]
 
 
 @pytest.mark.slow
@@ -103,27 +244,17 @@ def test_vip(dcos_api_session,
     for vip, hosts, cmd, origin_app, proxy_app in tests:
         log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
         log.info("Remote command: {}".format(cmd))
-        proxy_info = dcos_api_session.marathon.get('v2/apps/{}'.format(proxy_app['id'])).json()
-        proxy_task_info = proxy_info['app']['tasks'][0]
-        if proxy_net == marathon.Network.USER:
-            proxy_host = proxy_task_info['ipAddresses'][0]['ipAddress']
-            if container == marathon.Container.DOCKER:
-                proxy_port = proxy_task_info['ports'][0]
-            else:
-                proxy_port = proxy_app['ipAddress']['discovery']['ports'][0]['number']
-        else:
-            proxy_host = proxy_task_info['host']
-            proxy_port = proxy_task_info['ports'][0]
+        proxy_host, proxy_port = proxy_app.hostport(dcos_api_session)
         try:
-            ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app['env']['DCOS_TEST_UUID']
+            ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == origin_app.uuid
         except Exception as e:
             log.error('Exception: {}'.format(e))
             errors = errors + 1
         finally:
-            log.info('Purging application: {}'.format(origin_app['id']))
-            dcos_api_session.marathon.delete('v2/apps/{}'.format(origin_app['id'])).raise_for_status()
-            log.info('Purging application: {}'.format(proxy_app['id']))
-            dcos_api_session.marathon.delete('v2/apps/{}'.format(proxy_app['id'])).raise_for_status()
+            log.info('Purging application: {}'.format(origin_app.id))
+            origin_app.purge(dcos_api_session)
+            log.info('Purging application: {}'.format(proxy_app.id))
+            origin_app.purge(dcos_api_session)
     assert errors == 0
 
 
@@ -136,23 +267,24 @@ def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
         # We do not need the service endpoints because we have deterministically assigned them
         log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
         log.info("Origin app: {}".format(origin_app))
-        dcos_api_session.marathon.post('v2/apps', json=origin_app).raise_for_status()
+        origin_app.deploy(dcos_api_session)
         log.info("Proxy app: {}".format(proxy_app))
-        dcos_api_session.marathon.post('v2/apps', json=proxy_app).raise_for_status()
+        proxy_app.deploy(dcos_api_session)
     for vip, hosts, cmd, origin_app, proxy_app in tests:
         log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info('Deploying origin app: {}'.format(origin_app['id']))
-        wait_for_tasks_healthy(dcos_api_session, origin_app)
-        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
-        wait_for_tasks_healthy(dcos_api_session, proxy_app)
+        log.info('Deploying origin app: {}'.format(origin_app.id))
+        origin_app.wait(dcos_api_session)
+        log.info('Deploying proxy app: {}'.format(proxy_app.id))
+        proxy_app.wait(dcos_api_session)
         log.info('Apps are ready')
     return tests
 
 
 def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip, same_host):
+    slaves = dcos_api_session.slaves + dcos_api_session.public_slaves
     vip_port = unused_port()
-    origin_host = dcos_api_session.all_slaves[0]
-    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
+    origin_host = slaves[0]
+    proxy_host = slaves[0] if same_host else slaves[1]
     if named_vip:
         vip = '/namedvip:{}'.format(vip_port)
         vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
@@ -160,157 +292,10 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
         vip = '1.1.1.7:{}'.format(vip_port)
         vipaddr = vip
     cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-    origin_app, origin_app_uuid = vip_app(container, vip_net, origin_host, vip)
-    proxy_app, proxy_app_uuid = vip_app(container, proxy_net, proxy_host, None)
-    # allow these apps to run on public slaves
-    origin_app['acceptedResourceRoles'] = ['*', 'slave_public']
-    proxy_app['acceptedResourceRoles'] = ['*', 'slave_public']
+    origin_app = MarathonApp(container, vip_net, origin_host, vip)
+    proxy_app = MarathonApp(container, proxy_net, proxy_host, None)
     hosts = list(set([origin_host, proxy_host]))
     return (vip, hosts, cmd, origin_app, proxy_app)
-
-
-def pod_vip_app(network: marathon.Network, host: str, vip: str):
-    ''' Creates a single app in docker container in pod
-    '''
-    container_port = 0
-    if network is not marathon.Network.HOST:
-        container_port = unused_port(network)
-    test_uuid = uuid.uuid4().hex
-    app = {
-        'id': '/integration-test-{}'.format(test_uuid),
-        'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
-        'containers': [{
-            'name': 'app-{}'.format(test_uuid),
-            'resources': {'cpus': 0.01, 'mem': 32},
-            'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
-            'exec': {'command': {
-                'shell': '/opt/mesosphere/bin/dcos-shell python '
-                         '/opt/mesosphere/active/dcos-integration-test/util/python_test_server.py {}'.format(
-                             '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port)
-            }},
-            'volumeMounts': [{'name': 'opt', 'mountPath': '/opt/mesosphere'}],
-            'endpoints': [{'name': 'test', 'protocol': ['tcp'], 'hostPort': 0}],
-            'environment': {'DCOS_TEST_UUID': test_uuid, 'HOME': '/'}
-        }],
-        'networks': [{'mode': 'host'}],
-        'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
-    }
-    if host is not None:
-        app['scheduling']['placement']['constraints'] = [{
-            'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
-    if vip is not None:
-        app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
-    if network == marathon.Network.USER:
-        del app['containers'][0]['endpoints'][0]['hostPort']
-        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
-        app['networks'] = [{'name': 'dcos', 'mode': 'container'}]
-    elif network == marathon.Network.BRIDGE:
-        app['containers'][0]['endpoints'][0]['containerPort'] = container_port
-        app['networks'] = [{'mode': 'container/bridge'}]
-    return app, test_uuid
-
-
-def generate_pod_vip_app_permutations():
-    """ Generate all possible network interface permutations for applying vips
-    """
-    return [(vip_net, proxy_net)
-            for vip_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
-            for proxy_net in [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]]
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-@pytest.mark.parametrize('vip_net,proxy_net', generate_pod_vip_app_permutations())
-def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: marathon.Network):
-    """ Same as test_vip but for pods
-        * containers: UCR
-        * networks: USER, HOST
-        * vips: named and unnamed vip
-    """
-    errors = 0
-    tests = setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net)
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info("Testing :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info("Remote command: {}".format(cmd))
-        proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(proxy_app['id'])).json()
-        log.info(proxy_info)
-        if proxy_net == marathon.Network.USER:
-            proxy_host = proxy_info['instances'][0]['networks'][0]['addresses'][0]
-            proxy_port = proxy_app['containers'][0]['endpoints'][0]['containerPort']
-        else:
-            proxy_host = proxy_info['instances'][0]['agentHostname']
-            proxy_port = proxy_info['instances'][0]['containers'][0]['endpoints'][0]['allocatedHostPort']
-        try:
-            assert ensure_routable(cmd, proxy_host, proxy_port)['test_uuid'] == \
-                origin_app['containers'][0]['environment']['DCOS_TEST_UUID']
-        except Exception as ex:
-            log.error('Exception: {}'.format(ex))
-            errors = errors + 1
-        finally:
-            log.info('Purging application: {}'.format(origin_app['id']))
-            dcos_api_session.marathon.delete('v2/pods/{}'.format(origin_app['id']))
-            log.info('Purging application: {}'.format(proxy_app['id']))
-            dcos_api_session.marathon.delete('v2/pods/{}'.format(proxy_app['id']))
-    assert errors == 0
-
-
-def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
-    if len(dcos_api_session.all_slaves) < 2 and vip_net is marathon.Network.BRIDGE:
-        return []
-    same_hosts = [True, False] if vip_net is not marathon.Network.BRIDGE else [False]
-    tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
-             for named_vip in [True, False]
-             for same_host in same_hosts]
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info('Starting apps :: VIP: {}, Hosts: {}'.format(vip, hosts))
-        log.info("Origin app: {}".format(origin_app))
-        dcos_api_session.marathon.post('v2/pods', json=origin_app).raise_for_status()
-        log.info("Proxy app: {}".format(proxy_app))
-        dcos_api_session.marathon.post('v2/pods', json=proxy_app).raise_for_status()
-    for vip, hosts, cmd, origin_app, proxy_app in tests:
-        log.info("Deploying apps :: VIP: {}, Hosts: {}".format(vip, hosts))
-        log.info('Deploying origin app: {}'.format(origin_app['id']))
-        wait_for_pod_tasks_healthy(dcos_api_session, origin_app)
-        log.info('Deploying proxy app: {}'.format(proxy_app['id']))
-        wait_for_pod_tasks_healthy(dcos_api_session, proxy_app)
-        log.info('Apps are ready')
-    return tests
-
-
-def pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host):
-    origin_host = dcos_api_session.all_slaves[0]
-    proxy_host = dcos_api_session.all_slaves[0] if same_host else dcos_api_session.all_slaves[1]
-    if named_vip:
-        vip_port = unused_port('namedvip')
-        vip = '/namedvip:{}'.format(vip_port)
-        vipaddr = 'namedvip.marathon.l4lb.thisdcos.directory:{}'.format(vip_port)
-    else:
-        vip_port = unused_port('1.1.1.7')
-        vip = '1.1.1.7:{}'.format(vip_port)
-        vipaddr = vip
-    cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-    origin_app, origin_app_uuid = pod_vip_app(vip_net, origin_host, vip)
-    proxy_app, proxy_app_uuid = pod_vip_app(proxy_net, proxy_host, None)
-    hosts = list(set([origin_host, proxy_host]))
-    return (vip, hosts, cmd, origin_app, proxy_app)
-
-
-@retrying.retry(
-    wait_fixed=5000,
-    stop_max_delay=20 * 60 * 1000,
-    retry_on_result=lambda res: res is False)
-def wait_for_tasks_healthy(dcos_api_session, app_definition):
-    info = dcos_api_session.marathon.get('v2/apps/{}'.format(app_definition['id'])).json()
-    return info['app']['tasksHealthy'] == app_definition['instances']
-
-
-@retrying.retry(
-    wait_fixed=5000,
-    stop_max_delay=20 * 60 * 1000,
-    retry_on_result=lambda res: res is False)
-def wait_for_pod_tasks_healthy(dcos_api_session, pod_definition):
-    proxy_info = dcos_api_session.marathon.get('v2/pods/{}::status'.format(pod_definition['id'])).json()
-    return 'status' in proxy_info and proxy_info['status'] == 'STABLE'
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -38,7 +38,7 @@ class MarathonApp:
                 healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
         elif network == marathon.Network.USER:
             self.app, self.uuid = test_helpers.marathon_test_app(
-                network=network,
+                network=marathon.Network.USER,
                 host_port=unused_port(),
                 host_constraint=host,
                 vip=vip,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -178,7 +178,7 @@ def pod_vip_app(network: marathon.Network, host: str, vip: str):
     test_uuid = uuid.uuid4().hex
     app = {
         'id': '/integration-test-{}'.format(test_uuid),
-        'placement': {'acceptedResourceRoles': ['*', 'slave_public']},
+        'scheduling': {'placement': {'acceptedResourceRoles': ['*', 'slave_public']}},
         'containers': [{
             'name': 'app-{}'.format(test_uuid),
             'resources': {'cpus': 0.01, 'mem': 32},
@@ -196,7 +196,8 @@ def pod_vip_app(network: marathon.Network, host: str, vip: str):
         'volumes': [{'name': 'opt', 'host': '/opt/mesosphere'}]
     }
     if host is not None:
-        app['placement']['constraints'] = [{'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
+        app['scheduling']['placement']['constraints'] = [{
+            'fieldName': 'hostname', 'operator': 'CLUSTER', 'value': host}]
     if vip is not None:
         app['containers'][0]['endpoints'][0]['labels'] = {'VIP_0': vip}
     if network == marathon.Network.USER:
@@ -254,7 +255,9 @@ def test_pod_vip(dcos_api_session, vip_net: marathon.Network, proxy_net: maratho
 
 
 def setup_pod_vip_workload_tests(dcos_api_session, vip_net, proxy_net):
-    same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    if len(dcos_api_session.all_slaves) < 2 and vip_net is marathon.Network.BRIDGE:
+        return []
+    same_hosts = [True, False] if vip_net is not marathon.Network.BRIDGE else [False]
     tests = [pod_vip_workload_test(dcos_api_session, vip_net, proxy_net, named_vip, same_host)
              for named_vip in [True, False]
              for same_host in same_hosts]

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -44,6 +44,8 @@ class MarathonApp:
                 vip=vip,
                 container_type=container,
                 healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP)
+            if vip is not None and container == marathon.Container.DOCKER:
+                del self.app['container']['docker']['portMappings'][0]['hostPort']
         # allow this app to run on public slaves
         self.app['acceptedResourceRoles'] = ['*', 'slave_public']
         self.id = self.app['id']

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -355,7 +355,7 @@ def test_ip_per_container(dcos_api_session):
 
     with dcos_api_session.marathon.deploy_and_cleanup(app_definition, check_health=True):
         service_points = dcos_api_session.marathon.get_app_service_endpoints(app_definition['id'])
-        app_port = app_definition['container']['docker']['portMappings'][0]['containerPort']
+        app_port = app_definition['container']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -246,7 +246,7 @@ def test_vip(dcos_api_session,
             log.info('Purging application: {}'.format(origin_app.id))
             origin_app.purge(dcos_api_session)
             log.info('Purging application: {}'.format(proxy_app.id))
-            origin_app.purge(dcos_api_session)
+            proxy_app.purge(dcos_api_session)
     assert errors == 0
 
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -328,13 +328,14 @@ def test_ip_per_container(dcos_api_session):
     '''Test if we are able to connect to a task with ip-per-container mode
     '''
     # Launch the test_server in ip-per-container mode (user network)
+    if len(dcos_api_session.slaves) < 2:
+        pytest.skip("IP Per Container tests require 2 private agents to work")
+
     app_definition, test_uuid = test_helpers.marathon_test_app(
         healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         container_type=marathon.Container.DOCKER,
         network=marathon.Network.USER,
         host_port=9080)
-
-    assert len(dcos_api_session.slaves) >= 2, 'IP Per Container tests require 2 private agents to work'
 
     app_definition['instances'] = 2
     app_definition['constraints'] = [['hostname', 'UNIQUE']]

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -24,7 +24,7 @@ class Container(enum.Enum):
     POD = 'POD'
 
 
-class MarathonApp():
+class MarathonApp:
     def __init__(self, container, network, host, vip=None):
         self._network = network
         self._container = container
@@ -90,7 +90,7 @@ class MarathonApp():
         return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
 
 
-class MarathonPod():
+class MarathonPod:
     def __init__(self, network, host, vip=None):
         self._network = network
         container_port = 0
@@ -199,18 +199,11 @@ def ensure_routable(cmd, host, port):
 def generate_vip_app_permutations():
     """ Generate all possible network interface permutations for applying vips
     """
-    containers = \
-        [marathon.Container.NONE, marathon.Container.MESOS,
-         marathon.Container.DOCKER, Container.POD]
-    networks = \
-        [marathon.Network.USER, marathon.Network.BRIDGE, marathon.Network.HOST]
+    containers = list(marathon.Container) + [Container.POD]
     return [(container, vip_net, proxy_net)
             for container in containers
-            for vip_net in networks
-            for proxy_net in networks
-            # only DOCKER containers support BRIDGE network
-            if marathon.Network.BRIDGE not in (vip_net, proxy_net) \
-            or container == marathon.Container.DOCKER]
+            for vip_net in list(marathon.Network)
+            for proxy_net in list(marathon.Network)]
 
 
 @pytest.mark.slow
@@ -226,7 +219,7 @@ def test_vip(dcos_api_session,
              proxy_net: marathon.Network):
     '''Test VIPs between the following source and destination configurations:
         * containers: DOCKER, UCR and NONE
-        * networks: USER, BRIDGE (docker only), HOST
+        * networks: USER, BRIDGE, HOST
         * agents: source and destnations on same agent or different agents
         * vips: named and unnamed vip
 
@@ -257,6 +250,13 @@ def test_vip(dcos_api_session,
 
 def setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net):
     same_hosts = [True, False] if len(dcos_api_session.all_slaves) > 1 else [True]
+    if marathon.Network.BRIDGE in [vip_net, proxy_net]:
+        if container == marathon.Container.DOCKER:
+            pass
+        elif container == marathon.Container.NONE:
+            same_hosts = []
+        else:
+            same_hosts.remove(True)
     tests = [vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip, same_host)
              for named_vip in [True, False]
              for same_host in same_hosts]

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -25,10 +25,7 @@ class Container(enum.Enum):
 
 
 class MarathonApp():
-    def __init__(self, container, network, host, vip):
-        if container == Container.POD:
-            self.__class__ = MarathonPod
-            return MarathonPod.__init__(self, network, host, vip)
+    def __init__(self, container, network, host, vip=None):
         self._network = network
         self._container = container
         if network in [marathon.Network.HOST, marathon.Network.BRIDGE]:
@@ -94,13 +91,13 @@ class MarathonApp():
 
 
 class MarathonPod():
-    def __init__(self, network, host, vip):
+    def __init__(self, network, host, vip=None):
         self._network = network
         container_port = 0
         if network is not marathon.Network.HOST:
             container_port = unused_port()
         # ENDPOINT_TEST will be computed from the `endpoints` definition. See [1], [2]
-        # [1] https://dcos.io/docs/1.9/deploying-services/pods/technical-overview/#environment-variables
+        # [1] https://dcos.io/docs/1.10/deploying-services/pods/technical-overview/#environment-variables
         # [2] https://github.com/mesosphere/marathon/blob/v1.5.0/
         #     src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala#L420-L443
         port = '$ENDPOINT_TEST' if network == marathon.Network.HOST else container_port
@@ -292,8 +289,12 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
         vip = '1.1.1.7:{}'.format(vip_port)
         vipaddr = vip
     cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}/test_uuid'.format(vipaddr)
-    origin_app = MarathonApp(container, vip_net, origin_host, vip)
-    proxy_app = MarathonApp(container, proxy_net, proxy_host, None)
+    if container == Container.POD:
+        origin_app = MarathonPod(vip_net, origin_host, vip)
+        proxy_app = MarathonPod(proxy_net, proxy_host)
+    else:
+        origin_app = MarathonApp(container, vip_net, origin_host, vip)
+        proxy_app = MarathonApp(container, proxy_net, proxy_host)
     hosts = list(set([origin_host, proxy_host]))
     return (vip, hosts, cmd, origin_app, proxy_app)
 

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -232,7 +232,6 @@ def test_service_discovery_mesos_host(dcos_api_session):
 def test_service_discovery_mesos_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.MESOS,
-        host_port=9080,
         healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         network=marathon.Network.USER)
 
@@ -258,15 +257,14 @@ def test_service_discovery_docker_bridge(dcos_api_session):
 def test_service_discovery_docker_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
-        network=marathon.Network.USER,
-        host_port=9080)
-    del app_definition['container']['docker']['portMappings'][0]['hostPort']
+        network=marathon.Network.USER)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay])
 
 
 def test_service_discovery_docker_overlay_port_mapping(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,
+        healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
         network=marathon.Network.USER,
         host_port=9080)
     assert_service_discovery(dcos_api_session, app_definition, [DNSOverlay, DNSPortMap])


### PR DESCRIPTION
## High-level description

Marathon randomly assigns host ports. In rare cases it causes port conflicts in the networking integration tests. We shouldn't rely on this feature and have to assign unique port numbers manually.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46220](https://jira.mesosphere.com/browse/DCOS-46220) test_networking.test_vip can fail because Marathon says Constraints for run spec [xxx] not satisfied.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-3736](https://jira.mesosphere.com/browse/DCOS_OSS-3736) Update marathon app configuration to match Marathon 1.5 syntax

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).