### PR TITLE
[WIP] [1.12] Use prometheus parser for metrics tests

### DIFF
--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -11,6 +11,6 @@ for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
 done
 
 for package in aiohttp checksumdir coloredlogs humanfriendly multidict \
-    oauthlib waitress websocket-client; do
+    oauthlib prometheus_client waitress websocket-client; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package
 done

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -111,6 +111,11 @@
       "url": "https://pypi.python.org/packages/a8/11/fb71ced7057b2a8929f51959f4e97bcee9f687aaf896c521984e67118b90/oauthlib-1.1.2.tar.gz",
       "sha1": "68e894d3b41080e14ec3a93ce0858d546617e809"
     },
+    "prometheus_client": {
+      "kind": "url_extract",
+      "url": "https://files.pythonhosted.org/packages/bc/e1/3cddac03c8992815519c5f50493097f6508fa153d067b494db8ab5e9c4ce/prometheus_client-0.5.0.tar.gz",
+      "sha1": "885ba6707492d8ff97e3f612ed266f0273ee8363"
+    },
     "requests-oauthlib": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/3d/b9/895abf47ce871c80460727ba385d10d246a2d9ded1bc82ba3748d02e5196/requests_oauthlib-0.6.1-py2.py3-none-any.whl",

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 import retrying
 
+from prometheus_client.parser import text_string_to_metric_families
 from test_helpers import get_expanded_config
 
 __maintainer__ = 'mnaboka'
@@ -111,19 +112,20 @@ def test_task_metrics_metadata(dcos_api_session):
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
         pytest.skip('MoM disabled for strict mode')
+
     with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
         node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
 
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
-            for line in response.text.splitlines():
-                if '#' in line:
-                    continue
-                if 'task_name="marathon-user"' in line:
-                    assert 'service_name="marathon"' in line
-                    # check for whitelisted label
-                    assert 'DCOS_SERVICE_NAME="marathon-user"' in line
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[1].get('task_name') == 'marathon-user':
+                        assert sample[1].get('service_name') == 'marathon'
+                        # check for whitelisted label
+                        assert sample[1].get('DCOS_SERVICE_NAME') == 'marathon-user'
+                        return True
         check_metrics_metadata()
 
 
@@ -139,16 +141,13 @@ def test_executor_metrics_metadata(dcos_api_session):
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_executor_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
-            for line in response.text.splitlines():
-                if '#' in line:
-                    continue
-                # ignore metrics from hello-world task started by marathon by checking
-                # for absence of 'marathon' string.
-                if 'cpus_nr_periods' in line and 'marathon' not in line:
-                    assert 'service_name="hello-world"' in line
-                    assert 'task_name=""' in line  # this is an executor, not a task
-                    # hello-world executors can be named "hello" or "world"
-                    assert ('executor_name="hello"' in line or 'executor_name="world"' in line)
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[0] == 'cpus_nr_periods' and sample[1].get('service_name') == 'hello-world':
+                        assert sample[1].get('task_name') == ''
+                        # hello-world executors can be named "hello" or "world"
+                        assert (sample[1].get('executor_name') == 'hello' or sample[1].get('executor_name') == 'world')
+                        return True
         check_executor_metrics_metadata()
 
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'coloredlogs',
         'docopt',
         'passlib',
+        'prometheus_client',
         'py',
         'pytest',
         'pyyaml',


### PR DESCRIPTION
## High-level description

Improve metrics integration tests by using the `prometheus_client` python library to parse prom responses for expected metrics instead of checking for substrings in the response string.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4572](https://jira.mesosphere.com/browse/DCOS_OSS-4572) Parse Prometheus exporter responses in integration tests


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration test changes only
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
