### PR TITLE
Fix dcos-cli, remove artifacts that are too large

### DIFF
--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -5,8 +5,8 @@
 #   Fetched logs are comprised of journald logs, mesos logs, sandbox logs and diagnostics bundles for all nodes.
 #
 # USAGE:
-#   bash fetch_cluster_logs.bash open <ssh-user> <master-public-ip> [--login-token=<token>] [--identity-file=<path>] [--debug]
-#   bash fetch_cluster_logs.bash enterprise <ssh-user> <master-public-ip> [--username=<username>] [--password=<password>] [--identity-file=<path>] [--debug]
+#   bash fetch_cluster_logs.bash open <ssh-user> <master-public-ip> [--login-token=<token>] [--identity-file=<path>] [--max-artifact-size] [--debug]
+#   bash fetch_cluster_logs.bash enterprise <ssh-user> <master-public-ip> [--username=<username>] [--password=<password>] [--identity-file=<path>] [--max-artifact-size] [--debug]
 #
 # COMMANDS
 #   open          Fetch the logs for an open cluster.
@@ -17,18 +17,25 @@
 #   <master-public-ip>    Public ip for the master node of your cluster.
 #
 # OPTIONAL ARGUMENTS
-#   --login-token=<token>     Token used to log in to your open DC/OS cluster. If omitted, you will be prompted for it
-#                             during the DC/OS CLI cluster setup.
-#   --username=<username>     Username to log in to your enterprise DC/OS cluster. If omitted, you will be prompted for
-#                             it during the DC/OS CLI cluster setup.
-#   --password=<password>     Password to log in to your DC/OS enterprise cluster. If omitted, you will be prompted for
-#                             it during the DC/OS CLI cluster setup.
-#   --identity-file=<path>    Path to the private ssh key that will be used to ssh into the nodes. If omitted, that key
-#                             must be added to your ssh-agent.
-#   --debug                   Turn on debug logging for the DC/OS CLI.
+#   --login-token=<token>       Token used to log in to your open DC/OS cluster. If omitted, you will be prompted for it during the DC/OS CLI cluster setup.
+#   --username=<username>       Username to log in to your enterprise DC/OS cluster. If omitted, you will be prompted for it during the DC/OS CLI cluster setup.
+#   --password=<password>       Password to log in to your DC/OS enterprise cluster. If omitted, you will be prompted for it during the DC/OS CLI cluster setup.
+#   --identity-file=<path>      Path to the private ssh key that will be used to ssh into the nodes. If omitted, that key must be added to your ssh-agent.
+#   --max-artifact-size=<size>  Maximum size (in bytes) of artifacts produced by this script. Any artifact exceeding that limit will be deleted.
+#   --debug                     Turn on debug logging for the DC/OS CLI.
 
 set +e
 set -x
+
+check_max_artifact_size() {
+  # checks that a given artifact is under the maximum allowed size. If it exceeds that limit, delete it.
+  artifact_name=$1
+  artifact_size=$(du -s ${artifact_name} | grep -Po "\d+" | head -1)
+  if (( $artifact_size > $max_artifact_size )); then
+    sudo rm -rf $artifact_name
+    echo "Deleting artifact ${artifact_name}. Size of ${artifact_size} bytes is exceeding limit of ${max_artifact_size} bytes."
+  fi
+}
 
 dcos_variant=$1
 if [[ -z $dcos_variant ]] || ([[ $dcos_variant != "open" ]] && [[ $dcos_variant != "enterprise" ]]); then
@@ -63,9 +70,13 @@ if [[ $dcos_variant == "open" ]]; then
       dcos_login_token_input="<<< ${i#*=}"
       shift
     ;;
-      --identity-file=*)
+    --identity-file=*)
       identity_file="${i#*=}"
-    shift
+      shift
+    ;;
+    --max-artifact-size=*)
+      max_artifact_size="${i#*=}"
+      shift
     ;;
     *)
       echo "ERROR: Unrecognized argument '$i' for command '$dcos_variant'"
@@ -93,12 +104,21 @@ else
       identity_file="${i#*=}"
       shift
     ;;
+    --max-artifact-size=*)
+      max_artifact_size="${i#*=}"
+      shift
+    ;;
     *)
       echo "ERROR: Unrecognized argument '$i' for command '$dcos_variant'"
       exit 0
     ;;
   esac
   done
+fi
+
+if [[ -z $max_artifact_size ]]; then
+  # default to 2GB
+  max_artifact_size=2000000000
 fi
 
 ssh_options="-A -T -l $ssh_user -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -133,6 +153,7 @@ done
 
 # get diagnostics bundle
 ./dcos-cli $debug_options node diagnostics download $bundle_name
+check_max_artifact_size "$bundle_name"
 
 # copy the identity file to the master node so we don't need the ssh-agent when agent forwarding
 if [[ ! -z $identity_file ]]; then
@@ -154,9 +175,11 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
   if [[ $pid == *"master"* ]]; then
     # get journald logs
     ssh $ssh_options $master_public_ip -- journalctl -x -b --no-pager > master_journald.log
+    check_max_artifact_size "master_journald.log"
 
     # get mesos logs
     ./dcos-cli $debug_options node log --leader > mesos_master.log
+    check_max_artifact_size "mesos_master.log"
   else
     mesos_sandbox_size=$(ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo du -s /var/lib/mesos/slave/ | grep -Po "\d+")
     free_space=$(ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo df --block-size=1 | grep -Po "\d+\s+\d+%\ /$" | grep -Po "\d+" | head -1)
