### PR TITLE
Add E2E test for superuser service account login

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,16 @@
+[mypy]
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = False
+disallow_untyped_defs = True
+follow_imports = 'silent'
+ignore_missing_imports = True
+no_implicit_optional = True
+strict_optional = True
+warn_no_return = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -1,0 +1,28 @@
+This directory contains end to end tests.
+
+To run these tests, create an environment which can run DC/OS E2E with Docker nodes as per the [requirements documentation](https://dcos-e2e.readthedocs.io/en/latest/docker-backend.html#requirements).
+
+Then, download the relevant build artifact and set various environment variables.
+For example:
+
+```sh
+ARTIFACT_URL=https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
+export DCOS_E2E_GENCONF_PATH=/tmp/dcos_generate_config.sh
+export DCOS_E2E_TMP_DIR_PATH=/tmp
+export DCOS_E2E_LOG_DIR=/tmp/logs
+
+rm -rf $DCOS_E2E_GENCONF_PATH
+curl -o $DCOS_E2E_GENCONF_PATH $ARTIFACT_URL
+```
+
+Then, install the test dependencies, preferably in a virtual environment:
+
+```sh
+pip3 install -r requirements.txt
+```
+
+and run the tests:
+
+```sh
+pytest --confcutdir .
+```

--- a/test-e2e/cluster_helpers.py
+++ b/test-e2e/cluster_helpers.py
@@ -1,0 +1,155 @@
+"""
+Helpers for working with DC/OS E2E clusters.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import List
+
+from _pytest.fixtures import SubRequest
+
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.exceptions import DCOSTimeoutError
+from dcos_e2e.node import Node
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_for_dcos_oss(
+    cluster: Cluster,
+    request: SubRequest,
+    log_dir: Path,
+) -> None:
+    """
+    Helper for ``wait_for_dcos_oss`` that automatically dumps the journal of
+    every cluster node if a ``DCOSTimeoutError`` is hit.
+    """
+    try:
+        cluster.wait_for_dcos_oss()
+    except DCOSTimeoutError:
+        # Dumping the logs on timeout only works if DC/OS has already started
+        # the systemd units that the logs are retrieved from.
+        # This does currently not pose a problem since the ``wait_for_dcos_ee``
+        # timeout is set to one hour. We expect the systemd units to have
+        # started by then.
+        dump_cluster_journals(
+            cluster=cluster,
+            target_dir=log_dir / artifact_dir_format(request.node.name),
+        )
+        raise
+
+
+def artifact_dir_format(test_name: str) -> str:
+    """
+    Create a common target test directory name format.
+    """
+    return test_name + '_' + str(datetime.now().isoformat().split('.')[0])
+
+
+def dump_cluster_journals(cluster: Cluster, target_dir: Path) -> None:
+    """
+    Dump logs for each cluster node to the ``target_dir``. Logs are separated into directories per node.
+    """
+    target_dir.mkdir(parents=True)
+    for role, nodes in (
+        ('master', cluster.masters),
+        ('agent', cluster.agents),
+        ('public_agent', cluster.public_agents),
+    ):
+        for index, node in enumerate(nodes):
+            node_str = (
+                '{role}-{index}_{private_ip}'
+            ).format(
+                role=role,
+                index=index,
+                private_ip=node.private_ip_address,
+            )
+            node_dir = Path(target_dir) / node_str
+            _dump_node_journals(node, node_dir)
+
+
+def _dump_node_journals(node: Node, node_dir: Path) -> None:
+    """
+    Dump logs from the given cluster node to the ``node_dir``.
+
+    Dumping the diagnostics bundle is unreliable in case that DC/OS
+    components are broken. This is likely if ``wait_for_dcos_ee``
+    times out. Instead this dumps the journal for each systemd unit
+    started by DC/OS.
+    """
+    LOGGER.info('Dumping journals from {node}'.format(node=node))
+    node_dir.mkdir(parents=True)
+    try:
+        _dump_stdout_to_file(node, ['journalctl'], node_dir / 'journal')
+    except CalledProcessError as exc:
+        # Continue dumping further journals even if an error occurs.
+        LOGGER.warn('Unable to dump journalctl: {exc}'.format(exc=str(exc)))
+
+    for unit in _dcos_systemd_units(node):
+        if unit.endswith('.service'):
+            name = unit.split('.')[0]
+            try:
+                _dump_stdout_to_file(
+                    node=node,
+                    cmd=['journalctl', '-u', unit],
+                    file_path=node_dir / name,
+                )
+            except CalledProcessError as exc:
+                # Continue dumping further journals even if an error occurs.
+                message = 'Unable to dump {unit} journal: {exc}'.format(
+                    unit=unit,
+                    exc=str(exc),
+                )
+                LOGGER.warn(message)
+
+
+def _dump_stdout_to_file(node: Node, cmd: List[str], file_path: Path) -> None:
+    """
+    Dump ``stdout`` of the given command to ``file_path``.
+
+    Raises:
+        CalledProcessError: If an error occurs when running the given command.
+    """
+    chunk_size = 2048
+    proc = node.popen(args=cmd)
+    with open(str(file_path), 'wb') as dumpfile:
+        while True:
+            chunk = proc.stdout.read(chunk_size)
+            if chunk:
+                dumpfile.write(chunk)
+            else:
+                break
+    proc.wait()
+    if proc.returncode != 0:
+        exception = CalledProcessError(
+            returncode=proc.returncode,
+            cmd=cmd,
+            output=bytes(proc.stdout),
+            stderr=bytes(proc.stderr),
+        )
+        message = (
+            'Failed to complete "{cmd}": {exception}'
+        ).format(
+            cmd=cmd,
+            exception=exception,
+        )
+        LOGGER.warn(message)
+        raise exception
+
+
+def _dcos_systemd_units(node: Node) -> List[str]:
+    """
+    Return all systemd services that are started up by DC/OS.
+    """
+    result = node.run(
+        args=[
+            'sudo', 'systemctl', 'show', '-p', 'Wants', 'dcos.target', '|',
+            'cut', '-d=', '-f2'
+        ],
+        shell=True,
+    )
+    systemd_units_string = result.stdout.strip().decode()
+    return str(systemd_units_string).split(' ')

--- a/test-e2e/conftest.py
+++ b/test-e2e/conftest.py
@@ -1,0 +1,4 @@
+# Hack to exclude test-e2e/conftest.py from the top-level tox config py35-unittests.
+# https://stackoverflow.com/a/37493203
+pytest_plugins = ['test_e2e_module']
+# Actual content of conftest.py can be found in test_e2e_module.py.

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,0 +1,5 @@
+git+https://github.com/dcos/dcos-e2e.git@2019.01.05.0
+cryptography==2.5
+jwt==0.5.4
+pytest==4.1.1
+requests==2.21.0

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -1,0 +1,38 @@
+"""
+Surrogate conftest.py contents loaded by the conftest.py file.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from dcos_e2e.backends import Docker
+
+
+@pytest.fixture(scope='session')
+def docker_backend() -> Docker:
+    """
+    Creates a common Docker backend configuration that works within the pytest
+    environment directory.
+    """
+    tmp_dir_path = Path(os.environ['DCOS_E2E_TMP_DIR_PATH'])
+    assert tmp_dir_path.exists() and tmp_dir_path.is_dir()
+
+    return Docker(workspace_dir=tmp_dir_path)
+
+
+@pytest.fixture(scope='session')
+def artifact_path() -> Path:
+    """
+    Return the path to a DC/OS build artifact to test against.
+    """
+    generate_config_path = Path(os.environ['DCOS_E2E_GENCONF_PATH'])
+    return generate_config_path
+
+
+@pytest.fixture(scope='session')
+def log_dir() -> Path:
+    """
+    Return the path to a directory which logs should be stored in.
+    """
+    return Path(os.environ['DCOS_E2E_LOG_DIR'])

--- a/test-e2e/test_service_account.py
+++ b/test-e2e/test_service_account.py
@@ -1,0 +1,103 @@
+import time
+import uuid
+from pathlib import Path
+from typing import Tuple
+
+import cryptography.hazmat.backends
+import jwt
+import requests
+from _pytest.fixtures import SubRequest
+from cluster_helpers import (
+    wait_for_dcos_oss,
+)
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from dcos_e2e.base_classes import ClusterBackend
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Output
+
+
+cryptography_default_backend = cryptography.hazmat.backends.default_backend()
+
+
+def generate_rsa_keypair() -> Tuple[str, str]:
+    """
+    Generate an RSA keypair with a key size of 2048 bits and an
+    exponent of 65537. Serialize the public key in the the
+    X.509 SubjectPublicKeyInfo/OpenSSL PEM public key format
+    (RFC 5280). Serialize the private key in the PKCS#8 (RFC 3447)
+    format.
+
+    Returns:
+        (private key, public key) 2-tuple, both unicode
+        objects holding the serialized keys.
+    """
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=cryptography_default_backend,
+    )
+    privkey_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key = private_key.public_key()
+    pubkey_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return privkey_pem.decode('ascii'), pubkey_pem.decode('ascii')
+
+
+def test_superuser_service_account_login(
+    docker_backend: ClusterBackend,
+    artifact_path: Path,
+    request: SubRequest,
+    log_dir: Path,
+) -> None:
+    """
+    Tests for successful superuser service account login which asserts
+    that the default user has been created during cluster start.
+    """
+    superuser_uid = str(uuid.uuid4())
+    superuser_private_key, superuser_public_key = generate_rsa_keypair()
+    config = {
+        'superuser_service_account_uid': superuser_uid,
+        'superuser_service_account_public_key': superuser_public_key,
+    }
+    with Cluster(
+        cluster_backend=docker_backend,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config={
+                **cluster.base_config,
+                **config,
+            },
+            output=Output.LOG_AND_CAPTURE,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        master = next(iter(cluster.masters))
+        master_url = 'http://' + str(master.public_ip_address)
+        login_endpoint = master_url + '/acs/api/v1/auth/login'
+
+        service_login_token = jwt.encode(
+            {'uid': superuser_uid, 'exp': time.time() + 30},
+            superuser_private_key,
+            algorithm='RS256'
+        ).decode('ascii')
+
+        response = requests.post(
+            login_endpoint,
+            json={'uid': superuser_uid, 'token': service_login_token}
+        )
+        assert response.status_code == 200

--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,12 @@ deps =
   webtest
   webtest-aiohttp==1.1.0
   schema
+# Hack to stop pytest from collecting test-e2e tests.
+# Simpler ways of achieving this would not work.
+# https://stackoverflow.com/a/37493203
+# TODO(tweidner): Set pytest collect directories explicitly.
 commands=
-  pytest --basetemp={envtmpdir} {posargs}
+  pytest -p no:test_e2e_module --basetemp={envtmpdir} {posargs}
 
 [testenv:py36-unittests-win32]
 platform=win32
@@ -154,3 +158,9 @@ changedir=packages/bootstrap/extra
 commands=
   pip install .
   pytest --basetemp={envtmpdir} {posargs}
+
+[testenv:mypy]
+deps=
+  mypy-mypyc==0.660
+commands=
+  mypy ./test-e2e


### PR DESCRIPTION
## High-level description

This PR add a test for the newly introduced superuser service account login in DC/OS 1.13.

This test is not run on CI - [DCOS_OSS-2032](https://jira.mesosphere.com/browse/DCOS_OSS-2032) is needed for that. It was tested locally and is known to pass.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45325](https://jira.mesosphere.com/browse/DCOS-45325) Build E2E tests for testing new config options superuser_service_account_uid/public_key (for both DC/OS variants).

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: It's just a test.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)