### PR TITLE
[1.12] enable_mesos_input_plugin config option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 * Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot. (DCOS_OSS-4667)
 
+* Add config option to enable/disable the Mesos input plugin in Telegraf. (DCOS_OSS-4667)
+
 ### Security Updates
 
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -994,6 +994,7 @@ entry = {
         lambda enable_mesos_ipv6_discovery: validate_true_false(enable_mesos_ipv6_discovery),
         lambda log_offers: validate_true_false(log_offers),
         lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
+        lambda enable_mesos_input_plugin: validate_true_false(enable_mesos_input_plugin),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -1112,7 +1113,8 @@ entry = {
         'license_key_contents': '',
         'enable_mesos_ipv6_discovery': 'false',
         'log_offers': 'true',
-        'mesos_cni_root_dir_persist': 'false'
+        'mesos_cni_root_dir_persist': 'false',
+        'enable_mesos_input_plugin': 'false'
     },
     'must': {
         'fault_domain_enabled': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1348,6 +1348,33 @@ package:
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        # A list of Mesos masters.
+        masters = ["http://$DCOS_NODE_PRIVATE_IP:5050"]
+        # Master metrics groups to be collected.
+        master_collections = [
+          "resources",
+          "master",
+          "agents",
+          "frameworks",
+          "framework_offers",
+          "tasks",
+          "messages",
+          "evqueue",
+          "registrar",
+          "allocator",
+       ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"
@@ -1380,6 +1407,28 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          "executors",
+          "tasks",
+          "messages",
+        ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
@@ -1428,6 +1477,28 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
+      # Telegraf plugin for gathering metrics from mesos
+      [[inputs.mesos]]
+        # The interval at which to collect metrics
+        interval = "60s"
+        # Timeout, in ms.
+        timeout = 30000
+        ## A list of Mesos slaves
+        slaves = ["http://$DCOS_NODE_PRIVATE_IP:5051"]
+        # Slave metrics groups to be collected.
+        slave_collections = [
+          "resources",
+          "agent",
+          "executors",
+          "tasks",
+          "messages",
+        ]
+        ## The user agent to send with requests
+        user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -27,6 +27,15 @@ def test_invalid_telemetry_enabled():
         err_msg)
 
 
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="configuration not present on windows")
+def test_invalid_enable_mesos_input_plugin():
+    err_msg = "Must be one of 'true', 'false'. Got 'foo'."
+    validate_error(
+        {'enable_mesos_input_plugin': 'foo'},
+        'enable_mesos_input_plugin',
+        err_msg)
+
+
 # TODO: DCOS_OSS-3462 - muted Windows tests requiring investigation
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="test fails on Windows reason unknown")
 def test_invalid_ports():


### PR DESCRIPTION
## High-level description

Adds a `enable_mesos_input_plugin` config option to allow operator to turn on/off the Mesos input plugin. Defaults to `false` in 1.12.

I have tested this by using minidcos to run a cluster off the TeamCity build of this PR, and then passing in the config option `enable_mesos_input_plugin: true` which added the plugin to the Telegraf config.

Still need to: update docs and make changes to Terraform to add the config option to the installer


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4688](https://jira.mesosphere.com/browse/DCOS_OSS-4688) Add config option to turn on/off mesos input plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

