### PR TITLE
updating 1.12 to the latest metronome

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.5.71-2294545/metronome-0.5.71-2294545.tgz",
-    "sha1": "4c4325c58ed59f76e40983f0573334151a7b87fa"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.10-391637c/metronome-0.6.10-391637c.tgz",
+    "sha1": "38fa4a2c3d281935d0fb123bdfdf64b0df7b48ae"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-46752](https://jira.mesosphere.com/browse/DCOS_OSS-46752) Release Metronome latest 0.6 on 1.12.


## Related tickets (optional)

Other tickets related to this change:

  - [PR-317](https://github.com/dcos/metronome/pull/317) Updated to the latest version of Marathon 1.7 lib.
  - [DCOS-41675](https://jira.mesosphere.com/browse/DCOS-41675) Azure Out of memory: Java heap space Exception. Observed on Azure platform.
- This supersedes https://github.com/dcos/dcos/pull/3922

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/37be650...391637c)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/51/)
  - [ ] Code Coverage (if available):  N/A
