### PR TITLE
packages: Upgrade cockroachdb to 2.0.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,8 +57,6 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Allow setting environment variables for `docker-gc` in `/var/lib/dcos/docker-gc.env`
 
-* CockroachDB has been updated to version 2.0.7
-
 
 ### Breaking changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 * Expose internal metrics for the Telegraf metrics pipeline (DCOS_OSS-4608)
 
 * Allow setting environment variables for `docker-gc` in `/var/lib/dcos/docker-gc.env`
+* CockroachDB has been updated to version 2.0.7
 
 
 ### Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 * Expose internal metrics for the Telegraf metrics pipeline (DCOS_OSS-4608)
 
 * Allow setting environment variables for `docker-gc` in `/var/lib/dcos/docker-gc.env`
+
 * CockroachDB has been updated to version 2.0.7
 
 

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -39,13 +39,13 @@
     },
     "sqlalchemy": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/e2/0a/05b7d13618ad41c108a6c2b886af83bf9bb7e35f8951227abb18b1330745/SQLAlchemy-1.2.14.tar.gz",
-      "sha1": "7e7260c3886ff633bbf6ffbcee3a394a7e520145"
+      "url": "https://files.pythonhosted.org/packages/c6/52/73d1c92944cd294a5b165097038418abb6a235f5956d43d06f97254f73bf/SQLAlchemy-1.2.17.tar.gz",
+      "sha1": "0aa3388617a876f8b8e22eda7d347455a44973ee"
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/fa/cd/cf58d3a95a619262f0f52eedc707d143b6ada636ed24f6765544c049fdf9/SQLAlchemy-Utils-0.33.8.tar.gz",
-      "sha1": "b1e398f693b81506e64109ccb873a263219fb882"
+      "url": "https://files.pythonhosted.org/packages/fe/8b/a68f81076e9a2729675253228f43986914f0510078c86f14f6cd51dd3f01/SQLAlchemy-Utils-0.33.11.tar.gz",
+      "sha1": "e10ac4957637a67d433afde01032654a914c00a8"
     },
     "mako": {
       "kind": "url_extract",
@@ -69,8 +69,8 @@
     },
     "cockroachdb-python": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/00/1c/cbbeab7ecdd5ecf1213785bacf9cec05b8b5b49f2a1a84954a3deaf0acf2/cockroachdb-0.1.0.tar.gz",
-      "sha1": "679408a97802e9a4c8c79c6866eee8074f63eab0"
+      "url": "https://files.pythonhosted.org/packages/3b/9a/2d73ea47a3c276a41ddd21d3b607320bdbc95575b483a7276f63aba08acd/cockroachdb-0.3.0.tar.gz",
+      "sha1": "7a5e14930eaaf974b5382c00d59e7f420eb893bd"
     }
   },
   "username": "dcos_bouncer",

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -39,13 +39,13 @@
     },
     "sqlalchemy": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/c6/52/73d1c92944cd294a5b165097038418abb6a235f5956d43d06f97254f73bf/SQLAlchemy-1.2.17.tar.gz",
-      "sha1": "0aa3388617a876f8b8e22eda7d347455a44973ee"
+      "url": "https://files.pythonhosted.org/packages/0c/7d/769c5fc22c0cdefd097b91cc525b6d8c88bf2afd8b0315b1e7ca088956b4/SQLAlchemy-1.2.15.tar.gz",
+      "sha1": "dd645321a887703b9be08434a73abb4041ae220f"
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/fe/8b/a68f81076e9a2729675253228f43986914f0510078c86f14f6cd51dd3f01/SQLAlchemy-Utils-0.33.11.tar.gz",
-      "sha1": "e10ac4957637a67d433afde01032654a914c00a8"
+      "url": "https://files.pythonhosted.org/packages/7b/2e/7b7634446fcbb37f666a708c366337482d13ffc259e96b2fff93b28a8e24/SQLAlchemy-Utils-0.33.9.tar.gz",
+      "sha1": "e3667b224797eb341f66539448c311629e1f8861"
     },
     "mako": {
       "kind": "url_extract",
@@ -69,8 +69,8 @@
     },
     "cockroachdb-python": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/3b/9a/2d73ea47a3c276a41ddd21d3b607320bdbc95575b483a7276f63aba08acd/cockroachdb-0.3.0.tar.gz",
-      "sha1": "7a5e14930eaaf974b5382c00d59e7f420eb893bd"
+      "url": "https://files.pythonhosted.org/packages/1c/7d/063bd5cc3ffe13561ded9eddbe736d795e984a7a9dfe5d0eca0986134f6e/cockroachdb-0.2.1.tar.gz",
+      "sha1": "af40b0e6e0b9b141f6faf28bcb96b10add941886"
     }
   },
   "username": "dcos_bouncer",

