### PR TITLE
[1.11] DCOS-45295 - Bump dcos-installer-ui to latest commit to pull in the fixes for issues with dependencies and gulp.

### DIFF
--- a/packages/dcos-installer-ui/buildinfo.json
+++ b/packages/dcos-installer-ui/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-installer-ui.git",
-    "ref": "9de2e8d245afc0cfea973b646b2ba202b620af0f",
+    "ref": "13e08e23eddaf47a1e57fe0e42848f5a4645ad16",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

The uncached nightly builds for 1.11 are failing due to issues with the dcos-installer-ui package. These issues have been fixed in dcos-installer-ui's master branch, but not updated here.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45295](https://jira.mesosphere.com/browse/DCOS-45295) Nightly Uncached Build is failing on 1.12,1.11,1.10

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A just updated dcos-installer-ui to latest commit, which contains only fixes for gulp and dependency versions.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: fixes broken build.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)