### PR TITLE
Add AR routing logic support for ip-per-container feature

### DIFF
--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.html
@@ -479,9 +479,33 @@
         <label class="heading"><span class="route-type toggle-route-type">File</span> <span class="route-desc">retrieves static files.</span> </label>
         </input>
       </li>
+      <li class="route route-type-unknown">
+        <input type="checkbox" data-type="unknown" checked="checked">
+        <label class="heading"><span class="route-type toggle-route-type">Unknown</span> <span class="route-desc">unrecognized routing mechanism.</span> </label>
+        </input>
+      </li>
     </ul>
   </div>
   <ul class="resources">
+    <li id="resource-other" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="other" href="#other" aria-hidden="true" class="toggle-route-group" data-id="other">
+            <div class="arrow arrow-right"></div>Other</a>
+        </h2>
+        <span class="options"><a href="#other" class="toggle-route-group" data-id="other">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-other" class="routes">
+        <li class="route route-type-unknown">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Unknown</span>
+              <span class="route-path"><code>/</code></span>
+            </h3>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-metadata" class="resource">
       <div class="heading">
         <h2>

--- a/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.agent.yaml
@@ -17,6 +17,10 @@ backends:
     name: DC/OS Component Package Manager (Pkgpanda)
     reference: 'https://dcos.io/docs/1.10/administering-clusters/component-management/'
 routes:
+  /:
+    group: Other
+    matcher: path
+    path: /
   /dcos-metadata/dcos-version.json:
     group: Metadata
     matcher: path

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -934,6 +934,53 @@
         </li>
       </ul>
     </li>
+    <li id="resource-dcos-net" class="resource">
+      <div class="heading">
+        <h2>
+          <a id="dcos-net" href="#dcos-net" aria-hidden="true" class="toggle-route-group" data-id="dcos-net">
+            <div class="arrow arrow-right"></div>DC/OS Net</a>
+        </h2>
+        <span class="options"><a href="#dcos-net" class="toggle-route-group" data-id="dcos-net">Show/Hide</a> </span>
+      </div>
+      <ul id="routes-dcos-net" class="routes">
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/navstar/lashup/key</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend/lashup/key</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>127.0.0.1:62080</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Net
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
+      </ul>
+    </li>
     <li id="resource-exhibitor" class="resource">
       <div class="heading">
         <h2>
@@ -1100,7 +1147,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>$historyservice_upstream</code>
+                  <code>$leader_host</code>
                 </td>
               </tr>
             </table>
@@ -1492,53 +1539,6 @@
         </li>
       </ul>
     </li>
-    <li id="resource-dcos-net" class="resource">
-      <div class="heading">
-        <h2>
-          <a id="dcos-net" href="#dcos-net" aria-hidden="true" class="toggle-route-group" data-id="dcos-net">
-            <div class="arrow arrow-right"></div>DC/OS Net</a>
-        </h2>
-        <span class="options"><a href="#dcos-net" class="toggle-route-group" data-id="dcos-net">Show/Hide</a> </span>
-      </div>
-      <ul id="routes-dcos-net" class="routes">
-        <li class="route route-type-proxy">
-          <div class="heading">
-            <h3>
-              <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/navstar/lashup/key</code></span>
-            </h3>
-          </div>
-          <div class="route-meta" style="display:none">
-            <table>
-              <tr>
-                <td>
-                  Path:
-                </td>
-                <td>
-                  <code>http://$backend/lashup/key</code>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Server:
-                </td>
-                <td>
-                  <code>127.0.0.1:62080</code>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Backend:
-                </td>
-                <td>
-                  DC/OS Net
-                </td>
-              </tr>
-            </table>
-          </div>
-        </li>
-      </ul>
-    </li>
     <li id="resource-other" class="resource">
       <div class="heading">
         <h2>
@@ -1900,7 +1900,7 @@
                   Path:
                 </td>
                 <td>
-                  <code>$mleader_host/system/v1$url$is_args$query_string</code>
+                  <code>$leader_host/system/v1$url$is_args$query_string</code>
                 </td>
               </tr>
             </table>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -115,6 +115,13 @@ routes:
         replacement: /$1
         type: break
     path: /cosmos/service/
+  /navstar/lashup/key:
+    group: DC/OS Net
+    matcher: path
+    proxy:
+      path: 'http://$backend/lashup/key'
+      backend: dcos_net
+    path: /navstar/lashup/key
   /exhibitor:
     group: Exhibitor
     matcher: exact
