### PR TITLE
[Backport] [1.10] Exposes mesos flag to persist cni root directory across host reboot.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Format of the entries must be.
 
 * Added support CoreOS 1800.6.0 1800.7.0, & 1855.4.0. (DCOS_43865) 
 
+* Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot. (DCOS_OSS-4667)
+
 ### Security Updates
 
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -884,7 +884,8 @@ entry = {
         validate_mesos_max_completed_tasks_per_framework,
         lambda check_config: validate_check_config(check_config),
         lambda custom_checks: validate_check_config(custom_checks),
-        lambda custom_checks, check_config: validate_custom_checks(custom_checks, check_config)
+        lambda custom_checks, check_config: validate_custom_checks(custom_checks, check_config),
+        lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -972,7 +973,8 @@ entry = {
         'cosmos_config': '{}',
         'gpus_are_scarce': 'true',
         'check_config': calculate_check_config,
-        'custom_checks': '{}'
+        'custom_checks': '{}',
+        'mesos_cni_root_dir_persist': 'false'
     },
     'must': {
         'custom_auth': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -445,6 +445,7 @@ package:
       MESOS_ISOLATION={{ mesos_isolation }}
       MESOS_DOCKER_VOLUME_CHECKPOINT_DIR=/var/lib/mesos/isolators/docker/volume
       MESOS_IMAGE_PROVIDERS=docker
+      MESOS_NETWORK_CNI_ROOT_DIR_PERSIST={{ mesos_cni_root_dir_persist }}
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_WORK_DIR=/var/lib/mesos/slave

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -709,6 +709,13 @@ def test_validate_custom_checks():
     )
 
 
+def test_invalid_mesos_cni_root_dir_persist():
+    validate_error(
+        {'mesos_cni_root_dir_persist': 'foo'},
+        'mesos_cni_root_dir_persist',
+        true_false_msg)
+
+
 def test_exhibitor_admin_password_obscured():
     var_name = 'exhibitor_admin_password'
     var_value = 'secret'


### PR DESCRIPTION
This patch exposes a mesos flag --network_cni_root_dir_persist
through dcos config so that an operator may choose to persist
the cni root dir across the host reboot. The default value is `false` 
for the backward compatibility

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - [DCOS_OSS-4667](https://jira.mesosphere.com/browse/DCOS_OSS-4667) Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
