### PR TITLE
DCOS-46438 - Support collecting integration tests locally without a cluster.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+dnspython
+pytest==3.3.2
+PyYAML
+webtest
+webtest-aiohttp==1.1.0
+schema
+pytest-catchlog==1.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -154,3 +154,34 @@ changedir=packages/bootstrap/extra
 commands=
   pip install .
   pytest --basetemp={envtmpdir} {posargs}
+
+
+[testenv:py35-collect-tests]
+platform=linux|darwin
+# See the following link for AWS_* environment variables:
+# http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
+passenv =
+  TEAMCITY_VERSION
+  SSH_AUTH_SOCK
+  AZURE_PROD_STORAGE_ACCOUNT
+  AZURE_PROD_STORAGE_ACCESS_KEY
+  AZURE_DEV_STORAGE_ACCOUNT
+  AZURE_DEV_STORAGE_ACCESS_KEY
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY
+  AWS_SESSION_TOKEN
+  AWS_PROFILE
+  AWS_CONFIG_FILE
+  AWS_DEFAULT_REGION
+deps =
+  git+https://github.com/dcos/dcos-test-utils.git
+  dnspython
+  pytest==3.8.2
+  PyYAML
+  webtest
+  webtest-aiohttp==1.1.0
+  schema
+  kazoo
+
+commands=
+  pytest --collect-only --basetemp={envtmpdir} packages/dcos-integration-test/extra/

--- a/tox.ini
+++ b/tox.ini
@@ -60,14 +60,7 @@ passenv =
   AWS_PROFILE
   AWS_CONFIG_FILE
   AWS_DEFAULT_REGION
-deps =
-  dnspython
-  pytest==3.3.2
-  pytest-catchlog==1.2.2
-  PyYAML
-  webtest
-  webtest-aiohttp==1.1.0
-  schema
+deps = -rrequirements.txt
 commands=
   pytest --basetemp={envtmpdir} {posargs}
 
@@ -93,15 +86,8 @@ passenv =
   AWS_DEV_ACCESS_KEY_ID
   AWS_DEV_SECRET_ACCESS_KEY
   AWS_DEFAULT_REGION
-deps =
-  dnspython
+deps = -rrequirements.txt
   teamcity-messages
-  pytest==3.3.2
-  pytest-catchlog==1.2.2
-  PyYAML
-  webtest
-  webtest-aiohttp==1.1.0
-  schema
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 
@@ -113,9 +99,7 @@ platform=linux|darwin
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
-deps =
-  pytest==3.3.2
-  schema
+deps = -rrequirements.txt
 changedir=pkgpanda/build/tests
 commands=
   pytest --basetemp={envtmpdir} {posargs} build_integration_test.py
@@ -125,9 +109,7 @@ platform=win32
 passenv =
   TEAMCITY_VERSION
   SSH_AUTH_SOCK
-deps =
-  pytest==3.3.2
-  schema
+deps = -rrequirements.txt
 changedir=pkgpanda/build/tests
 commands=
   py.test --basetemp={envtmpdir} {posargs} build_integration_test.py
@@ -137,8 +119,7 @@ commands=
 platform=linux|darwin
 passenv =
   TEAMCITY_VERSION
-deps=
-  pytest==3.3.2
+deps= -rrequirements.txt
 changedir=packages/bootstrap/extra
 commands=
   pip install .
@@ -148,40 +129,17 @@ commands=
 platform=win32
 passenv =
   TEAMCITY_VERSION
-deps=
-  pytest==3.3.2
+deps= -rrequirements.txt
 changedir=packages/bootstrap/extra
 commands=
   pip install .
   pytest --basetemp={envtmpdir} {posargs}
 
 
-[testenv:py35-collect-tests]
+[testenv:py35-collect-integration-tests]
 platform=linux|darwin
-# See the following link for AWS_* environment variables:
-# http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
-passenv =
-  TEAMCITY_VERSION
-  SSH_AUTH_SOCK
-  AZURE_PROD_STORAGE_ACCOUNT
-  AZURE_PROD_STORAGE_ACCESS_KEY
-  AZURE_DEV_STORAGE_ACCOUNT
-  AZURE_DEV_STORAGE_ACCESS_KEY
-  AWS_ACCESS_KEY_ID
-  AWS_SECRET_ACCESS_KEY
-  AWS_SESSION_TOKEN
-  AWS_PROFILE
-  AWS_CONFIG_FILE
-  AWS_DEFAULT_REGION
-deps =
-  git+https://github.com/dcos/dcos-test-utils.git
-  dnspython
-  pytest==3.8.2
-  PyYAML
-  webtest
-  webtest-aiohttp==1.1.0
-  schema
+deps = -rrequirements.txt
+  git+https://github.com/dcos/dcos-test-utils.git@5c582b0dc5da861b0b4f5719574725c084a72062
   kazoo
-
 commands=
   pytest --collect-only --basetemp={envtmpdir} packages/dcos-integration-test/extra/


### PR DESCRIPTION
## High-level description

This enables us to collect the integration tests locally without running inside of a cluster. While it doesn't allow us to actually run the tests (due to missing DCOS files), it allows us to import the tests and gather some statistics (for example, to unblock DCOS-46439).

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster

## Related tickets (optional)

Other tickets related to this change:

- [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) xfailflake dashboard - collect marked issues without a cluster and without regex
- [DCOS-47044](https://jira.mesosphere.com/browse/DCOS-47044) Hand off the xfailflake dashboard script.
- [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A, change is for CI
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)