### PR TITLE
1.12.1 update version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## DC/OS 1.12-dev
 
+## DC/OS 1.12.1
+
 ### Notable changes
 
 * Users can now supply additional Telegraf settings (DCOS-42214)

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -86,7 +86,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.12.0',
+        'version': '1.12.1',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.12.0'
+DCOS_VERSION = '1.12.1'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 


### PR DESCRIPTION
Update 1.12.1 version that. Port https://github.com/dcos/dcos/pull/3955 to the minor branch that was missed.