### PR TITLE
[1.11] Backport adamdangoor/test-utils-diagnostics

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -7,12 +7,8 @@ import pytest
 import requests
 
 from dcos_test_utils import logger
-from test_dcos_diagnostics import (
-    _get_bundle_list,
-    check_json,
-    wait_for_diagnostics_job,
-    wait_for_diagnostics_list
-)
+from dcos_test_utils.diagnostics import Diagnostics
+
 logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 log = logging.getLogger(__name__)
 
@@ -133,29 +129,34 @@ def _dump_diagnostics(request, dcos_api_session):
 
     make_diagnostics_report = os.environ.get('DIAGNOSTICS_DIRECTORY') is not None
     if make_diagnostics_report:
-        log.info('Create diagnostics report for all nodes')
-        check_json(dcos_api_session.health.post('/report/diagnostics/create', json={"nodes": ["all"]}))
-
         last_datapoint = {
             'time': None,
             'value': 0
         }
 
+        health_url = dcos_api_session.default_url.copy(
+            query='cache=0',
+            path='system/health/v1',
+        )
+
+        diagnostics = Diagnostics(
+            default_url=health_url,
+            masters=dcos_api_session.masters,
+            all_slaves=dcos_api_session.all_slaves,
+            session=dcos_api_session.copy().session,
+        )
+
+        log.info('Create diagnostics report for all nodes')
+        diagnostics.start_diagnostics_job()
+
         log.info('\nWait for diagnostics job to complete')
-        wait_for_diagnostics_job(dcos_api_session, last_datapoint)
+        diagnostics.wait_for_diagnostics_job(last_datapoint=last_datapoint)
 
         log.info('\nWait for diagnostics report to become available')
-        wait_for_diagnostics_list(dcos_api_session)
+        diagnostics.wait_for_diagnostics_reports()
 
         log.info('\nDownload zipped diagnostics reports')
-        bundles = _get_bundle_list(dcos_api_session)
-        for bundle in bundles:
-            for master_node in dcos_api_session.masters:
-                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
-                                                node=master_node)
-                bundle_path = os.path.join(os.path.expanduser('~'), bundle)
-                with open(bundle_path, 'wb') as f:
-                    for chunk in r.iter_content(1024):
-                        f.write(chunk)
+        bundles = diagnostics.get_diagnostics_reports()
+        diagnostics.download_diagnostics_reports(diagnostics_bundles=bundles)
     else:
         log.info('\nNot downloading diagnostics bundle for this session.')

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -400,7 +400,6 @@ def _delete_bundle(dcos_api_session, bundle):
     )
 
     bundles = diagnostics.get_diagnostics_reports()
-    assert bundles, 'no bundles found'
 
     dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -388,14 +388,6 @@ def _create_bundle(dcos_api_session):
 
 
 def _delete_bundle(dcos_api_session, bundle):
-<<<<<<< HEAD
-    bundles = _get_bundle_list(dcos_api_session)
-    assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
-
-    dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
-
-    bundles = _get_bundle_list(dcos_api_session)
-=======
     health_url = dcos_api_session.default_url.copy(
         query='cache=0',
         path='system/health/v1',
@@ -408,12 +400,11 @@ def _delete_bundle(dcos_api_session, bundle):
     )
 
     bundles = diagnostics.get_diagnostics_reports()
-    assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
+    assert bundles, 'no bundles found'
 
     dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 
     bundles = diagnostics.get_diagnostics_reports()
->>>>>>> a8e31664... Use helpers from DC/OS Test Utils for creating and managing diagnostics bundles
     assert bundle not in bundles, 'found {} in {}'.format(bundle, bundles)
 
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -400,6 +400,7 @@ def _delete_bundle(dcos_api_session, bundle):
     )
 
     bundles = diagnostics.get_diagnostics_reports()
+    assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
 
     dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -88,7 +88,7 @@ def delete_ec2_volume(name, timeout=600):
         try:
             log.info("Issuing volume.delete()")
             volume.delete()  # Raises ClientError (VolumeInUse) if the volume is still attached.
-        except exceptions.ClientError as exc:
+        except exceptions.ClientError:
             log.exception("volume.delete() failed.")
             raise
 


### PR DESCRIPTION
This is a backport of https://github.com/dcos/dcos/pull/4148

See original description below:

```
## High-level description

There are multiple benefits to merging this pair of PRs (this PR + the DC/OS Enterprise change).

The driver for this is to progress towards making it possible to use `pytest` to collect and later run integration tests from a computer which is not a DC/OS cluster, such as a developer's laptop.
That will allow us to complete [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) but will also allow for greater developer productivity.
This PR alone does not achieve that, but it helps, as someone with a checkout of the DC/OS Enterprise repository will not necessarily be able to import open source tests.

I also consider this to be a clean up of some technical debt - this removes:

* Imports from test files - all common helpers should go in a common helpers file, or in DC/OS Test Utils
* Imports of private functions
* Duplication of code between DC/OS and DC/OS Test Utils - this is about to be a problem as these two code bases diverge in https://github.com/dcos/dcos/pull/3952/files

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster.

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a test-only change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a test-only change
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
```