### PR TITLE
Bump dcos-test-utils

### DIFF
--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8",
+    "ref": "74a1b6d184eff18002ff576b774ff59b589a0739",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This makes sure DC/OS 1.13 integration tests use the appropriate version
of the DC/OS CLI. They currently use the DC/OS 1.12 CLI.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45807](https://jira.mesosphere.com/browse/DCOS-45807) Own end-to-end that the "correct CLI version" is used in the DC/OS integration test suite; in every branch
