### PR TITLE
Update mergebot 1.10 config to 1.10.11

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -31,7 +31,7 @@
             "master": "DC/OS 1.13.0",
             "1.12": "DC/OS 1.12.2",
             "1.11": "DC/OS 1.11.9",
-            "1.10": "DC/OS 1.10.10",
+            "1.10": "DC/OS 1.10.11",
             "1.9": "DC/OS 1.9.11"
         },
         "jira_regex": "((?:DCOS|DCOS_OSS|COPS|MARATHON)-\\d+)"


### PR DESCRIPTION
Note: We should update this as soon as the code freeze is over.
