### PR TITLE
Configure telegraf's internal metrics to on

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,10 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Prometheus-format metrics can be gathered from tasks (DCOS_OSS-3717)
 
-* Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot (DCOS_OSS-4667) 
+* Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot (DCOS_OSS-4667)
+
+* Expose internal metrics for the Telegraf metrics pipeline (DCOS_OSS-4608)
+
 
 ### Breaking changes
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1360,6 +1360,10 @@ package:
       [[inputs.processes]]
       # Read metrics about system load & uptime
       [[inputs.system]]
+      # Collect statistics about itself
+      [[inputs.internal]]
+        ## If true, collect telegraf memory stats.
+        collect_memstats = true
       # Configuration for the Prometheus client to spawn
       [[outputs.prometheus_client]]
         ## Address to listen on


### PR DESCRIPTION
## High-level description

This PR enables telegraf's internal metrics plugin.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4608](https://jira.mesosphere.com/browse/DCOS_OSS-4608) Enable telegraf's internal metrics plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this change is a simple configuration change, it is well tested in the upstream project
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)