### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 5f6225b

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "9d5cc18a2065864350c23ad56f1c4caa2ae308c5",
+    "ref": "f1a0c5870e6744c79714e16e4adfee1010ebf78f",
     "ref_origin": "1.11"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "6fd91063da7230c2a65bea11ca4c69f241ba0877",
+    "ref": "5f6225bd6e039c633b7758f02d2b5fbabc8e0169",
     "ref_origin": "1.5.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,4 +1,4 @@
-From 653e5b8de6f4cdb547ca2c39fae0f877918e15c6 Mon Sep 17 00:00:00 2001
+From 2f3d5a8aa20b435b67949a3c3d9577fc730ecc77 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
 Subject: [PATCH] Set LIBPROCESS_IP into docker container.
@@ -24,5 +24,5 @@ index ef4ef265b..18c8270cc 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,4 +1,4 @@
-From f32bc063f2352e5d342c138fb22a093d87e11933 Mon Sep 17 00:00:00 2001
+From 6b93b666f26d6b7939b0029b44fbb1bc19f78ce4 Mon Sep 17 00:00:00 2001
 From: Gaston Kleiman <gaston.kleiman@gmail.com>
 Date: Mon, 9 Oct 2017 15:19:08 -0700
 Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
@@ -47,5 +47,5 @@ index 59665869d..6e0a40f93 100644
              'Mesos Master (' + $scope.$location.host() + ':' + $scope.$location.port() + ')');
        }
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,4 +1,4 @@
-From 8f7bbe0e138e53613e709a0638c4c7a86ce4927d Mon Sep 17 00:00:00 2001
+From 3816fd7547f8be4fc7cc3ad03f7d6db34d5885cd Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
 Subject: [PATCH] Revert "Fixed the broken metrics information of master in
@@ -9,7 +9,7 @@ This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
 In DC/OS, redirection to the leading master is handled by the
 Adminrouter component.
 ---
- src/webui/master/static/js/controllers.js | 24 +++++++----------------
+ src/webui/master/static/js/controllers.js | 24 +++++++-----------------
  1 file changed, 7 insertions(+), 17 deletions(-)
 
 diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
@@ -69,5 +69,5 @@ index 6e0a40f93..8d9b5f49d 100644
              $timeout(pollMetrics, $scope.delay);
            }
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,4 +1,4 @@
-From 3aab21cb77d1cb7df6ef4c1a7db0fc1f0aa32e63 Mon Sep 17 00:00:00 2001
+From 6676da9be0ad56064a089a5c91f47a3560f1f38b Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
 Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
@@ -19,7 +19,7 @@ This is a decent compromise.
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 1f7558380..b9a12ee72 100644
+index 47f86211b..53899397c 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -424,8 +424,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -45,5 +45,5 @@ index 1f7558380..b9a12ee72 100644
      }
    }
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
+++ b/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
@@ -1,4 +1,4 @@
-From cdd835b565e502912bde5536da81861b9eb4ebe3 Mon Sep 17 00:00:00 2001
+From da2881641fa4ddb143416cfca38d7366599ef1bd Mon Sep 17 00:00:00 2001
 From: Benjamin Bannier <benjamin.bannier@mesosphere.io>
 Date: Tue, 20 Mar 2018 10:08:09 +0100
 Subject: [PATCH] Displayed resource provider resources in
@@ -87,5 +87,5 @@ index 01440330f..5985070f8 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,4 +1,4 @@
-From 1ec1824b7ecb472e0f5d72d1398985c164e6bc2b Mon Sep 17 00:00:00 2001
+From 16950c2a545494a06be1212c65fd286788a94618 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Tue, 10 Jul 2018 08:06:32 -0700
 Subject: [PATCH] Improved logging for offers and inverse offers.
@@ -19,10 +19,10 @@ Review: https://reviews.apache.org/r/67817/
  1 file changed, 18 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 0229d1bca..73a0102c4 100644
