### PR TITLE
[1.13] Fix missing metrics timestamp causing metrics api 204s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Mark `dcos6` overlay network as disabled if `enable_ipv6` is set to false (DCOS-40539)
 
+* Fix CLI task metrics summary command which was occasionally failing to find metrics (DCOS_OSS-4679)
+
 ### Notable changes
 
 * Bumped DC/OS UI to [master+v2.40.10](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.40.10)

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "644970f36a64f412576550ed2b7707cdde364efa",
+    "ref": "b70b317578710ef5636f341f520af4f2479d46cd",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

Bumps telegraf version to include a fix that was causing the metrics api to occasionally 204 on the /containers endpoint.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4679](https://jira.mesosphere.com/browse/DCOS_OSS-4679) Metric timestamp field not set


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-4333](https://jira.mesosphere.com/browse/COPS-4333) DC/OS 1.12; "dcos task metrics summary <task-id>" returns HTTP 204


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: upstream and existing tests should be sufficient
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

