### PR TITLE
Unmute test_metrics_containers

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -395,11 +395,6 @@ def test_metrics_node(dcos_api_session):
         assert expected_dimension_response(response.json())
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS_OSS-4486',
-    reason='test_metrics_containers fails with container metrics response status 204',
-    since='2018-11-20',
-)
 def test_metrics_containers(dcos_api_session):
     """If there's a deployed container on the slave, iterate through them to check for
     the statsd-emitter executor. When found, query it's /app endpoint to test that

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,11 +1,11 @@
 import contextlib
-
 import logging
 import pprint
 import uuid
 
 import pytest
 import retrying
+
 from test_helpers import get_expanded_config
 
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,6 +1,7 @@
 import contextlib
 
 import logging
+import pprint
 import uuid
 
 import pytest
@@ -653,11 +654,13 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     assert 'dimensions' in container_metrics, (
         'container metrics must include dimensions. Got: {}'.format(container_metrics)
     )
+
     # task_name is an important dimension for identifying metrics, but it may take some time to appear in the container
     # metrics response.
-    assert 'task_name' in container_metrics['dimensions'], (
-        'task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions'])
-    )
+    if 'task_name' not in container_metrics['dimensions']:
+        print("Missing task_name. Container metrics:")
+        pprint.pprint(container_metrics)
+        raise Exception('task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions']))
 
     return container_metrics
 


### PR DESCRIPTION
## High-level description

This unmutes a flaky test that [fails infrequently](https://teamcity.mesosphere.io/project.html?tab=testDetails&projectId=DcOs_Open_Test_IntegrationTest&testNameId=-4813183735307993658&branch_DcOs_Open_Test_IntegrationTest=%3Cdefault%3E&page=1), and has been difficult to reproduce manually, in order to collect more data around the failure. This is specifically intended to help collect DC/OS component logs, which are only collected by CI if an integration test job fails.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4486](https://jira.mesosphere.com/browse/DCOS_OSS-4486) test_metrics.test_metrics_containers / test_metrics_containers_app fails with container metrics response status 204


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This only touches tests.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This only touches tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]