@@ -168,6 +191,7 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
 
       # get sandbox logs
       ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo tar --exclude=provisioner -zc mesos_sandbox > sandbox_${ip_underscores}.tar.gz
+      check_max_artifact_size "sandbox_${ip_underscores}.tar.gz"
       ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo rm -rf mesos_sandbox
     else
       echo "Cannot copy and collect mesos sandbox: insufficient disk space."
@@ -175,8 +199,11 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
 
     # get journald logs
     ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- journalctl -x -b --no-pager > agent_${ip_underscores}_journald.log
+    check_max_artifact_size "agent_${ip_underscores}_journald.log"
 
     # get mesos logs
     ./dcos-cli $debug_options node log --mesos-id=$id > mesos_agent_${ip_underscores}.log
+    check_max_artifact_size "mesos_agent_${ip_underscores}.log"
   fi
 done
+

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -128,13 +128,13 @@ fi
 
 # download the DC/OS CLI
 if [ ! -f dcos-cli ]; then
-  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.4/dcos --output-document=dcos-cli
+  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.5/dcos --output-document=dcos-cli
   chmod +x dcos-cli
 fi
 
 # link the CLI with the cluster
 if [[ $dcos_variant == "open" ]]; then
-  bash -c "./dcos-cli $debug_options cluster setup http://$master_public_ip --provider=dcos-oidc-auth0 --insecure $dcos_login_token_input"
+  bash -c "./dcos-cli $debug_options cluster setup $master_public_ip --provider=dcos-oidc-auth0 --insecure $dcos_login_token_input"
 else
   ./dcos-cli $debug_options cluster setup $master_public_ip $dcos_username $dcos_password --insecure
 fi

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -63,7 +63,7 @@ if [[ $dcos_variant == "open" ]]; then
   do
   case $i in
     --debug)
-      debug_options="--debug --log-level=debug"
+      debug_options="-vv"
       shift
     ;;
     --login-token=*)
@@ -89,7 +89,7 @@ else
   do
   case $i in
     --debug)
-      debug_options="--debug --log-level=debug"
+      debug_options="-vv"
       shift
     ;;
     --username=*)
@@ -128,7 +128,7 @@ fi
 
 # download the DC/OS CLI
 if [ ! -f dcos-cli ]; then
-  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.1/dcos --output-document=dcos-cli
+  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.4/dcos --output-document=dcos-cli
   chmod +x dcos-cli
 fi
 

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -128,7 +128,7 @@ fi
 
 # download the DC/OS CLI
 if [ ! -f dcos-cli ]; then
-  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.4/dcos --output-document=dcos-cli
+  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.5/dcos --output-document=dcos-cli
   chmod +x dcos-cli
 fi
 

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -128,13 +128,13 @@ fi
 
 # download the DC/OS CLI
 if [ ! -f dcos-cli ]; then
-  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.5/dcos --output-document=dcos-cli
+  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.4/dcos --output-document=dcos-cli
   chmod +x dcos-cli
 fi
 
 # link the CLI with the cluster
 if [[ $dcos_variant == "open" ]]; then
-  bash -c "./dcos-cli $debug_options cluster setup $master_public_ip --provider=dcos-oidc-auth0 --insecure $dcos_login_token_input"
+  bash -c "./dcos-cli $debug_options cluster setup http://$master_public_ip --provider=dcos-oidc-auth0 --insecure $dcos_login_token_input"
 else
   ./dcos-cli $debug_options cluster setup $master_public_ip $dcos_username $dcos_password --insecure
 fi

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -108,7 +108,7 @@ fi
 
 # download the DC/OS CLI
 if [ ! -f dcos-cli ]; then
-  wget https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos --output-document=dcos-cli
+  wget https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.7.1/dcos --output-document=dcos-cli
   chmod +x dcos-cli
 fi
 
@@ -171,7 +171,7 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
       ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- sudo rm -rf mesos_sandbox
     else
       echo "Cannot copy and collect mesos sandbox: insufficient disk space."
-    fi 
+    fi
 
     # get journald logs
     ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- journalctl -x -b --no-pager > agent_${ip_underscores}_journald.log

--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -134,7 +134,7 @@ fi
 
 # link the CLI with the cluster
 if [[ $dcos_variant == "open" ]]; then
-  bash -c "./dcos-cli $debug_options cluster setup $master_public_ip --insecure $dcos_login_token_input"
+  bash -c "./dcos-cli $debug_options cluster setup $master_public_ip --provider=dcos-oidc-auth0 --insecure $dcos_login_token_input"
 else
   ./dcos-cli $debug_options cluster setup $master_public_ip $dcos_username $dcos_password --insecure
 fi


### PR DESCRIPTION
Everything works:

open dcos aws cluster:
https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsOnpremWStaticBackendCopyLogCollectionTest&buildId=1403810

DC/OS E2E Docker Integration Tests:
https://teamcity.mesosphere.io/viewLog.html?buildId=1403807&buildTypeId=DcOs_Open_Test_DcosDocker_CopyForLogCollectionDcOsE2eDockerIntegrationTests&tab=artifacts

master journald logs was over the set limit and was deleted:
https://teamcity.mesosphere.io/viewLog.html?buildId=1403812&buildTypeId=DcOs_Enterprise_Test_Inte_AwsOnpremWStaticBackendAndSecurityStrictCopyLogCollect&tab=artifacts