### PR TITLE
[1.11] Allow the collection of tests without a cluster

### DIFF
--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -4,13 +4,14 @@ via the make_session_fixture() method
 """
 
 from dcos_test_utils import dcos_api
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 
 def make_session_fixture():
     args = dcos_api.DcosApiSession.get_args_from_env()
 
     exhibitor_admin_password = None
+    expanded_config = get_expanded_config()
     if expanded_config['exhibitor_admin_password_enabled'] == 'true':
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -20,7 +20,8 @@ def deploy_test_app_and_check(dcos_api_session, app: dict, test_uuid: str):
     from the app's Dockerfile, which, for the test application
     is the default, root
     """
-    default_os_user = 'nobody' if test_helpers.expanded_config.get('security') == 'strict' else 'root'
+    expanded_config = test_helpers.get_expanded_config()
+    default_os_user = 'nobody' if expanded_config.get('security') == 'strict' else 'root'
 
     if 'container' in app and app['container']['type'] == 'DOCKER':
         marathon_user = 'root'
@@ -157,17 +158,16 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
         pass
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('security') == 'strict',
-    reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
 def test_octarine(dcos_api_session, timeout=30):
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config.get('security') == 'strict':
+        pytest.skip(reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"
     # to go to localhost, the port attached there is only used to
     # determine which port to send traffic to on localhost. When it
     # reaches the proxy, the port is not used, and a request is made
     # to port 80.
-
     app, uuid = test_helpers.marathon_test_app(host_port=80)
     app['acceptedResourceRoles'] = ["slave_public"]
     app['requirePorts'] = True

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -161,7 +161,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
 def test_octarine(dcos_api_session, timeout=30):
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
+        pytest.skip('See: https://jira.mesosphere.com/browse/DCOS-14760')
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"
     # to go to localhost, the port attached there is only used to

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -15,7 +15,7 @@ def auth_enabled():
 def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_session):
     reason = 'Can only test adminrouter enforcement if auth is enabled'
     if not auth_enabled():
-        pytest.skip(reason=reason)
+        pytest.skip(reason)
     r = noauth_api_session.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -12,9 +12,10 @@ def auth_enabled():
     return out == 'true'
 
 
-@pytest.mark.skipif(not auth_enabled(),
-                    reason='Can only test adminrouter enforcement if auth is enabled')
 def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_session):
+    reason = 'Can only test adminrouter enforcement if auth is enabled'
+    if not auth_enabled():
+        pytest.skip(reason=reason)
     r = noauth_api_session.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -10,7 +10,7 @@ import kazoo.client
 import pytest
 import requests
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 
 @pytest.mark.first
@@ -128,6 +128,7 @@ def test_signal_service(dcos_api_session):
         }
     }
 