--- a/packages/bouncer/buildinfo.json
+++ b/packages/bouncer/buildinfo.json
@@ -4,8 +4,8 @@
     "bouncer": {
       "kind": "git",
       "git": "git@github.com:dcos/bouncer.git",
-      "ref": "98989df58a2df0867e6c9414e80375d5ea2f4e43",
-      "ref_origin": "master"
+      "ref": "325c4a68c2d241aa066726217a04df48266f6dfb",
+      "ref_origin": "mh/cockroach-2.0"
     }
   },
   "username": "dcos_bouncer",

--- a/packages/bouncer/buildinfo.json
+++ b/packages/bouncer/buildinfo.json
@@ -4,7 +4,7 @@
     "bouncer": {
       "kind": "git",
       "git": "git@github.com:dcos/bouncer.git",
-      "ref": "c2a2ac589c89c8139761e9194cc7b773d7fd8b7a",
+      "ref": "9decbdfb9dc377d61723fd900d6c897db848deda",
       "ref_origin": "mh/cockroach-2.0"
     }
   },

--- a/packages/bouncer/buildinfo.json
+++ b/packages/bouncer/buildinfo.json
@@ -4,8 +4,8 @@
     "bouncer": {
       "kind": "git",
       "git": "git@github.com:dcos/bouncer.git",
-      "ref": "c2a2ac589c89c8139761e9194cc7b773d7fd8b7a",
-      "ref_origin": "mh/cockroach-2.0"
+      "ref": "4beab0338e6859508d58f254d52942cd7bdd9fbd",
+      "ref_origin": "master"
     }
   },
   "username": "dcos_bouncer",

--- a/packages/bouncer/buildinfo.json
+++ b/packages/bouncer/buildinfo.json
@@ -4,7 +4,7 @@
     "bouncer": {
       "kind": "git",
       "git": "git@github.com:dcos/bouncer.git",
-      "ref": "325c4a68c2d241aa066726217a04df48266f6dfb",
+      "ref": "c2a2ac589c89c8139761e9194cc7b773d7fd8b7a",
       "ref_origin": "mh/cockroach-2.0"
     }
   },

--- a/packages/bouncer/buildinfo.json
+++ b/packages/bouncer/buildinfo.json
@@ -4,7 +4,7 @@
     "bouncer": {
       "kind": "git",
       "git": "git@github.com:dcos/bouncer.git",
-      "ref": "9decbdfb9dc377d61723fd900d6c897db848deda",
+      "ref": "c2a2ac589c89c8139761e9194cc7b773d7fd8b7a",
       "ref_origin": "mh/cockroach-2.0"
     }
   },

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -1,18 +1,34 @@
  #!/bin/bash
 
-set -e
+set -ex
 
-# cockroachdb requires gcc 4.9+
+# Support https sources in apt
 apt-get -y update
-apt-get install -y gcc-4.9 g++-4.9 cpp-4.9
+apt-get -y install apt-transport-https software-properties-common
 
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 40
-update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-4.9 40
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 40
+# CockroachDB requires node and yarn to build UI
+# https://github.com/cockroachdb/cockroach/blob/v2.0.7/build/bootstrap/bootstrap-debian.sh#L8-L12
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+echo "deb https://deb.nodesource.com/node_6.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list
 
-GOLANG_VERSION=1.9.4
+curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+add-apt-repository ppa:ubuntu-toolchain-r/test
+
+# cockroachdb requires gcc 6.0+
+apt-get -y update
+apt-get install -y gcc-6 g++-6 cpp-6 \
+    libncurses-dev \
+    nodejs yarn
+
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 40
+update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-6 40
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 40
+
+GOLANG_VERSION=1.11.4
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779
+GOLANG_DOWNLOAD_SHA256=fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b
 
 rm -rf /usr/local/go
 curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz
@@ -20,17 +36,18 @@ echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c -
 tar -C /usr/local -xzf golang.tar.gz
 rm golang.tar.gz
 
-mkdir -p /gopath/src/github.com/cockroachdb
-mv /pkg/src/cockroach /gopath/src/github.com/cockroachdb/
-
-cd /gopath/src/github.com/cockroachdb/cockroach
+cd /pkg/src/cockroach
 
 # Build the cockroach binary.
-make build TYPE=portable
+# We need to set CC_PATH and CXX_PATH becuase the build in the teamcity is not
+# recognizing paths correctly
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+make build TYPE=release-linux-gnu CC_PATH=/usr/bin/gcc  CXX_PATH=/usr/bin/g++
 
 # Copy the cockroach binary to the the package bin directory.
 mkdir -p $PKG_PATH/bin
