### PR TITLE
[1.11] dcos6 interface shown in the UI even when enable_ipv6 was set to false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 
 * [DCOS_OSS-2535](https://jira.mesosphere.com/browse/DCOS_OSS-2535) Info endpoint shows incorrect version of Metronome.
 
+* Mark `dcos6` overlay network as disabled if `enable_ipv6` is set to false (DCOS-40539)
 
 
 ### Security Updates
@@ -127,6 +128,7 @@
 
 ## DC/OS 1.11.3
 
+* Mark `dcos6` overlay network as disabled if `enable_ipv6` is set to false (DCOS-40539)
 
 ### Notable changes
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -345,6 +345,20 @@ def validate_dcos_overlay_network(dcos_overlay_network):
                     "Incorrect value for overlay subnet6 {}."
                     " Only IPv6 values are allowed".format(overlay_network['subnet6'])) from ex
 
+        if 'enabled' in overlay:
+            gen.internals.validate_one_of(overlay['enabled'], [True, False])
+
+
+def calculate_dcos_overlay_network_json(dcos_overlay_network, enable_ipv6):
+    overlay_network = json.loads(dcos_overlay_network)
+    overlays = []
+    for overlay in overlay_network['overlays']:
+        if enable_ipv6 == 'false' and 'subnet' not in overlay:
+            overlay['enabled'] = False
+        overlays.append(overlay)
+    overlay_network['overlays'] = overlays
+    return json.dumps(overlay_network)
+
 
 def validate_num_masters(num_masters):
     assert int(num_masters) in [1, 3, 5, 7, 9], "Must have 1, 3, 5, 7, or 9 masters. Found {}".format(num_masters)
@@ -905,6 +919,7 @@ entry = {
         lambda master_dns_bindall: validate_true_false(master_dns_bindall),
         validate_os_type,
         validate_dcos_overlay_network,
+        lambda dcos_overlay_network_json: validate_dcos_overlay_network(dcos_overlay_network_json),
         validate_dcos_ucr_default_bridge_subnet,
         lambda dcos_net_rest_enable: validate_true_false(dcos_net_rest_enable),
         lambda dcos_net_watchdog: validate_true_false(dcos_net_watchdog),
@@ -1002,6 +1017,7 @@ entry = {
         'dcos_overlay_config_attempts': '4',
         'dcos_overlay_mtu': '1420',
         'dcos_overlay_enable': "true",
+        'dcos_overlay_network_json': calculate_dcos_overlay_network_json,
         'dcos_overlay_network': json.dumps({
             'vtep_subnet': '44.128.0.0/20',
             'vtep_subnet6': 'fd01:a::/64',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -194,7 +194,7 @@ package:
     content: |
       {
         "replicated_log_dir":"/var/lib/dcos/mesos/master/",
-        "network": {{ dcos_overlay_network }}
+        "network": {{ dcos_overlay_network_json }}
        }
   - path: /etc/dcos/network/cni/ucr-default-bridge.conf
     content: |

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -178,7 +178,7 @@ def test_if_overlay_master_is_up(dcos_api_session):
         }]
     }
 
-    assert json['network'] == dcos_overlay_network
+    assert nested_match(dcos_overlay_network, json['network'])
 
 
 def test_if_overlay_master_agent_is_up(dcos_api_session):
@@ -275,7 +275,7 @@ def _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlay):
             }
         }
 
-    assert expected == agent_overlay
+    assert nested_match(expected, agent_overlay)
 
 
 def _validate_overlay_subnet(agent_subnet, overlay_subnet, prefixlen):
@@ -336,3 +336,22 @@ def test_if_cosmos_is_only_available_locally(dcos_api_session):
     # we expect a 200
     r = dcos_api_session.get('/', host="127.0.0.1", port=9990, scheme='http')
     assert r.status_code == 200
+
+
+def nested_match(expect, value):
+    if expect == value:
+        return True
+    if isinstance(expect, dict) and isinstance(value, dict):
+        for k, v in expect.items():
+            if k in value:
+                if not nested_match(v, value[k]):
+                    return False
+            else:
+                return False
+        return True
+    if isinstance(expect, list) and isinstance(value, list):
+        for x, y in zip(expect, value):
+            if not nested_match(x, y):
+                return False
+        return True
+    return False

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "9d5cc18a2065864350c23ad56f1c4caa2ae308c5",
+    "ref": "f1a0c5870e6744c79714e16e4adfee1010ebf78f",
     "ref_origin": "1.11"
   }
 }


### PR DESCRIPTION
## High-level description

dcos6 interface shown in the UI even when enable_ipv6 was set to false.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40539](https://jira.mesosphere.com/browse/DCOS-40539) dcos6 interface shown in the UI even when enable_ipv6 was set to false

## Related tickets (optional)

Other tickets related to this change:

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
https://github.com/dcos/dcos-mesos-modules/compare/9d5cc18a2065864350c23ad56f1c4caa2ae308c5...f1a0c5870e6744c79714e16e4adfee1010ebf78f
https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/modules/job/DCOS_OSS_Mesos_Modules-pr/30/

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).