### PR TITLE
Master train 01/11/2019

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,20 +13,26 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
-* Admin Router Nginx Virtual Hosts metrics are now collected by default. An Ningx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
+* Admin Router Nginx Virtual Hosts metrics are now collected by default. An Nginx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
 
 * CockroachDB metrics are now collected by Telegraf (DCOS_OSS-4529).
 
 * ZooKeeper metrics are now collected by Telegraf (DCOS_OSS-4477).
 
 * Mesos metrics are now available by default. (DCOS_OSS-3815)
+
 * Metronome supports UCR
+
 * Metronome supports file based secrets
+
 * Metronome supports hybrid cloud
 
 * Expose Public IP (DCOS_OSS-4514)
 
 * Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot (DCOS_OSS-4667) 
+
+* Prometheus-format metrics can be gathered from tasks (DCOS_OSS-3717)
+
 
 ### Breaking changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Expose Public IP (DCOS_OSS-4514)
 
+* Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot (DCOS_OSS-4667) 
+
 ### Breaking changes
 
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1055,6 +1055,7 @@ entry = {
         lambda licensing_enabled: validate_true_false(licensing_enabled),
         lambda enable_mesos_ipv6_discovery: validate_true_false(enable_mesos_ipv6_discovery),
         lambda log_offers: validate_true_false(log_offers),
+        lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -1174,7 +1175,8 @@ entry = {
         'fault_domain_detect_contents': calculate_fault_domain_detect_contents,
         'license_key_contents': '',
         'enable_mesos_ipv6_discovery': 'false',
-        'log_offers': 'true'
+        'log_offers': 'true',
+        'mesos_cni_root_dir_persist': 'false'
     },
     'must': {
         'fault_domain_enabled': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1578,6 +1578,12 @@ package:
         percentile_limit = 1000
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
+        ## The URL of the local mesos agent
+        mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        ## The period after which requests to mesos agent should time out
+        mesos_timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-prometheus"
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
@@ -1690,6 +1696,13 @@ package:
         percentile_limit = 1000
       # Read metrics from Admin Router Nginx Prometheus endpoint.
       [[inputs.prometheus]]
+        ## The URL of the local mesos agent
+        mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:5051"
+        ## The period after which requests to mesos agent should time out
+        mesos_timeout = "10s"
+        ## The user agent to send with requests
+        user_agent = "Telegraf-prometheus"
+
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -559,6 +559,7 @@ package:
       MESOS_MASTER=zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos
       MESOS_MEMORY_PROFILING=true
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-slave-modules
+      MESOS_NETWORK_CNI_ROOT_DIR_PERSIST={{ mesos_cni_root_dir_persist }}
       MESOS_NETWORK_CNI_CONFIG_DIR=/opt/mesosphere/etc/dcos/network/cni
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
       MESOS_RECONFIGURATION_POLICY=additive

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -793,6 +793,14 @@ def test_validate_mesos_work_dir():
     )
 
 
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="configuration not present on windows")
+def test_invalid_mesos_cni_root_dir_persist():
+    validate_error(
+        {'mesos_cni_root_dir_persist': 'foo'},
+        'mesos_cni_root_dir_persist',
+        true_false_msg)
+
+
 # TODO: DCOS_OSS-3462 - muted Windows tests requiring investigation
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason='TODO: Needs porting on Windows')
 def test_fault_domain_disabled():

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -63,7 +63,12 @@ def test_checks_cli(dcos_api_session):
 
 
 def test_checks_api(dcos_api_session):
-    """Test the checks API at /system/checks/"""
+    """
+    Test the checks API at /system/checks/
+    This will test that all checks run on all agents return a normal status. A
+    failure in this test may be an indicator that some unrelated component
+    failed and dcos-checks functioned properly.
+    """
     checks_uri = '/system/checks/v1/'
     # Test that we can list and run node and cluster checks on a master, agent, and public agent.
     check_nodes = []
@@ -88,7 +93,11 @@ def test_checks_api(dcos_api_session):
             assert r.status_code == 200
             results = r.json()
             assert isinstance(results, dict)
-            assert results['status'] == 0
 
-            # Make sure we ran all the listed checks.
-            assert set(checks.keys()) == set(results['checks'].keys())
+            # check that the returned statuses of each check is 0
+            expected_status = {c: 0 for c in checks.keys()}
+            response_status = {c: v['status'] for c, v in results['checks'].items()}
+            assert expected_status == response_status
+
+            # check that overall status is also 0
+            assert results['status'] == 0

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -698,7 +698,24 @@ def validate_unit(unit):
 def verify_archived_items(folder, archived_items, expected_files):
     for expected_file in expected_files:
         expected_file = folder + expected_file
