### PR TITLE
[1.13] Add user-editable telegraf config dir

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1272,6 +1272,7 @@ package:
     content: |
       TELEGRAF_CONFIG_FILE=/opt/mesosphere/etc/telegraf/telegraf.conf
       TELEGRAF_CONFIG_DIR=/opt/mesosphere/etc/telegraf/telegraf.d/
+      TELEGRAF_USER_CONFIG_DIR=/var/lib/dcos/telegraf/telegraf.d/
       TELEGRAF_CONTAINERS_DIR=/run/dcos/telegraf/dcos_statsd/containers
       LEGACY_CONTAINERS_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers
   - path: /etc/telegraf/telegraf.conf

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "a88d78350c9244336607e37cc808bb76a40e8b89",
+    "ref": "4d195ab4ea296d9a34dfc8560f376d24cac4f4ce",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -20,5 +20,7 @@ ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
 
+ExecStartPre=/bin/bash -c "mkdir -p ${TELEGRAF_USER_CONFIG_DIR}"
+
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
-ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}
+ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR},${TELEGRAF_USER_CONFIG_DIR}


### PR DESCRIPTION
## High-level description

Previously, the only way for a user to supply additional telegraf configuration was to modify/add conf files to the telegraf config directory, which is within `/opt/mesosphere`. Now, users can add additional conf files to the `/var/lib/dcos/telegraf/telegraf.d/` directory, which gets automatically pulled in to telegraf at startup.

Will add documentation on this in a docs pr.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-42214](https://jira.mesosphere.com/browse/DCOS-42214) support methods to configure additional settings on dcos-telegraf


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: will be added to 1.12 changelog
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: tough to add integration test - manually tested this on a cluster
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
