### PR TITLE
[1.12] Add user-editable telegraf config dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Notable changes
 
+* Users can now supply additional Telegraf settings (DCOS-42214)
+
 ### Breaking changes
 
 ### Fixed and improved

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1236,6 +1236,7 @@ package:
     content: |
       TELEGRAF_CONFIG_FILE=/opt/mesosphere/etc/telegraf/telegraf.conf
       TELEGRAF_CONFIG_DIR=/opt/mesosphere/etc/telegraf/telegraf.d/
+      TELEGRAF_USER_CONFIG_DIR=/var/lib/dcos/telegraf/telegraf.d/
       TELEGRAF_CONTAINERS_DIR=/run/dcos/telegraf/dcos_statsd/containers
       LEGACY_CONTAINERS_PARENT_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule
       LEGACY_CONTAINERS_DIR=/run/dcos/mesos/isolators/com_mesosphere_MetricsIsolatorModule/containers

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "a88d78350c9244336607e37cc808bb76a40e8b89",
+    "ref": "4d195ab4ea296d9a34dfc8560f376d24cac4f4ce",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -19,9 +19,10 @@ LimitNOFILE=16384
 ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown dcos_telegraf:dcos_telegraf /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "mkdir -p ${TELEGRAF_USER_CONFIG_DIR}"
 # Ensure that start_telegraf.sh can move the legacy container directory; note that
 # the container directory may not exist; hence we ignore any error.
 ExecStartPre=/bin/bash -c "chown -R dcos_telegraf:dcos_telegraf ${LEGACY_CONTAINERS_PARENT_DIR} || true"
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
-ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR}
+ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR},${TELEGRAF_USER_CONFIG_DIR}


### PR DESCRIPTION
## High-level description

This is a backport of https://github.com/dcos/dcos/pull/4004.

Previously, the only way for a user to supply additional telegraf configuration was to modify/add conf files to the telegraf config directory, which is within `/opt/mesosphere`. Now, users can add additional conf files to the `/var/lib/dcos/telegraf/telegraf.d/` directory, which gets automatically pulled in to telegraf at startup.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS-42214](https://jira.mesosphere.com/browse/DCOS-42214) support methods to configure additional settings on dcos-telegraf


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This was tested manually on a cluster. The additional settings file was pulled in from the extra `/var/lib` config dir.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