-        assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+
+        # We don't know in advance whether the file will be gzipped or not,
+        # because that depends on the size of the diagnostics file, which can
+        # be influenced by multiple factors that are not under our control
+        # here.
+        # Since we only want to check whether the file _exists_ and don't care
+        # about whether it's gzipped or not, we check for an optional `.gz`
+        # file type in case it wasn't explicitly specified in the assertion.
+        # For more context, see: https://jira.mesosphere.com/browse/DCOS_OSS-4531
+        if expected_file.endswith('.gz'):
+            assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+        else:
+            expected_gzipped_file = (expected_file + '.gz')
+            unzipped_exists = expected_file in archived_items
+            gzipped_exists = expected_gzipped_file in archived_items
+
+            message = ('expecting {} or {} in {}'.format(expected_file, expected_gzipped_file, archived_items))
+            assert (unzipped_exists or gzipped_exists), message
 
 
 def verify_unit_response(zip_ext_file, min_lines):

--- a/packages/dcos-integration-test/extra/test_meta.py
+++ b/packages/dcos-integration-test/extra/test_meta.py
@@ -13,6 +13,8 @@ import yaml
 
 from get_test_group import patterns_from_group
 
+__maintainer__ = 'adam'
+__contact__ = 'tools-infra-team@mesosphere.io'
 
 log = logging.getLogger(__file__)
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -12,7 +12,6 @@ __maintainer__ = 'philipnrmn'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
-LATENCY = 60
 METRICS_WAITTIME = 5 * 60 * 1000
 METRICS_INTERVAL = 2 * 1000
 STD_WAITTIME = 15 * 60 * 1000
@@ -355,8 +354,8 @@ def test_metrics_node(dcos_api_session):
 
         return True
 
-    # Retry for 30 seconds for for the node metrics content to appear.
-    @retrying.retry(stop_max_delay=30000)
+    # Retry for 5 minutes for for the node metrics content to appear.
+    @retrying.retry(stop_max_delay=METRICS_WAITTIME)
     def wait_for_node_response(node):
         response = dcos_api_session.metrics.get('/node', node=node)
         assert response.status_code == 200
@@ -395,7 +394,7 @@ def test_metrics_containers(dcos_api_session):
     the statsd-emitter executor. When found, query it's /app endpoint to test that
     it's sending the statsd metrics as expected.
     """
-    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=LATENCY * 1000)
+    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def test_containers(app_endpoints):
 
         debug_task_name = []
@@ -617,8 +616,8 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     return None
 
 
-# Retry for two and a half minutes since the collector collects
-# state every 2 minutes to propagate containers to the API
+# Retry for 5 minutes since the collector collects state
+# every 2 minutes to propogate containers to the API
 @retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_container_ids(dcos_api_session, node: str):
     """Return container IDs reported by the metrics API on node.
@@ -633,12 +632,12 @@ def get_container_ids(dcos_api_session, node: str):
     return container_ids
 
 
-@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
     Retries on error, non-200 status, or missing response fields for up
-    to 30 seconds.
+    to 5 minutes.
 
     """
     response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
@@ -655,11 +654,11 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     return container_metrics
 
 
-@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=(30 * 1000))
+@retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
 def get_app_metrics(dcos_api_session, node: str, container_id: str):
     """Return app metrics for container_id from the metrics API on node.
 
-    Retries on error or non-200 status for up to 30 seconds.
+    Retries on error or non-200 status for up to 5 minutes.
 
     """
     resp = dcos_api_session.metrics.get('/containers/' + container_id + '/app', node=node)
@@ -752,13 +751,13 @@ def test_standalone_container_metrics(dcos_api_session):
     }
 
     # There is a short delay between the container starting and metrics becoming
-    # available via the metrics service. Because of this, we wait up to 10
-    # seconds for these metrics to appear before throwing an exception.
+    # available via the metrics service. Because of this, we wait up to 5
+    # minutes for these metrics to appear before throwing an exception.
     def _should_retry_metrics_fetch(response):
         return response.status_code == 204
 
-    @retrying.retry(wait_fixed=1000,
-                    stop_max_delay=10000,
+    @retrying.retry(wait_fixed=METRICS_INTERVAL,
+                    stop_max_delay=METRICS_WAITTIME,
                     retry_on_result=_should_retry_metrics_fetch,
                     retry_on_exception=lambda x: False)
     def _get_metrics():
@@ -824,7 +823,7 @@ def test_pod_application_metrics(dcos_api_session):
     1) Container statistics metrics are provided for the executor container
     2) Application metrics are exposed for the task container
     """