@@ -149,7 +156,7 @@ routes:
     group: History
     matcher: path
     proxy:
-      path: $historyservice_upstream
+      path: $leader_host
     path: /dcos-history-service/
   /marathon:
     group: Marathon
@@ -245,13 +252,6 @@ routes:
     lua:
       file: conf/lib/metadata.lua
     path: /metadata
-  /navstar/lashup/key:
-    group: DC/OS Net
-    matcher: path
-    proxy:
-      path: 'http://$backend/lashup/key'
-      backend: dcos_net
-    path: /navstar/lashup/key
   /internal/mesos_dns/:
     group: Other
     matcher: path
@@ -325,7 +325,7 @@ routes:
     matcher: regex
     description: System proxy to the master node with the Marathon leader
     proxy:
-      path: $mleader_host/system/v1$url$is_args$query_string
+      path: $leader_host/system/v1$url$is_args$query_string
     path: /system/v1/leader/marathon(?<url>.*)
   /system/v1/leader/mesos(?<url>.*):
     group: System

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -136,13 +136,10 @@ local function request(url, accept_404_reply, auth_token)
     return res, nil
 end
 
-local function is_ip_per_task(app)
-    return app["ipAddress"] ~= nil and app["ipAddress"] ~= cjson_safe.null
-end
-
-local function is_user_network(app)
+local function is_container_network(app)
     local container = app["container"]
-    return container and container["type"] == "DOCKER" and container["docker"]["network"] == "USER"
+    local network = app["networks"][1]
+    return container and network and (network["mode"] == "container")
 end
 
 local function fetch_and_store_marathon_apps(auth_token)
@@ -220,8 +217,8 @@ local function fetch_and_store_marathon_apps(auth_token)
           )
 
        local host_or_ip = task["host"] --take host  by default
-       if is_ip_per_task(app) then
-          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is using ip-per-task")
+       if is_container_network(app) then
+          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is in a container network")
           -- override with the ip of the task
           local task_ip_addresses = task["ipAddresses"]
           if task_ip_addresses then
@@ -238,23 +235,26 @@ local function fetch_and_store_marathon_apps(auth_token)
        end
 
        local ports = task["ports"] --task host port mapping by default