+index 36b167fee..1e9775122 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -8699,6 +8699,9 @@ void Master::offer(
+@@ -8713,6 +8713,9 @@ void Master::offer(
    // and a single allocation role.
    ResourceOffersMessage message;
  
@@ -32,7 +32,7 @@ index 0229d1bca..73a0102c4 100644
    foreachkey (const string& role, resources) {
      foreachpair (const SlaveID& slaveId,
                   const Resources& offered,
-@@ -8843,6 +8846,13 @@ void Master::offer(
+@@ -8857,6 +8860,13 @@ void Master::offer(
        // Add the offer *AND* the corresponding slave's PID.
        message.add_offers()->MergeFrom(offer_);
        message.add_pids(slave->pid);
@@ -46,7 +46,7 @@ index 0229d1bca..73a0102c4 100644
      }
    }
  
-@@ -8850,8 +8860,7 @@ void Master::offer(
+@@ -8864,8 +8874,7 @@ void Master::offer(
      return;
    }
  
@@ -56,7 +56,7 @@ index 0229d1bca..73a0102c4 100644
  
    framework->send(message);
  }
-@@ -8939,8 +8948,13 @@ void Master::inverseOffer(
+@@ -8953,8 +8962,13 @@ void Master::inverseOffer(
      return;
    }
  
@@ -73,5 +73,5 @@ index 0229d1bca..73a0102c4 100644
    framework->send(message);
  }
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
+++ b/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
@@ -1,4 +1,4 @@
-From e285b706666a65752098cef0feb59546ebfcb2c8 Mon Sep 17 00:00:00 2001
+From 9a0a7cbaf34995ba72f631836b72fdb0d9a29b9f Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:53 -0700
 Subject: [PATCH] Introduced a push-based gauge metric.
@@ -20,8 +20,8 @@ the `Process` pushes new values in.
 
 Review: https://reviews.apache.org/r/66828/
 ---
- 3rdparty/libprocess/include/Makefile.am       |   1 +
- .../include/process/metrics/push_gauge.hpp    | 100 ++++++++++++++++++
+ 3rdparty/libprocess/include/Makefile.am            |   1 +
+ .../include/process/metrics/push_gauge.hpp         | 100 +++++++++++++++++++++
  2 files changed, 101 insertions(+)
  create mode 100644 3rdparty/libprocess/include/process/metrics/push_gauge.hpp
 
@@ -144,5 +144,5 @@ index 000000000..5c3984617
 +
 +#endif // __PROCESS_METRICS_PUSH_GAUGE_HPP__
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
+++ b/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
@@ -1,11 +1,11 @@
-From 57971fa7f9e26f1615489c0eaee904dd641c3b6f Mon Sep 17 00:00:00 2001
+From 22577ebbce1b65245caafdcf34018fb1eae48527 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:58 -0700
 Subject: [PATCH] Added a test for PushGauge.
 
 Review: https://reviews.apache.org/r/66830/
 ---
- .../libprocess/src/tests/metrics_tests.cpp    | 32 +++++++++++++++++++
+ 3rdparty/libprocess/src/tests/metrics_tests.cpp | 32 +++++++++++++++++++++++++
  1 file changed, 32 insertions(+)
 
 diff --git a/3rdparty/libprocess/src/tests/metrics_tests.cpp b/3rdparty/libprocess/src/tests/metrics_tests.cpp
@@ -66,5 +66,5 @@ index bb7c9e37e..d394a42bf 100644
  {
    Counter counter("test/counter", process::TIME_SERIES_WINDOW);
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
+++ b/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
@@ -1,4 +1,4 @@
-From 3174722a7896f06a87334ef24b582a80e273cd27 Mon Sep 17 00:00:00 2001
+From 95b4a13df1d37dc8903bc138d3f05f277ebe8239 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:01 -0700
 Subject: [PATCH] Renamed Gauge to PullGauge and documented differences to
@@ -9,13 +9,13 @@ gauge types and document the the caveats of `PullGauge`.
 
 Review: https://reviews.apache.org/r/66831/
 ---
- 3rdparty/libprocess/include/Makefile.am       |  2 +-
- .../include/process/metrics/gauge.hpp         | 58 --------------
- .../include/process/metrics/metric.hpp        |  2 +-
- .../include/process/metrics/pull_gauge.hpp    | 77 +++++++++++++++++++
- .../libprocess/include/process/system.hpp     | 14 ++--
- .../libprocess/src/tests/metrics_tests.cpp    | 51 ++++++------
- .../libprocess/src/tests/system_tests.cpp     |  2 +-
+ 3rdparty/libprocess/include/Makefile.am            |  2 +-
+ .../libprocess/include/process/metrics/gauge.hpp   | 58 ----------------
+ .../libprocess/include/process/metrics/metric.hpp  |  2 +-
+ .../include/process/metrics/pull_gauge.hpp         | 77 ++++++++++++++++++++++
+ 3rdparty/libprocess/include/process/system.hpp     | 14 ++--
+ 3rdparty/libprocess/src/tests/metrics_tests.cpp    | 51 +++++++-------
+ 3rdparty/libprocess/src/tests/system_tests.cpp     |  2 +-
  7 files changed, 116 insertions(+), 90 deletions(-)
  delete mode 100644 3rdparty/libprocess/include/process/metrics/gauge.hpp
  create mode 100644 3rdparty/libprocess/include/process/metrics/pull_gauge.hpp
@@ -353,5 +353,5 @@ index 6beb973e0..4a193d778 100644
  // endpoint. This has been observed specifically for the memory
  // metrics. If in the future we put the error message from the Failure
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
+++ b/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
@@ -1,31 +1,31 @@
-From eab69da63d2b20ad28e0e508dfc9fdc0ed38427f Mon Sep 17 00:00:00 2001
+From 4f8f62199b35f97617a3095618b6fc8c0141f07b Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:05 -0700
 Subject: [PATCH] Updated mesos source for Gauge -> PullGauge renaming.
 
 Review: https://reviews.apache.org/r/66832/
 ---
- src/examples/balloon_framework.cpp            |  8 +--
- src/examples/disk_full_framework.cpp          |  8 +--
- src/examples/long_lived_framework.cpp         |  8 +--
- src/log/log.hpp                               |  2 +-
- src/log/metrics.hpp                           |  6 +--
- src/master/allocator/mesos/metrics.cpp        | 32 +++++------
- src/master/allocator/mesos/metrics.hpp        | 26 ++++-----
- src/master/allocator/sorter/drf/metrics.cpp   |  6 +--
- src/master/allocator/sorter/drf/metrics.hpp   |  4 +-
- src/master/master.hpp                         |  2 +-
- src/master/metrics.cpp                        | 28 +++++-----
- src/master/metrics.hpp                        | 54 +++++++++----------
- src/master/registrar.cpp                      | 10 ++--
- src/sched/sched.cpp                           |  6 +--
- src/scheduler/scheduler.cpp                   |  6 +--
- src/slave/containerizer/fetcher_process.hpp   |  6 +--
- .../mesos/isolators/filesystem/linux.hpp      |  4 +-
- src/slave/gc_process.hpp                      |  4 +-
- src/slave/metrics.cpp                         | 28 +++++-----
- src/slave/metrics.hpp                         | 36 ++++++-------
- src/slave/slave.hpp                           |  2 +-
+ src/examples/balloon_framework.cpp                 |  8 ++--
+ src/examples/disk_full_framework.cpp               |  8 ++--
+ src/examples/long_lived_framework.cpp              |  8 ++--
+ src/log/log.hpp                                    |  2 +-
+ src/log/metrics.hpp                                |  6 +--
+ src/master/allocator/mesos/metrics.cpp             | 32 ++++++-------
+ src/master/allocator/mesos/metrics.hpp             | 26 +++++------
+ src/master/allocator/sorter/drf/metrics.cpp        |  6 +--
+ src/master/allocator/sorter/drf/metrics.hpp        |  4 +-
+ src/master/master.hpp                              |  2 +-
+ src/master/metrics.cpp                             | 28 +++++------
+ src/master/metrics.hpp                             | 54 +++++++++++-----------
+ src/master/registrar.cpp                           | 10 ++--
+ src/sched/sched.cpp                                |  6 +--
+ src/scheduler/scheduler.cpp                        |  6 +--
+ src/slave/containerizer/fetcher_process.hpp        |  6 +--
+ .../mesos/isolators/filesystem/linux.hpp           |  4 +-
+ src/slave/gc_process.hpp                           |  4 +-
+ src/slave/metrics.cpp                              | 28 +++++------
+ src/slave/metrics.hpp                              | 36 +++++++--------
+ src/slave/slave.hpp                                |  2 +-
  21 files changed, 143 insertions(+), 143 deletions(-)
 
 diff --git a/src/examples/balloon_framework.cpp b/src/examples/balloon_framework.cpp
@@ -404,7 +404,7 @@ index 61568cb52..1ff7489ee 100644
  
  } // namespace allocator {
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index c1db276b4..282925da5 100644
+index 0705fcdb5..5f2590e01 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -2097,7 +2097,7 @@ private:
@@ -954,5 +954,5 @@ index d638b8806..8d42011be 100644
    {
      return static_cast<double>(frameworks.size());
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
+++ b/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
@@ -1,4 +1,4 @@
-From e687b38ee1045d14b59ca84e8c850126119149a8 Mon Sep 17 00:00:00 2001
+From d12b7703893796c8d19d1ae6e89cc9e8c90bd466 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:57:56 -0700
 Subject: [PATCH] Enabled per-framework metrics in the master.
@@ -14,10 +14,10 @@ Review: https://reviews.apache.org/r/67962/
  3 files changed, 36 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 282925da5..c8a4b7621 100644
+index 5f2590e01..197d03af4 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -2909,6 +2909,9 @@ struct Framework
+@@ -2924,6 +2924,9 @@ struct Framework
    Option<process::Owned<Heartbeater<scheduler::Event, v1::scheduler::Event>>>
      heartbeater;
  
@@ -27,7 +27,7 @@ index 282925da5..c8a4b7621 100644
  private:
    Framework(Master* const _master,
              const Flags& masterFlags,
-@@ -2923,8 +2926,11 @@ private:
+@@ -2938,8 +2941,11 @@ private:
        registeredTime(time),
        reregisteredTime(time),
        completedTasks(masterFlags.max_completed_tasks_per_framework),
@@ -99,5 +99,5 @@ index 1ef74dedf..9f10aecba 100644
  } // namespace internal {
  } // namespace mesos {
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
+++ b/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
@@ -1,4 +1,4 @@
-From db5ba69852d66320243de6b884119938c89f55cb Mon Sep 17 00:00:00 2001
+From 4cdfdb1b6a432298daaf1a34300c9e1f2d014ffe Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Wed, 1 Aug 2018 07:58:06 -0700
 Subject: [PATCH] Added per-framework 'subscribed' metric and helpers.
@@ -12,10 +12,10 @@ Review: https://reviews.apache.org/r/66820/
  4 files changed, 30 insertions(+), 8 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 73a0102c4..13a0af995 100644
+index 1e9775122..075c6ad2d 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -452,6 +452,13 @@ void Framework::untrackUnderRole(const string& role)
+@@ -455,6 +455,13 @@ void Framework::untrackUnderRole(const string& role)
  }
  
  
@@ -29,7 +29,7 @@ index 73a0102c4..13a0af995 100644
  void Master::initialize()
  {
    LOG(INFO) << "Master " << info_.id() << " (" << info_.hostname() << ")"
-@@ -3234,7 +3241,7 @@ void Master::_subscribe(
+@@ -3229,7 +3236,7 @@ void Master::_subscribe(
        // NOTE: We do this after recovering resources (above) so that
        // the allocator has the correct view of the framework's share.
        if (!framework->active()) {
@@ -38,7 +38,7 @@ index 73a0102c4..13a0af995 100644
          allocator->activateFramework(framework->id());
        }
  
-@@ -3348,7 +3355,7 @@ void Master::disconnect(Framework* framework)
+@@ -3343,7 +3350,7 @@ void Master::disconnect(Framework* framework)
  
    LOG(INFO) << "Disconnecting framework " << *framework;
  
@@ -47,7 +47,7 @@ index 73a0102c4..13a0af995 100644
  
    if (framework->pid.isSome()) {
      // Remove the framework from authenticated. This is safe because
-@@ -3371,7 +3378,7 @@ void Master::deactivate(Framework* framework, bool rescind)
+@@ -3366,7 +3373,7 @@ void Master::deactivate(Framework* framework, bool rescind)
  
    LOG(INFO) << "Deactivating framework " << *framework;
  
@@ -56,7 +56,7 @@ index 73a0102c4..13a0af995 100644
  
    // Tell the allocator to stop allocating resources to this framework.
    allocator->deactivateFramework(framework->id());
-@@ -9382,7 +9389,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -9396,7 +9403,7 @@ Try<Nothing> Master::activateRecoveredFramework(
    }
  
    // Activate the framework.
@@ -65,7 +65,7 @@ index 73a0102c4..13a0af995 100644
    allocator->activateFramework(framework->id());
  
    // Export framework metrics if a principal is specified in `FrameworkInfo`.
-@@ -9532,7 +9539,7 @@ void Master::_failoverFramework(Framework* framework)
+@@ -9546,7 +9553,7 @@ void Master::_failoverFramework(Framework* framework)
    // NOTE: We do this after recovering resources (above) so that
    // the allocator has the correct view of the framework's share.
    if (!framework->active()) {
@@ -75,7 +75,7 @@ index 73a0102c4..13a0af995 100644
    }
  
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index c8a4b7621..332033e9c 100644
+index 197d03af4..f3641936f 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -1740,6 +1740,7 @@ private:
@@ -86,7 +86,7 @@ index c8a4b7621..332033e9c 100644
    friend struct Metrics;
    friend struct Slave;
    friend struct SlavesWriter;
-@@ -2813,6 +2814,8 @@ struct Framework
+@@ -2828,6 +2829,8 @@ struct Framework
    void trackUnderRole(const std::string& role);
    void untrackUnderRole(const std::string& role);
  
@@ -95,7 +95,7 @@ index c8a4b7621..332033e9c 100644
    Master* const master;
  
    FrameworkInfo info;
-@@ -2922,7 +2925,6 @@ private:
+@@ -2937,7 +2940,6 @@ private:
        info(_info),
        roles(protobuf::framework::getRoles(_info)),
        capabilities(_info.capabilities()),
@@ -103,7 +103,7 @@ index c8a4b7621..332033e9c 100644
        registeredTime(time),
        reregisteredTime(time),
        completedTasks(masterFlags.max_completed_tasks_per_framework),
-@@ -2931,6 +2933,8 @@ private:
+@@ -2946,6 +2948,8 @@ private:
    {
      CHECK(_info.has_id());
  
@@ -159,5 +159,5 @@ index 9f10aecba..d3f093f9d 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
+++ b/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
@@ -1,4 +1,4 @@
-From 1f73ece29f37ac29610945bec2b5145d0e7cc87f Mon Sep 17 00:00:00 2001
+From 796760ed0fc41693a790e326377834d9af2c82a5 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:14 -0700
 Subject: [PATCH] Added per-framework metrics for scheduler calls.
@@ -7,7 +7,7 @@ Review: https://reviews.apache.org/r/67776/
 ---
  src/master/http.cpp    |  2 ++
  src/master/master.cpp  |  6 ++++++
- src/master/metrics.cpp | 43 +++++++++++++++++++++++++++++++++++++++++-
+ src/master/metrics.cpp | 43 ++++++++++++++++++++++++++++++++++++++++++-
  src/master/metrics.hpp |  7 +++++++
  4 files changed, 57 insertions(+), 1 deletion(-)
 
@@ -25,10 +25,10 @@ index 1f9aac44f..f4cd2dc68 100644
    // into the authorizer. See MESOS-7399.
    if (principal.isSome() && principal != framework->info.principal()) {
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 13a0af995..bf1e61eb5 100644
+index 075c6ad2d..ed827c1b2 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -2487,6 +2487,8 @@ void Master::receive(
+@@ -2482,6 +2482,8 @@ void Master::receive(
      return;
    }
  
@@ -37,7 +37,7 @@ index 13a0af995..bf1e61eb5 100644
    // This is possible when master --> framework link is broken (i.e., one
    // way network partition) and the framework is not aware of it. There
    // is no way for driver based frameworks to detect this in the absence
-@@ -2808,6 +2810,8 @@ void Master::_subscribe(
+@@ -2803,6 +2805,8 @@ void Master::_subscribe(
  
      addFramework(framework, suppressedRoles);
  
@@ -46,7 +46,7 @@ index 13a0af995..bf1e61eb5 100644
      FrameworkRegisteredMessage message;
      message.mutable_framework_id()->MergeFrom(framework->id());
      message.mutable_master_info()->MergeFrom(info_);
-@@ -2841,6 +2845,8 @@ void Master::_subscribe(
+@@ -2836,6 +2840,8 @@ void Master::_subscribe(
  
    CHECK_NOTNULL(framework);
  
@@ -153,5 +153,5 @@ index d3f093f9d..7a7b3a316 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
+++ b/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
@@ -1,4 +1,4 @@
-From 83950c1f97f5708ed49a99b1a9fde68aae336bdd Mon Sep 17 00:00:00 2001
+From 257f968c5d3860baa1297b4eee76afbc37192a19 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:22 -0700
 Subject: [PATCH] Added per-framework metrics for scheduler events.
@@ -172,5 +172,5 @@ index 7a7b3a316..fac4440da 100644
  
  
 -- 
-2.13.6 (Apple Git-96)
+2.14.3
 

--- a/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
+++ b/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
@@ -1,4 +1,4 @@
-From f914709f1f1d881bdab02a1826c3d51912fe0f2b Mon Sep 17 00:00:00 2001
+From af2c2800eba96a4a7fbfbb8fedf78301286ffd71 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:25 -0700
 Subject: [PATCH] Added per-framework offer metrics.
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67812/
  3 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index bf1e61eb5..a743a6c9c 100644
+index ed827c1b2..bb39b48e8 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -3989,6 +3989,8 @@ void Master::accept(
+@@ -3984,6 +3984,8 @@ void Master::accept(
      // Validate the offers.
      error = validation::offer::validate(accept.offer_ids(), this, framework);
  
@@ -23,7 +23,7 @@ index bf1e61eb5..a743a6c9c 100644
      // Compute offered resources and remove the offers. If the
      // validation failed, return resources to the allocator.
      foreach (const OfferID& offerId, accept.offer_ids()) {
-@@ -4006,6 +4008,8 @@ void Master::accept(
+@@ -4001,6 +4003,8 @@ void Master::accept(
            slaveId = offer->slave_id();
            allocationInfo = offer->allocation_info();
            offeredResources += offer->resources();
@@ -32,7 +32,7 @@ index bf1e61eb5..a743a6c9c 100644
          }
  
          removeOffer(offer);
-@@ -4017,6 +4021,8 @@ void Master::accept(
+@@ -4012,6 +4016,8 @@ void Master::accept(
        LOG(WARNING) << "Ignoring accept of offer " << offerId
                     << " since it is no longer valid";
      }
@@ -41,7 +41,7 @@ index bf1e61eb5..a743a6c9c 100644
    }
  
    // If invalid, send TASK_DROPPED for the launch attempts. If the
-@@ -5530,6 +5536,8 @@ void Master::decline(
+@@ -5534,6 +5540,8 @@ void Master::decline(
  
    ++metrics->messages_decline_offers;
  
@@ -50,7 +50,7 @@ index bf1e61eb5..a743a6c9c 100644
    //  Return resources to the allocator.
    foreach (const OfferID& offerId, decline.offer_ids()) {
      Offer* offer = getOffer(offerId);
-@@ -5541,6 +5549,8 @@ void Master::decline(
+@@ -5545,6 +5553,8 @@ void Master::decline(
            decline.filters());
  
        removeOffer(offer);
@@ -59,7 +59,7 @@ index bf1e61eb5..a743a6c9c 100644
        continue;
      }
  
-@@ -5549,6 +5559,8 @@ void Master::decline(
+@@ -5553,6 +5563,8 @@ void Master::decline(
      LOG(WARNING) << "Ignoring decline of offer " << offerId
                   << " since it is no longer valid";
    }
@@ -68,7 +68,7 @@ index bf1e61eb5..a743a6c9c 100644
  }
  
  
-@@ -8875,6 +8887,7 @@ void Master::offer(
+@@ -8889,6 +8901,7 @@ void Master::offer(
  
    LOG(INFO) << "Sending offers " << offerIds << " to framework " << *framework;
  
@@ -76,7 +76,7 @@ index bf1e61eb5..a743a6c9c 100644
    framework->send(message);
  }
  
-@@ -10803,6 +10816,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
+@@ -10817,6 +10830,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
    if (rescind) {
      RescindResourceOfferMessage message;
      message.mutable_offer_id()->MergeFrom(offer->id());
@@ -142,5 +142,5 @@ index fac4440da..b6fe20fb5 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
+++ b/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
@@ -1,21 +1,21 @@
-From 4a2be618a885210742ec0d6df27a6c02b9c28bbb Mon Sep 17 00:00:00 2001
+From 4d88c19345bc6f50f66c5c7114e592cc22460a94 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:31 -0700
 Subject: [PATCH] Added per-framework metrics for task states.
 
 Review: https://reviews.apache.org/r/67813/
 ---
- src/master/master.cpp  | 18 ++++++++++++--
+ src/master/master.cpp  | 18 +++++++++++++++--
  src/master/master.hpp  |  2 ++
- src/master/metrics.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++
- src/master/metrics.hpp |  7 ++++++
+ src/master/metrics.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/master/metrics.hpp |  7 +++++++
  4 files changed, 79 insertions(+), 2 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index a743a6c9c..40f8bec29 100644
+index bb39b48e8..c9d8d4a84 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -10243,6 +10243,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10257,6 +10257,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
    // task transitioned to a new state.
    bool sendSubscribersUpdate = false;
  
@@ -24,7 +24,7 @@ index a743a6c9c..40f8bec29 100644
    // Set 'removable' to true if this is the first time the task
    // transitioned to a removable state. Also set the latest state.
    bool removable;
-@@ -10256,6 +10258,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10270,6 +10272,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -38,7 +38,7 @@ index a743a6c9c..40f8bec29 100644
        task->set_state(latestState.get());
      }
    } else {
-@@ -10269,6 +10278,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10283,6 +10292,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -52,7 +52,7 @@ index a743a6c9c..40f8bec29 100644
        task->set_state(status.state());
      }
    }
-@@ -10300,7 +10316,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10314,7 +10330,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
      // transitioned to `TASK_KILLED` by `removeFramework()`, thus
      // `sendSubscribersUpdate` shouldn't have been set to true.
      // TODO(chhsiao): This may be changed after MESOS-6608 is resolved.
@@ -60,7 +60,7 @@ index a743a6c9c..40f8bec29 100644
      CHECK_NOTNULL(framework);
  
      subscribers.send(
-@@ -10329,7 +10344,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10343,7 +10358,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
  
      slave->recoverResources(task);
  
@@ -69,7 +69,7 @@ index a743a6c9c..40f8bec29 100644
        framework->recoverResources(task);
      }
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 5dd1ffa0a..536e4fe7c 100644
+index 05e530cfa..ac5048d9a 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -2295,6 +2295,8 @@ struct Framework
@@ -200,5 +200,5 @@ index b6fe20fb5..071246b71 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
+++ b/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
@@ -1,4 +1,4 @@
-From 759cb104e9b4406239cc6815774f934e8d485048 Mon Sep 17 00:00:00 2001
+From 52c1c07b36c1721538fd97567fa9cfc12f5fa4de Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:39 -0700
 Subject: [PATCH] Added per-framework metrics for offer operations.
@@ -11,7 +11,7 @@ Review: https://reviews.apache.org/r/67814/
  3 files changed, 59 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 40f8bec29..7bb2062fc 100644
+index c9d8d4a84..7f11211df 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -5072,6 +5072,10 @@ void Master::_accept(
@@ -25,7 +25,7 @@ index 40f8bec29..7bb2062fc 100644
              send(slave->pid, message);
            }
          }
-@@ -5279,6 +5283,10 @@ void Master::_accept(
+@@ -5278,6 +5282,10 @@ void Master::_accept(
                    << *slave << " on "
                    << (launchExecutor ? " new executor" : " existing executor");
  
@@ -36,7 +36,7 @@ index 40f8bec29..7bb2062fc 100644
          send(slave->pid, message);
  
          break;
-@@ -10792,6 +10800,12 @@ void Master::_apply(
+@@ -10806,6 +10814,12 @@ void Master::_apply(
  
      send(slave->pid, message);
    }
@@ -146,5 +146,5 @@ index 071246b71..7ce3941b2 100644
  
  
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
@@ -1,4 +1,4 @@
-From 2615a4c21e95657250cf7494c9743245777943c1 Mon Sep 17 00:00:00 2001
+From d1e5c97a1f2a4674e63e2d20332097fe1ad9aeab Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:45 -0700
 Subject: [PATCH] Enabled per-framework metrics in the allocator.
@@ -15,10 +15,10 @@ Review: https://reviews.apache.org/r/66843/
  4 files changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index 58155ad4c..5b32b3da2 100644
+index 87e7d536e..96671033b 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -140,7 +140,8 @@ HierarchicalAllocatorProcess::Framework::Framework(
+@@ -141,7 +141,8 @@ HierarchicalAllocatorProcess::Framework::Framework(
    : roles(protobuf::framework::getRoles(frameworkInfo)),
      suppressedRoles(_suppressedRoles),
      capabilities(frameworkInfo.capabilities()),
@@ -29,7 +29,7 @@ index 58155ad4c..5b32b3da2 100644
  
  void HierarchicalAllocatorProcess::initialize(
 diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
-index ec45e163e..ff96beea3 100644
+index 4da109709..ec4d445f5 100644
 --- a/src/master/allocator/mesos/hierarchical.hpp
 +++ b/src/master/allocator/mesos/hierarchical.hpp
 @@ -332,6 +332,8 @@ protected:
@@ -81,5 +81,5 @@ index 6d386225c..daac93f7e 100644
  } // namespace allocator {
  } // namespace master {
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
+++ b/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
@@ -1,4 +1,4 @@
-From da74108a1a691b805c5c65033c08d95f7e5a6b16 Mon Sep 17 00:00:00 2001
+From a5049d41009c8ca16de1fa2cf77968dfb56f7cc8 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:48 -0700
 Subject: [PATCH] Changed the 'capacity_' member of 'BoundedHashMap' to
@@ -25,5 +25,5 @@ index 09a9b96f0..f73ec6b66 100644
    map keys_; // Map from key to "pointer" to key's location in list.
  };
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
@@ -1,4 +1,4 @@
-From 35eb904c028dfe50a49e5b1a46617a444117965d Mon Sep 17 00:00:00 2001
+From 194f7fa2730abbfbdcadbe2bc55afc72fb93b0c8 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:49 -0700
 Subject: [PATCH] Tracked completed framework metrics in the allocator.
@@ -9,44 +9,45 @@ which are tracked in the master.
 
 Review: https://reviews.apache.org/r/66856/
 ---
- include/mesos/allocator/allocator.hpp       |  3 +-
- src/master/allocator/mesos/allocator.hpp    | 12 ++++---
- src/master/allocator/mesos/hierarchical.cpp | 15 +++++++--
- src/master/allocator/mesos/hierarchical.hpp |  8 ++++-
- src/master/master.cpp                       |  3 +-
- src/tests/allocator.hpp                     | 11 ++++---
- src/tests/api_tests.cpp                     |  4 +--
- src/tests/master_allocator_tests.cpp        | 36 ++++++++++-----------
- src/tests/master_quota_tests.cpp            | 20 ++++++------
- src/tests/reservation_tests.cpp             |  6 ++--
+ include/mesos/allocator/allocator.hpp       |  4 +++-
+ src/master/allocator/mesos/allocator.hpp    | 12 ++++++----
+ src/master/allocator/mesos/hierarchical.cpp | 15 ++++++++++--
+ src/master/allocator/mesos/hierarchical.hpp |  8 ++++++-
+ src/master/master.cpp                       |  3 ++-
+ src/tests/allocator.hpp                     | 11 +++++----
+ src/tests/api_tests.cpp                     |  4 ++--
+ src/tests/master_allocator_tests.cpp        | 36 ++++++++++++++---------------
+ src/tests/master_quota_tests.cpp            | 20 ++++++++--------
+ src/tests/reservation_tests.cpp             |  6 ++---
  src/tests/resource_offers_tests.cpp         |  2 +-
  src/tests/slave_recovery_tests.cpp          |  2 +-
- 12 files changed, 73 insertions(+), 49 deletions(-)
+ 12 files changed, 74 insertions(+), 49 deletions(-)
 
 diff --git a/include/mesos/allocator/allocator.hpp b/include/mesos/allocator/allocator.hpp
-index c19ab64ff..fadd4e8e3 100644
+index df64faf2d..a0375776c 100644
 --- a/include/mesos/allocator/allocator.hpp
 +++ b/include/mesos/allocator/allocator.hpp
-@@ -103,7 +103,8 @@ public:
+@@ -105,7 +105,9 @@ public:
        bool filterGpuResources = true,
        const Option<DomainInfo>& domain = None(),
-       const Option<std::vector<Resources>>&
+       const Option<std::vector<mesos::internal::ResourceQuantities>>&
 -        minAllocatableResources = None()) = 0;
 +        minAllocatableResources = None(),
 +      const size_t maxCompletedFrameworks = 0) = 0;
++
  
    /**
     * Informs the allocator of the recovered state from the master.
 diff --git a/src/master/allocator/mesos/allocator.hpp b/src/master/allocator/mesos/allocator.hpp
-index 900c8ee40..d5f2f794d 100644
+index 32dd40cb0..bc35d2fff 100644
 --- a/src/master/allocator/mesos/allocator.hpp
 +++ b/src/master/allocator/mesos/allocator.hpp
 @@ -60,7 +60,8 @@ public:
-         fairnessExcludeResourceNames = None(),
        bool filterGpuResources = true,
        const Option<DomainInfo>& domain = None(),
--      const Option<std::vector<Resources>>& minAllocatableResources = None());
-+      const Option<std::vector<Resources>>& minAllocatableResources = None(),
+       const Option<std::vector<mesos::internal::ResourceQuantities>>&
+-        minAllocatableResources = None());
++        minAllocatableResources = None(),
 +      const size_t maxCompletedFrameworks = 0);
  
    void recover(
@@ -54,24 +55,24 @@ index 900c8ee40..d5f2f794d 100644
 @@ -208,7 +209,8 @@ public:
        bool filterGpuResources = true,
        const Option<DomainInfo>& domain = None(),
-       const Option<std::vector<Resources>>&
+       const Option<std::vector<mesos::internal::ResourceQuantities>>&
 -        minAllocatableResources = None()) = 0;
 +        minAllocatableResources = None(),
 +      const size_t maxCompletedFrameworks = 0) = 0;
  
    virtual void recover(
        const int expectedAgentCount,
-@@ -364,7 +366,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
-     const Option<std::set<std::string>>& fairnessExcludeResourceNames,
+@@ -365,7 +367,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
      bool filterGpuResources,
      const Option<DomainInfo>& domain,
--    const Option<std::vector<Resources>>& minAllocatableResources)
-+    const Option<std::vector<Resources>>& minAllocatableResources,
+     const Option<std::vector<mesos::internal::ResourceQuantities>>&
+-      minAllocatableResources)
++      minAllocatableResources,
 +    const size_t maxCompletedFrameworks)
  {
    process::dispatch(
        process,
-@@ -375,7 +378,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
+@@ -376,7 +379,8 @@ inline void MesosAllocator<AllocatorProcess>::initialize(
        fairnessExcludeResourceNames,
        filterGpuResources,
        domain,
@@ -82,20 +83,20 @@ index 900c8ee40..d5f2f794d 100644
  
  
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index 5b32b3da2..c39685bcc 100644
+index 96671033b..2af633c5c 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -157,7 +157,8 @@ void HierarchicalAllocatorProcess::initialize(
-     const Option<set<string>>& _fairnessExcludeResourceNames,
+@@ -159,7 +159,8 @@ void HierarchicalAllocatorProcess::initialize(
      bool _filterGpuResources,
      const Option<DomainInfo>& _domain,
--    const Option<std::vector<Resources>>& _minAllocatableResources)
-+    const Option<std::vector<Resources>>& _minAllocatableResources,
+     const Option<std::vector<mesos::internal::ResourceQuantities>>&
+-      _minAllocatableResources)
++      _minAllocatableResources,
 +    const size_t maxCompletedFrameworks)
  {
    allocationInterval = _allocationInterval;
    offerCallback = _offerCallback;
-@@ -169,6 +170,10 @@ void HierarchicalAllocatorProcess::initialize(
+@@ -171,6 +172,10 @@ void HierarchicalAllocatorProcess::initialize(
    initialized = true;
    paused = false;
  
@@ -106,7 +107,7 @@ index 5b32b3da2..c39685bcc 100644
    // Resources for quota'ed roles are allocated separately and prior to
    // non-quota'ed roles, hence a dedicated sorter for quota'ed roles is
    // necessary.
-@@ -313,7 +318,7 @@ void HierarchicalAllocatorProcess::removeFramework(
+@@ -315,7 +320,7 @@ void HierarchicalAllocatorProcess::removeFramework(
    CHECK(initialized);
    CHECK(frameworks.contains(frameworkId)) << frameworkId;
  
@@ -115,7 +116,7 @@ index 5b32b3da2..c39685bcc 100644
  
    foreach (const string& role, framework.roles) {
      // Might not be in 'frameworkSorters[role]' because it
-@@ -338,6 +343,12 @@ void HierarchicalAllocatorProcess::removeFramework(
+@@ -340,6 +345,12 @@ void HierarchicalAllocatorProcess::removeFramework(
      untrackFrameworkUnderRole(frameworkId, role);
    }
  
@@ -129,7 +130,7 @@ index 5b32b3da2..c39685bcc 100644
    // framework's `offerFilters` hashset yet, see comments in
    // HierarchicalAllocatorProcess::reviveOffers and
 diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
-index ff96beea3..b86b01b00 100644
+index ec4d445f5..6baf15add 100644
 --- a/src/master/allocator/mesos/hierarchical.hpp
 +++ b/src/master/allocator/mesos/hierarchical.hpp
 @@ -26,6 +26,7 @@
@@ -151,7 +152,7 @@ index ff96beea3..b86b01b00 100644
 @@ -113,7 +115,8 @@ public:
        bool filterGpuResources = true,
        const Option<DomainInfo>& domain = None(),
-       const Option<std::vector<Resources>>&
+       const Option<std::vector<mesos::internal::ResourceQuantities>>&
 -        minAllocatableResources = None());
 +        minAllocatableResources = None(),
 +      const size_t maxCompletedFrameworks = 0);
@@ -169,21 +170,21 @@ index ff96beea3..b86b01b00 100644
    {
    public:
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 7bb2062fc..8761cf0a5 100644
+index 7f11211df..05b7111e5 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -810,7 +810,8 @@ void Master::initialize()
+@@ -805,7 +805,8 @@ void Master::initialize()
        flags.fair_sharing_excluded_resource_names,
        flags.filter_gpu_resources,
        flags.domain,
--      CHECK_NOTERROR(minAllocatableResources));
-+      CHECK_NOTERROR(minAllocatableResources),
+-      minAllocatableResources);
++      minAllocatableResources,
 +      flags.max_completed_frameworks);
  
    // Parse the whitelist. Passing Allocator::updateWhitelist()
    // callback is safe because we shut down the whitelistWatcher in
 diff --git a/src/tests/allocator.hpp b/src/tests/allocator.hpp
-index 73fc06043..eef876609 100644
+index c57d2089d..91a1d577c 100644
 --- a/src/tests/allocator.hpp
 +++ b/src/tests/allocator.hpp
 @@ -45,7 +45,7 @@ namespace tests {
@@ -220,8 +221,8 @@ index 73fc06043..eef876609 100644
        const Option<std::set<std::string>>&,
        bool,
        const Option<DomainInfo>&,
--      const Option<std::vector<Resources>>&));
-+      const Option<std::vector<Resources>>&,
+-      const Option<std::vector<mesos::internal::ResourceQuantities>>&));
++      const Option<std::vector<mesos::internal::ResourceQuantities>>&,
 +      const size_t maxCompletedFrameworks));
  
    MOCK_METHOD2(recover, void(
@@ -249,7 +250,7 @@ index 5985070f8..742496ba5 100644
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
 diff --git a/src/tests/master_allocator_tests.cpp b/src/tests/master_allocator_tests.cpp
-index 9b73277cc..bece1920c 100644
+index fec69b2f7..10ed36d69 100644
 --- a/src/tests/master_allocator_tests.cpp
 +++ b/src/tests/master_allocator_tests.cpp
 @@ -164,7 +164,7 @@ TYPED_TEST(MasterAllocatorTest, SingleFramework)
@@ -342,7 +343,7 @@ index 9b73277cc..bece1920c 100644
  
    master::Flags masterFlags = this->CreateMasterFlags();
    masterFlags.allocation_interval = Milliseconds(50);
-@@ -1235,7 +1235,7 @@ TYPED_TEST(MasterAllocatorTest, Whitelist)
+@@ -1341,7 +1341,7 @@ TYPED_TEST(MasterAllocatorTest, Whitelist)
  
    TestAllocator<TypeParam> allocator;
  
@@ -351,7 +352,7 @@ index 9b73277cc..bece1920c 100644
  
    Future<Nothing> updateWhitelist1;
    EXPECT_CALL(allocator, updateWhitelist(Option<hashset<string>>(hosts)))
-@@ -1274,7 +1274,7 @@ TYPED_TEST(MasterAllocatorTest, RoleTest)
+@@ -1380,7 +1380,7 @@ TYPED_TEST(MasterAllocatorTest, RoleTest)
  {
    TestAllocator<TypeParam> allocator;
  
@@ -360,7 +361,7 @@ index 9b73277cc..bece1920c 100644
  
    master::Flags masterFlags = this->CreateMasterFlags();
    masterFlags.roles = Some("role2");
-@@ -1369,7 +1369,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
+@@ -1475,7 +1475,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
    {
      TestAllocator<TypeParam> allocator;
  
@@ -369,7 +370,7 @@ index 9b73277cc..bece1920c 100644
  
      Try<Owned<cluster::Master>> master = this->StartMaster(
          &allocator, masterFlags);
-@@ -1427,7 +1427,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
+@@ -1533,7 +1533,7 @@ TYPED_TEST(MasterAllocatorTest, FrameworkReregistersFirst)
    {
      TestAllocator<TypeParam> allocator2;
  
@@ -378,7 +379,7 @@ index 9b73277cc..bece1920c 100644
  
      Future<Nothing> addFramework;
      EXPECT_CALL(allocator2, addFramework(_, _, _, _, _))
-@@ -1495,7 +1495,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
+@@ -1601,7 +1601,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
    {
      TestAllocator<TypeParam> allocator;
  
@@ -387,7 +388,7 @@ index 9b73277cc..bece1920c 100644
  
      Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
      ASSERT_SOME(master);
-@@ -1551,7 +1551,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
+@@ -1657,7 +1657,7 @@ TYPED_TEST(MasterAllocatorTest, SlaveReregistersFirst)
    {
      TestAllocator<TypeParam> allocator2;
  
@@ -396,7 +397,7 @@ index 9b73277cc..bece1920c 100644
  
      Future<Nothing> addSlave;
      EXPECT_CALL(allocator2, addSlave(_, _, _, _, _, _))
-@@ -1618,7 +1618,7 @@ TYPED_TEST(MasterAllocatorTest, RebalancedForUpdatedWeights)
+@@ -1724,7 +1724,7 @@ TYPED_TEST(MasterAllocatorTest, RebalancedForUpdatedWeights)
  
    TestAllocator<TypeParam> allocator;
  
@@ -405,7 +406,7 @@ index 9b73277cc..bece1920c 100644
  
    // Start Mesos master.
    master::Flags masterFlags = this->CreateMasterFlags();
-@@ -1811,7 +1811,7 @@ TYPED_TEST(MasterAllocatorTest, NestedRoles)
+@@ -1917,7 +1917,7 @@ TYPED_TEST(MasterAllocatorTest, NestedRoles)
  
    TestAllocator<TypeParam> allocator;
  
@@ -553,10 +554,10 @@ index 6b1e494aa..b0492af7c 100644
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
 diff --git a/src/tests/slave_recovery_tests.cpp b/src/tests/slave_recovery_tests.cpp
-index 60efba54b..036b96c65 100644
+index d012d396a..348ad492f 100644
 --- a/src/tests/slave_recovery_tests.cpp
 +++ b/src/tests/slave_recovery_tests.cpp
-@@ -3707,7 +3707,7 @@ TYPED_TEST(SlaveRecoveryTest, ReconcileTasksMissingFromSlave)
+@@ -3704,7 +3704,7 @@ TYPED_TEST(SlaveRecoveryTest, ReconcileTasksMissingFromSlave)
  {
    TestAllocator<master::allocator::HierarchicalDRFAllocator> allocator;
  
@@ -566,5 +567,5 @@ index 60efba54b..036b96c65 100644
    Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
    ASSERT_SOME(master);
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
+++ b/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
@@ -1,20 +1,20 @@
-From 3a4d8a406830260ed29b763053e82de58f5e533f Mon Sep 17 00:00:00 2001
+From 1304a0d3b5d18c9a5590b0cf0003e8e251982d9e Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:59:04 -0700
 Subject: [PATCH] Added per-framework metrics for suppressed roles.
 
 Review: https://reviews.apache.org/r/66870/
 ---
- src/master/allocator/mesos/hierarchical.cpp | 17 ++++++
- src/master/allocator/mesos/metrics.cpp      | 66 ++++++++++++++++++++-
- src/master/allocator/mesos/metrics.hpp      | 12 ++++
+ src/master/allocator/mesos/hierarchical.cpp | 17 ++++++++
+ src/master/allocator/mesos/metrics.cpp      | 66 ++++++++++++++++++++++++++++-
+ src/master/allocator/mesos/metrics.hpp      | 12 ++++++
  3 files changed, 93 insertions(+), 2 deletions(-)
 
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index c39685bcc..c77cd497f 100644
+index 2af633c5c..27fa561c8 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -283,8 +283,10 @@ void HierarchicalAllocatorProcess::addFramework(
+@@ -285,8 +285,10 @@ void HierarchicalAllocatorProcess::addFramework(
  
      if (suppressedRoles.count(role)) {
        frameworkSorters.at(role)->deactivate(frameworkId.value());
@@ -25,7 +25,7 @@ index c39685bcc..c77cd497f 100644
      }
    }
  
-@@ -452,6 +454,10 @@ void HierarchicalAllocatorProcess::updateFramework(
+@@ -454,6 +456,10 @@ void HierarchicalAllocatorProcess::updateFramework(
      return result;
    }();
  
@@ -36,7 +36,7 @@ index c39685bcc..c77cd497f 100644
    foreach (const string& role, removedRoles | newSuppressedRoles) {
      CHECK(frameworkSorters.contains(role));
      frameworkSorters.at(role)->deactivate(frameworkId.value());
-@@ -467,6 +473,8 @@ void HierarchicalAllocatorProcess::updateFramework(
+@@ -469,6 +475,8 @@ void HierarchicalAllocatorProcess::updateFramework(
      if (framework.offerFilters.contains(role)) {
        framework.offerFilters.erase(role);
      }
@@ -45,7 +45,7 @@ index c39685bcc..c77cd497f 100644
    }
  
    const set<string> addedRoles = [&]() {
-@@ -485,7 +493,13 @@ void HierarchicalAllocatorProcess::updateFramework(
+@@ -487,7 +495,13 @@ void HierarchicalAllocatorProcess::updateFramework(
      return result;
    }();
  
@@ -59,7 +59,7 @@ index c39685bcc..c77cd497f 100644
      // NOTE: It's possible that we're already tracking this framework
      // under the role because a framework can unsubscribe from a role
      // while it still has resources allocated to the role.
-@@ -750,6 +764,7 @@ void HierarchicalAllocatorProcess::removeFilters(const SlaveID& slaveId)
+@@ -752,6 +766,7 @@ void HierarchicalAllocatorProcess::removeFilters(const SlaveID& slaveId)
        if (erased) {
          frameworkSorters.at(role)->activate(id.value());
          framework.suppressedRoles.erase(role);
@@ -67,7 +67,7 @@ index c39685bcc..c77cd497f 100644
        }
      }
    }
-@@ -1314,6 +1329,7 @@ void HierarchicalAllocatorProcess::suppressOffers(
+@@ -1316,6 +1331,7 @@ void HierarchicalAllocatorProcess::suppressOffers(
  
      frameworkSorters.at(role)->deactivate(frameworkId.value());
      framework.suppressedRoles.insert(role);
@@ -75,7 +75,7 @@ index c39685bcc..c77cd497f 100644
    }
  
    LOG(INFO) << "Suppressed offers for roles " << stringify(roles)
-@@ -1342,6 +1358,7 @@ void HierarchicalAllocatorProcess::reviveOffers(
+@@ -1344,6 +1360,7 @@ void HierarchicalAllocatorProcess::reviveOffers(
  
      frameworkSorters.at(role)->activate(frameworkId.value());
      framework.suppressedRoles.erase(role);
@@ -210,5 +210,5 @@ index daac93f7e..34cc16b3a 100644
  
  } // namespace internal {
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,4 +1,4 @@
-From 99703756b4dad1d55b0649f874dce152b8f0543c Mon Sep 17 00:00:00 2001
+From f342d0d485c3cc48c187a2682264aa1828123284 Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Fri, 2 Nov 2018 16:13:01 -0700
 Subject: [PATCH] Added task health check definitions to master API responses.
@@ -101,5 +101,5 @@ index fda130727..5f3c2ae61 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
+++ b/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
@@ -1,4 +1,4 @@
-From 5e56ee627019b035e736ffa166a8473eeabdc5f0 Mon Sep 17 00:00:00 2001
+From 4554a4fca4b1280bcb0d8c2ab858cd294aba69f1 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 27 Sep 2018 15:20:01 +0200
 Subject: [PATCH] Put `TerminateEvent` at the end of the queue in the Mesos
@@ -34,5 +34,5 @@ index c04cfbc42..7ca306702 100644
  
      delete process;
 -- 
-2.17.1
+2.14.3
 

--- a/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
+++ b/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
@@ -1,4 +1,4 @@
-From dc0477937b92439f7ac2594589db8cbf08685e78 Mon Sep 17 00:00:00 2001
+From dd75a794b9cbcfcd675f5b01d5824b62ec09fa5b Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Tue, 9 Oct 2018 18:22:16 +0200
 Subject: [PATCH] Waited for TEARDOWN to be sent in v1 Java scheduler shim.
@@ -9,7 +9,7 @@ nullifies its reference to the V1Mesos library immediately after
 sending `TEARDOWN`. We want to make sure that `TEARDOWN` is sent
 before the Mesos library is destructed.
 ---
- .../org_apache_mesos_v1_scheduler_V1Mesos.cpp   | 17 +++++++++++++++++
+ src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
@@ -48,5 +48,5 @@ index 2a5fbd79a..6ec771111 100644
  
  
 -- 
-2.17.1
+2.14.3
 


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/6fd91063da7230c2a65bea11ca4c69f241ba0877...5f6225bd6e039c633b7758f02d2b5fbabc8e0169
    https://github.com/dcos/dcos-mesos-modules/compare/9d5cc18a2065864350c23ad56f1c4caa2ae308c5...f1a0c5870e6744c79714e16e4adfee1010ebf78f
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
