### PR TITLE
[1.11] Fix validation of overlay backends

### DIFF
--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -292,26 +292,25 @@ def _validate_overlay_subnet(agent_subnet, overlay_subnet, prefixlen):
 def _validate_overlay_backend(overlay_name, backend):
     try:
         # Make sure the backend has the right VNI.
-        vxlan = backend.pop('vxlan')
+        vxlan = backend['vxlan']
 
         # Verify the VTEP IP is allocated from the right subnet.
-        vtep_ip = vxlan.pop('vtep_ip')
-        assert vtep_ip.startswith('44.128')
-        assert vtep_ip.endswith('/20')
+        if overlay_name == 'dcos':
+            vtep_ip = vxlan['vtep_ip']
+            assert vtep_ip.startswith('44.128')
+            assert vtep_ip.endswith('/20')
 
-        vtep_ip6 = vxlan.pop('vtep_ip6')
-        assert vtep_ip6.startswith('fd01:a')
-        assert vtep_ip6.endswith('/64')
+        if overlay_name == 'dcos6':
+            vtep_ip6 = vxlan['vtep_ip6']
+            assert vtep_ip6.startswith('fd01:a')
+            assert vtep_ip6.endswith('/64')
 
-        # Verify OUI of the VTEP MAC.
-        vtep_mac = vxlan.pop('vtep_mac')
+        # Verify VTEP configuration.
+        vtep_mac = vxlan['vtep_mac']
         assert vtep_mac.startswith('70:b3:d5:')
 
-        expected_vxlan = {
-            'vni': 1024,
-            'vtep_name': 'vtep1024'
-        }
-        assert vxlan == expected_vxlan
+        assert vxlan['vni'] == 1024
+        assert vxlan['vtep_name'] == 'vtep1024'
 
     except KeyError as ex:
         raise AssertionError("Could not find key :" + str(ex)) from ex


### PR DESCRIPTION
## High-level description

test_endpoints.test_if_overlay_master_agent_is_up fails for 1.11 upgraded clusters.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46506](https://jira.mesosphere.com/browse/DCOS-46506) test_endpoints.test_if_overlay_master_agent_is_up fails for 1.11 upgraded clusters

## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: it's a fix for integration tests.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).