### PR TITLE
[1.13] Add enable_mesos_input_plugin config option

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1072,6 +1072,7 @@ entry = {
         lambda enable_mesos_ipv6_discovery: validate_true_false(enable_mesos_ipv6_discovery),
         lambda log_offers: validate_true_false(log_offers),
         lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
+        lambda enable_mesos_input_plugin: validate_true_false(enable_mesos_input_plugin),
     ],
     'default': {
         'bootstrap_tmp_dir': 'tmp',
@@ -1194,7 +1195,8 @@ entry = {
         'license_key_contents': '',
         'enable_mesos_ipv6_discovery': 'false',
         'log_offers': 'true',
-        'mesos_cni_root_dir_persist': 'false'
+        'mesos_cni_root_dir_persist': 'false',
+        'enable_mesos_input_plugin': 'true'
     },
     'must': {
         'fault_domain_enabled': 'false',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1371,6 +1371,8 @@ package:
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
       # Telegraf plugin for gathering metrics from mesos
       [[inputs.mesos]]
         # The interval at which to collect metrics
@@ -1394,6 +1396,8 @@ package:
         ]
         ## The user agent to send with requests
         user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Statsd UDP/TCP Server
       [[inputs.statsd]]
         ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
@@ -1508,6 +1512,8 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
       # Telegraf plugin for gathering metrics from mesos
       [[inputs.mesos]]
         # The interval at which to collect metrics
@@ -1526,6 +1532,8 @@ package:
         ]
         ## The user agent to send with requests
         user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Statsd UDP/TCP Server
       [[inputs.statsd]]
         ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)
@@ -1626,6 +1634,8 @@ package:
         timeout = "15s"
         ## The hostname or IP address on which to host statsd servers
         statsd_host = "198.51.100.1"
+{% switch enable_mesos_input_plugin %}
+{% case "true" %}
       # Telegraf plugin for gathering metrics from mesos
       [[inputs.mesos]]
         # The interval at which to collect metrics
@@ -1644,6 +1654,8 @@ package:
         ]
         ## The user agent to send with requests
         user_agent = "Telegraf-mesos"
+{% case "false" %}
+{% endswitch %}
       # Statsd UDP/TCP Server
       [[inputs.statsd]]
         ## Protocol, must be "tcp", "udp", "udp4" or "udp6" (default=udp)

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -27,6 +27,15 @@ def test_invalid_telemetry_enabled():
         err_msg)
 
 
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="configuration not present on windows")
+def test_invalid_enable_mesos_input_plugin():
+    err_msg = "Must be one of 'true', 'false'. Got 'foo'."
+    validate_error(
+        {'enable_mesos_input_plugin': 'foo'},
+        'enable_mesos_input_plugin',
+        err_msg)
+
+
 # TODO: DCOS_OSS-3462 - muted Windows tests requiring investigation
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="test fails on Windows reason unknown")
 def test_invalid_ports():


### PR DESCRIPTION
## High-level description

Adds a `enable_mesos_input_plugin` config option to allow operator to turn on/off the Mesos input plugin. Defaults to `true` in 1.13+ (defaults to false in 1.12).


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4688](https://jira.mesosphere.com/browse/DCOS_OSS-4688) Add config option to turn on/off mesos input plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
