### PR TITLE
[1.13] Unmute test_executor_metrics_metadata test

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -290,11 +290,6 @@ def test_task_metrics_metadata(dcos_api_session):
         check_metrics_metadata()
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS_OSS-4568',
-    reason='Framework hello-world still running',
-    since='2018-12-14',
-)
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()


### PR DESCRIPTION
## High-level description

Flaky test fix was done in https://github.com/dcos/dcos/pull/3947 but test is still muted - unmuting the test here.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4568](https://jira.mesosphere.com/browse/DCOS_OSS-4568) test_metrics.deploy_and_cleanup_dcos_package Framework hello-world still running



## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: unmuting integration test
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: 
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
