### PR TITLE
[1.12] dcos6 interface shown in the UI even when enable_ipv6 was set to false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 ## DC/OS 1.12-dev
 
+### Notable changes
+
+### Breaking changes
+
+### Fixed and improved
+
+* Mark `dcos6` overlay network as disabled if `enable_ipv6` is set to false (DCOS-40539)
+
+### Security Updates
+
 ## DC/OS 1.12.1
 
 ### Notable changes
@@ -127,6 +137,7 @@ Format of the entries must be.
 
 ### Security Updates
 
+* Mark `dcos6` overlay network as disabled if `enable_ipv6` is set to false (DCOS-40539)
 
 ### Notable changes
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -192,7 +192,7 @@ package:
     content: |
       {
         "replicated_log_dir":"/var/lib/dcos/mesos/master/",
-        "network": {{ dcos_overlay_network }}
+        "network": {{ dcos_overlay_network_json }}
        }
   - path: /etc/dcos/network/cni/ucr-default-bridge.conf
     content: |

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -201,7 +201,7 @@ def test_if_overlay_master_is_up(dcos_api_session):
         }]
     }
 
-    assert json['network'] == dcos_overlay_network
+    assert nested_match(dcos_overlay_network, json['network'])
 
 
 def test_if_overlay_master_agent_is_up(dcos_api_session):
@@ -298,7 +298,7 @@ def _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlay):
             }
         }
 
-    assert expected == agent_overlay
+    assert nested_match(expected, agent_overlay)
 
 
 def _validate_overlay_subnet(agent_subnet, overlay_subnet, prefixlen):
@@ -360,3 +360,22 @@ def test_if_cosmos_is_only_available_locally(dcos_api_session):
     # we expect a 200
     r = dcos_api_session.get('/', host="127.0.0.1", port=9990, scheme='http')
     assert r.status_code == 200
+
+
+def nested_match(expect, value):
+    if expect == value:
+        return True
+    if isinstance(expect, dict) and isinstance(value, dict):
+        for k, v in expect.items():
+            if k in value:
+                if not nested_match(v, value[k]):
+                    return False
+            else:
+                return False
+        return True
+    if isinstance(expect, list) and isinstance(value, list):
+        for x, y in zip(expect, value):
+            if not nested_match(x, y):
+                return False
+        return True
+    return False

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "545c3ff25e8bf5dcff166b83ee419584db22a5c4",
+    "ref": "85a3ee2e4ac2b180b13690ea98fd87a8ef473697",
     "ref_origin": "1.12"
   }
 }


### PR DESCRIPTION
## High-level description

dcos6 interface shown in the UI even when enable_ipv6 was set to false.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40539](https://jira.mesosphere.com/browse/DCOS-40539) dcos6 interface shown in the UI even when enable_ipv6 was set to false

## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
https://github.com/dcos/dcos-mesos-modules/compare/545c3ff25e8bf5dcff166b83ee419584db22a5c4...85a3ee2e4ac2b180b13690ea98fd87a8ef473697
https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/modules/job/DCOS_OSS_Mesos_Modules-pr/23/

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).