### PR TITLE
[1.10] Bump Mesos to nightly 1.4.x e929d41

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "6791ab059b9f2fb3968a54cb257d219c28fdcba1",
+    "ref": "e929d413328e10f6d358899500d5aaedd9d9bc51",
     "ref_origin": "1.4.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,7 +1,7 @@
-From 5aaa4341a0de615a8f036f904686a5768ffee714 Mon Sep 17 00:00:00 2001
+From f9ed5183812b7e5d4def29fac7135076cfed658b Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH 01/13] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
@@ -24,5 +24,5 @@ index 921f7bd83..792dbd5cf 100755
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0002-Mesos-UI-Change-paths-pailer-and-logs-to-work-with-a.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-Change-paths-pailer-and-logs-to-work-with-a.patch
@@ -1,7 +1,7 @@
-From c381399b8f7a16a53fda82e8a40b9e82bb375a04 Mon Sep 17 00:00:00 2001
+From 777265e2a7ee30cdb6cab0f09cf925765b3e3908 Mon Sep 17 00:00:00 2001
 From: mlunoe <michael.lunoe@gmail.com>
 Date: Thu, 14 May 2015 15:05:23 -0700
-Subject: [PATCH 02/13] Mesos UI: Change paths, pailer, and logs to work with a
+Subject: [PATCH] Mesos UI: Change paths, pailer, and logs to work with a
  reverse proxy.
 
 Includes using relative paths.
@@ -10,10 +10,10 @@ Redirect from old mesos ui location to new dcos mesos ui location.
 Fixed the broken 'Roles' tab of the webui.
 ---
  src/webui/master/static/browse.html       |  2 +-
- src/webui/master/static/index.html        | 30 +++++++-------
- src/webui/master/static/js/controllers.js | 49 +++++++++++------------
+ src/webui/master/static/index.html        | 30 +++++++++----------
+ src/webui/master/static/js/controllers.js | 49 +++++++++++++++----------------
  src/webui/master/static/js/services.js    |  2 +-
- src/webui/master/static/pailer.html       |  6 +--
+ src/webui/master/static/pailer.html       |  6 ++--
  5 files changed, 44 insertions(+), 45 deletions(-)
 
 diff --git a/src/webui/master/static/browse.html b/src/webui/master/static/browse.html
@@ -286,5 +286,5 @@ index 759b18023..c8ada4b19 100644
      <script>
        var $body = $('body');
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,15 +1,15 @@
-From 078cf2d4b344ae9bc39677628920c7ce643ddfe9 Mon Sep 17 00:00:00 2001
+From 09b15768cda68946863d8b2cc82a7a92538e9a7d Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
-Subject: [PATCH 03/13] Revert "Fixed the broken metrics information of master
- in WebUI."
+Subject: [PATCH] Revert "Fixed the broken metrics information of master in
+ WebUI."
 
 This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
 
 In DC/OS, redirection to the leading master is handled by the
 Adminrouter component.
 ---
- src/webui/master/static/js/controllers.js | 24 +++++++----------------
+ src/webui/master/static/js/controllers.js | 24 +++++++-----------------
  1 file changed, 7 insertions(+), 17 deletions(-)
 
 diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
@@ -69,5 +69,5 @@ index ed60f7d40..d69e92017 100644
              $timeout(pollMetrics, $scope.delay);
            }
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From 44058e434d96c241290d689e6b97c794574e6192 Mon Sep 17 00:00:00 2001
+From caac3277a84e0c7193f58ede5ebcfe6f21f6b0aa Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH 04/13] Updated mesos containerizer to ignore GPU isolator
- creation failure.
+Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
+ failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -19,7 +19,7 @@ This is a decent compromise.
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 73334ffce..48dd16d64 100644
+index 3fdd14558..63182cda4 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -364,8 +364,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -45,5 +45,5 @@ index 73334ffce..48dd16d64 100644
      }
    }
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0005-Included-nested-command-check-output-in-the-executor.patch
+++ b/packages/mesos/extra/patches/0005-Included-nested-command-check-output-in-the-executor.patch
@@ -1,8 +1,7 @@
-From 1947a51cf92cc41e78bd5df8fcf8eec21e5f9629 Mon Sep 17 00:00:00 2001
+From 8a42a07180add3a2a2923d996e74d596ddc7c1f9 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Mon, 21 Aug 2017 15:28:36 -0700
-Subject: [PATCH 05/13] Included nested command check output in the executor
- logs.
+Subject: [PATCH] Included nested command check output in the executor logs.
 
 This patch updates the checker and health checker to include the output
 of COMMAND checks and health checks in its logs by default. This has
@@ -11,7 +10,7 @@ debugging.
 
 Review: https://reviews.apache.org/r/61697/
 ---
