### PR TITLE
[Backport][1.12] Exposes mesos flag to persist cni root directory across host reboot.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ## DC/OS 1.12-dev
 
+### Notable changes
+
+### Breaking changes
+
+### Fixed and improved
+
+* Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot. (DCOS_OSS-4667)
+
 ## DC/OS 1.12.1
 
 ### Notable changes

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -975,6 +975,7 @@ entry = {
         lambda licensing_enabled: validate_true_false(licensing_enabled),
         lambda enable_mesos_ipv6_discovery: validate_true_false(enable_mesos_ipv6_discovery),
         lambda log_offers: validate_true_false(log_offers),
+        lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -1090,7 +1091,8 @@ entry = {
         'fault_domain_detect_contents': calculate_fault_domain_detect_contents,
         'license_key_contents': '',
         'enable_mesos_ipv6_discovery': 'false',
-        'log_offers': 'true'
+        'log_offers': 'true',
+        'mesos_cni_root_dir_persist': 'false'
     },
     'must': {
         'fault_domain_enabled': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -559,6 +559,7 @@ package:
       MESOS_MASTER=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       MESOS_MEMORY_PROFILING=true
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
+      MESOS_NETWORK_CNI_ROOT_DIR_PERSIST={{ mesos_cni_root_dir_persist }}
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_RECONFIGURATION_POLICY=additive

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -793,6 +793,14 @@ def test_validate_mesos_work_dir():
     )
 
 
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="configuration not present on windows")
+def test_invalid_mesos_cni_root_dir_persist():
+    validate_error(
+        {'mesos_cni_root_dir_persist': 'foo'},
+        'mesos_cni_root_dir_persist',
+        true_false_msg)
+
+
 # TODO: DCOS_OSS-3462 - muted Windows tests requiring investigation
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason='TODO: Needs porting on Windows')
 def test_fault_domain_disabled():


### PR DESCRIPTION
This patch exposes a mesos flag --network_cni_root_dir_persist
through dcos config so that an operator may choose to persist
the cni root dir across the host reboot. The default value is `false` 
for the backward compatibility

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4667](https://jira.mesosphere.com/browse/DCOS_OSS-4667) Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
