### PR TITLE
[Backport 1.11] DCOS-45295 - Upgrade dvdcli golang to a more recent version to prevent build failures

### DIFF
--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "docker": "golang:1.7",
+  "docker": "golang:1.11",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/dvdcli.git",


### PR DESCRIPTION
## High-level description

The dvdcli package fails to build because the golang image that is using is out of date.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45295](https://jira.mesosphere.com/browse/DCOS-45295) Nightly Uncached Build is failing on 1.12,1.11,1.10

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A just changed the build container for dvdcli
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: fixes broken build.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)