### PR TITLE
DCOS-46756 - Replace dcos-e2e cli with minidcos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,26 +134,27 @@ The tests can be run via Pytest while SSH'd as root into a master node of the cl
     dcos-shell pytest
     ```
 
-## Using a Docker Cluster with DC/OS E2E
+## Using a Docker Cluster with miniDC/OS
 
-One way to run the integration tests is to use the [DC/OS E2E CLI](http://dcos-e2e.readthedocs.io/en/latest/cli.html).
+One way to run the integration tests is to use the [miniDC/OS CLI](https://minidcos.readthedocs.io/en/latest/).
 
 This lets you create, run and manage clusters in test environments.
 Each DC/OS node is represented by a Docker container.
 
-1. Setup DC/OS in containers using the [DC/OS E2E CLI](http://dcos-e2e.readthedocs.io/en/latest/cli.html).
+1. Setup DC/OS in containers using the [miniDC/OS CLI](http://minidcos.readthedocs.io/en/latest/).
 
-For example, after [installing the DC/OS E2E CLI](http://dcos-e2e.readthedocs.io/en/latest/cli.html#installation), create a cluster:
+For example, after [installing the DC/OS E2E CLI](http://minidcos.readthedocs.io/en/latest/#installation), create a cluster:
 
 ```
-dcos-docker create /tmp/dcos_generate_config.sh \
+minidcos docker download-installer
+minidcos docker create /tmp/dcos_generate_config.sh \
     --masters 1 \
     --agents 2 \
     --public-agents 1 \
     --cluster-id default
 ```
 
-2. Run `dcos-docker wait`
+2. Run `minidcos docker wait`
 
 Wait for DC/OS to start.
 Running wait command allows to make sure that the cluster is set up properly before any other actions that could otherwise cause errors in `pytest` command in the next step.
@@ -163,13 +164,13 @@ Running wait command allows to make sure that the cluster is set up properly bef
 For example:
 
 ```
-dcos-docker run --test-env pytest
+minidcos docker run --test-env pytest
 ```
 
 4. Destroy the cluster.
 
 ```
-dcos-docker destroy
+minidcos docker destroy
 ```
 
 # Build

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Each DC/OS node is represented by a Docker container.
 
 1. Setup DC/OS in containers using the [miniDC/OS CLI](http://minidcos.readthedocs.io/en/latest/).
 
-For example, after [installing the DC/OS E2E CLI](http://minidcos.readthedocs.io/en/latest/#installation), create a cluster:
+For example, after [installing the miniDC/OS CLI](http://minidcos.readthedocs.io/en/latest/#installation), create a cluster:
 
 ```
 minidcos docker download-installer

--- a/README.md
+++ b/README.md
@@ -187,11 +187,13 @@ DC/OS builds are packaged as a self-extracting Docker image wrapped in a bash sc
 ./build_local.sh
 ```
 
-That will run a simple local build, and output the resulting DC/OS installers to $HOME/dcos-artifacts. You can run the created `dcos_generate_config.sh like so:
+That will run a simple local build, and output the resulting DC/OS installers to `./packages/cache/dcos_generate_config.sh`:
 
 ```
-$ $HOME/dcos-artifacts/testing/`whoami`/dcos_generate_config.sh
+$ ./packages/cache/dcos_generate_config.sh
 ```
+
+See the section on [running in Docker](#using-a-docker-cluster-with-minidcos) to test the installer.
 
 ## Build Details
 


### PR DESCRIPTION
## High-level description

The DC/OS readme currently tells users to use dcos-e2e which is deprecated in favor of minidcos (and some of the links are broken). Updates the README to reference minidcos instead.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46756](https://jira.mesosphere.com/browse/DCOS-46756) Update DCOS documentation to refer to minidcos instead of dcos-e2e
  - [DCOS_OSS-4591](https://jira.mesosphere.com/browse/DCOS_OSS-4591) DC/OS OSS README - Use new `minidcos` commands

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A documentation update
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A documentation update
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
