### PR TITLE
Prevent hang in test_composition.test_dcos_cluster_is_up

### DIFF
--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -21,7 +21,7 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 def test_dcos_cluster_is_up(dcos_api_session):
     def _docker_info(component):
         # sudo is required for non-coreOS installs
-        return subprocess.check_output(['sudo', 'docker', 'version', '-f', component]).decode('utf-8').rstrip()
+        return subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=120).decode('utf-8').rstrip()
 
     cluster_environment = {
         "docker_client_version": _docker_info('{{.Client.Version}}'),

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -21,11 +21,21 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 def test_dcos_cluster_is_up(dcos_api_session):
     def _docker_info(component):
         # sudo is required for non-coreOS installs
-        return subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=120).decode('utf-8').rstrip()
+        return subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=60).decode('utf-8').rstrip()
+
+    try:
+        docker_client = _docker_info('{{.Client.Version}}')
+    except subprocess.TimeoutExpired:
+        docker_client = "Error: docker call timed out"
+
+    try:
+        docker_server = _docker_info('{{.Server.Version}}')
+    except subprocess.TimeoutExpired:
+        docker_server = "Error: docker call timed out"
 
     cluster_environment = {
-        "docker_client_version": _docker_info('{{.Client.Version}}'),
-        "docker_server_version": _docker_info('{{.Server.Version}}'),
+        "docker_client_version": docker_client,
+        "docker_server_version": docker_server,
         "system_platform": platform.platform(),
         "system_platform_system": platform.system(),
         "system_platform_release": platform.release(),

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -21,7 +21,10 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 def test_dcos_cluster_is_up(dcos_api_session):
     def _docker_info(component):
         # sudo is required for non-coreOS installs
-        return subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=60).decode('utf-8').rstrip()
+        return (subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=60)
+                .decode('utf-8')
+                .rstrip()
+                )
 
     try:
         docker_client = _docker_info('{{.Client.Version}}')


### PR DESCRIPTION
## High-level description
This prevents `test_dcos_cluster_is_up` from hanging indefinitely when something goes wrong with the calls to `docker`. It will wait 1 minute for each call and if the call times out, it will continue logging only an error message. Any other failures will still cause the test to fail.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-41679](https://jira.mesosphere.com/browse/DCOS-41679)

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: test change
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: test change
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
