### PR TITLE
[1.12] Fix flaky test_pod_application_metrics test

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -678,15 +678,41 @@ def test_pod_application_metrics(dcos_api_session):
     """
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=LATENCY * 1000)
     def test_application_metrics(agent_ip, agent_id, task_name, num_containers):
-        # Retry for two and a half minutes since the collector collects
-        # state every minute to propagate containers to the API
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=150000)
-        def wait_for_container_metrics_propagation():
+        # Get expected 2 container ids from mesos state endpoint
+        # (one container + its parent container)
+        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        def get_container_ids_from_state(dcos_api_session, num_containers):
+            state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+            assert state_response.status_code == 200
+            state = state_response.json()
+
+            cids = set()
+            for framework in state['frameworks']:
+                if framework['name'] == 'marathon':
+                    for task in framework['tasks']:
+                        if task['name'] == 'statsd-emitter-task':
+                            container = task['statuses'][0]['container_status']['container_id']
+                            cids.add(container['value'])
+                            if 'parent' in container:
+                                cids.add(container['parent']['value'])
+                            break
+                    break
+
+            assert len(cids) == num_containers, 'Test should create {} containers'.format(num_containers)
+            return cids
+
+        container_ids = get_container_ids_from_state(dcos_api_session, num_containers)
+
+        # Retry for 5 minutes since the collector collects state
+        # every 2 minutes to propagate containers to the API
+        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        def wait_for_container_metrics_propagation(container_ids):
             response = dcos_api_session.metrics.get('/containers', node=agent_ip)
             assert response.status_code == 200
-            assert len(response.json()) == num_containers, 'Test should create {} containers'.format(num_containers)
+            assert container_ids.issubset(
+                response.json()), "Containers {} should have been propagated".format(container_ids)
 
-        wait_for_container_metrics_propagation()
+        wait_for_container_metrics_propagation(container_ids)
 
         get_containers = {
             "type": "GET_CONTAINERS",
@@ -699,9 +725,8 @@ def test_pod_application_metrics(dcos_api_session):
         r = dcos_api_session.post('/agent/{}/api/v1'.format(agent_id), json=get_containers)
         r.raise_for_status()
         mesos_agent_containers = r.json()['get_containers']['containers']
-
-        assert len(mesos_agent_containers) == num_containers, 'Agent operator API should report '\
-            'exactly {} running containers'.format(num_containers)
+        mesos_agent_cids = [container['container_id']['value'] for container in mesos_agent_containers]
+        assert container_ids.issubset(mesos_agent_cids), "Missing expected containers {}".format(container_ids)
 
         def is_nested_container(container):
             """Helper to check whether or not a container returned in the


### PR DESCRIPTION
## High-level description

Fix flaky `test_pod_application_metrics` by getting the task's container ids and asserting the ids instead of checking for the number of running containers, which can fail assertions occasionally if previous tests' containers were not torn down completely or any other cases where other containers might be running at the same time.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4571](https://jira.mesosphere.com/browse/DCOS_OSS-4571) test_metrics test_pod_application_metrics failed with 'Test should create 2 containers'



## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration test change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
