### PR TITLE
[1.12] Fix missing metrics timestamp causing metrics api 204s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,9 @@
 
 * Add config option to enable/disable the Mesos input plugin in Telegraf. (DCOS_OSS-4667)
 
-### Security Updates
+* Fix CLI task metrics summary command which was occasionally failing to find metrics (DCOS_OSS-4679)
 
+### Security Updates
 
 ## DC/OS 1.12.1
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "4d195ab4ea296d9a34dfc8560f376d24cac4f4ce",
+    "ref": "b70b317578710ef5636f341f520af4f2479d46cd",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

Bumps telegraf version to include a fix that was causing the metrics api to occasionally 204 on the /containers endpoint. Curious to see if this will fix https://jira.mesosphere.com/browse/DCOS_OSS-4682 as well.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4679](https://jira.mesosphere.com/browse/DCOS_OSS-4679) Metric timestamp field not set


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-4333](https://jira.mesosphere.com/browse/COPS-4333) DC/OS 1.12; "dcos task metrics summary <task-id>" returns HTTP 204


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: upstream and existing tests should be sufficient
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/4d195ab4ea296d9a34dfc8560f376d24cac4f4ce...dcos:b70b317578710ef5636f341f520af4f2479d46cd
  - [x] Test Results: [link to CI job test results for component] https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/174/
  - [ ] Code Coverage (if available): [link to code coverage report]