### PR TITLE
[1.11] dcos-metrics: bump to latest commit.

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "033c3f4c51b06c14a3e204274b3ffc06c0edad38",
+    "ref": "606ebcf702f2fafa0b9db6a545d9d905d32023e7",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This bump ensures that containers are tracked in Mesos metrics isolator,
which prevents remove attempts of unknown containers.

## Related tickets

  - [DCOS_OSS-4630](https://jira.mesosphere.com/browse/DCOS_OSS-4630) com_mesosphere_MetricsIsolatorModule fails to track individual containers' lifecycle.
  - [COPS-4310](https://jira.mesosphere.com/browse/COPS-4310)

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
      * This has been tested manually on a 1.11.8 cluster, see https://github.com/dcos/dcos-metrics/pull/172
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review):
    * https://github.com/dcos/dcos-metrics/compare/033c3f4c51b06c14a3e204274b3ffc06c0edad38...606ebcf702f2fafa0b9db6a545d9d905d32023e7
  - [ ] Test Results.
  - [ ] Code Coverage (if available): [link to code coverage report]
    * N/A