### PR TITLE
Fix handling of 204s from metrics v0 API in metrics tests

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -670,11 +670,17 @@ def get_container_ids(dcos_api_session, node: str):
 def get_container_metrics(dcos_api_session, node: str, container_id: str):
     """Return container_id's metrics from the metrics API on node.
 
+    Returns None on 204.
+
     Retries on error, non-200 status, or missing response fields for up
     to 5 minutes.
 
     """
     response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
+
+    if response.status_code == 204:
+        return None
+
     assert response.status_code == 200
     container_metrics = response.json()
 
@@ -692,14 +698,22 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
 def get_app_metrics(dcos_api_session, node: str, container_id: str):
     """Return app metrics for container_id from the metrics API on node.
 
+    Returns None on 204.
+
     Retries on error or non-200 status for up to 5 minutes.
 
     """
     resp = dcos_api_session.metrics.get('/containers/' + container_id + '/app', node=node)
+
+    if resp.status_code == 204:
+        return None
+
     assert resp.status_code == 200, 'got {}'.format(resp.status_code)
     app_metrics = resp.json()
+
     assert 'datapoints' in app_metrics, 'got {}'.format(app_metrics)
     assert 'dimensions' in app_metrics, 'got {}'.format(app_metrics)
+
     return app_metrics
 
 


### PR DESCRIPTION
## High-level description

This changes metrics tests to be more tolerant of 204s for container metrics, which are not necessarily an error. Some tasks are not expected to provide container metrics.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4682](https://jira.mesosphere.com/browse/DCOS_OSS-4682) Metrics tests (test_metrics_containers) fail on expected 204 from v0 metrics API


## Related tickets (optional)

Other tickets related to this change:

  - N/A


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This only affects tests.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This only affects tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]