### PR TITLE
[1.12] Additional container metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@
 
 * Make cluster identity configurable in dcos-net (DCOS_OSS-4620)
 
+* Include additional container metrics if provided (DCOS_OSS-4624)
+
 ### Security Updates
 
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "b70b317578710ef5636f341f520af4f2479d46cd",
+    "ref": "e62db07bc444254df19eed062ad265f2c6b30664",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

Includes additional container metrics if provided
- DiskStatistics (tags with `volume_persistence_id`, `volume_persistence_principal` if applicable)
- Perf
- NetTrafficControlStatistics
- NetSNMPStatistics
- Blkio cfq_recursive and throttling stats; return all ops, not just `TOTAL`

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4624](https://jira.mesosphere.com/browse/DCOS_OSS-4624) Add missing container metrics


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Lightweight frameworks don't produce any of these new container metrics. I would prefer not to install a heavier weight framework as they have proven to occasionally flake (e.g. the hello-world framework occasionally fails in the uninstall step for unknown reasons). This is tested upstream, and existing metrics tests should be sufficient.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/b70b317578710ef5636f341f520af4f2479d46cd...e62db07bc444254df19eed062ad265f2c6b30664
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/173/
  - [ ] Code Coverage (if available): [link to code coverage report]