-       if is_ip_per_task(app) then
+       -- task["ports"] will contain the host ports made available to the task:
+       -- see https://mesosphere.github.io/marathon/docs/ports.html#definitions,
+       -- note on the hostPort definitions.
+       -- AR, however, needs the container port to route the request to.
+       -- In "container" mode we find the container port out from portMappings array
+       -- for the case when container port is fixed (non-zero value specified).
+       -- When container port is specified as 0 it will be randomly assigned
+       -- by Marathon and the actual container port will be the same as the host port:
+       -- https://mesosphere.github.io/marathon/docs/ports.html#random-port-assignment
+       -- We do not override it with container port from the portMappings array
+       -- in that case.
+       -- In "container/bridge" and "host" networking modes we need to use the
+       -- host port for routing (available via task's ports array)
+       if is_container_network(app) and app["container"]["portMappings"][portIdx]["containerPort"] ~= 0 then
          ports = {}
-         if is_user_network(app) then
-            -- override with ports from the container's portMappings
-            local port_mappings = app["container"]["docker"]["portMappings"] or app["portDefinitions"] or {}
-            local port_attr = app["container"]["docker"]["portMappings"] and "containerPort" or "port"
-            for _, port_mapping in ipairs(port_mappings) do
-               table.insert(ports, port_mapping[port_attr])
-            end
-         else
-            --override with the discovery ports
-            local discovery_ports = app["ipAddress"]["discovery"]["ports"]
-            for _, discovery_port in ipairs(discovery_ports) do
-                table.insert(ports, discovery_port["number"])
-            end
-         end
-       end
+         local port_mappings = app["container"]["portMappings"] or {}
+          for _, port_mapping in ipairs(port_mappings) do
+             table.insert(ports, port_mapping["containerPort"])
+          end
+        end
 
        if not ports then
           ngx.log(ngx.NOTICE, "Cannot find ports for app '" .. appId .. "'")
@@ -267,8 +267,37 @@ local function fetch_and_store_marathon_apps(auth_token)
           goto continue
        end
 
+       local do_rewrite_req_url = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
+       if do_rewrite_req_url == false or do_rewrite_req_url == 'false' then
+          ngx.log(ngx.INFO, "DCOS_SERVICE_REWRITE_REQUEST_URLS for app '" .. appId .. "' set to 'false'")
+          do_rewrite_req_url = false
+       else
+          -- Treat everything else as true, i.e.:
+          -- * label is absent
+          -- * label is set to "true" (string) or true (bool)
+          -- * label is set to some random string
+          do_rewrite_req_url = true
+       end
+
+       local do_request_buffering = labels["DCOS_SERVICE_REQUEST_BUFFERING"]
+       if do_request_buffering == false or do_request_buffering == 'false' then
+          ngx.log(ngx.INFO, "DCOS_SERVICE_REQUEST_BUFFERING for app '" .. appId .. "' set to 'false'")
+          do_request_buffering = false
+       else
+          -- Treat everything else as true, i.e.:
+          -- * label is absent
+          -- * label is set to "true" (string) or true (bool)
+          -- * label is set to some random string
+          do_request_buffering = true
+       end
+
        local url = scheme .. "://" .. host_or_ip .. ":" .. port
-       svcApps[svcId] = {scheme=scheme, url=url}
+       svcApps[svcId] = {
+         scheme=scheme,
+         url=url,
+         do_rewrite_req_url=do_rewrite_req_url,
+         do_request_buffering=do_request_buffering,
+       }
 
        ::continue::
     end

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -265,6 +265,8 @@ local function fetch_and_store_marathon_apps(auth_token)
           goto continue
        end
 
+       -- Details on how Admin Router interprets DCOS_SERVICE_REWRITE_REQUEST_URLS label:
+       -- https://github.com/dcos/dcos/blob/master/packages/adminrouter/extra/src/README.md#disabling-url-path-rewriting-for-selected-applications
        local do_rewrite_req_url = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
        if do_rewrite_req_url == false or do_rewrite_req_url == 'false' then
           ngx.log(ngx.INFO, "DCOS_SERVICE_REWRITE_REQUEST_URLS for app '" .. appId .. "' set to 'false'")
@@ -277,6 +279,8 @@ local function fetch_and_store_marathon_apps(auth_token)
           do_rewrite_req_url = true
        end
 
+       -- Details on how Admin Router interprets DCOS_SERVICE_REQUEST_BUFFERING label:
+       -- https://github.com/dcos/dcos/blob/master/packages/adminrouter/extra/src/README.md#disabling-request-buffering-for-selected-applications
        local do_request_buffering = labels["DCOS_SERVICE_REQUEST_BUFFERING"]
        if do_request_buffering == false or do_request_buffering == 'false' then
           ngx.log(ngx.INFO, "DCOS_SERVICE_REQUEST_BUFFERING for app '" .. appId .. "' set to 'false'")

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
@@ -50,28 +50,30 @@ SCHEDULER_APP_TEMPLATE = {
         "volumes": [],
         "docker": {
             "image": "bitnami/nginx:1.10.2-r0",
-            "network": "BRIDGE",
-            "portMappings": [
-                {
-                    "containerPort": 80,
-                    "hostPort": 0,
-                    "servicePort": 10000,
-                    "protocol": "tcp",
-                    "labels": {}
-                },
-                {
-                    "containerPort": 443,
-                    "hostPort": 0,
-                    "servicePort": 10001,
-                    "protocol": "tcp",
-                    "labels": {}
-                }
-            ],
             "privileged": False,
             "parameters": [],
             "forcePullImage": False
-        }
+        },
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                "servicePort": 10000,
+                "protocol": "tcp",
+                "labels": {}
+            },
+            {
+                "containerPort": 443,
+                "hostPort": 0,
+                "servicePort": 10001,
+                "protocol": "tcp",
+                "labels": {}
+            }
+        ],
     },
