### PR TITLE
[1.13] Fix flaky test_standalone_container_metrics

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -12,7 +12,6 @@ __maintainer__ = 'philipnrmn'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
-LATENCY = 60
 METRICS_WAITTIME = 5 * 60 * 1000
 METRICS_INTERVAL = 2 * 1000
 STD_WAITTIME = 15 * 60 * 1000
@@ -357,8 +356,8 @@ def test_metrics_node(dcos_api_session):
 
         return True
 
-    # Retry for 30 seconds for for the node metrics content to appear.
-    @retrying.retry(stop_max_delay=30000)
+    # Retry for 5 minutes for for the node metrics content to appear.
+    @retrying.retry(stop_max_delay=METRICS_WAITTIME)
     def wait_for_node_response(node):
         response = dcos_api_session.metrics.get('/node', node=node)
         assert response.status_code == 200
@@ -402,7 +401,7 @@ def test_metrics_containers(dcos_api_session):
     the statsd-emitter executor. When found, query it's /app endpoint to test that
     it's sending the statsd metrics as expected.
     """
-    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=LATENCY * 1000)
+    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def test_containers(app_endpoints):
 
         debug_task_name = []
@@ -621,8 +620,8 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     return None
 
 
-# Retry for two and a half minutes since the collector collects
-# state every 2 minutes to propagate containers to the API
+# Retry for 5 minutes since the collector collects state
+# every 2 minutes to propogate containers to the API
 @retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_container_ids(dcos_api_session, node: str):
     """Return container IDs reported by the metrics API on node.
@@ -637,12 +636,12 @@ def get_container_ids(dcos_api_session, node: str):
     return container_ids
 
 
-@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
     Retries on error, non-200 status, or missing response fields for up
-    to 30 seconds.
+    to 5 minutes.
 
     """
     response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
@@ -664,11 +663,11 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     return container_metrics
 
 
-@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_app_metrics(dcos_api_session, node: str, container_id: str):
     """Return app metrics for container_id from the metrics API on node.
 
-    Retries on error or non-200 status for up to 30 seconds.
+    Retries on error or non-200 status for up to 5 minutes.
 
     """
     resp = dcos_api_session.metrics.get('/containers/' + container_id + '/app', node=node)
@@ -757,13 +756,13 @@ def test_standalone_container_metrics(dcos_api_session):
     }
 
     # There is a short delay between the container starting and metrics becoming
-    # available via the metrics service. Because of this, we wait up to 10
-    # seconds for these metrics to appear before throwing an exception.
+    # available via the metrics service. Because of this, we wait up to 5
+    # minutes for these metrics to appear before throwing an exception.
     def _should_retry_metrics_fetch(response):
         return response.status_code == 204
 
-    @retrying.retry(wait_fixed=1000,
-                    stop_max_delay=10000,
+    @retrying.retry(wait_fixed=METRICS_INTERVAL,
+                    stop_max_delay=METRICS_WAITTIME,
                     retry_on_result=_should_retry_metrics_fetch,
                     retry_on_exception=lambda x: False)
     def _get_metrics():
@@ -829,7 +828,7 @@ def test_pod_application_metrics(dcos_api_session):
     1) Container statistics metrics are provided for the executor container
     2) Application metrics are exposed for the task container
     """
-    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=LATENCY * 1000)
+    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def test_application_metrics(agent_ip, agent_id, task_name, num_containers):
         # Get expected 2 container ids from mesos state endpoint
         # (one container + its parent container)
@@ -858,7 +857,7 @@ def test_pod_application_metrics(dcos_api_session):
 
         # Retry for two and a half minutes since the collector collects
         # state every 2 minutes to propagate containers to the API
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=150000)
+        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def wait_for_container_metrics_propagation(container_ids):
             response = dcos_api_session.metrics.get('/containers', node=agent_ip)
             assert response.status_code == 200
@@ -894,10 +893,10 @@ def test_pod_application_metrics(dcos_api_session):
             container_id_path = '/containers/{}'.format(container_id)
 
             if (is_nested_container(container)):
-                # Retry for 30 seconds for each nested container to appear.
+                # Retry for 5 minutes for each nested container to appear.
                 # Since nested containers do not report resource statistics, we
                 # expect the response code to be 204.
-                @retrying.retry(stop_max_delay=30000)
+                @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
                     response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
                     assert response.status_code == 204
@@ -946,9 +945,9 @@ def test_pod_application_metrics(dcos_api_session):
                 assert task_name.strip('/') == app_response.json()['dimensions']['task_name'],\
                     'Nested container was not tagged with the correct task name'
             else:
-                # Retry for 30 seconds for each parent container to present its
+                # Retry for 5 minutes for each parent container to present its
                 # content.
-                @retrying.retry(stop_max_delay=30000)
+                @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
                     response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
                     assert response.status_code == 200


### PR DESCRIPTION
## High-level description

Increases retry period from 10s to 5min. Also increased all other retry periods to minimum of 5min to avoid more potential flakes down the line.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46190](https://jira.mesosphere.com/browse/DCOS-46190) test_metrics.test_standalone_container_metrics


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration test change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
