### PR TITLE
DCOS_OSS-4531 - Fix flaky test by making it more resilient

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -698,7 +698,24 @@ def validate_unit(unit):
 def verify_archived_items(folder, archived_items, expected_files):
     for expected_file in expected_files:
         expected_file = folder + expected_file
-        assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+
+        # We don't know in advance whether the file will be gzipped or not,
+        # because that depends on the size of the diagnostics file, which can
+        # be influenced by multiple factors that are not under our control
+        # here.
+        # Since we only want to check whether the file _exists_ and don't care
+        # about whether it's gzipped or not, we check for an optional `.gz`
+        # file type in case it wasn't explicitly specified in the assertion.
+        # For more context, see: https://jira.mesosphere.com/browse/DCOS_OSS-4531
+        if expected_file.endswith('.gz'):
+            assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+        else:
+            expected_gzipped_file = (expected_file + '.gz')
+            unzipped_exists = expected_file in archived_items
+            gzipped_exists = expected_gzipped_file in archived_items
+
+            message = ('expecting {} or {} in {}'.format(expected_file, expected_gzipped_file, archived_items))
+            assert (unzipped_exists or gzipped_exists), message
 
 
 def verify_unit_response(zip_ext_file, min_lines):


### PR DESCRIPTION
## High-level description

This PR fixes the flakyness of the test by making it more resilient to changing file types. Since we do not care about the file types but only that the files exist, this change makes sure that the test passes even if the file we expect exists in a gzipped version.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4531 ](https://jira.mesosphere.com/browse/DCOS_OSS-4531) test_dcos_diagnostics.test_dcos_diagnostics_bundle_download_and_extract assertionerror test bundle download and validate zip file

## Related tickets (optional)

Other tickets related to this change:

- [DCOS-44935](https://jira.mesosphere.com/browse/DCOS-44935) [test_dcos_diagnostics.test_dcos_diagnostics_bundle_create_download_delete] - Flaky Test

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
