### PR TITLE
[1.12] Add patches to address Mesos operator API subscriber leak.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,8 @@
 
 * Make cluster identity configurable in dcos-net (DCOS_OSS-4620)
 
+* Number of concurrent subscribers to Mesos master operator API is now capped to 1000 by default, with a Mesos master flag to configure (DCOS_OSS-4164)
+
 ### Security Updates
 
 * Update Java to 8u192. (DCOS_OSS-4381)

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,7 +1,7 @@
-From b90ed4730e927d36101fe4134f08c2d4a00ab6af Mon Sep 17 00:00:00 2001
+From ca0a8cea7ca6ba4087eeb37da6e6dbdafeca72e8 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH 01/12] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH 01/14] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,7 +1,7 @@
-From f85a2b2c2f0ba16cc2bc6e61309509526164bc95 Mon Sep 17 00:00:00 2001
+From d89477d37ca7553c27651951d86a0e15f09f98ac Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH 02/12] Updated mesos containerizer to ignore GPU isolator
+Subject: [PATCH 02/14] Updated mesos containerizer to ignore GPU isolator
  creation failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,7 +1,7 @@
-From 97fc4ab504344fa34358d8517cbc8854bc14d5fb Mon Sep 17 00:00:00 2001
+From 86a4dcd94d93ac6df98f57afcc0a77865e847777 Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
-Subject: [PATCH 03/12] Mesos UI: updated the URL generation to make it work
+Subject: [PATCH 03/14] Mesos UI: updated the URL generation to make it work
  with adminrouter.
 
 - Use /mesos as the leading master URL prefix.

--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,7 +1,7 @@
-From 7a80da3b2b35fbc4fe8d73dc71eb97b5ecabdb77 Mon Sep 17 00:00:00 2001
+From 3daf981cb8cb6cbb2af31f7d94cdefb9dbe6996e Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Mon, 13 Aug 2018 20:05:26 +0200
-Subject: [PATCH 04/12] Added 'received' timestamp into `process::Request`.
+Subject: [PATCH 04/14] Added 'received' timestamp into `process::Request`.
 
 This allows us to note when a request comes in and
 hence calculate request processing time.

--- a/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,7 +1,7 @@
-From 8a6f2b49522ff78ca166e8edef75650e74276a69 Mon Sep 17 00:00:00 2001
+From 0ca6e07cc3243eada057ed538c451cc27a82f48a Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Mon, 29 Oct 2018 11:25:58 -0700
-Subject: [PATCH 05/12] Added task health check definitions to master API
+Subject: [PATCH 05/14] Added task health check definitions to master API
  responses.
 
 The `Task` protobuf message is updated to include the health check
@@ -19,10 +19,10 @@ Review: https://reviews.apache.org/r/69110/
  4 files changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
-index 043a73710..d2b0f2bc9 100644
+index e98454138..c68bc2bbb 100644
 --- a/include/mesos/mesos.proto
 +++ b/include/mesos/mesos.proto
-@@ -2205,8 +2205,8 @@ message TaskGroupInfo {
+@@ -2217,8 +2217,8 @@ message TaskGroupInfo {
   *   1) we need additional IDs, such as a specific
   *      framework, executor, or agent; or
   *   2) we do not need the additional data, such as the command run by the
@@ -33,7 +33,7 @@ index 043a73710..d2b0f2bc9 100644
   *
   * `Task` is generally constructed from a `TaskInfo`.  See protobuf::createTask.
   */