-    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=LATENCY * 1000)
+    @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def test_application_metrics(agent_ip, agent_id, task_name, num_containers):
         # Get expected 2 container ids from mesos state endpoint
         # (one container + its parent container)
@@ -853,7 +852,7 @@ def test_pod_application_metrics(dcos_api_session):
 
         # Retry for two and a half minutes since the collector collects
         # state every 2 minutes to propagate containers to the API
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=150000)
+        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def wait_for_container_metrics_propagation(container_ids):
             response = dcos_api_session.metrics.get('/containers', node=agent_ip)
             assert response.status_code == 200
@@ -889,10 +888,10 @@ def test_pod_application_metrics(dcos_api_session):
             container_id_path = '/containers/{}'.format(container_id)
 
             if (is_nested_container(container)):
-                # Retry for 30 seconds for each nested container to appear.
+                # Retry for 5 minutes for each nested container to appear.
                 # Since nested containers do not report resource statistics, we
                 # expect the response code to be 204.
-                @retrying.retry(stop_max_delay=30000)
+                @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
                     response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
                     assert response.status_code == 204
@@ -941,9 +940,9 @@ def test_pod_application_metrics(dcos_api_session):
                 assert task_name.strip('/') == app_response.json()['dimensions']['task_name'],\
                     'Nested container was not tagged with the correct task name'
             else:
-                # Retry for 30 seconds for each parent container to present its
+                # Retry for 5 minutes for each parent container to present its
                 # content.
-                @retrying.retry(stop_max_delay=30000)
+                @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
                     response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
                     assert response.status_code == 200

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,6 +1,5 @@
 import contextlib
 import logging
-import pprint
 import uuid
 
 import pytest
@@ -406,6 +405,13 @@ def test_metrics_containers(dcos_api_session):
                 # Test that /containers/<id> responds with expected data
                 container_metrics = get_container_metrics(dcos_api_session, agent.host, c)
 
+                # Skip this container if it's not statsd-emitter.
+                if container_metrics['dimensions'].get('task_name') != 'statsd-emitter':
+                    # Store the task_name from this response for a debug message in case we can't find statsd-emitter.
+                    debug_task_name.append(container_metrics['dimensions']['task_name'])
+                    continue
+
+                # Check tags on each datapoint.
                 cid_registry = set()
                 for dp in container_metrics['datapoints']:
                     # Verify expected tags are present.
@@ -427,39 +433,35 @@ def test_metrics_containers(dcos_api_session):
 
                 assert len(cid_registry) == 1, 'Not all container IDs in the metrics response are equal'
 
-                debug_task_name.append(container_metrics['dimensions']['task_name'])
+                # Test that /app response is responding with expected data
+                app_metrics = get_app_metrics(dcos_api_session, agent.host, c)
 
-                # looking for "statsd-emitter"
-                if 'statsd-emitter' == container_metrics['dimensions']['task_name']:
-                    # Test that /app response is responding with expected data
-                    app_metrics = get_app_metrics(dcos_api_session, agent.host, c)
+                # Ensure all /container/<id>/app data is correct
+                # We expect three datapoints, could be in any order
+                uptime_dp = None
+                for dp in app_metrics['datapoints']:
+                    if dp['name'] == 'statsd_tester.time.uptime':
+                        uptime_dp = dp
+                        break
 
-                    # Ensure all /container/<id>/app data is correct
-                    # We expect three datapoints, could be in any order
-                    uptime_dp = None
-                    for dp in app_metrics['datapoints']:
-                        if dp['name'] == 'statsd_tester.time.uptime':
-                            uptime_dp = dp
-                            break
+                # If this metric is missing, statsd-emitter's metrics were not received
+                assert uptime_dp is not None, 'got {}'.format(app_metrics)
 
-                    # If this metric is missing, statsd-emitter's metrics were not received
-                    assert uptime_dp is not None, 'got {}'.format(app_metrics)
+                datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
+                for k in datapoint_keys:
+                    assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
-                    datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
-                    for k in datapoint_keys:
-                        assert k in uptime_dp, 'got {}'.format(uptime_dp)
+                expected_tag_names = {
+                    'dcos_cluster_id',
+                    'test_tag_key',
+                    'dcos_cluster_name',
+                    'host'
+                }
+                check_tags(uptime_dp['tags'], expected_tag_names)
+                assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+                assert uptime_dp['value'] > 0
 
-                    expected_tag_names = {
-                        'dcos_cluster_id',
-                        'test_tag_key',
-                        'dcos_cluster_name',
-                        'host'
-                    }
-                    check_tags(uptime_dp['tags'], expected_tag_names)
-                    assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
-                    assert uptime_dp['value'] > 0
-
-                    return True
+                return True
 
         assert False, 'Did not find statsd-emitter container, executor IDs found: {}'.format(debug_task_name)
 