+    "networks": [
+        {}
+    ],
     "healthChecks": [
         {
             "gracePeriodSeconds": 300,

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -949,7 +949,7 @@ class TestCacheMesosLeader:
 
 class TestCacheMarathon:
     @pytest.mark.parametrize('host_port', [12345, 0, None])
-    def test_app_with_container_networking_and_fixed_container_port(
+    def test_app_with_container_networking_and_defined_container_port(
             self, nginx_class, mocker, valid_user_header, host_port):
         # Testing the case when a non-zero container port is specified
         # in Marathon app definition with networking mode 'container'.
@@ -990,10 +990,8 @@ class TestCacheMarathon:
         # Testing the case when container port is specified as 0
         # in Marathon app definition with networking mode 'container'.
         # This means that the Marathon app container port is randomly assigned
-        # by Marathon. The chosen container port number is same as hostPort
-        # and is available through task["ports"] array. We are reusing port
-        # 16000 on 127.0.0.1 exposed by the mock server, as the one randomly
-        # chosen by Marathon.
+        # by Marathon. We are reusing port 16000 on 127.0.0.1 exposed by the
+        # mock server, as the one randomly chosen by Marathon.
         # It does not matter if the host port is fixed (non-zero),
         # randomly assigned by Marathon (0) or is not present at all:
         # Admin Router must route the request to the specified container port.

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -1186,19 +1186,6 @@ class TestCacheMarathon:
         self._assert_filter_regexp_for_invalid_app(
             filter_regexp, app, nginx_class, mocker, valid_user_header)
 
-    def test_app_without_task_ports(
-            self, nginx_class, mocker, valid_user_header):
-        app = self._scheduler_alwaysthere_app()
-        app["tasks"][0].pop("ports", None)
-
-        filter_regexp = {
-            "Cannot find ports for app '{}'".format(app["id"]):
-                SearchCriteria(1, True),
-        }
-
-        self._assert_filter_regexp_for_invalid_app(
-            filter_regexp, app, nginx_class, mocker, valid_user_header)
-
     def test_app_without_task_specified_port_idx(
             self, nginx_class, mocker, valid_user_header):
         app = self._scheduler_alwaysthere_app()

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -948,7 +948,7 @@ class TestCacheMesosLeader:
 
 
 class TestCacheMarathon:
-    @pytest.mark.parametrize('host_port', ['12345', '0', None])
+    @pytest.mark.parametrize('host_port', [12345, 0, None])
     def test_app_with_container_networking_and_fixed_container_port(
             self, nginx_class, mocker, valid_user_header, host_port):
         # Testing the case when a non-zero container port is specified
@@ -961,7 +961,7 @@ class TestCacheMarathon:
             'mode': 'container',
             'name': 'samplenet'
         }]
-        if host_port:
+        if host_port is not None:
             app['container']['portMappings'] = [{'containerPort': 80, 'hostPort': host_port}]
         else:
             app['container']['portMappings'] = [{'containerPort': 80}]
@@ -984,7 +984,7 @@ class TestCacheMarathon:
             req_data = resp.json()
             assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
 
-    @pytest.mark.parametrize('host_port', ['12345', '0', None])
+    @pytest.mark.parametrize('host_port', [12345, 0, None])
     def test_app_with_container_networking_and_random_container_port(
             self, nginx_class, mocker, valid_user_header, host_port):
         # Testing the case when container port is specified as 0
@@ -1002,7 +1002,7 @@ class TestCacheMarathon:
             'mode': 'container',
             'name': 'samplenet'
         }]
-        if host_port:
+        if host_port is not None:
             app['container']['portMappings'] = [{'containerPort': 0, 'hostPort': host_port}]
         else:
             app['container']['portMappings'] = [{'containerPort': 0}]
@@ -1033,7 +1033,7 @@ class TestCacheMarathon:
     def test_app_with_bridge_and_host_networking(
             self, nginx_class, mocker, valid_user_header, container_port, networking_mode):
         # Testing the cases when networking mode is either 'container' or 'host'.
-        # The host port can non-zero or 0. In the latter case Marathon will
+        # The host port can be non-zero or 0. In the latter case Marathon will
         # randomly choose the host port. For simplicity in this test we are
         # reusing port 16000 on 127.0.0.1 exposed by the mock server, as both
         # the fixed (non-zero) one and the one randomly chosen by Marathon.

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -4,6 +4,7 @@ import json
 import logging
 import subprocess
 import threading
+import time
 import uuid
 from collections import deque
 
@@ -429,6 +430,65 @@ def test_ip_per_container(dcos_api_session):
         app_port = app_definition['container']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