+    expanded_config = get_expanded_config()
     # Generic properties which are the same between all tracks
     generic_properties = {
         'platform': expanded_config['platform'],

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -20,14 +20,16 @@ def get_exhibitor_admin_password():
     return password
 
 
-# make the expanded config available at import time to allow determining
-# which tests should run before the test suite kicks off
-with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
-    expanded_config = json.load(f)
-    # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
-    # Exhibitor's config.
-    # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
-    expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
+def get_expanded_config():
+    # make the expanded config available at import time to allow determining
+    # which tests should run before the test suite kicks off
+    with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
+        expanded_config = json.load(f)
+        # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
+        # Exhibitor's config.
+        # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
+        expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
+    return expanded_config
 
 
 def marathon_test_app(

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -286,7 +286,7 @@ def get_region_zone(domain):
 def test_fault_domain(dcos_api_session):
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config['fault_domain_enabled'] == 'false':
-        pytest.skip(reason='fault domain is not set')
+        pytest.skip('fault domain is not set')
     master_ip = dcos_api_session.masters[0]
     r = dcos_api_session.get('/state', host=master_ip, port=5050)
     assert r.status_code == 200

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -283,10 +283,10 @@ def get_region_zone(domain):
     return region, zone
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config['fault_domain_enabled'] == 'false',
-    reason='fault domain is not set')
 def test_fault_domain(dcos_api_session):
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config['fault_domain_enabled'] == 'false':
+        pytest.skip(reason='fault domain is not set')
     master_ip = dcos_api_session.masters[0]
     r = dcos_api_session.get('/state', host=master_ip, port=5050)
     assert r.status_code == 200

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,8 +1,6 @@
 import pytest
 import retrying
 
-from test_helpers import get_expanded_config
-
 
 LATENCY = 60
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,6 +1,8 @@
 import pytest
 import retrying
 
+from test_helpers import get_expanded_config
+
 
 LATENCY = 60
 

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -3,7 +3,7 @@ import os
 
 import yaml
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 
 # Test that user config is loadable
@@ -20,6 +20,7 @@ def test_load_user_config():
 
 
 def test_expanded_config():
+    expanded_config = get_expanded_config()
     # Caluclated parameters should be present
     assert 'master_quorum' in expanded_config
 
@@ -29,6 +30,7 @@ def test_expanded_config():
 
 def test_profile_symlink():
     """Assert the DC/OS profile script is symlinked from the correct source."""
+    expanded_config = get_expanded_config()
     symlink_target = expanded_config['profile_symlink_target']
     expected_symlink_source = expanded_config['profile_symlink_source']
     assert expected_symlink_source == os.readlink(symlink_target)

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -297,7 +297,7 @@ def test_vip(dcos_api_session,
     that the expected origin app UUID was returned
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
 
     errors = []
     tests = setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net, ipv6)
@@ -401,7 +401,7 @@ def test_if_overlay_ok(dcos_api_session):
 def test_if_dcos_l4lb_disabled(dcos_api_session):
     '''Test to make sure dcos_l4lb is disabled'''
     if lb_enabled():
-        pytest.skip(reason='Load Balancer enabled')
+        pytest.skip('Load Balancer enabled')
     data = check_output(['/usr/bin/env', 'ip', 'rule'])
     # dcos-net creates this ip rule: `9999: from 9.0.0.0/8 lookup 42`
     # We check it doesn't exist
@@ -450,7 +450,7 @@ def test_l4lb(dcos_api_session):
        * only testing if all 5 are hit at least once
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
     numapps = 5
     numthreads = numapps * 4
     apps = []
@@ -528,11 +528,11 @@ def test_dcos_cni_l4lb(dcos_api_session):
     test-case to PASS.
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
 
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='Cannot setup CNI config with EE strict mode enabled')
+        pytest.skip('Cannot setup CNI config with EE strict mode enabled')
 
     # CNI configuration of `spartan-net`.
     spartan_net = {

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -1,15 +1,20 @@
 import logging
 
 import pytest
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(
-    'advanced' in expanded_config['template_filenames'],
-    reason='Will not work on advanced CF templates, see: https://jira.mesosphere.com/browse/DCOS_OSS-1375')
 def test_pkgpanda_api(dcos_api_session):
+
+    expanded_config = get_expanded_config()
+    if 'advanced' in expanded_config['template_filenames']:
+        reason = (
+            'Will not work on advanced CF templates, see: '
+            'https://jira.mesosphere.com/browse/DCOS_OSS-1375'
+        )
+        pytest.skip(reason=reason)
 
     def get_and_validate_package_ids(path, node):
         r = dcos_api_session.get(path, node=node)

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -14,7 +14,7 @@ def test_pkgpanda_api(dcos_api_session):
             'Will not work on advanced CF templates, see: '
             'https://jira.mesosphere.com/browse/DCOS_OSS-1375'
         )
-        pytest.skip(reason=reason)
+        pytest.skip(reason)
 
     def get_and_validate_package_ids(path, node):
         r = dcos_api_session.get(path, node=node)

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -16,7 +16,7 @@ def test_move_external_volume_to_new_agent(dcos_api_session):
     """
     expanded_config = get_expanded_config()
     if not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'):
-        pytest.skip(reason='Must be run in an AWS environment!')
+        pytest.skip('Must be run in an AWS environment!')
 
     hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -4,12 +4,9 @@ import uuid
 
 import pytest
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 
-@pytest.mark.skipif(
-    not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),
-    reason='Must be run in an AWS environment!')
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 
@@ -17,6 +14,10 @@ def test_move_external_volume_to_new_agent(dcos_api_session):
     reattached to the same agent.
 
     """
+    expanded_config = get_expanded_config()
+    if not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'):
+        pytest.skip(reason='Must be run in an AWS environment!')
+
     hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex
     test_label = 'integration-test-move-external-volume-{}'.format(test_uuid)

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -309,7 +309,8 @@ def test_if_search_is_working(dcos_api_session):
         expected_error = {'error': '[Errno -2] Name or service not known'}
 
         # Check that result matches expectations for this dcos_api_session
-        if test_helpers.expanded_config['dns_search']:
+        expanded_config = test_helpers.get_expanded_config()
+        if expanded_config['dns_search']:
             assert r_data['search_hit_leader'] in dcos_api_session.masters
             assert r_data['always_hit_leader'] in dcos_api_session.masters
             assert r_data['always_miss'] == expected_error


### PR DESCRIPTION
## High-level description

This allows one to run `pytest --collect-only --confcutdir .` in the integration tests directory of a DC/OS OSS checkout without a cluster running, if the right requirements are installed.

This is part of https://jira.mesosphere.com/browse/DCOS-46438.

This will allow a dashboard which knows about test flakes.
This is also progress towards a test suite which can be run from any host against any cluster.

* Put "skip" conditions which require a cluster into functions, rather than as decorators
* Put import-level opening of files which exist on a cluster into functions