### PR TITLE
[1.10] Backport adamdangoor/test-utils-diagnostics

### DIFF
--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -3,8 +3,8 @@ DcosApiSession object that will be injected into the pytest 'dcos_api_session' f
 via the make_session_fixture() method
 """
 
-from dcos_test_utils import dcos_api, helpers
-from test_helpers import get_expanded_config
+from dcos_test_utils import dcos_api
+from test_helpers import expanded_config
 
 
 def make_session_fixture():
@@ -16,7 +16,6 @@ def make_session_fixture():
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 
     dcos_api_session = dcos_api.DcosApiSession(
-        auth_user=dcos_api.DcosUser(helpers.CI_CREDENTIALS),
         exhibitor_admin_password=exhibitor_admin_password,
         **args)
     dcos_api_session.wait_for_dcos()

--- a/packages/dcos-integration-test/extra/api_session_fixture.py
+++ b/packages/dcos-integration-test/extra/api_session_fixture.py
@@ -4,7 +4,7 @@ via the make_session_fixture() method
 """
 
 from dcos_test_utils import dcos_api
-from test_helpers import expanded_config
+from test_helpers import get_expanded_config
 
 
 def make_session_fixture():

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -4,7 +4,6 @@ import os
 import api_session_fixture
 import pytest
 from dcos_test_utils import logger
-from dcos_test_utils.diagnostics import Diagnostics
 
 logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -4,6 +4,7 @@ import os
 import api_session_fixture
 import pytest
 from dcos_test_utils import logger
+from dcos_test_utils.diagnostics import Diagnostics
 
 logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -16,18 +16,6 @@ from dcos_test_utils.helpers import check_json
 LATENCY = 120
 
 
-def check_json(response):
-    response.raise_for_status()
-    try:
-        json_response = response.json()
-        logging.debug('Response: {}'.format(json_response))
-    except ValueError:
-        logging.exception('Could not deserialize response contents:{}'.format(response.content.decode()))
-        raise
-    assert len(json_response) > 0, 'Empty JSON returned from dcos-diagnostics request'
-    return json_response
-
-
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_health(dcos_api_session):
     """

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -104,7 +104,7 @@ def test_dcos_diagnostics_nodes(dcos_api_session):
     test a list of nodes with statuses endpoint /system/health/v1/nodes
     """
     for master in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('nodes', node=master))
+        response = check_json(dcos_api_session.health.get('/nodes', node=master))
         assert len(response) == 1, 'nodes response must have only one field: nodes'
         assert 'nodes' in response
         assert isinstance(response['nodes'], list)
@@ -235,7 +235,7 @@ def test_systemd_units_health(dcos_api_session):
     """
     unhealthy_output = []
     assert dcos_api_session.masters, "Must have at least 1 master node"
-    report_response = check_json(dcos_api_session.health.get('report', node=dcos_api_session.masters[0]))
+    report_response = check_json(dcos_api_session.health.get('/report', node=dcos_api_session.masters[0]))
     assert 'Units' in report_response, "Missing `Units` field in response"
     for unit_name, unit_props in report_response['Units'].items():
         assert 'Health' in unit_props, "Unit {} missing `Health` field".format(unit_name)
@@ -377,7 +377,7 @@ def test_dcos_diagnostics_report(dcos_api_session):
     test dcos-diagnostics report endpoint /system/health/v1/report
     """
     for master in dcos_api_session.masters:
-        report_response = check_json(dcos_api_session.health.get('report', node=master))
+        report_response = check_json(dcos_api_session.health.get('/report', node=master))
         assert 'Units' in report_response
         assert len(report_response['Units']) > 0
 
@@ -527,7 +527,7 @@ def _download_bundle_from_master(dcos_api_session, master_index):
         for bundle in bundles:
             bundle_full_location = os.path.join(tmp_dir, bundle)
             with open(bundle_full_location, 'wb') as f:
-                r = dcos_api_session.health.get(os.path.join('report/diagnostics/serve', bundle), stream=True,
+                r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
                                                 node=dcos_api_session.masters[master_index])
 
                 for chunk in r.iter_content(1024):
@@ -608,7 +608,7 @@ def test_bundle_delete(dcos_api_session):
     bundles = diagnostics.get_diagnostics_reports()
     assert bundles, 'no bundles found'
     for bundle in bundles:
-        dcos_api_session.health.post(os.path.join('report/diagnostics/delete', bundle))
+        dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
 
     bundles = diagnostics.get_diagnostics_reports()
     assert len(bundles) == 0, 'Could not remove bundles {}'.format(bundles)
@@ -616,7 +616,7 @@ def test_bundle_delete(dcos_api_session):
 
 def test_diagnostics_bundle_status(dcos_api_session):
     # validate diagnostics job status response