-install -m 755 /gopath/src/github.com/cockroachdb/cockroach/cockroach $PKG_PATH/bin
+install -m 755 /pkg/src/cockroach/src/github.com/cockroachdb/cockroach/cockroach-linux-2.6.32-gnu-amd64 $PKG_PATH/bin/cockroach
 
 # Copy the registration script to the package bin directory.
 install -m 755 /pkg/extra/register.py $PKG_PATH/bin/register.py

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -43,7 +43,7 @@ sed -i 's/LDFLAGS: -lncurses/LDFLAGS: -L\/opt\/mesosphere\/active\/ncurses\/lib 
 sed -i 's/CFLAGS: -Wno-unused-result/CFLAGS: -Wno-unused-result -I\/opt\/mesosphere\/active\/ncurses\/include -I\/opt\/mesosphere\/active\/ncurses\/include\/ncurses/g' src/github.com/cockroachdb/cockroach/vendor/github.com/knz/go-libedit/unix/editline_unix.go
 
 # Build the cockroach binary.
-# We need to set CC_PATH and CXX_PATH becuase the build in the teamcity is not
+# We need to set CC_PATH and CXX_PATH because the build in the teamcity is not
 # recognizing paths correctly
 export CC=/usr/bin/gcc
 export CXX=/usr/bin/g++

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -25,9 +25,9 @@ update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 40
 update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-6 40
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 40
 
-GOLANG_VERSION=1.11.4
+GOLANG_VERSION=1.11.5
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b
+GOLANG_DOWNLOAD_SHA256=ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25
 
 rm -rf /usr/local/go
 curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -19,7 +19,6 @@ add-apt-repository ppa:ubuntu-toolchain-r/test
 # cockroachdb requires gcc 6.0+
 apt-get -y update
 apt-get install -y gcc-6 g++-6 cpp-6 \
-    libncurses-dev \
     nodejs yarn
 
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 40
@@ -37,6 +36,11 @@ tar -C /usr/local -xzf golang.tar.gz
 rm golang.tar.gz
 
 cd /pkg/src/cockroach
+
+# go-libedit requries `ncurses` library. We need to replace `cgo` flags so that
+# go compiler passes path to DCOS included ncurses library.
+sed -i 's/LDFLAGS: -lncurses/LDFLAGS: -L\/opt\/mesosphere\/active\/ncurses\/lib -ltinfo -lncurses/g' src/github.com/cockroachdb/cockroach/vendor/github.com/knz/go-libedit/unix/editline_unix.go
+sed -i 's/CFLAGS: -Wno-unused-result/CFLAGS: -Wno-unused-result -I\/opt\/mesosphere\/active\/ncurses\/include -I\/opt\/mesosphere\/active\/ncurses\/include\/ncurses/g' src/github.com/cockroachdb/cockroach/vendor/github.com/knz/go-libedit/unix/editline_unix.go
 
 # Build the cockroach binary.
 # We need to set CC_PATH and CXX_PATH becuase the build in the teamcity is not