-@@ -2237,6 +2237,10 @@ message Task {
+@@ -2249,6 +2249,10 @@ message Task {
    // Container information for the task.
    optional ContainerInfo container = 13;
  
@@ -45,10 +45,10 @@ index 043a73710..d2b0f2bc9 100644
    optional string user = 14;
  }
 diff --git a/include/mesos/v1/mesos.proto b/include/mesos/v1/mesos.proto
-index 9830c0b18..22b5a9629 100644
+index dac7f5163..c34a8d8cf 100644
 --- a/include/mesos/v1/mesos.proto
 +++ b/include/mesos/v1/mesos.proto
-@@ -2198,8 +2198,8 @@ message TaskGroupInfo {
+@@ -2210,8 +2210,8 @@ message TaskGroupInfo {
   *   1) we need additional IDs, such as a specific
   *      framework, executor, or agent; or
   *   2) we do not need the additional data, such as the command run by the
@@ -59,7 +59,7 @@ index 9830c0b18..22b5a9629 100644
   *
   * `Task` is generally constructed from a `TaskInfo`.  See protobuf::createTask.
   */
-@@ -2230,6 +2230,10 @@ message Task {
+@@ -2242,6 +2242,10 @@ message Task {
    // Container information for the task.
    optional ContainerInfo container = 13;
  
@@ -86,7 +86,7 @@ index 932111dde..81102d845 100644
  
  
 diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
-index 14e582a43..e4ea0b51b 100644
+index b9289a206..fa949cc5e 100644
 --- a/src/common/protobuf_utils.cpp
 +++ b/src/common/protobuf_utils.cpp
 @@ -341,6 +341,10 @@ Task createTask(

--- a/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
@@ -1,7 +1,7 @@
-From b7e74be95cb8fe540340ba8087196ef08b1ab834 Mon Sep 17 00:00:00 2001
+From 57962673f67209f1449495f5879e9da6baf343a6 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:40:37 +0200
-Subject: [PATCH 06/12] Introduced `logResponse` for http handlers.
+Subject: [PATCH 06/14] Introduced `logResponse` for http handlers.
 
 Currently we use `logRequest` function to log requests to endpoints
 in Mesos `MasterProcess`, `SlaveProcess`, and `FilesProcess`. Each

--- a/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,7 +1,7 @@
-From ba39f2842446eb238ebfea99e84e99b25efb48c1 Mon Sep 17 00:00:00 2001
+From 2382c03e496f3f647905628df49efec6474e45e8 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:58:41 +0200
-Subject: [PATCH 07/12] Logged request processing time for some endpoints.
+Subject: [PATCH 07/14] Logged request processing time for some endpoints.
 
 This patch leverages `logResponse()` function to print response status
 code together with the request processing time for some endpoints on
@@ -21,7 +21,7 @@ Review: https://reviews.apache.org/r/68994
  2 files changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index fc29781ed..5ebdcb1ff 100644
+index f33a5aa79..423bbe533 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -909,7 +909,10 @@ void Master::initialize()

--- a/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
+++ b/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
@@ -1,7 +1,7 @@
-From 85f1214d8060776ff30e04d52a32d4fd88388ea0 Mon Sep 17 00:00:00 2001
+From 8dea81118ec585e17e5d21940b30782f4dcec4ad Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Fri, 23 Nov 2018 10:54:58 +0800
-Subject: [PATCH 08/12] Changed sandbox mode to 0755 in docker containerizer
+Subject: [PATCH 08/14] Changed sandbox mode to 0755 in docker containerizer
  container launch.
 
 Starting from Mesos 1.6.0, sandbox permission was changed from 0755

--- a/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
+++ b/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
@@ -1,7 +1,7 @@
-From 905a122a103f4c0c168d0f1101a7632010c57d50 Mon Sep 17 00:00:00 2001
+From 44e939258baca36130555191ce700c49460d6c62 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:21 -0800
-Subject: [PATCH 09/12] Added HEARTBEAT events and calls for the executor HTTP
+Subject: [PATCH 09/14] Added HEARTBEAT events and calls for the executor HTTP
  API.
 
 These new messages are meant to be backwards compatible, in that

--- a/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
+++ b/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
@@ -1,7 +1,7 @@
-From c56af418edcff533f5e87e894d4bcb5b45fbfac3 Mon Sep 17 00:00:00 2001
+From a3b9778ae09707918df23067ea74fe7b7d825935 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:24 -0800
-Subject: [PATCH 10/12] Refactored master and agent streaming connections.
+Subject: [PATCH 10/14] Refactored master and agent streaming connections.
 
 This moves the very similar `HttpConnection` classes inside the
 master and agent into a common header.  The refactored
@@ -371,7 +371,7 @@ index e2773ed78..0e2c2bb78 100644
  
      return ok;
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 5ebdcb1ff..035c99a3b 100644
+index 423bbe533..51ad910d7 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -1256,7 +1256,9 @@ void Master::finalize()
@@ -412,7 +412,7 @@ index 5ebdcb1ff..035c99a3b 100644
      const FrameworkInfo& frameworkInfo,
      bool force,
      const set<string>& suppressedRoles,
-@@ -9883,7 +9885,8 @@ void Master::addFramework(
+@@ -9977,7 +9979,8 @@ void Master::addFramework(
      } else {
        CHECK_SOME(framework->http);
  
@@ -422,7 +422,7 @@ index 5ebdcb1ff..035c99a3b 100644
  
        http.closed()
          .onAny(defer(self(), &Self::exited, framework->id(), http));
-@@ -9973,7 +9976,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10067,7 +10070,7 @@ Try<Nothing> Master::activateRecoveredFramework(
      Framework* framework,
      const FrameworkInfo& frameworkInfo,
      const Option<UPID>& pid,
@@ -431,7 +431,7 @@ index 5ebdcb1ff..035c99a3b 100644
      const set<string>& suppressedRoles)
  {
    // Exactly one of `pid` or `http` must be provided.
-@@ -10051,7 +10054,9 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10145,7 +10148,9 @@ Try<Nothing> Master::activateRecoveredFramework(
  }
  
  
@@ -442,7 +442,7 @@ index 5ebdcb1ff..035c99a3b 100644
  {
    CHECK_NOTNULL(framework);
  
-@@ -11935,7 +11940,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12029,7 +12034,7 @@ void Master::Subscribers::Subscriber::send(
        if (approvers->approved<VIEW_TASK>(
                event->task_added().task(), *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -451,7 +451,7 @@ index 5ebdcb1ff..035c99a3b 100644
        }
        break;
      }
-@@ -11945,7 +11950,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12039,7 +12044,7 @@ void Master::Subscribers::Subscriber::send(
  
        if (approvers->approved<VIEW_TASK>(*task, *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -460,7 +460,7 @@ index 5ebdcb1ff..035c99a3b 100644
        }
        break;
      }
-@@ -11976,7 +11981,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12070,7 +12075,7 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -469,7 +469,7 @@ index 5ebdcb1ff..035c99a3b 100644
        }
        break;
      }
-@@ -12007,14 +12012,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12101,14 +12106,14 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -486,7 +486,7 @@ index 5ebdcb1ff..035c99a3b 100644
        }
        break;
      }
-@@ -12032,14 +12037,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12126,14 +12131,14 @@ void Master::Subscribers::Subscriber::send(
          }
        }
  
@@ -503,7 +503,7 @@ index 5ebdcb1ff..035c99a3b 100644
        break;
    }
  }
-@@ -12060,7 +12065,7 @@ void Master::exited(const id::UUID& id)
+@@ -12154,7 +12159,7 @@ void Master::exited(const id::UUID& id)
  
  
  void Master::subscribe(

--- a/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
+++ b/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
@@ -1,7 +1,7 @@
-From b76b0e2497243ec3c5c910da483c01cf8615fb9e Mon Sep 17 00:00:00 2001
+From c1e7b7dcc53e9807188286e2597e059f379b9cf7 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:36 -0800
-Subject: [PATCH 11/12] Added heartbeaters for agent and HTTP executors.
+Subject: [PATCH 11/14] Added heartbeaters for agent and HTTP executors.
 
 This implements two separate heartbeaters for Executor Events (agent
 to executor) and Executor Calls (executor to agent).  Both are set to

--- a/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
+++ b/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
@@ -1,7 +1,7 @@
-From 29ffa1c0ebdd6da6f8b3ba3a48cba666275cbd56 Mon Sep 17 00:00:00 2001
+From d02bfbc8a2964c8222a3bd06237aa3264a43ae30 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:43 -0800
-Subject: [PATCH 12/12] Added tests for agent/executor heartbeating.
+Subject: [PATCH 12/14] Added tests for agent/executor heartbeating.
 
 This adds two separate tests which check if the Agent sends heartbeats
 to HTTP executors, and if the HTTP executor driver sends heartbeats

--- a/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
+++ b/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
@@ -1,0 +1,356 @@
+From b4b363a7f9ea76b98a6fad1f486f2d873563b9a8 Mon Sep 17 00:00:00 2001
+From: Joseph Wu <joseph@mesosphere.io>
+Date: Thu, 13 Dec 2018 16:35:03 -0800
+Subject: [PATCH 13/14] Changed master to hold subscribers in a circular
+ buffer.
+
+This adds a flag (--max_operator_event_stream_subscribers) to the
+master which controls how many active subscribers on the Master's
+event stream will be allowed at any time.
+
+The default is 1000 subscribers, which is purposefully higher
+than we expect is needed.  Operators aware that their  network
+has clients/proxies whom do not close connections have the
+option of lowering this flag.
+
+Review: https://reviews.apache.org/r/69307/
+---
+ docs/configuration/master.md |  16 ++++
+ src/master/constants.hpp     |   4 +
+ src/master/flags.cpp         |  11 +++
+ src/master/flags.hpp         |   1 +
+ src/master/master.cpp        |  17 +++-
+ src/master/master.hpp        |   6 +-
+ src/tests/api_tests.cpp      | 167 +++++++++++++++++++++++++++++++++++
+ 7 files changed, 217 insertions(+), 5 deletions(-)
+
+diff --git a/docs/configuration/master.md b/docs/configuration/master.md
+index f290e377b..48ffe3822 100644
+--- a/docs/configuration/master.md
++++ b/docs/configuration/master.md
+@@ -444,6 +444,22 @@ Maximum number of completed tasks per framework to store in memory. (default: 10
+   </td>
+ </tr>
+ 
++<tr id="max_operator_event_stream_subscribers">
++  <td>
++    --max_operator_event_stream_subscribers=VALUE
++  </td>
++  <td>
++Maximum number of simultaneous subscribers to the master's operator event
++stream. If new connections bring the total number of subscribers over this
++value, older connections will be closed by the master.
++
++This flag should generally not be changed unless the operator is mitigating
++known problems with their network setup, such as clients/proxies that do not
++close connections to the master.
++(default: 1000)
++  </td>
++</tr>
++
+ <tr id="max_unreachable_tasks_per_framework">
+   <td>
+     --max_unreachable_tasks_per_framework=VALUE
+diff --git a/src/master/constants.hpp b/src/master/constants.hpp
+index 76ad0c3b1..b0ab9187b 100644
+--- a/src/master/constants.hpp
++++ b/src/master/constants.hpp
+@@ -91,6 +91,10 @@ constexpr double RECOVERY_AGENT_REMOVAL_PERCENT_LIMIT = 1.0; // 100%.
+ // Maximum number of removed slaves to store in the cache.
+ constexpr size_t MAX_REMOVED_SLAVES = 100000;
+ 
++// Default maximum number of subscribers to the master's event stream
++// to keep active at any time.
++constexpr size_t DEFAULT_MAX_OPERATOR_EVENT_STREAM_SUBSCRIBERS = 1000;
++
+ // Default maximum number of completed frameworks to store in the cache.
+ constexpr size_t DEFAULT_MAX_COMPLETED_FRAMEWORKS = 50;
+ 
+diff --git a/src/master/flags.cpp b/src/master/flags.cpp
+index 6ad53ed44..96ba3c59a 100644
+--- a/src/master/flags.cpp
++++ b/src/master/flags.cpp
+@@ -572,6 +572,17 @@ mesos::internal::master::Flags::Flags()
+       "Currently there is no support for multiple HTTP framework\n"
+       "authenticators.");
+ 
++  add(&Flags::max_operator_event_stream_subscribers,
++      "max_operator_event_stream_subscribers",
++      "Maximum number of simultaneous subscribers to the master's operator\n"
++      "event stream. If new connections bring the total number of subscribers\n"
++      "over this value, older connections will be closed by the master.\n"
++      "\n"
++      "This flag should generally not be changed unless the operator is\n"
++      "mitigating known problems with their network setup, such as\n"
++      "clients/proxies that do not close connections to the master.",
++      DEFAULT_MAX_OPERATOR_EVENT_STREAM_SUBSCRIBERS);
++
+   add(&Flags::max_completed_frameworks,
+       "max_completed_frameworks",
+       "Maximum number of completed frameworks to store in memory.",
+diff --git a/src/master/flags.hpp b/src/master/flags.hpp
+index 4a260155b..c29cebf7b 100644
+--- a/src/master/flags.hpp
++++ b/src/master/flags.hpp
+@@ -90,6 +90,7 @@ public:
+   std::string authorizers;
+   std::string http_authenticators;
+   Option<std::string> http_framework_authenticators;
++  size_t max_operator_event_stream_subscribers;
+   size_t max_completed_frameworks;
+   size_t max_completed_tasks_per_framework;
+   size_t max_unreachable_tasks_per_framework;
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 51ad910d7..56189807e 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -324,7 +324,7 @@ Master::Master(
+     detector(_detector),
+     authorizer(_authorizer),
+     frameworks(flags),
+-    subscribers(this),
++    subscribers(this, flags.max_operator_event_stream_subscribers),
+     authenticator(None()),
+     metrics(new Metrics(*this)),
+     electedTime(None())
+@@ -12147,7 +12147,9 @@ void Master::Subscribers::Subscriber::send(
+ void Master::exited(const id::UUID& id)
+ {
+   if (!subscribers.subscribed.contains(id)) {
+-    LOG(WARNING) << "Unknown subscriber " << id << " disconnected";
++    // NOTE: This is only possible when the master closes an event stream
++    // by deleting the subscriber from the `subscribed` map. There will
++    // be separate logging when that happens.
+     return;
+   }
+ 
+@@ -12171,7 +12173,16 @@ void Master::subscribe(
+              exited(http.streamId);
+            }));
+ 
+-  subscribers.subscribed.put(
++  if (subscribers.subscribed.size() >=
++      flags.max_operator_event_stream_subscribers) {
++    LOG(INFO)
++      << "Reached the maximum number of operator event stream subscribers ("
++      << flags.max_operator_event_stream_subscribers << ") so the oldest "
++      << "connection (" << std::get<0>(*subscribers.subscribed.begin())
++      << ") will be closed";
++  }
++
++  subscribers.subscribed.set(
+       http.streamId,
+       Owned<Subscribers::Subscriber>(
+           new Subscribers::Subscriber{http, principal}));
+diff --git a/src/master/master.hpp b/src/master/master.hpp
+index 4118502a4..150e791de 100644
+--- a/src/master/master.hpp
++++ b/src/master/master.hpp
+@@ -1999,7 +1999,9 @@ private:
+ 
+   struct Subscribers
+   {
+-    Subscribers(Master* _master) : master(_master) {};
++    Subscribers(Master* _master, size_t maxSubscribers)
++      : master(_master),
++        subscribed(maxSubscribers) {};
+ 
+     // Represents a client subscribed to the 'api/vX' endpoint.
+     //
+@@ -2059,7 +2061,7 @@ private:
+ 
+     // Active subscribers to the 'api/vX' endpoint keyed by the stream
+     // identifier.
+-    hashmap<id::UUID, process::Owned<Subscriber>> subscribed;
++    BoundedHashMap<id::UUID, process::Owned<Subscriber>> subscribed;
+   };
+ 
+   Subscribers subscribers;
+diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
+index b42628ac9..9d61ff59d 100644
+--- a/src/tests/api_tests.cpp
++++ b/src/tests/api_tests.cpp
+@@ -36,6 +36,7 @@
+ #include <stout/gtest.hpp>
+ #include <stout/jsonify.hpp>
+ #include <stout/nothing.hpp>
++#include <stout/numify.hpp>
+ #include <stout/recordio.hpp>
+ #include <stout/stringify.hpp>
+ #include <stout/try.hpp>
+@@ -3519,6 +3520,172 @@ TEST_P(MasterAPITest, Heartbeat)
+ }
+ 
+ 
++// Verifies that old subscribers are disconnected when too many
++// active subscribers are attached to the master's event stream at once.
++TEST_P(MasterAPITest, MaxEventStreamSubscribers)
++{
++  Clock::pause();
++
++  ContentType contentType = GetParam();
++
++  // Lower the max number of connections for this test.
++  master::Flags masterFlags = CreateMasterFlags();
++  masterFlags.max_operator_event_stream_subscribers = 2;
++
++  Try<Owned<cluster::Master>> master = this->StartMaster(masterFlags);
++  ASSERT_SOME(master);
++
++  // Define some objects we'll use for all the SUBSCRIBE calls.
++  v1::master::Call v1Call;
++  v1Call.set_type(v1::master::Call::SUBSCRIBE);
++
++  http::Headers headers = createBasicAuthHeaders(DEFAULT_CREDENTIAL);
++  headers["Accept"] = stringify(contentType);
++
++  auto deserializer =
++    lambda::bind(deserialize<v1::master::Event>, contentType, lambda::_1);
++
++  Future<Result<v1::master::Event>> event;
++
++  // Send two connections to fill up the circular buffer.
++  Future<http::Response> response1 = http::streaming::post(
++      master.get()->pid,
++      "api/v1",
++      headers,
++      serialize(contentType, v1Call),
++      stringify(contentType));
++
++  AWAIT_EXPECT_RESPONSE_STATUS_EQ(http::OK().status, response1);
++  ASSERT_EQ(http::Response::PIPE, response1->type);
++  ASSERT_SOME(response1->reader);
++  http::Pipe::Reader reader1 = response1->reader.get();
++
++  Reader<v1::master::Event> decoder1(
++      Decoder<v1::master::Event>(deserializer), reader1);
++
++  event = decoder1.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::SUBSCRIBED, event->get().type());
++  event = decoder1.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++  Future<http::Response> response2 = http::streaming::post(
++      master.get()->pid,
++      "api/v1",
++      headers,
++      serialize(contentType, v1Call),
++      stringify(contentType));
++
++  AWAIT_EXPECT_RESPONSE_STATUS_EQ(http::OK().status, response2);
++  ASSERT_EQ(http::Response::PIPE, response2->type);
++  ASSERT_SOME(response2->reader);
++  http::Pipe::Reader reader2 = response2->reader.get();
++
++  Reader<v1::master::Event> decoder2(
++      Decoder<v1::master::Event>(deserializer), reader2);
++
++  event = decoder2.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::SUBSCRIBED, event->get().type());
++  event = decoder2.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++  // Start a third connection.
++  {
++    // This is basically `http::streaming::post` unwrapped inside the
++    // test body. We must do this in order to control the lifetime of
++    // the `http::Connection`. The HTTP helper will keep the streaming
++    // connection alive until the server closes it, but this test wants
++    // to prematurely close the connection.
++    http::URL url(
++        "http",
++        master.get()->pid.address.ip,
++        master.get()->pid.address.port,
++        strings::join("/", master.get()->pid.id, "api/v1"));
++
++    http::Request request;
++    request.method = "POST";
++    request.url = url;
++    request.keepAlive = false;
++    request.headers = headers;
++    request.body = serialize(contentType, v1Call);
++    request.headers["Content-Type"] = stringify(contentType);
++
++    Future<http::Connection> connection = http::connect(request.url);
++
++    Future<http::Response> response3 = connection
++      .then([request](http::Connection connection) {
++        return connection.send(request, true);
++      });
++
++    AWAIT_EXPECT_RESPONSE_STATUS_EQ(http::OK().status, response3);
++    ASSERT_EQ(http::Response::PIPE, response3->type);
++    ASSERT_SOME(response3->reader);
++    http::Pipe::Reader reader3 = response3->reader.get();
++
++    Reader<v1::master::Event> decoder3(
++        Decoder<v1::master::Event>(deserializer), reader3);
++
++    event = decoder3.read();
++    AWAIT_READY(event);
++    ASSERT_EQ(v1::master::Event::SUBSCRIBED, event->get().type());
++    event = decoder3.read();
++    AWAIT_READY(event);
++    ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++    // The first connection should have been kicked out by the third.
++    event = decoder1.read();
++    AWAIT_READY(event);
++    ASSERT_TRUE(event->isNone());
++
++    // The connection will go out of scope and be destructed, which brings
++    // the total active connections below the maximum.
++  }
++
++  // Verify that the second connection is still open.
++  Clock::advance(DEFAULT_HEARTBEAT_INTERVAL);
++  event = decoder2.read();
++  AWAIT_READY(event);
++  ASSERT_TRUE(event->isSome());
++  ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++  // Start a fourth connection. This should be under the maximum
++  // and should not cause any disconnections.
++  Future<http::Response> response4 = http::streaming::post(
++      master.get()->pid,
++      "api/v1",
++      headers,
++      serialize(contentType, v1Call),
++      stringify(contentType));
++
++  AWAIT_EXPECT_RESPONSE_STATUS_EQ(http::OK().status, response4);
++  ASSERT_EQ(http::Response::PIPE, response4->type);
++  ASSERT_SOME(response4->reader);
++  http::Pipe::Reader reader4 = response4->reader.get();
++
++  Reader<v1::master::Event> decoder4(
++      Decoder<v1::master::Event>(deserializer), reader4);
++
++  event = decoder4.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::SUBSCRIBED, event->get().type());
++  event = decoder4.read();
++  AWAIT_READY(event);
++  ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++  // Verify that the second connection is still open.
++  Clock::advance(DEFAULT_HEARTBEAT_INTERVAL);
++  event = decoder2.read();
++  AWAIT_READY(event);
++  ASSERT_TRUE(event->isSome());
++  ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
++
++  Clock::resume();
++}
++
++
+ // This test verifies if we can retrieve the current quota status through
+ // `GET_QUOTA` call, after we set quota resources through `SET_QUOTA` call.
+ TEST_P(MasterAPITest, GetQuota)
+-- 
+2.17.0
+

--- a/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
+++ b/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
@@ -1,0 +1,172 @@
+From 2810ae2801f8a32aaa80f24af496a51e4c66de48 Mon Sep 17 00:00:00 2001
+From: Joseph Wu <joseph@mesosphere.io>
+Date: Thu, 13 Dec 2018 16:35:12 -0800
+Subject: [PATCH 14/14] Added gauge metric for operator event stream
+ subscribers.
+
+This metric "master/operator_event_stream_subscribers" returns
+the total number of subscribers to the master's operator event stream.
+
+Review: https://reviews.apache.org/r/69514/
+---
+ docs/monitoring.md         | 7 +++++++
+ docs/operator-http-api.md  | 4 ++++
+ src/master/master.cpp      | 6 ++++++
+ src/master/metrics.cpp     | 6 ++++++
+ src/master/metrics.hpp     | 2 ++
+ src/tests/api_tests.cpp    | 9 +++++++++
+ src/tests/master_tests.cpp | 3 +++
+ 7 files changed, 37 insertions(+)
+
+diff --git a/docs/monitoring.md b/docs/monitoring.md
+index 00c6ea94b..2c2320ad0 100644
+--- a/docs/monitoring.md
++++ b/docs/monitoring.md
+@@ -979,6 +979,13 @@ event queue.
+   <td>Number of messages in the event queue</td>
+   <td>Gauge</td>
+ </tr>
++<tr>
++  <td>
++  <code>master/operator_event_stream_subscribers</code>
++  </td>
++  <td>Number of subscribers to the operator event stream</td>
++  <td>Gauge</td>
++</tr>
+ </table>
+ 
+ #### Registrar
+diff --git a/docs/operator-http-api.md b/docs/operator-http-api.md
+index 6edf36104..2d4a9b66e 100644
+--- a/docs/operator-http-api.md
++++ b/docs/operator-http-api.md
+@@ -716,6 +716,10 @@ Content-Type: application/json
+         "name": "master/outstanding_offers",
+         "value": 0.0
+       },
++      {
++        "name": "master/operator_event_stream_subscribers",
++        "value": 0.0
++      },
+       {
+         "name": "master/frameworks_active",
+         "value": 0.0
+diff --git a/src/master/master.cpp b/src/master/master.cpp
+index 56189807e..13ba4a42e 100644
+--- a/src/master/master.cpp
++++ b/src/master/master.cpp
+@@ -12157,6 +12157,9 @@ void Master::exited(const id::UUID& id)
+             << " from the list of active subscribers";
+ 
+   subscribers.subscribed.erase(id);
++
++  metrics->operator_event_stream_subscribers =
++    subscribers.subscribed.size();
+ }
+ 
+ 
+@@ -12186,6 +12189,9 @@ void Master::subscribe(
+       http.streamId,
+       Owned<Subscribers::Subscriber>(
+           new Subscribers::Subscriber{http, principal}));
++
++  metrics->operator_event_stream_subscribers =
++    subscribers.subscribed.size();
+ }
+ 
+ 
+diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
+index 56a7eef2d..3ed0827ad 100644
+--- a/src/master/metrics.cpp
++++ b/src/master/metrics.cpp
+@@ -80,6 +80,8 @@ Metrics::Metrics(const Master& master)
+     outstanding_offers(
+         "master/outstanding_offers",
+         defer(master, &Master::_outstanding_offers)),
++    operator_event_stream_subscribers(
++        "master/operator_event_stream_subscribers"),
+     tasks_staging(
+         "master/tasks_staging",
+         defer(master, &Master::_tasks_staging)),
+@@ -232,6 +234,8 @@ Metrics::Metrics(const Master& master)
+ 
+   process::metrics::add(outstanding_offers);
+ 
++  process::metrics::add(operator_event_stream_subscribers);
++
+   process::metrics::add(tasks_staging);
+   process::metrics::add(tasks_starting);
+   process::metrics::add(tasks_running);
+@@ -383,6 +387,8 @@ Metrics::~Metrics()
+ 
+   process::metrics::remove(outstanding_offers);
+ 
++  process::metrics::remove(operator_event_stream_subscribers);
++
+   process::metrics::remove(tasks_staging);
+   process::metrics::remove(tasks_starting);
+   process::metrics::remove(tasks_running);
+diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
+index a8055159b..1cf03301e 100644
+--- a/src/master/metrics.hpp
++++ b/src/master/metrics.hpp
+@@ -60,6 +60,8 @@ struct Metrics
+ 
+   process::metrics::PullGauge outstanding_offers;
+ 
++  process::metrics::PushGauge operator_event_stream_subscribers;
++
+   // Task state metrics.
+   process::metrics::PullGauge tasks_staging;
+   process::metrics::PullGauge tasks_starting;
+diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
+index 9d61ff59d..00c2ce77f 100644
+--- a/src/tests/api_tests.cpp
++++ b/src/tests/api_tests.cpp
+@@ -3527,6 +3527,7 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+   Clock::pause();
+ 
+   ContentType contentType = GetParam();
++  const string METRIC_NAME("master/operator_event_stream_subscribers");
+ 
+   // Lower the max number of connections for this test.
+   master::Flags masterFlags = CreateMasterFlags();
+@@ -3592,6 +3593,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+   AWAIT_READY(event);
+   ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
+ 
++  // Check the relevant metric for total active subscribers.
++  JSON::Object metrics = Metrics();
++  EXPECT_EQ(2, metrics.values.at(METRIC_NAME));
++
+   // Start a third connection.
+   {
+     // This is basically `http::streaming::post` unwrapped inside the
+@@ -3651,6 +3656,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+   ASSERT_TRUE(event->isSome());
+   ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
+ 
++  // Check the metric again.
++  metrics = Metrics();
++  EXPECT_EQ(1, metrics.values.at(METRIC_NAME));
++
+   // Start a fourth connection. This should be under the maximum
+   // and should not cause any disconnections.
+   Future<http::Response> response4 = http::streaming::post(
+diff --git a/src/tests/master_tests.cpp b/src/tests/master_tests.cpp
+index 9d5d5a3bd..1e840c478 100644
+--- a/src/tests/master_tests.cpp
++++ b/src/tests/master_tests.cpp
+@@ -2265,6 +2265,9 @@ TEST_F(MasterTest, MetricsInMetricsEndpoint)
+ 
+   EXPECT_EQ(1u, snapshot.values.count("master/outstanding_offers"));
+ 
++  EXPECT_EQ(1u, snapshot.values.count(
++      "master/operator_event_stream_subscribers"));
++
+   EXPECT_EQ(1u, snapshot.values.count("master/tasks_staging"));
+   EXPECT_EQ(1u, snapshot.values.count("master/tasks_starting"));
+   EXPECT_EQ(1u, snapshot.values.count("master/tasks_running"));
+-- 
+2.17.0
+


### PR DESCRIPTION
## High-level description

This PR adds new patches on top of OSS Mesos which address an issue where connections of subscribers to the master's operator API can leak due to network intermediaries such as ELB.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4164](https://jira.mesosphere.com/browse/DCOS_OSS-4164) Prevent subscribers to the master's event stream from leaking connections


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This change is tested in the Mesos integration tests, and there are no DC/OS components which affect the behavior added here.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