- src/checks/checker_process.cpp | 68 ++++++++++++++++++++++++++++++++++
+ src/checks/checker_process.cpp | 68 ++++++++++++++++++++++++++++++++++++++++++
  1 file changed, 68 insertions(+)
 
 diff --git a/src/checks/checker_process.cpp b/src/checks/checker_process.cpp
@@ -120,5 +119,5 @@ index 8554a85e7..28353840b 100644
      .onFailed([promise](const string& failure) {
        promise->fail(
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0006-Made-the-log-output-handling-of-TCP-and-HTTP-checks-.patch
+++ b/packages/mesos/extra/patches/0006-Made-the-log-output-handling-of-TCP-and-HTTP-checks-.patch
@@ -1,7 +1,7 @@
-From fc6c2727cfc372c7daadfb50dcf54c94c8dbf653 Mon Sep 17 00:00:00 2001
+From d809caaf6ed11df9fbce378265c10c4dbd31514e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Mon, 21 Aug 2017 15:28:37 -0700
-Subject: [PATCH 06/13] Made the log output handling of TCP and HTTP checks
+Subject: [PATCH] Made the log output handling of TCP and HTTP checks
  consistent.
 
 Review: https://reviews.apache.org/r/61766/
@@ -69,5 +69,5 @@ index 28353840b..47d864803 100644
  
    if (exitCode != 0) {
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0007-Raised-the-logging-level-of-some-check-and-health-ch.patch
+++ b/packages/mesos/extra/patches/0007-Raised-the-logging-level-of-some-check-and-health-ch.patch
@@ -1,7 +1,7 @@
-From b3bc639206ce6cd3487ba4fc5de8e79dd8b0f8a5 Mon Sep 17 00:00:00 2001
+From 694b86b3ae16ff9428658b4558c445db28abd7f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Mon, 21 Aug 2017 15:28:39 -0700
-Subject: [PATCH 07/13] Raised the logging level of some check and health check
+Subject: [PATCH] Raised the logging level of some check and health check
  messages.
 
 Some users pointed out that always logging the result of checks and
@@ -48,5 +48,5 @@ index 47d864803..204510660 100644
      CheckStatusInfo checkStatusInfo;
      checkStatusInfo.set_type(check.type());
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0008-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0008-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,7 +1,7 @@
-From 8dab68096bcbe5345eecdbd048f3c62f638eb164 Mon Sep 17 00:00:00 2001
+From 0047b30d6d971c91f46b3c2ecd0a347e1a01ca0f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston.kleiman@gmail.com>
 Date: Tue, 3 Jul 2018 12:09:16 -0700
-Subject: [PATCH 08/13] Improved logging for offers and inverse offers.
+Subject: [PATCH] Improved logging for offers and inverse offers.
 
 Log offer IDs and inverse offer IDs when sending out offers and
 inverse offers so it is easier to match them to their ACCEPT or DECLINE
@@ -19,10 +19,10 @@ Review: https://reviews.apache.org/r/67817
  1 file changed, 18 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index d8dcfc158..16e15bad1 100644
+index 91e5feef7..6896b6e1e 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -7566,6 +7566,9 @@ void Master::offer(
+@@ -7577,6 +7577,9 @@ void Master::offer(
    // and a single allocation role.
    ResourceOffersMessage message;
  
@@ -32,7 +32,7 @@ index d8dcfc158..16e15bad1 100644
    foreachkey (const string& role, resources) {
      foreachpair (const SlaveID& slaveId,
                   const Resources& offered,
-@@ -7710,6 +7713,13 @@ void Master::offer(
+@@ -7721,6 +7724,13 @@ void Master::offer(
        // Add the offer *AND* the corresponding slave's PID.
        message.add_offers()->MergeFrom(offer_);
        message.add_pids(slave->pid);
@@ -46,7 +46,7 @@ index d8dcfc158..16e15bad1 100644
      }
    }
  
-@@ -7717,8 +7727,7 @@ void Master::offer(
+@@ -7728,8 +7738,7 @@ void Master::offer(
      return;
    }
  
@@ -56,7 +56,7 @@ index d8dcfc158..16e15bad1 100644
  
    framework->send(message);
  }
-@@ -7806,8 +7815,13 @@ void Master::inverseOffer(
+@@ -7817,8 +7826,13 @@ void Master::inverseOffer(
      return;
    }
  
@@ -73,5 +73,5 @@ index d8dcfc158..16e15bad1 100644
    framework->send(message);
  }
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0009-Logged-the-resources-in-DRF-sorter-CHECKs.patch
+++ b/packages/mesos/extra/patches/0009-Logged-the-resources-in-DRF-sorter-CHECKs.patch
@@ -1,7 +1,7 @@
-From c6467b0c9f1c337204de61431ae3ba5b87669e51 Mon Sep 17 00:00:00 2001
+From 4c74330cff4319fe938cfa46211fe2752a98c83d Mon Sep 17 00:00:00 2001
 From: Zhitao Li <zhitaoli.cs@gmail.com>
 Date: Thu, 26 Oct 2017 12:03:47 -0700
-Subject: [PATCH 09/13] Logged the resources in DRF sorter CHECKs.
+Subject: [PATCH] Logged the resources in DRF sorter CHECKs.
 
 If calls to these checks fail, log related resources objects which
 caused the failure.
@@ -13,10 +13,10 @@ Review: https://reviews.apache.org/r/63332/
  1 file changed, 13 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/allocator/sorter/drf/sorter.hpp b/src/master/allocator/sorter/drf/sorter.hpp
-index 77e52dec7..1a7681c69 100644
+index d10f34824..fea4b779f 100644
 --- a/src/master/allocator/sorter/drf/sorter.hpp
 +++ b/src/master/allocator/sorter/drf/sorter.hpp
-@@ -346,7 +346,9 @@ struct DRFSorter::Node
+@@ -348,7 +348,9 @@ struct DRFSorter::Node
      void subtract(const SlaveID& slaveId, const Resources& toRemove)
      {
        CHECK(resources.contains(slaveId));
@@ -27,7 +27,7 @@ index 77e52dec7..1a7681c69 100644
  
        resources[slaveId] -= toRemove;
  
-@@ -364,7 +366,9 @@ struct DRFSorter::Node
+@@ -366,7 +368,9 @@ struct DRFSorter::Node
          totals[resource.name()] -= resource.scalar();
        }
  
@@ -38,7 +38,7 @@ index 77e52dec7..1a7681c69 100644
        scalarQuantities -= quantitiesToRemove;
  
        if (resources[slaveId].empty()) {
-@@ -382,8 +386,13 @@ struct DRFSorter::Node
+@@ -384,8 +388,13 @@ struct DRFSorter::Node
        const Resources newAllocationQuantity =
          newAllocation.createStrippedScalarQuantity();
  
@@ -55,5 +55,5 @@ index 77e52dec7..1a7681c69 100644
        resources[slaveId] -= oldAllocation;
        resources[slaveId] += newAllocation;
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0010-Added-verbose-logging-in-Sorter-Allocation.patch
+++ b/packages/mesos/extra/patches/0010-Added-verbose-logging-in-Sorter-Allocation.patch
@@ -1,17 +1,17 @@
-From 16d40b86b5ae982b7bb8b87efb57624d2a24f7d0 Mon Sep 17 00:00:00 2001
+From c1a8c833db1fb9e3b525072677ec3797d56325e2 Mon Sep 17 00:00:00 2001
 From: Meng Zhu <mzhu@mesosphere.io>
 Date: Mon, 10 Sep 2018 17:52:39 -0700
-Subject: [PATCH 10/13] Added verbose logging in `Sorter::Allocation`.
+Subject: [PATCH] Added verbose logging in `Sorter::Allocation`.
 
 See summary.
 
 (cherry picked from commit cd3efb6a2d6bb387c828fd2536660282fbff5e9e)
 ---
- src/master/allocator/sorter/drf/sorter.hpp | 67 ++++++++++++++++++----
- 1 file changed, 56 insertions(+), 11 deletions(-)
+ src/master/allocator/sorter/drf/sorter.hpp | 66 +++++++++++++++++++++++++-----
+ 1 file changed, 55 insertions(+), 11 deletions(-)
 
 diff --git a/src/master/allocator/sorter/drf/sorter.hpp b/src/master/allocator/sorter/drf/sorter.hpp
-index 1a7681c69..3b9008728 100644
+index fea4b779f..ed93690a4 100644
 --- a/src/master/allocator/sorter/drf/sorter.hpp
 +++ b/src/master/allocator/sorter/drf/sorter.hpp
 @@ -29,6 +29,7 @@
@@ -20,9 +20,9 @@ index 1a7681c69..3b9008728 100644
  #include <stout/option.hpp>
 +#include <stout/stringify.hpp>
  
- #include "master/allocator/sorter/drf/metrics.hpp"
+ #include "common/resource_quantities.hpp"
  
-@@ -323,6 +324,10 @@ struct DRFSorter::Node
+@@ -325,6 +326,10 @@ struct DRFSorter::Node
  
      void add(const SlaveID& slaveId, const Resources& toAdd)
      {
@@ -33,11 +33,10 @@ index 1a7681c69..3b9008728 100644
        // Add shared resources to the allocated quantities when the same
        // resources don't already exist in the allocation.
        const Resources sharedToAdd = toAdd.shared()
-@@ -341,16 +346,19 @@ struct DRFSorter::Node
+@@ -343,16 +348,18 @@ struct DRFSorter::Node
        }
  
        count++;
-+
 +      VLOG(2) << "Added allocation on " << slaveId << " resources "
 +              << stringify(resources) << " scalarQuantities "
 +              << scalarQuantities;
@@ -58,7 +57,7 @@ index 1a7681c69..3b9008728 100644
  
        // Remove shared resources from the allocated quantities when there
        // are no instances of same resources left in the allocation.
-@@ -362,18 +370,35 @@ struct DRFSorter::Node
+@@ -364,18 +371,35 @@ struct DRFSorter::Node
        const Resources quantitiesToRemove =
          (toRemove.nonShared() + sharedToRemove).createStrippedScalarQuantity();
  
@@ -97,7 +96,7 @@ index 1a7681c69..3b9008728 100644
      }
  
      void update(
-@@ -381,6 +406,11 @@ struct DRFSorter::Node
+@@ -383,6 +407,11 @@ struct DRFSorter::Node
          const Resources& oldAllocation,
          const Resources& newAllocation)
      {
@@ -109,7 +108,7 @@ index 1a7681c69..3b9008728 100644
        const Resources oldAllocationQuantity =
          oldAllocation.createStrippedScalarQuantity();
        const Resources newAllocationQuantity =
-@@ -388,11 +418,22 @@ struct DRFSorter::Node
+@@ -390,11 +419,22 @@ struct DRFSorter::Node
  
        CHECK(resources.contains(slaveId));
        CHECK(resources[slaveId].contains(oldAllocation))
@@ -135,7 +134,7 @@ index 1a7681c69..3b9008728 100644
  
        resources[slaveId] -= oldAllocation;
        resources[slaveId] += newAllocation;
-@@ -407,6 +448,10 @@ struct DRFSorter::Node
+@@ -409,6 +449,10 @@ struct DRFSorter::Node
        foreach (const Resource& resource, newAllocationQuantity) {
          totals[resource.name()] += resource.scalar();
        }
@@ -147,5 +146,5 @@ index 1a7681c69..3b9008728 100644
  
      // We store the number of times this client has been chosen for
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0011-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
+++ b/packages/mesos/extra/patches/0011-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
@@ -1,8 +1,8 @@
-From 12dab2f9f91835d2966d73849c444d953108193d Mon Sep 17 00:00:00 2001
+From 39efc9425bd9d866fc02d9d4a85a93ddeacd779a Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 27 Sep 2018 15:20:01 +0200
-Subject: [PATCH 11/13] Put `TerminateEvent` at the end of the queue in the
- Mesos library.
+Subject: [PATCH] Put `TerminateEvent` at the end of the queue in the Mesos
+ library.
 
 This is to ensure all pending dispatches are processed. However
 multistage events, e.g., `Call`, might still be dropped, because
@@ -34,5 +34,5 @@ index ce6925802..d805d243e 100644
  
      delete process;
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0012-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
+++ b/packages/mesos/extra/patches/0012-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
@@ -1,8 +1,7 @@
-From c186e2d5e2277652af8104ef3fe851c7dd6685d5 Mon Sep 17 00:00:00 2001
+From 9f02c38790ba9b81ec62fa1592c7a6ee441bf2b9 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Tue, 9 Oct 2018 18:22:16 +0200
-Subject: [PATCH 12/13] Waited for TEARDOWN to be sent in v1 Java scheduler
- shim.
+Subject: [PATCH] Waited for TEARDOWN to be sent in v1 Java scheduler shim.
 
 Destruction of the library is not always under our control. For
 example, the JVM can call JNI `finalize()` if the Java scheduler
@@ -10,7 +9,7 @@ nullifies its reference to the V1Mesos library immediately after
 sending `TEARDOWN`. We want to make sure that `TEARDOWN` is sent
 before the Mesos library is destructed.
 ---
- .../org_apache_mesos_v1_scheduler_V1Mesos.cpp   | 17 +++++++++++++++++
+ src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
@@ -49,5 +48,5 @@ index 2a5fbd79a..6ec771111 100644
  
  
 -- 
-2.17.0
+2.14.3
 

--- a/packages/mesos/extra/patches/0013-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0013-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,8 +1,7 @@
-From 16f4779b71a17c600da0d282555dba92ad912240 Mon Sep 17 00:00:00 2001
+From c3275809c664459449daa95944a806e7b410e4fb Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Fri, 2 Nov 2018 16:13:01 -0700
-Subject: [PATCH 13/13] Added task health check definitions to master API
- responses.
+Subject: [PATCH] Added task health check definitions to master API responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified. Associated helpers are
@@ -102,5 +101,5 @@ index 3ae68e93a..d8996c9cd 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.17.0
+2.14.3
 


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/6791ab059b9f2fb3968a54cb257d219c28fdcba1...e929d413328e10f6d358899500d5aaedd9d9bc51
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
