### PR TITLE
[1.12] Allow the collection of tests without a cluster

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -10,7 +10,7 @@ from test_dcos_diagnostics import (
     wait_for_diagnostics_job,
     wait_for_diagnostics_list
 )
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ def dcos_api_session(dcos_api_session_factory):
     args = dcos_api_session_factory.get_args_from_env()
 
     exhibitor_admin_password = None
+    expanded_config = get_expanded_config()
     if expanded_config['exhibitor_admin_password_enabled'] == 'true':
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -189,7 +189,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
 def test_octarine(dcos_api_session, timeout=30):
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
+        pytest.skip('See: https://jira.mesosphere.com/browse/DCOS-14760')
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"
     # to go to localhost, the port attached there is only used to

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -23,7 +23,8 @@ def deploy_test_app_and_check(dcos_api_session, app: dict, test_uuid: str):
     from the app's Dockerfile, which, for the test application
     is the default, root
     """
-    default_os_user = 'nobody' if test_helpers.expanded_config.get('security') == 'strict' else 'root'
+    expanded_config = test_helpers.get_expanded_config()
+    default_os_user = 'nobody' if expanded_config.get('security') == 'strict' else 'root'
 
     if 'container' in app and app['container']['type'] == 'DOCKER':
         marathon_user = 'root'
@@ -185,17 +186,16 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
         pass
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('security') == 'strict',
-    reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
 def test_octarine(dcos_api_session, timeout=30):
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config.get('security') == 'strict':
+        pytest.skip(reason='See: https://jira.mesosphere.com/browse/DCOS-14760')
     # This app binds to port 80. This is only required by the http (not srv)
     # transparent mode test. In transparent mode, we use ".mydcos.directory"
     # to go to localhost, the port attached there is only used to
     # determine which port to send traffic to on localhost. When it
     # reaches the proxy, the port is not used, and a request is made
     # to port 80.
-
     app, uuid = test_helpers.marathon_test_app(host_port=80)
     app['acceptedResourceRoles'] = ["slave_public"]
     app['requirePorts'] = True

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -15,9 +15,10 @@ def auth_enabled():
     return out == 'true'
 
 
-@pytest.mark.skipif(not auth_enabled(),
-                    reason='Can only test adminrouter enforcement if auth is enabled')
 def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_session):
+    reason = 'Can only test adminrouter enforcement if auth is enabled'
+    if not auth_enabled():
+        pytest.skip(reason=reason)
     r = noauth_api_session.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -18,7 +18,7 @@ def auth_enabled():
 def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_session):
     reason = 'Can only test adminrouter enforcement if auth is enabled'
     if not auth_enabled():
-        pytest.skip(reason=reason)
+        pytest.skip(reason)
     r = noauth_api_session.get('/acs/api/v1')
     assert r.status_code == 401
     assert r.headers['WWW-Authenticate'] in ('acsjwt', 'oauthjwt')

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -10,7 +10,7 @@ import kazoo.client
 import pytest
 import requests
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 __maintainer__ = 'mnaboka'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
@@ -284,6 +284,7 @@ def test_signal_service(dcos_api_session):
         }
     }
 
+    expanded_config = get_expanded_config()
     # Generic properties which are the same between all tracks
     generic_properties = {
         'platform': expanded_config['platform'],

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -23,14 +23,16 @@ def get_exhibitor_admin_password():
     return password
 
 
-# make the expanded config available at import time to allow determining
-# which tests should run before the test suite kicks off
-with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
-    expanded_config = json.load(f)
-    # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
-    # Exhibitor's config.
-    # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
-    expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
+def get_expanded_config():
+    # make the expanded config available at import time to allow determining
+    # which tests should run before the test suite kicks off
+    with open('/opt/mesosphere/etc/expanded.config.json', 'r') as f:
+        expanded_config = json.load(f)
+        # expanded.config.json doesn't contain secret values, so we need to read the Exhibitor admin password from
+        # Exhibitor's config.
+        # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
+        expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
+    return expanded_config
 
 
 def marathon_test_app_linux(

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -316,7 +316,7 @@ def get_region_zone(domain):
 def test_fault_domain(dcos_api_session):
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config['fault_domain_enabled'] == 'false':
-        pytest.skip(reason='fault domain is not set')
+        pytest.skip('fault domain is not set')
     master_ip = dcos_api_session.masters[0]
     r = dcos_api_session.get('/state', host=master_ip, port=5050)
     assert r.status_code == 200
@@ -462,7 +462,7 @@ def test_min_allocatable_resources(reserved_disk):
     # offers.
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='Missing framework authentication for mesos-execute')
+        pytest.skip('Missing framework authentication for mesos-execute')
 
     name = \
         'test-min-test_min-allocatable-resources-{}'.format(uuid.uuid4().hex)

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -313,10 +313,10 @@ def get_region_zone(domain):
 
 
 @pytest.mark.supportedwindows
-@pytest.mark.skipif(
-    test_helpers.expanded_config['fault_domain_enabled'] == 'false',
-    reason='fault domain is not set')
 def test_fault_domain(dcos_api_session):
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config['fault_domain_enabled'] == 'false':
+        pytest.skip(reason='fault domain is not set')
     master_ip = dcos_api_session.masters[0]
     r = dcos_api_session.get('/state', host=master_ip, port=5050)
     assert r.status_code == 200
@@ -456,13 +456,14 @@ def reserved_disk(dcos_api_session):
             assert r.status_code == 202, r.text
 
 
-@pytest.mark.skipif(
-    test_helpers.expanded_config.get('security') == 'strict',
-    reason='Missing framework authentication for mesos-execute')
 def test_min_allocatable_resources(reserved_disk):
     """Test that the Mesos master creates offers for just `disk` resources."""
     # We use `mesos-execute` since e.g., Marathon cannot make use of disk-only
     # offers.
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config.get('security') == 'strict':
+        pytest.skip(reason='Missing framework authentication for mesos-execute')
+
     name = \
         'test-min-test_min-allocatable-resources-{}'.format(uuid.uuid4().hex)
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -5,7 +5,6 @@ import uuid
 import pytest
 
 import retrying
-import test_helpers
 from test_helpers import get_expanded_config
 
 __maintainer__ = 'mnaboka'

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -119,7 +119,7 @@ def test_task_metrics_metadata(dcos_api_session):
     """Test that task metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='MoM disabled for strict mode')
