### PR TITLE
(1.12) Fix container metrics tests for the v0 metrics API

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import pprint
 import uuid
 
 import pytest
@@ -267,6 +266,13 @@ def test_metrics_containers(dcos_api_session):
                 # Test that /containers/<id> responds with expected data
                 container_metrics = get_container_metrics(dcos_api_session, agent.host, c)
 
+                # Skip this container if it's not statsd-emitter.
+                if container_metrics['dimensions'].get('task_name') != 'statsd-emitter':
+                    # Store the task_name from this response for a debug message in case we can't find statsd-emitter.
+                    debug_task_name.append(container_metrics['dimensions']['task_name'])
+                    continue
+
+                # Check tags on each datapoint.
                 cid_registry = []
                 for dp in container_metrics['datapoints']:
                     # Verify expected tags are present.
@@ -290,41 +296,37 @@ def test_metrics_containers(dcos_api_session):
                 assert container_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(
                     container_metrics['dimensions'])
 
-                debug_task_name.append(container_metrics['dimensions']['task_name'])
+                # Test that /app response is responding with expected data
+                app_metrics = get_app_metrics(dcos_api_session, agent.host, c)
 
-                # looking for "statsd-emitter"
-                if 'statsd-emitter' == container_metrics['dimensions']['task_name']:
-                    # Test that /app response is responding with expected data
-                    app_metrics = get_app_metrics(dcos_api_session, agent.host, c)
+                # Ensure all /container/<id>/app data is correct
+                # We expect three datapoints, could be in any order
+                uptime_dp = None
+                for dp in app_metrics['datapoints']:
+                    if dp['name'] == 'statsd_tester.time.uptime':
+                        uptime_dp = dp
+                        break
 
-                    # Ensure all /container/<id>/app data is correct
-                    # We expect three datapoints, could be in any order
-                    uptime_dp = None
-                    for dp in app_metrics['datapoints']:
-                        if dp['name'] == 'statsd_tester.time.uptime':
-                            uptime_dp = dp
-                            break
+                # If this metric is missing, statsd-emitter's metrics were not received
+                assert uptime_dp is not None, 'got {}'.format(app_metrics)
 
-                    # If this metric is missing, statsd-emitter's metrics were not received
-                    assert uptime_dp is not None, 'got {}'.format(app_metrics)
+                datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
+                for k in datapoint_keys:
+                    assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
-                    datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
-                    for k in datapoint_keys:
-                        assert k in uptime_dp, 'got {}'.format(uptime_dp)
+                expected_tag_names = {
+                    'dcos_cluster_id',
+                    'test_tag_key',
+                    'dcos_cluster_name',
+                    'host'
+                }
+                check_tags(uptime_dp['tags'], expected_tag_names)
+                assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+                assert uptime_dp['value'] > 0
+                assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
+                assert app_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(app_metrics)
 
-                    expected_tag_names = {
-                        'dcos_cluster_id',
-                        'test_tag_key',
-                        'dcos_cluster_name',
-                        'host'
-                    }
-                    check_tags(uptime_dp['tags'], expected_tag_names)
-                    assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
-
-                    assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
-                    assert app_metrics['dimensions']['mesos_id'] == '', 'got {}'.format(app_metrics)
-
-                    return True
+                return True
 
         assert False, 'Did not find statsd-emitter container, executor IDs found: {}'.format(debug_task_name)
 
@@ -518,13 +520,6 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     assert 'dimensions' in container_metrics, (
         'container metrics must include dimensions. Got: {}'.format(container_metrics)
     )
-
-    # task_name is an important dimension for identifying metrics, but it may take some time to appear in the container
-    # metrics response.
-    if 'task_name' not in container_metrics['dimensions']:
-        print("Missing task_name. Container metrics:")
-        pprint.pprint(container_metrics)
-        raise Exception('task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions']))
 
     return container_metrics
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -481,7 +481,7 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     """
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
-        if container_metrics['dimensions']['task_name'] == task_name:
+        if container_metrics['dimensions'].get('task_name') == task_name:
             return get_app_metrics(dcos_api_session, node, cid)
     return None
 


### PR DESCRIPTION
## High-level description

This is a 1.12 backport of #4161.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4486](https://jira.mesosphere.com/browse/DCOS_OSS-4486) test_metrics.test_metrics_containers / test_metrics_containers_app fails with container metrics response status 204


## Related tickets (optional)

Other tickets related to this change:

  - N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This PR only fixes a test.
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This PR only fixes a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]