@@ -610,7 +612,7 @@ def get_app_metrics_for_task(dcos_api_session, node: str, task_name: str):
     """
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
-        if container_metrics['dimensions']['task_name'] == task_name:
+        if container_metrics['dimensions'].get('task_name') == task_name:
             return get_app_metrics(dcos_api_session, node, cid)
     return None
 
@@ -649,13 +651,6 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     assert 'dimensions' in container_metrics, (
         'container metrics must include dimensions. Got: {}'.format(container_metrics)
     )
-
-    # task_name is an important dimension for identifying metrics, but it may take some time to appear in the container
-    # metrics response.
-    if 'task_name' not in container_metrics['dimensions']:
-        print("Missing task_name. Container metrics:")
-        pprint.pprint(container_metrics)
-        raise Exception('task_name missing in dimensions. Got: {}'.format(container_metrics['dimensions']))
 
     return container_metrics
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -483,10 +483,10 @@ def test_metrics_containers(dcos_api_session):
         test_containers(endpoints)
 
 
-def test_metrics_containers_app(dcos_api_session):
-    """Assert that app metrics appear in the v0 metrics API."""
-    task_name = 'test-metrics-containers-app'
-    metric_name_pfx = 'test_metrics_containers_app'
+def test_statsd_metrics_containers_app(dcos_api_session):
+    """Assert that statsd app metrics appear in the v0 metrics API."""
+    task_name = 'test-statsd-metrics-containers-app'
+    metric_name_pfx = 'test_statsd_metrics_containers_app'
     marathon_app = {
         'id': '/' + task_name,
         'instances': 1,
@@ -529,6 +529,60 @@ def test_metrics_containers_app(dcos_api_session):
         ('.'.join([metric_name_pfx, 'count']), 2),
         ('.'.join([metric_name_pfx, 'timing', 'count']), 3),
         ('.'.join([metric_name_pfx, 'histogram', 'count']), 4),
+    ]
+
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
+        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+        node = endpoints[0].host
+        for metric_name, metric_value in expected_metrics:
+            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+
+
+def test_prom_metrics_containers_app(dcos_api_session):
+    """Assert that prometheus app metrics appear in the v0 metrics API."""
+    task_name = 'test-prom-metrics-containers-app'
+    metric_name_pfx = 'test_prom_metrics_containers_app'
+    marathon_app = {
+        'id': '/' + task_name,
+        'instances': 1,
+        'cpus': 0.1,
+        'mem': 128,
+        'cmd': '\n'.join([
+            'echo "Creating metrics file..."',
+            'touch metrics',
+
+            'echo "# TYPE {}_gauge gauge" >> metrics'.format(metric_name_pfx),
+            'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
+
+            'echo "# TYPE {}_count counter" >> metrics'.format(metric_name_pfx),
+            'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
+
+            'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
+
+            'echo "Serving prometheus metrics on http://localhost:$PORT0"',
+            'python3 -m http.server $PORT0',
+        ]),
+        'container': {
+            'type': 'MESOS',
+            'docker': {'image': 'library/python:3'}
+        },
+        'portDefinitions': [{
+            'protocol': 'tcp',
+            'port': 0,
+            'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
+        }],
+    }
+
+    logging.debug('Starting marathon app with config: %s', marathon_app)
+    expected_metrics = [
+        # metric_name, metric_value
+        ('_'.join([metric_name_pfx, 'gauge.gauge']), 100),
+        ('_'.join([metric_name_pfx, 'count.counter']), 2),
+        ('_'.join([metric_name_pfx, 'histogram_seconds', 'count']), 4),
     ]
 
     with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):

--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "docker": "golang:1.7",
+  "docker": "golang:1.11",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/dvdcli.git",

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "4d195ab4ea296d9a34dfc8560f376d24cac4f4ce",
+    "ref": "644970f36a64f412576550ed2b7707cdde364efa",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
Exposes mesos flag to persist cni root directory across host reboot.  #4167
 
DCOS_OSS-4531 - Fix flaky test by making it more resilient #4162  
 
Fix container metrics tests for the v0 metrics API #4161  
 
DCOS-45295 - Upgrade dvdcli golang to a more recent version to prevent build failures #4139 
 
dcos-integration-test/test_meta.py: add contact metadata #4080
 
 [1.13] Fix flaky test_standalone_container_metrics #4058
 
Gather Prometheus metrics from tasks #3940  

Change test_checks to improve its output and reduce the number of irrelevant failures #3899
 