+        pytest.skip('MoM disabled for strict mode')
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
         node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
 
@@ -145,7 +145,7 @@ def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='Framework disabled for strict mode')
+        pytest.skip('Framework disabled for strict mode')
 
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'):
         node = get_task_hostname(dcos_api_session, 'marathon', 'hello-world')
@@ -566,7 +566,7 @@ def test_standalone_container_metrics(dcos_api_session):
             'Only resource providers are authorized to launch standalone '
             'containers in strict mode. See DCOS-42325.'
         )
-        pytest.skip(reason=reason)
+        pytest.skip(reason)
     # Fetch the mesos master state to get an agent ID
     master_ip = dcos_api_session.masters[0]
     r = dcos_api_session.get('/state', host=master_ip, port=5050)

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -135,11 +135,6 @@ def test_task_metrics_metadata(dcos_api_session):
         check_metrics_metadata()
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS_OSS-4568',
-    reason='Framework hello-world still running',
-    since='2018-12-14',
-)
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import yaml
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
@@ -27,6 +27,7 @@ def test_load_user_config():
 
 @pytest.mark.supportedwindows
 def test_expanded_config():
+    expanded_config = get_expanded_config()
     # Caluclated parameters should be present
     assert 'master_quorum' in expanded_config
     # Defined and used parameters should be present
@@ -39,6 +40,7 @@ def test_expanded_config():
 @pytest.mark.supportedwindows
 def test_profile_symlink():
     """Assert the DC/OS profile script is symlinked from the correct source."""
+    expanded_config = get_expanded_config()
     symlink_target = expanded_config['profile_symlink_target']
     expected_symlink_source = expanded_config['profile_symlink_source']
     assert expected_symlink_source == os.readlink(symlink_target)

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -300,7 +300,7 @@ def test_vip(dcos_api_session,
     that the expected origin app UUID was returned
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
 
     errors = []
     tests = setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net, ipv6)
@@ -404,7 +404,7 @@ def test_if_overlay_ok(dcos_api_session):
 def test_if_dcos_l4lb_disabled(dcos_api_session):
     '''Test to make sure dcos_l4lb is disabled'''
     if lb_enabled():