--- a/packages/cockroach/buildinfo.json
+++ b/packages/cockroach/buildinfo.json
@@ -1,9 +1,8 @@
 {
   "single_source" : {
-      "kind": "git",
-      "git": "git@github.com:cockroachdb/cockroach.git",
-      "ref": "486632793834b3fded5cf8bc87dddf0041f2297e",
-      "ref_origin": "v1.1.9"
+      "kind": "url_extract",
+      "url": "https://binaries.cockroachdb.com/cockroach-v2.0.7.src.tgz",
+      "sha1": "8b3940ef9ab46646b4178bc93c9904b57d9f3c50"
   },
   "username": "dcos_cockroach",
   "state_directory": true

--- a/packages/cockroach/buildinfo.json
+++ b/packages/cockroach/buildinfo.json
@@ -1,4 +1,5 @@
 {
+  "requires": ["ncurses"],
   "single_source" : {
       "kind": "url_extract",
       "url": "https://binaries.cockroachdb.com/cockroach-v2.0.7.src.tgz",

--- a/packages/cockroach/extra/cockroachdb-change-config.py
+++ b/packages/cockroach/extra/cockroachdb-change-config.py
@@ -101,8 +101,8 @@ def main() -> None:
 
     set_num_replicas(my_internal_ip, master_node_count)
 
-    # We are running CockroachDB v1.1.x so pass '1.1'.
-    set_cluster_version(my_internal_ip, '1.1')
+    # We are running CockroachDB v2.0.x so pass '2.0'.
+    set_cluster_version(my_internal_ip, '2.0')
 
 
 if __name__ == '__main__':

--- a/packages/cockroach/extra/cockroachdb-change-config.py
+++ b/packages/cockroach/extra/cockroachdb-change-config.py
@@ -57,20 +57,26 @@ def set_num_replicas(my_internal_ip: str, num_replicas: int) -> None:
 
     Relevant JIRA ticket: https://jira.mesosphere.com/browse/DCOS-20352
     """
-    command = [
-        '/opt/mesosphere/active/cockroach/bin/cockroach',
-        'zone',
-        'set',
-        '.default',
-        '--insecure',
-        '--host={}'.format(my_internal_ip),
-        '-f',
-        '-'
-        ]
-    config_text = 'num_replicas: %s' % (num_replicas, )
-    log.info('Set `%s` via command `%s`', config_text, ' '.join(command))
-    subprocess.run(command, input=config_text.encode('ascii'))
-    log.info('Command returned')
+
+    def _set_replicas_for_zone(zone: str) -> None:
+        command = [
+            '/opt/mesosphere/active/cockroach/bin/cockroach',
+            'zone',
+            'set',
+            zone,
+            '--insecure',
+            '--host={}'.format(my_internal_ip),
+            '-f',
+            '-'
+            ]
+        config_text = 'num_replicas: %s' % (num_replicas, )
+        log.info('Set `%s` via command `%s`', config_text, ' '.join(command))
+        subprocess.run(command, input=config_text.encode('ascii'))
+        log.info('Command returned')
+
+    zones = ['.default', '.liveness', '.meta']
+    for zone in zones:
+        _set_replicas_for_zone(zone=zone)
 
 
 def get_expected_master_node_count() -> int:

--- a/packages/cockroach/extra/iam-database-restore
+++ b/packages/cockroach/extra/iam-database-restore
@@ -82,22 +82,32 @@ def recover_database(my_internal_ip: str, backup_file_path: str, db_suffix: str)
                 log.error('Failed to load data into database `{}`.'.format(dbname))
                 raise
 
-    def _rename_database(oldname: str, newname: str) -> None:
+    def _replace_database(source: str, existing: str, backup: str) -> None:
+        transaction = '; '.join([
+            'BEGIN',
+            'SAVEPOINT cockroach_restart',
+            # iam -> iam_old
+            'ALTER DATABASE {} RENAME TO {}'.format(existing, backup),
+            # iam_new -> iam
+            'ALTER DATABASE {} RENAME TO {}'.format(source, existing),
+            'RELEASE SAVEPOINT cockroach_restart',
+            'COMMIT',
+        ])
         command = [
             '/opt/mesosphere/active/cockroach/bin/cockroach',
             'sql',
             '--insecure',
             '--host={}'.format(my_internal_ip),
             '-e',
-            'ALTER DATABASE {} RENAME to {}'.format(oldname, newname),
+            transaction,
             ]
-        msg = 'Rename database `{}` to `{}` via command `{}`'.format(
-            oldname, newname, ' '.join(command))
+        msg = 'Replace database `{}` to `{}` via command `{}`'.format(
+            source, existing, ' '.join(command))
         log.info(msg)
         try:
             subprocess.run(command, check=True)
         except CalledProcessError:
-            log.error('Failed to rename database `{}` -> `{}`.'.format(oldname, newname))
+            log.error('Failed to replace database `{}` -> `{}`.'.format(source, existing))
             raise
 
     def _drop_database(dbname: str) -> None:
@@ -137,25 +147,15 @@ def recover_database(my_internal_ip: str, backup_file_path: str, db_suffix: str)
         _drop_database(newdbname)
         raise
 
-    # 3. Then rename the active `iam` database to `iam_old`.
+    # 3. In a single transaction replace original `iam` database with `iam_new`
+    #    and keep original `iam` as `iam_old`.
     try:
-        _rename_database(oldname=curdbname, newname=olddbname)
+        _replace_database(source=newdbname, existing=curdbname, backup=olddbname)
     except CalledProcessError:
-        # Renaming the existing database failed, so remove the 'iam_new' database
         _drop_database(newdbname)
         raise
 
-    # 4. Finally, rename the `iam_new` database to `iam`.
-    try:
-        _rename_database(oldname=newdbname, newname=curdbname)
-    except CalledProcessError:
-        # Renaming the new database failed, so rename the old one back and
-        # remove the 'iam_new' database
-        _rename_database(oldname=olddbname, newname=curdbname)
-        _drop_database(newdbname)
-        raise
-
-    # 5. Remove the original (old) database that isn't used anymore
+    # 4. Remove the original (old) database that isn't used anymore
     try:
         _drop_database(olddbname)
     except CalledProcessError:


### PR DESCRIPTION
## High-level description

This PR:
- bumps `cockroachdb` to vesion `2.0.7`
- bumps `bouncer` to the latest version that is compatible with `cockroachdb` version `2.0.7`
- improves `iam-database-restore` script to do the DB rename in a single transaction

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-38395](https://jira.mesosphere.com/browse/DCOS-38395) bouncer: upgrade to cockroachdb v2.0.7

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/bouncer/compare/6cf322b5c66c765b6433ae23824bb11e609a2204..325c4a6
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-security/job/bouncer-upstream/job/PR-6/7/
  - [ ] Code Coverage (if available): n/a
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**