### PR TITLE
Add a test for launching pod with non-root user and ephemeral volume.

### DIFF
--- a/packages/dcos-integration-test/extra/test_ucr.py
+++ b/packages/dcos-integration-test/extra/test_ucr.py
@@ -300,3 +300,47 @@ def test_if_ucr_pods_can_be_deployed_with_auto_cgroups(dcos_api_session):
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
         pass
+
+
+def test_if_ucr_pods_can_be_deployed_with_non_root_user_ephemeral_volume(dcos_api_session):
+    """Marathon pods inside ucr deployment integration test.
+
+    This test launches a marathon ucr pod with a non-root user (nobody)
+    and an ephemeral volume, and verifies the container in the pod can
+    write to the ephemeral volume. In strict mode, the parent container
+    (i.e., the default executor) is launched as nobody as well, so the
+    nested container has the permission to write to the volume since it
+    is launched with nobody in this test. In permissive mode, the user
+    of the parent container and the nested container are different (root
+    and nobody), in this case the volume gid manager in Mesos agent will
+    set the volume owner group to a unique gid and the nested container
+    will be launched with that gid as its supplementary group so that it
+    has the permission to write to the volume.
+    """
+    test_uuid = uuid.uuid4().hex
+    pod_definition = {
+        'id': '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {'kind': 'fixed', 'instances': 1},
+        'environment': {'PING': 'PONG'},
+        'containers': [
+            {
+                'name': 'container1',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'image': {'kind': 'DOCKER', 'id': 'library/alpine'},
+                'exec': {'command': {'shell': 'echo data > ./etc/file'}},
+                'user': 'nobody',
+                "volumeMounts": [{"name": "volume1", "mountPath": "etc"}]
+            },
+            {
+                'name': 'container2',
+                'resources': {'cpus': 0.1, 'mem': 32},
+                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
+                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+            }
+        ],
+        'networks': [{'mode': 'host'}],
+        'volumes': [{'name': 'volume1'}]
+    }
+    with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
+        # Trivial app if it deploys, there is nothing else to check
+        pass


### PR DESCRIPTION
## High-level description

Add an integration for launching pod with non-root user and ephemeral volume

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-47640](https://jira.mesosphere.com/browse/DCOS-47640) Add an integration test for launching pod with non-root user and ephemeral volume.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-47501](https://jira.mesosphere.com/browse/DCOS-47501) Pod cannot be launched with non-root user.
  - [DCOS-39884](https://jira.mesosphere.com/browse/DCOS-39884) Volume ownership and permission improvements.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
