### PR TITLE
[master/1.13] Use DC/OS Test Utils helpers for diagnostics tests

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -1,4 +1,3 @@
-import datetime
 import gzip
 import json
 import logging
@@ -8,6 +7,8 @@ import zipfile
 
 import pytest
 import retrying
+from dcos_test_utils.diagnostics import Diagnostics
+from dcos_test_utils.helpers import check_json
 
 
 __maintainer__ = 'mnaboka'
@@ -359,22 +360,27 @@ def _check_diagnostics_bundle_status(dcos_api_session):
 
 
 def _create_bundle(dcos_api_session):
-    # start the diagnostics bundle job
-    create_response = check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
-
-    # make sure the job is done, timeout is 5 sec, wait between retying is 1 sec
-
     last_datapoint = {
         'time': None,
         'value': 0
     }
 
-    wait_for_diagnostics_job(dcos_api_session, last_datapoint)
-    wait_for_diagnostics_list(dcos_api_session)
+    health_url = dcos_api_session.default_url.copy(
+        query='cache=0',
+        path='system/health/v1',
+    )
 
-    # the job should be complete at this point.
-    # check the listing for a zip file
-    bundles = _get_bundle_list(dcos_api_session)
+    diagnostics = Diagnostics(
+        default_url=health_url,
+        masters=dcos_api_session.masters,
+        all_slaves=dcos_api_session.all_slaves,
+        session=dcos_api_session.copy().session,
+    )
+
+    create_response = diagnostics.start_diagnostics_job().json()
+    diagnostics.wait_for_diagnostics_job(last_datapoint=last_datapoint)
+    diagnostics.wait_for_diagnostics_reports()
+    bundles = diagnostics.get_diagnostics_reports()
     assert len(bundles) == 1, 'bundle file not found'
     assert bundles[0] == create_response['extra']['bundle_name']
 
@@ -382,12 +388,23 @@ def _create_bundle(dcos_api_session):
 
 
 def _delete_bundle(dcos_api_session, bundle):
-    bundles = _get_bundle_list(dcos_api_session)
+    health_url = dcos_api_session.default_url.copy(
+        query='cache=0',
+        path='system/health/v1',
+    )
+    diagnostics = Diagnostics(
+        default_url=health_url,
+        masters=dcos_api_session.masters,
+        all_slaves=dcos_api_session.all_slaves,
+        session=dcos_api_session.copy().session,
+    )
+
+    bundles = diagnostics.get_diagnostics_reports()
     assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
 
     dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 
-    bundles = _get_bundle_list(dcos_api_session)
+    bundles = diagnostics.get_diagnostics_reports()
     assert bundle not in bundles, 'found {} in {}'.format(bundle, bundles)
 
 
@@ -412,7 +429,19 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
     assert len(dcos_api_session.masters) >= master_index + 1, '{} masters required. Got {}'.format(
         master_index + 1, len(dcos_api_session.masters))
 
-    bundles = _get_bundle_list(dcos_api_session)
+    health_url = dcos_api_session.default_url.copy(
+        query='cache=0',
+        path='system/health/v1',
+    )
+
+    diagnostics = Diagnostics(
+        default_url=health_url,
+        masters=dcos_api_session.masters,
+        all_slaves=dcos_api_session.all_slaves,
+        session=dcos_api_session.copy().session,
+    )
+
+    bundles = diagnostics.get_diagnostics_reports()
     assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
 
     expected_common_files = ['dmesg_-T.output.gz',
@@ -570,28 +599,6 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
             verify_archived_items(agent_public_folder, archived_items, expected_public_agent_files)
 
 
-def _get_bundle_list(dcos_api_session):
-    response = check_json(dcos_api_session.health.get('/report/diagnostics/list/all'))
-    bundles = []
-    for _, bundle_list in response.items():
-        if bundle_list is not None and isinstance(bundle_list, list) and len(bundle_list) > 0:
-            # append bundles and get just the filename.
-            bundles += map(lambda s: os.path.basename(s['file_name']), bundle_list)
-    return bundles
-
-
-def check_json(response):
-    response.raise_for_status()
-    try:
-        json_response = response.json()
-        logging.debug('Response: {}'.format(json_response))
-    except ValueError:
-        logging.exception('Could not deserialize response contents:{}'.format(response.content.decode()))
-        raise
-    assert len(json_response) > 0, 'Empty JSON returned from dcos-diagnostics request'
-    return json_response
-
-
 def make_nodes_ip_map(dcos_api_session):
     """
     a helper function to make a map detected_ip -> external_ip
@@ -606,41 +613,6 @@ def make_nodes_ip_map(dcos_api_session):
         node_private_public_ip_map[detected_ip] = node
 
     return node_private_public_ip_map
-
-
-@retrying.retry(wait_fixed=2000, stop_max_delay=120000,
-                retry_on_result=lambda x: x is False)
-def wait_for_diagnostics_job(dcos_api_session, last_datapoint):
-    response = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
-    # find if the job is still running
-    job_running = False
-    percent_done = 0
-    for _, attributes in response.items():
-        assert 'is_running' in attributes, '`is_running` field is missing in response'
-        assert 'job_progress_percentage' in attributes, '`job_progress_percentage` field is missing in response'
-
-        if attributes['is_running']:
-            percent_done = attributes['job_progress_percentage']
-            logging.info("Job is running. Progress: {}".format(percent_done))
-            job_running = True
-            break
-
-    # if we ran this bit previously compare the current datapoint with the one we saved
-    if last_datapoint['time'] and last_datapoint['value']:
-        if percent_done <= last_datapoint['value']:
-            assert (datetime.datetime.now() - last_datapoint['time']) < datetime.timedelta(seconds=15), (
-                "Job is not progressing"
-            )
-    last_datapoint['value'] = percent_done
-    last_datapoint['time'] = datetime.datetime.now()
-
-    return not job_running
-
-
-# sometimes it may take extra few seconds to list bundles after the job is finished.
-@retrying.retry(stop_max_delay=5000)
-def wait_for_diagnostics_list(dcos_api_session):
-    assert _get_bundle_list(dcos_api_session), 'get a list of bundles timeout'
 
 
 def validate_node(nodes):

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -88,7 +88,7 @@ def delete_ec2_volume(name, timeout=600):
         try:
             log.info("Issuing volume.delete()")
             volume.delete()  # Raises ClientError (VolumeInUse) if the volume is still attached.
-        except exceptions.ClientError as exc:
+        except exceptions.ClientError:
             log.exception("volume.delete() failed.")
             raise
 


### PR DESCRIPTION
## High-level description

There are multiple benefits to merging this pair of PRs (this PR + the DC/OS Enterprise change).

The driver for this is to progress towards making it possible to use `pytest` to collect and later run integration tests from a computer which is not a DC/OS cluster, such as a developer's laptop.
That will allow us to complete [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) but will also allow for greater developer productivity.
This PR alone does not achieve that, but it helps, as someone with a checkout of the DC/OS Enterprise repository will not necessarily be able to import open source tests.

I also consider this to be a clean up of some technical debt - this removes:

* Imports from test files - all common helpers should go in a common helpers file, or in DC/OS Test Utils
* Imports of private functions
* Duplication of code between DC/OS and DC/OS Test Utils - this is about to be a problem as these two code bases diverge in https://github.com/dcos/dcos/pull/3952/files

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster.

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a test-only change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a test-only change
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)