### PR TITLE
Fix superuser service account credentials checking

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -725,24 +725,16 @@ def calculate_check_config_contents(check_config, custom_checks, check_search_pa
     return yaml.dump(json.dumps(merged_checks, indent=2))
 
 
-def calculate__superuser_credentials_given(
+def validate_superuser_credentials_not_partially_given(
         superuser_service_account_uid, superuser_service_account_public_key):
     pair = (superuser_service_account_uid, superuser_service_account_public_key)
 
-    if all(pair):
-        return 'true'
-
-    if not any(pair):
-        return 'false'
-
-    # `calculate_` functions are not supposed to error out, but
-    # in this case here (multi-arg input) this check cannot
-    # currently be replaced by a `validate_` function.
-    raise AssertionError(
-        "'superuser_service_account_uid' and "
-        "'superuser_service_account_public_key' "
-        "must both be empty or both be non-empty"
-    )
+    if any(pair) and not all(pair):
+        raise AssertionError(
+            "'superuser_service_account_uid' and "
+            "'superuser_service_account_public_key' "
+            "must both be empty or both be non-empty"
+        )
 
 
 def calculate__superuser_service_account_public_key_json(
@@ -1013,6 +1005,7 @@ entry = {
         validate_dns_forward_zones,
         validate_zk_hosts,
         validate_zk_path,
+        validate_superuser_credentials_not_partially_given,
         lambda auth_cookie_secure_flag: validate_true_false(auth_cookie_secure_flag),
         lambda oauth_enabled: validate_true_false(oauth_enabled),
         lambda oauth_available: validate_true_false(oauth_available),
@@ -1176,7 +1169,6 @@ entry = {
         'superuser_service_account_uid': '',
         'superuser_service_account_public_key': '',
         '_superuser_service_account_public_key_json': calculate__superuser_service_account_public_key_json,
-        '_superuser_credentials_given': calculate__superuser_credentials_given,
         'enable_gpu_isolation': 'true',
         'cluster_docker_registry_url': '',
         'cluster_docker_credentials_dcos_owned': calculate_docker_credentials_dcos_owned,

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -7,15 +7,7 @@ import yaml
 
 import gen
 import pkgpanda.util
-from gen.tests.utils import make_arguments, true_false_msg, validate_error, validate_success
-
-
-def validate_error_multikey(new_arguments, keys, message, unset=None):
-    assert gen.validate(arguments=make_arguments(new_arguments)) == {
-        'status': 'errors',
-        'errors': {key: {'message': message} for key in keys},
-        'unset': set() if unset is None else unset,
-    }
+from gen.tests.utils import make_arguments, true_false_msg, validate_error, validate_error_multikey, validate_success
 
 
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="configuration not present on windows")

--- a/gen/tests/test_service_account.py
+++ b/gen/tests/test_service_account.py
@@ -1,0 +1,138 @@
+import uuid
+
+import cryptography.hazmat.backends
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import pkgpanda.util
+from gen.tests.utils import validate_error, validate_error_multikey, validate_success
+
+
+cryptography_default_backend = cryptography.hazmat.backends.default_backend()
+
+
+def generate_rsa_public_key():
+    """
+    Generate an RSA keypair with a key size of 2048 bits and an
+    exponent of 65537. Serialize the public key in the the
+    X.509 SubjectPublicKeyInfo/OpenSSL PEM public key format
+    (RFC 5280).
+    Returns:
+        public key as unicode objects holding the serialized key.
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=cryptography_default_backend,
+    )
+    public_key = private_key.public_key()
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode('ascii')
+
+
+# TODO(tweidner): DCOS_OSS-4741 - muted Windows validate always returns {`status`: `ok`}
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows validate never errors out")
+class TestSuperuserServiceAccountCredentials:
+    """
+    Tests superuser service account credential parsing.
+    """
+
+    def test_uid_and_public_key_not_provided(self):
+        """
+        No error is shown if ``superuser_service_account_uid`` and
+        ``superuser_service_account_public_key`` are not provided.
+        """
+        validate_success(new_arguments={})
+
+    def test_uid_and_public_key_provided(self):
+        """
+        No error is shown if valid ``superuser_service_account_uid`` and
+        ``superuser_service_account_public_key`` are provided.
+        """
+        validate_success(
+            new_arguments={
+                'superuser_service_account_uid': str(uuid.uuid4()),
+                'superuser_service_account_public_key': generate_rsa_public_key(),
+            }
+        )
+
+    def test_uid_not_provided(self):
+        """
+        An error is shown when ``superuser_service_account_public_key`` is
+        provided but ``superuser_service_account_uid`` is not.
+        """
+        validate_error_multikey(
+            new_arguments={
+                'superuser_service_account_public_key': generate_rsa_public_key(),
+            },
+            keys=[
+                'superuser_service_account_uid',
+                'superuser_service_account_public_key',
+            ],
+            message=(
+                "'superuser_service_account_uid' and "
+                "'superuser_service_account_public_key' "
+                "must both be empty or both be non-empty"
+            )
+        )
+
+    def test_public_key_not_provided(self):
+        """
+        An error is shown when ``superuser_service_account_uid`` is
+        provided but ``superuser_service_account_public_key`` is not.
+        """
+        validate_error_multikey(
+            new_arguments={'superuser_service_account_uid': str(uuid.uuid4())},
+            keys=[
+                'superuser_service_account_uid',
+                'superuser_service_account_public_key',
+            ],
+            message=(
+                "'superuser_service_account_uid' and "
+                "'superuser_service_account_public_key' "
+                "must both be empty or both be non-empty"
+            )
+        )
+
+    def test_provided_uid_empty(self):
+        """
+        An error is shown when an empty ``superuser_service_account_uid``
+        is together with a valid ``superuser_service_account_public_key``.
+        """
+        validate_error_multikey(
+            new_arguments={
+                'superuser_service_account_uid': '',
+                'superuser_service_account_public_key': generate_rsa_public_key(),
+            },
+            keys=[
+                'superuser_service_account_uid',
+                'superuser_service_account_public_key',
+            ],
+            message=(
+                "'superuser_service_account_uid' and "
+                "'superuser_service_account_public_key' "
+                "must both be empty or both be non-empty"
+            )
+        )
+
+    def test_provided_public_key_invalid(self):
+        """
+        An error is shown when ``superuser_service_account_public_key`` is
+        given a value which is not an RSA public key encoded in the OpenSSL PEM
+        format.
+        """
+        validate_error(
+            new_arguments={
+                'superuser_service_account_uid': str(uuid.uuid4()),
+                'superuser_service_account_public_key': str(uuid.uuid4()),
+            },
+            key='_superuser_service_account_public_key_json',
+            message=(
+                'superuser_service_account_public_key has an invalid value. It '
+                'must hold an RSA public key encoded in the OpenSSL PEM '
+                'format. Error: Could not deserialize key data.'
+            )
+        )

--- a/gen/tests/utils.py
+++ b/gen/tests/utils.py
@@ -41,9 +41,19 @@ def make_arguments(new_arguments):
 
 
 def validate_error(new_arguments, key, message, unset=None):
-    assert gen.validate(arguments=make_arguments(new_arguments)) == {
+    arguments = make_arguments(new_arguments)
+    validate_result = gen.validate(arguments=arguments)
+    assert validate_result == {
         'status': 'errors',
         'errors': {key: {'message': message}},
+        'unset': set() if unset is None else unset,
+    }
+
+
+def validate_error_multikey(new_arguments, keys, message, unset=None):
+    assert gen.validate(arguments=make_arguments(new_arguments)) == {
+        'status': 'errors',
+        'errors': {key: {'message': message} for key in keys},
         'unset': set() if unset is None else unset,
     }
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,7 @@ deps =
   webtest
   webtest-aiohttp==1.1.0
   schema
+  cryptography==2.5
 # Hack to stop pytest from collecting test-e2e tests.
 # Simpler ways of achieving this would not work.
 # https://stackoverflow.com/a/37493203
@@ -106,6 +107,7 @@ deps =
   webtest
   webtest-aiohttp==1.1.0
   schema
+  cryptography==2.5
 commands=
   py.test --basetemp={envtmpdir} {posargs}
 


### PR DESCRIPTION
## High-level description

This PR fixes the bug where DC/OS gen would accept partially specified superuser service account credentials (either uid or public_key missing).
It also adds unit tests for every possible combination.
Skipping the tests for Windows is tracked here:
https://jira.mesosphere.com/browse/DCOS_OSS-4741
This should be investigated and closed once DC/OS has full Windows build support.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-47650](https://jira.mesosphere.com/browse/DCOS-47650) Partially specified superuser_service_account_uid/public_key accepted by gen.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This functionality supposed to be already there in DC/OS but was untested.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)