-        pytest.skip(reason='Load Balancer enabled')
+        pytest.skip('Load Balancer enabled')
     data = check_output(['/usr/bin/env', 'ip', 'rule'])
     # dcos-net creates this ip rule: `9999: from 9.0.0.0/8 lookup 42`
     # We check it doesn't exist
@@ -453,7 +453,7 @@ def test_l4lb(dcos_api_session):
        * only testing if all 5 are hit at least once
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
     numapps = 5
     numthreads = numapps * 4
     apps = []
@@ -531,11 +531,11 @@ def test_dcos_cni_l4lb(dcos_api_session):
     test-case to PASS.
     '''
     if not lb_enabled():
-        pytest.skip(reason='Load Balancer disabled')
+        pytest.skip('Load Balancer disabled')
 
     expanded_config = test_helpers.get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='Cannot setup CNI config with EE strict mode enabled')
+        pytest.skip('Cannot setup CNI config with EE strict mode enabled')
 
     # CNI configuration of `spartan-net`.
     spartan_net = {

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -183,7 +183,8 @@ def unused_port():
 
 
 def lb_enabled():
-    return test_helpers.expanded_config['enable_lb'] == 'true'
+    expanded_config = test_helpers.get_expanded_config()
+    return expanded_config['enable_lb'] == 'true'
 
 
 @retrying.retry(wait_fixed=2000,
@@ -265,9 +266,6 @@ def test_vip_ipv6(dcos_api_session):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(
-    not lb_enabled(),
-    reason='Load Balancer disabled')
 @pytest.mark.parametrize(
     'container,vip_net,proxy_net',
     generate_vip_app_permutations())
@@ -301,6 +299,9 @@ def test_vip(dcos_api_session,
     proxy container that will ping the origin container VIP and then assert
     that the expected origin app UUID was returned
     '''
+    if not lb_enabled():
+        pytest.skip(reason='Load Balancer disabled')
+
     errors = []
     tests = setup_vip_workload_tests(dcos_api_session, container, vip_net, proxy_net, ipv6)
     for vip, hosts, cmd, origin_app, proxy_app in tests:
@@ -400,9 +401,10 @@ def test_if_overlay_ok(dcos_api_session):
         _check_overlay(slave, 5051)
 
 
-@pytest.mark.skipif(lb_enabled(), reason='Load Balancer enabled')
 def test_if_dcos_l4lb_disabled(dcos_api_session):
     '''Test to make sure dcos_l4lb is disabled'''
+    if lb_enabled():
+        pytest.skip(reason='Load Balancer enabled')
     data = check_output(['/usr/bin/env', 'ip', 'rule'])
     # dcos-net creates this ip rule: `9999: from 9.0.0.0/8 lookup 42`
     # We check it doesn't exist
@@ -443,7 +445,6 @@ def geturl(url):
     return r
 
 
-@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
 def test_l4lb(dcos_api_session):
     '''Test l4lb is load balancing between all the backends
        * create 5 apps using the same VIP
@@ -451,6 +452,8 @@ def test_l4lb(dcos_api_session):
        * verify that 5 uuids have been returned
        * only testing if all 5 are hit at least once
     '''
+    if not lb_enabled():
+        pytest.skip(reason='Load Balancer disabled')
     numapps = 5
     numthreads = numapps * 4
     apps = []
@@ -496,9 +499,6 @@ def test_l4lb(dcos_api_session):
     assert set(expected_uuids) == set(received_uuids)
 
 
-@pytest.mark.skipif(not lb_enabled(), reason='Load Balancer disabled')
-@pytest.mark.xfail(test_helpers.expanded_config.get('security') == 'strict',
-                   reason='Cannot setup CNI config with EE strict mode enabled', strict=True)
 def test_dcos_cni_l4lb(dcos_api_session):
     '''
     This tests the `dcos - l4lb` CNI plugins:
@@ -530,6 +530,12 @@ def test_dcos_cni_l4lb(dcos_api_session):
     would fail, with a successful `curl` execution on the VIP allowing the
     test-case to PASS.
     '''