-    diagnostics_bundle_status = check_json(dcos_api_session.health.get('report/diagnostics/status/all'))
+    diagnostics_bundle_status = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
     required_status_fields = ['is_running', 'status', 'errors', 'last_bundle_dir', 'job_started', 'job_ended',
                               'job_duration', 'diagnostics_bundle_dir', 'diagnostics_job_timeout_min',
                               'journald_logs_since_hours', 'diagnostics_job_get_since_url_timeout_min',

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -47,7 +47,7 @@ def check_response_ok(response: requests.models.Response, headers: dict):
 
 def test_log_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=10', node=node)
+        response = dcos_api_session.logs.get('/v1/range/?limit=10', node=node)
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 entries
@@ -58,21 +58,21 @@ def test_log_text(dcos_api_session):
 
 def test_log_json(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
         check_response_ok(response, {'Content-Type': 'application/json'})
         validate_json_entry(response.json())
 
 
 def test_log_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
+        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         validate_sse_entry(response.text)
 
 
 def test_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('v1/stream/?skip_prev=1', node=node, stream=True,
+        response = dcos_api_session.logs.get('/v1/stream/?skip_prev=1', node=node, stream=True,
                                              headers={'Accept': 'text/event-stream'})
         check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
         lines = response.iter_lines()

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -8,20 +8,20 @@ def test_metrics_agents_ping(dcos_api_session):
     """ Test that the metrics service is up on masters.
     """
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
         'agent.'
 
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('ping', node=agent)
+        response = dcos_api_session.metrics.get('/ping', node=agent)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
 def test_metrics_masters_ping(dcos_api_session):
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('ping', node=master)
+        response = dcos_api_session.metrics.get('/ping', node=master)
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
@@ -65,7 +65,7 @@ def test_metrics_node(dcos_api_session):
 
     # private agents
     for agent in dcos_api_session.slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -74,7 +74,7 @@ def test_metrics_node(dcos_api_session):
 
     # public agents
     for agent in dcos_api_session.public_slaves:
-        response = dcos_api_session.metrics.get('node', node=agent)
+        response = dcos_api_session.metrics.get('/node', node=agent)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -83,7 +83,7 @@ def test_metrics_node(dcos_api_session):
 
     # masters
     for master in dcos_api_session.masters:
-        response = dcos_api_session.metrics.get('node', node=master)
+        response = dcos_api_session.metrics.get('/node', node=master)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
             response.status_code, response.content)
@@ -119,16 +119,16 @@ def test_metrics_containers(dcos_api_session):
             # state every 2 minutes to propogate containers to the API
             @retrying.retry(wait_fixed=2000, stop_max_delay=150000)
             def wait_for_container_propogation():
-                response = dcos_api_session.metrics.get('containers', node=agent.host)
+                response = dcos_api_session.metrics.get('/containers', node=agent.host)
                 assert response.status_code == 200
                 assert len(response.json()) > 0, 'must have at least 1 container'
 
             wait_for_container_propogation()
 
-            response = dcos_api_session.metrics.get('containers', node=agent.host)
+            response = dcos_api_session.metrics.get('/containers', node=agent.host)
             for c in response.json():
                 # Test that /containers/<id> responds with expected data
-                container_id_path = 'containers/{}'.format(c)
+                container_id_path = '/containers/{}'.format(c)
                 container_response = dcos_api_session.metrics.get(container_id_path, node=agent.host)
 
                 # /containers/<container_id> should always respond succesfully
@@ -160,7 +160,7 @@ def test_metrics_containers(dcos_api_session):
                 # looking for "statsd-emitter.<some_uuid>"
                 if 'statsd-emitter' in container_response.json()['dimensions']['executor_id'].split('.'):
                     # Test that /app response is responding with expected data
-                    app_response = dcos_api_session.metrics.get('containers/{}/app'.format(c), node=agent.host)
+                    app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(c), node=agent.host)
                     assert app_response.status_code == 200
                     'got {}'.format(app_response.status_code)
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -48,14 +48,14 @@ class MarathonApp:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/apps', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/apps', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/apps/{}'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/apps/{}'.format(self.id))
         r.raise_for_status()
         self._info = r.json()
         return self._info['app']['tasksHealthy'] == self.app['instances']
@@ -63,8 +63,8 @@ class MarathonApp:
     def info(self, dcos_api_session):
         try:
             if self._info['app']['tasksHealthy'] != self.app['instances']:
-                raise
-        except:
+                raise Exception("Number of Healthy Tasks not equal to number of instances.")
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -81,7 +81,7 @@ class MarathonApp:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/apps/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/apps/{}'.format(self.id))
 
 
 class MarathonPod:
@@ -134,14 +134,14 @@ class MarathonPod:
         return str(self.app)
 
     def deploy(self, dcos_api_session):
-        return dcos_api_session.marathon.post('v2/pods', json=self.app).raise_for_status()
+        return dcos_api_session.marathon.post('/v2/pods', json=self.app).raise_for_status()
 
     @retrying.retry(
         wait_fixed=5000,
         stop_max_delay=20 * 60 * 1000,
         retry_on_result=lambda res: res is False)
     def wait(self, dcos_api_session):
-        r = dcos_api_session.marathon.get('v2/pods/{}::status'.format(self.id))
+        r = dcos_api_session.marathon.get('/v2/pods/{}::status'.format(self.id))
         r.raise_for_status()
         self._info = r.json()
         return self._info['status'] == 'STABLE'
@@ -149,8 +149,8 @@ class MarathonPod:
     def info(self, dcos_api_session):
         try:
             if self._info['status'] != 'STABLE':
-                raise
-        except:
+                raise Exception("The status information is not Stable!")
+        except Exception:
             self.wait(dcos_api_session)
         return self._info
 
@@ -165,7 +165,7 @@ class MarathonPod:
         return host, port
 
     def purge(self, dcos_api_session):
-        return dcos_api_session.marathon.delete('v2/pods/{}'.format(self.id))
+        return dcos_api_session.marathon.delete('/v2/pods/{}'.format(self.id))
 
 
 def unused_port():
@@ -308,7 +308,7 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
                 retry_on_exception=lambda x: True)
 def test_if_overlay_ok(dcos_api_session):
     def _check_overlay(hostname, port):
-        overlays = dcos_api_session.get('overlay-agent/overlay', host=hostname, port=port).json()['overlays']
+        overlays = dcos_api_session.get('/overlay-agent/overlay', host=hostname, port=port).json()['overlays']
         assert len(overlays) > 0
         for overlay in overlays:
             assert overlay['state']['status'] == 'STATUS_OK'

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -47,8 +47,8 @@ def test_pkgpanda_api(dcos_api_session):
                 assert package == buildinfo_package
 
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        package_ids = get_and_validate_package_ids('pkgpanda/repository/', node)
-        active_package_ids = get_and_validate_package_ids('pkgpanda/active/', node)
+        package_ids = get_and_validate_package_ids('/pkgpanda/repository/', node)
+        active_package_ids = get_and_validate_package_ids('/pkgpanda/active/', node)
 
         assert set(active_package_ids) <= set(package_ids)
         assert_packages_match_active_buildinfo(active_package_ids)
@@ -70,7 +70,7 @@ NGINX_PACKAGE_REQUIREMENTS = {
 def _get_cluster_resources(dcos_api_session):
     """Return the mesos state summary
     """
-    r = dcos_api_session.get('mesos/state-summary')
+    r = dcos_api_session.get('/mesos/state-summary')
     return r.json()
 
 

--- a/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
+++ b/packages/dcos-integration-test/extra/util/delete_ec2_volume.py
@@ -88,7 +88,7 @@ def delete_ec2_volume(name, timeout=600):
         try:
             log.info("Issuing volume.delete()")
             volume.delete()  # Raises ClientError (VolumeInUse) if the volume is still attached.
-        except exceptions.ClientError as exc:
+        except exceptions.ClientError:
             log.exception("volume.delete() failed.")
             raise
 

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "caf020d4c247bd0286fdfee8f361b7569dd92947",
+    "ref": "c1608590e010ca08c418f8bd9d9ebd764d511d57",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
This is a backport of https://github.com/dcos/dcos/pull/4148

See original description below.

However, this change also required a backport of a DC/OS Test Utils bump.
I pulled this in from #3789.

```
## High-level description

There are multiple benefits to merging this pair of PRs (this PR + the DC/OS Enterprise change).

The driver for this is to progress towards making it possible to use `pytest` to collect and later run integration tests from a computer which is not a DC/OS cluster, such as a developer's laptop.
That will allow us to complete [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) but will also allow for greater developer productivity.
This PR alone does not achieve that, but it helps, as someone with a checkout of the DC/OS Enterprise repository will not necessarily be able to import open source tests.

I also consider this to be a clean up of some technical debt - this removes:

* Imports from test files - all common helpers should go in a common helpers file, or in DC/OS Test Utils
* Imports of private functions
* Duplication of code between DC/OS and DC/OS Test Utils - this is about to be a problem as these two code bases diverge in https://github.com/dcos/dcos/pull/3952/files

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster.

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a test-only change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a test-only change
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
```