+
+
+@pytest.mark.parametrize('host_port', [9080, 0, None])
+def test_app_with_container_mode(dcos_api_session, host_port):
+    '''Testing the case when a non-zero container port is specified
+       in Marathon app definition with networking mode 'container'.
+       It does not matter if the host port is fixed (non-zero),
+       randomly assigned by Marathon (0) or is not present at all:
+       Admin Router must route the request to the specified container port.
+    '''
+
+    app_definition, test_uuid = test_helpers.marathon_test_app(
+        healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
+        container_type=marathon.Container.DOCKER,
+        network=marathon.Network.USER,
+        host_port=host_port)
+
+    dcos_service_name = uuid.uuid4().hex
+
+    app_definition['labels'] = {
+        'DCOS_SERVICE_NAME': dcos_service_name,
+        'DCOS_SERVICE_PORT_INDEX': '0',
+        'DCOS_SERVICE_SCHEME': 'http',
+    }
+
+    #  Arbitrary buffer time, accounting for propagation/processing delay.
+    buffer_time = 5
+
+    #  Cache refresh in Adminrouter takes 30 seconds at most.
+    #  CACHE_POLL_PERIOD=25s + valid=5s Nginx resolver DNS entry TTL
+    #  https://github.com/dcos/dcos/blob/cb9105ee537cc44cbe63cc7c53b3b01b764703a0/
+    #  packages/adminrouter/extra/src/includes/http/master.conf#L21
+    adminrouter_default_refresh = 25 + 5 + buffer_time
+    app_id = app_definition['id']
+    app_instances = app_definition['instances']
+
+    # For the routing check to work, two conditions must be true:
+    #
+    # 1. The application must be deployed and healthy, so that `/ping` responds
+    #    with 200.
+    # 2. The Admin Router routing layer must not be using an outdated
+    #    version of the Nginx resolver cache.
+    #
+    # We therefore wait until these conditions have certainly been met.
+    # We wait for the Admin Router cache refresh first so that there is
+    # unlikely to be much double-waiting. That is, we do not want to be waiting
+    # for the cache to refresh when it already refreshed while we were waiting
+    # for the app to become healthy.
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition, check_health=False):
+        time.sleep(adminrouter_default_refresh)
+        dcos_api_session.marathon.wait_for_app_deployment(
+            app_id=app_id,
+            app_instances=app_instances,
+            check_health=True,
+            ignore_failed_tasks=False,
+            timeout=1200,
+        )
+        r = dcos_api_session.get('/service/' + dcos_service_name + '/ping')
+    assert r.status_code == 200
 
 
 @retrying.retry(wait_fixed=2000,

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -432,7 +432,7 @@ def test_ip_per_container(dcos_api_session):
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
 
 
-@pytest.mark.parametrize('host_port', [9080, 0, None])
+@pytest.mark.parametrize('host_port', [9080, 0])
 def test_app_with_container_mode(dcos_api_session, host_port):
     '''Testing the case when a non-zero container port is specified
        in Marathon app definition with networking mode 'container'.
@@ -464,7 +464,9 @@ def test_app_with_container_mode(dcos_api_session, host_port):
     #  packages/adminrouter/extra/src/includes/http/master.conf#L21
     adminrouter_default_refresh = 25 + 5 + buffer_time
     app_id = app_definition['id']
+
     app_instances = app_definition['instances']
+    app_definition['constraints'] = [['hostname', 'UNIQUE']]
 
     # For the routing check to work, two conditions must be true:
     #
@@ -483,7 +485,7 @@ def test_app_with_container_mode(dcos_api_session, host_port):
         dcos_api_session.marathon.wait_for_app_deployment(
             app_id=app_id,
             app_instances=app_instances,
-            check_health=True,
+            check_health=False,
             ignore_failed_tasks=False,
             timeout=1200,
         )

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -432,13 +432,13 @@ def test_ip_per_container(dcos_api_session):
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
 
 
-@pytest.mark.parametrize('host_port', [9080, 0])
-def test_app_with_container_mode(dcos_api_session, host_port):
+@pytest.mark.parametrize('host_port', [9999, 0])
+def test_app_with_container_mode_with_defined_container_port(dcos_api_session, host_port):
     '''Testing the case when a non-zero container port is specified
        in Marathon app definition with networking mode 'container'.
        It does not matter if the host port is fixed (non-zero),
-       randomly assigned by Marathon (0) or is not present at all:
-       Admin Router must route the request to the specified container port.
+       randomly assigned by Marathon (0): Admin Router must route the request
+       to the specified container port.
     '''
 
     app_definition, test_uuid = test_helpers.marathon_test_app(


### PR DESCRIPTION
## High-level description
This PR is a particular case of https://github.com/dcos/dcos/pull/3855 for DC/OS v1.11.

Due to Marathon app description syntax change https://github.com/mesosphere/marathon/blob/master/docs/docs/upgrade/network-api-migration.md#example-definitions AR is not able to expose apps requiring ip-per-container feature at /service/<app-id> endpoint. This PR fixes this issue.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS-45468

## Related tickets (optional)

Other tickets related to this change:

https://jira.mesosphere.com/browse/DCOS-45468

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ x ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**