+    if not lb_enabled():
+        pytest.skip(reason='Load Balancer disabled')
+
+    expanded_config = test_helpers.get_expanded_config()
+    if expanded_config.get('security') == 'strict':
+        pytest.skip(reason='Cannot setup CNI config with EE strict mode enabled')
 
     # CNI configuration of `spartan-net`.
     spartan_net = {

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -2,7 +2,7 @@
 import logging
 
 import pytest
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 __maintainer__ = 'branden'
 __contact__ = 'marathon-team@mesosphere.io'
@@ -10,10 +10,15 @@ __contact__ = 'marathon-team@mesosphere.io'
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(
-    'advanced' in expanded_config['template_filenames'],
-    reason='Will not work on advanced CF templates, see: https://jira.mesosphere.com/browse/DCOS_OSS-1375')
 def test_pkgpanda_api(dcos_api_session):
+
+    expanded_config = get_expanded_config()
+    if 'advanced' in expanded_config['template_filenames']:
+        reason = (
+            'Will not work on advanced CF templates, see: '
+            'https://jira.mesosphere.com/browse/DCOS_OSS-1375'
+        )
+        pytest.skip(reason=reason)
 
     def get_and_validate_package_ids(path, node):
         r = dcos_api_session.get(path, node=node)
@@ -156,11 +161,12 @@ def test_packaging_api(dcos_api_session):
     assert len(packages) == 0
 
 
-@pytest.mark.skipif(expanded_config.get('security') == 'strict',
-                    reason="MoM disabled for strict mode")
 def test_mom_installation(dcos_api_session):
     """Test the Cosmos installation of marathon on marathon (MoM)
     """
+    expanded_config = get_expanded_config()
+    if expanded_config.get('security') == 'strict':
+        pytest.skip(reason='MoM disabled for strict mode')
 
     install_response = dcos_api_session.cosmos.install_package('marathon')
     data = install_response.json()

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -18,7 +18,7 @@ def test_pkgpanda_api(dcos_api_session):
             'Will not work on advanced CF templates, see: '
             'https://jira.mesosphere.com/browse/DCOS_OSS-1375'
         )
-        pytest.skip(reason=reason)
+        pytest.skip(reason)
 
     def get_and_validate_package_ids(path, node):
         r = dcos_api_session.get(path, node=node)
@@ -166,7 +166,7 @@ def test_mom_installation(dcos_api_session):
     """
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
-        pytest.skip(reason='MoM disabled for strict mode')
+        pytest.skip('MoM disabled for strict mode')
 
     install_response = dcos_api_session.cosmos.install_package('marathon')
     data = install_response.json()

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -4,16 +4,13 @@ import uuid
 
 import pytest
 
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
 
 @pytest.mark.supportedwindows
-@pytest.mark.skipif(
-    not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'),
-    reason='Must be run in an AWS environment!')
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 
@@ -21,6 +18,10 @@ def test_move_external_volume_to_new_agent(dcos_api_session):
     reattached to the same agent.
 
     """
+    expanded_config = get_expanded_config()
+    if not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'):
+        pytest.skip(reason='Must be run in an AWS environment!')
+
     hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex
     test_label = 'integration-test-move-external-volume-{}'.format(test_uuid)

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -20,7 +20,7 @@ def test_move_external_volume_to_new_agent(dcos_api_session):
     """
     expanded_config = get_expanded_config()
     if not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'):
-        pytest.skip(reason='Must be run in an AWS environment!')
+        pytest.skip('Must be run in an AWS environment!')
 
     hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -324,7 +324,8 @@ def test_if_search_is_working(dcos_api_session):
         expected_error = {'error': '[Errno -2] Name or service not known'}
 
         # Check that result matches expectations for this dcos_api_session
-        if test_helpers.expanded_config['dns_search']:
+        expanded_config = test_helpers.get_expanded_config()
+        if expanded_config['dns_search']:
             assert r_data['search_hit_leader'] in dcos_api_session.masters
             assert r_data['always_hit_leader'] in dcos_api_session.masters
             assert r_data['always_miss'] == expected_error


### PR DESCRIPTION
## High-level description

This allows one to run `pytest --collect-only --confcutdir .` in the integration tests directory of a DC/OS OSS checkout without a cluster running, if the right requirements are installed.

This will allow a dashboard which knows about test flakes.
This is also progress towards a test suite which can be run from any host against any cluster.

* Put "skip" conditions which require a cluster into functions, rather than as decorators
* Put import-level opening of files which exist on a cluster into functions