### PR TITLE
Fix container metrics tests for the v0 metrics API

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -612,7 +612,7 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     """
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
-        if container_metrics['dimensions']['task_name'] == task_name:
+        if container_metrics['dimensions'].get('task_name') == task_name:
             return get_app_metrics(dcos_api_session, node, cid)
     return None
 


### PR DESCRIPTION
## High-level description

`test_metrics_containers` and `test_metrics_containers_app` sometimes fail because they assume that all containers have a `task_name`, which is false. Some containers are executors, and will never have a `task_name`. `test_metrics_containers` now ignores all containers in a metrics API response that don't have a `task_name` of `statsd-emitter`. `test_metrics_containers_app` no longer fails if it finds container metrics that don't have a `task_name`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4486](https://jira.mesosphere.com/browse/DCOS_OSS-4486) test_metrics.test_metrics_containers / test_metrics_containers_app fails with container metrics response status 204


## Related tickets (optional)

Other tickets related to this change:

  - N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This PR only fixes a test.
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR only fixes a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]