### PR TITLE
[1.12] Reverted the sandbox permission change from 0750 back to 0755.

### DIFF
--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,14 +1,14 @@
-From ca0a8cea7ca6ba4087eeb37da6e6dbdafeca72e8 Mon Sep 17 00:00:00 2001
+From a7eb1fa97ee644e38c2fd260404523e7d08db1d8 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH 01/14] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/docker/docker.cpp b/src/docker/docker.cpp
-index 9ebb5f274..3c81d03b6 100644
+index 9ebb5f2..3c81d03 100644
 --- a/src/docker/docker.cpp
 +++ b/src/docker/docker.cpp
 @@ -681,6 +681,11 @@ Try<Docker::RunOptions> Docker::RunOptions::create(
@@ -24,5 +24,5 @@ index 9ebb5f274..3c81d03b6 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From d89477d37ca7553c27651951d86a0e15f09f98ac Mon Sep 17 00:00:00 2001
+From cf706fd49e47c36267244af398808184fd75ab95 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH 02/14] Updated mesos containerizer to ignore GPU isolator
- creation failure.
+Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
+ failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -23,7 +23,7 @@ by https://reviews.apache.org/r/62472/
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 2345193ef..6d4528587 100644
+index 5a32b84..f226dd2 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
 @@ -447,8 +447,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
@@ -51,5 +51,5 @@ index 2345193ef..6d4528587 100644
  
    // Next, apply any custom isolators in the order given by the flags.
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,8 +1,8 @@
-From 86a4dcd94d93ac6df98f57afcc0a77865e847777 Mon Sep 17 00:00:00 2001
+From 86a4fb684f55085efde06d5b381390a02ffe6860 Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
-Subject: [PATCH 03/14] Mesos UI: updated the URL generation to make it work
- with adminrouter.
+Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
+ adminrouter.
 
 - Use /mesos as the leading master URL prefix.
 - Use /mesos/agent/{agent_id}/{process_name} as the agent URL prefix.
@@ -13,7 +13,7 @@ Subject: [PATCH 03/14] Mesos UI: updated the URL generation to make it work
  1 file changed, 11 insertions(+), 10 deletions(-)
 
 diff --git a/src/webui/app/controllers.js b/src/webui/app/controllers.js
-index 8049cf611..74f65f574 100644
+index 8049cf6..74f65f5 100644
 --- a/src/webui/app/controllers.js
 +++ b/src/webui/app/controllers.js
 @@ -51,10 +51,10 @@
@@ -61,5 +61,5 @@ index 8049cf611..74f65f574 100644
  
      // Adding bindings into scope so that they can be used from within
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,7 +1,7 @@
-From 3daf981cb8cb6cbb2af31f7d94cdefb9dbe6996e Mon Sep 17 00:00:00 2001
+From 3570677514d4f08e1b81eac7ed54c5fce0aef2dc Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Mon, 13 Aug 2018 20:05:26 +0200
-Subject: [PATCH 04/14] Added 'received' timestamp into `process::Request`.
+Subject: [PATCH] Added 'received' timestamp into `process::Request`.
 
 This allows us to note when a request comes in and
 hence calculate request processing time.
@@ -13,7 +13,7 @@ Review: https://reviews.apache.org/r/68992
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/3rdparty/libprocess/include/process/http.hpp b/3rdparty/libprocess/include/process/http.hpp
-index fa66b0fe2..a1b0bb9e3 100644
+index fa66b0f..a1b0bb9 100644
 --- a/3rdparty/libprocess/include/process/http.hpp
 +++ b/3rdparty/libprocess/include/process/http.hpp
 @@ -27,6 +27,7 @@
@@ -43,5 +43,5 @@ index fa66b0fe2..a1b0bb9e3 100644
     * Returns whether the encoding is considered acceptable in the
     * response. See RFC 2616 section 14.3 for details.
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,8 +1,7 @@
-From 0ca6e07cc3243eada057ed538c451cc27a82f48a Mon Sep 17 00:00:00 2001
+From 8e59525ec9c8aaf1119003484c1a8bcb57b2c05d Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Mon, 29 Oct 2018 11:25:58 -0700
-Subject: [PATCH 05/14] Added task health check definitions to master API
- responses.
+Subject: [PATCH] Added task health check definitions to master API responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified, along with associated
@@ -19,7 +18,7 @@ Review: https://reviews.apache.org/r/69110/
  4 files changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
-index e98454138..c68bc2bbb 100644
+index e984541..c68bc2b 100644
 --- a/include/mesos/mesos.proto
 +++ b/include/mesos/mesos.proto
 @@ -2217,8 +2217,8 @@ message TaskGroupInfo {
@@ -45,7 +44,7 @@ index e98454138..c68bc2bbb 100644
    optional string user = 14;
  }
 diff --git a/include/mesos/v1/mesos.proto b/include/mesos/v1/mesos.proto
-index dac7f5163..c34a8d8cf 100644
+index dac7f51..c34a8d8 100644
 --- a/include/mesos/v1/mesos.proto
 +++ b/include/mesos/v1/mesos.proto
 @@ -2210,8 +2210,8 @@ message TaskGroupInfo {
@@ -71,7 +70,7 @@ index dac7f5163..c34a8d8cf 100644
    optional string user = 14;
  }
 diff --git a/src/common/http.cpp b/src/common/http.cpp
-index 932111dde..81102d845 100644
+index 932111d..81102d8 100644
 --- a/src/common/http.cpp
 +++ b/src/common/http.cpp
 @@ -733,6 +733,10 @@ void json(JSON::ObjectWriter* writer, const Task& task)
@@ -86,7 +85,7 @@ index 932111dde..81102d845 100644
  
  
 diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
-index b9289a206..fa949cc5e 100644
+index b9289a2..fa949cc 100644
 --- a/src/common/protobuf_utils.cpp
 +++ b/src/common/protobuf_utils.cpp
 @@ -341,6 +341,10 @@ Task createTask(
@@ -101,5 +100,5 @@ index b9289a206..fa949cc5e 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
@@ -1,7 +1,7 @@
-From 57962673f67209f1449495f5879e9da6baf343a6 Mon Sep 17 00:00:00 2001
+From 52ba2fe898c2e749ad1992dbc62dc988c2996326 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:40:37 +0200
-Subject: [PATCH 06/14] Introduced `logResponse` for http handlers.
+Subject: [PATCH] Introduced `logResponse` for http handlers.
 
 Currently we use `logRequest` function to log requests to endpoints
 in Mesos `MasterProcess`, `SlaveProcess`, and `FilesProcess`. Each
@@ -21,7 +21,7 @@ Review: https://reviews.apache.org/r/68993
  2 files changed, 26 insertions(+)
 
 diff --git a/src/common/http.cpp b/src/common/http.cpp
-index 81102d845..50c9b558b 100644
+index 81102d8..50c9b55 100644
 --- a/src/common/http.cpp
 +++ b/src/common/http.cpp
 @@ -32,6 +32,7 @@
@@ -52,7 +52,7 @@ index 81102d845..50c9b558b 100644
 +
  }  // namespace mesos {
 diff --git a/src/common/http.hpp b/src/common/http.hpp
-index 0901a5528..cc7f747d1 100644
+index 0901a55..cc7f747 100644
 --- a/src/common/http.hpp
 +++ b/src/common/http.hpp
 @@ -338,6 +338,17 @@ Try<Nothing> initializeHttpAuthenticators(
@@ -74,5 +74,5 @@ index 0901a5528..cc7f747d1 100644
  
  #endif // __COMMON_HTTP_HPP__
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,7 +1,7 @@
-From 2382c03e496f3f647905628df49efec6474e45e8 Mon Sep 17 00:00:00 2001
+From c2666e429be69bf34fe62acbf3bab813211c8d5a Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:58:41 +0200
-Subject: [PATCH 07/14] Logged request processing time for some endpoints.
+Subject: [PATCH] Logged request processing time for some endpoints.
 
 This patch leverages `logResponse()` function to print response status
 code together with the request processing time for some endpoints on
@@ -21,10 +21,10 @@ Review: https://reviews.apache.org/r/68994
  2 files changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index f33a5aa79..423bbe533 100644
+index 873d685..bb49f10 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -909,7 +909,10 @@ void Master::initialize()
+@@ -903,7 +903,10 @@ void Master::initialize()
          [this](const process::http::Request& request,
                 const Option<Principal>& principal) {
            logRequest(request);
@@ -36,7 +36,7 @@ index f33a5aa79..423bbe533 100644
          });
    route("/flags",
          READONLY_HTTP_AUTHENTICATION_REALM,
-@@ -969,7 +972,10 @@ void Master::initialize()
+@@ -963,7 +966,10 @@ void Master::initialize()
          [this](const process::http::Request& request,
                 const Option<Principal>& principal) {
            logRequest(request);
@@ -48,7 +48,7 @@ index f33a5aa79..423bbe533 100644
          });
    // TODO(ijimenez): Remove this endpoint at the end of the
    // deprecation cycle on 0.26.
-@@ -987,7 +993,10 @@ void Master::initialize()
+@@ -981,7 +987,10 @@ void Master::initialize()
          [this](const process::http::Request& request,
                 const Option<Principal>& principal) {
            logRequest(request);
@@ -60,7 +60,7 @@ index f33a5aa79..423bbe533 100644
          });
    route("/state-summary",
          READONLY_HTTP_AUTHENTICATION_REALM,
-@@ -995,7 +1004,10 @@ void Master::initialize()
+@@ -989,7 +998,10 @@ void Master::initialize()
          [this](const process::http::Request& request,
                 const Option<Principal>& principal) {
            logRequest(request);
@@ -72,7 +72,7 @@ index f33a5aa79..423bbe533 100644
          });
    // TODO(ijimenez): Remove this endpoint at the end of the
    // deprecation cycle.
-@@ -1013,7 +1025,10 @@ void Master::initialize()
+@@ -1007,7 +1019,10 @@ void Master::initialize()
          [this](const process::http::Request& request,
                 const Option<Principal>& principal) {
            logRequest(request);
@@ -85,7 +85,7 @@ index f33a5aa79..423bbe533 100644
    route("/maintenance/schedule",
          READWRITE_HTTP_AUTHENTICATION_REALM,
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 1d5dad528..07066a79f 100644
+index 1d5dad5..07066a7 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -809,7 +809,10 @@ void Slave::initialize()
@@ -113,5 +113,5 @@ index 1d5dad528..07066a79f 100644
  
    const PID<Slave> slavePid = self();
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
+++ b/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
@@ -1,7 +1,7 @@
-From 8dea81118ec585e17e5d21940b30782f4dcec4ad Mon Sep 17 00:00:00 2001
+From c048f4c6450d0dbf5d6370fabfa81c1e2bcd0370 Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Fri, 23 Nov 2018 10:54:58 +0800
-Subject: [PATCH 08/14] Changed sandbox mode to 0755 in docker containerizer
+Subject: [PATCH] Changed sandbox mode to 0755 in docker containerizer
  container launch.
 
 Starting from Mesos 1.6.0, sandbox permission was changed from 0755
@@ -20,7 +20,7 @@ removed in DC/OS 1.15.
  1 file changed, 12 insertions(+)
 
 diff --git a/src/slave/containerizer/docker.cpp b/src/slave/containerizer/docker.cpp
-index 192dc2957..7c3575a6c 100644
+index 192dc29..7c3575a 100644
 --- a/src/slave/containerizer/docker.cpp
 +++ b/src/slave/containerizer/docker.cpp
 @@ -1176,6 +1176,18 @@ Future<Containerizer::LaunchResult> DockerContainerizerProcess::launch(
@@ -43,5 +43,5 @@ index 192dc2957..7c3575a6c 100644
        containerId,
        containerConfig,
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
+++ b/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
@@ -1,8 +1,7 @@
-From 44e939258baca36130555191ce700c49460d6c62 Mon Sep 17 00:00:00 2001
+From 936ef7f80b52a5a54c1b24b8858117da61a5f842 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:21 -0800
-Subject: [PATCH 09/14] Added HEARTBEAT events and calls for the executor HTTP
- API.
+Subject: [PATCH] Added HEARTBEAT events and calls for the executor HTTP API.
 
 These new messages are meant to be backwards compatible, in that
 they won't cause crashes when new executors send heartbeats to old
@@ -18,7 +17,7 @@ Review: https://reviews.apache.org/r/69463/
  2 files changed, 24 insertions(+)
 
 diff --git a/include/mesos/executor/executor.proto b/include/mesos/executor/executor.proto
-index 1b5fa5dab..ce724c098 100644
+index 1b5fa5d..ce724c0 100644
 --- a/include/mesos/executor/executor.proto
 +++ b/include/mesos/executor/executor.proto
 @@ -66,6 +66,11 @@ message Event {
@@ -48,7 +47,7 @@ index 1b5fa5dab..ce724c098 100644
  
    // Request to subscribe with the slave. If subscribing after a disconnection,
 diff --git a/include/mesos/v1/executor/executor.proto b/include/mesos/v1/executor/executor.proto
-index b2ef325cf..51fa66d42 100644
+index b2ef325..51fa66d 100644
 --- a/include/mesos/v1/executor/executor.proto
 +++ b/include/mesos/v1/executor/executor.proto
 @@ -66,6 +66,11 @@ message Event {
@@ -78,5 +77,5 @@ index b2ef325cf..51fa66d42 100644
  
    // Request to subscribe with the agent. If subscribing after a disconnection,
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
+++ b/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
@@ -1,7 +1,7 @@
-From a3b9778ae09707918df23067ea74fe7b7d825935 Mon Sep 17 00:00:00 2001
+From 2ae174526cbcf02136acccccc8e278d96bd33b20 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:24 -0800
-Subject: [PATCH 10/14] Refactored master and agent streaming connections.
+Subject: [PATCH] Refactored master and agent streaming connections.
 
 This moves the very similar `HttpConnection` classes inside the
 master and agent into a common header.  The refactored
@@ -18,20 +18,20 @@ for agent->executor heartbeats.
 Review: https://reviews.apache.org/r/69472/
 ---
  src/Makefile.am            |   1 +
- src/common/heartbeater.hpp | 138 ++++++++++++++++++++++++++++++
- src/common/http.hpp        |  45 ++++++++++
- src/master/framework.cpp   |  37 ++++----
- src/master/http.cpp        |  11 ++-
- src/master/master.cpp      |  35 ++++----
- src/master/master.hpp      | 169 +++++++------------------------------
+ src/common/heartbeater.hpp | 138 ++++++++++++++++++++++++++++++++++++
+ src/common/http.hpp        |  45 ++++++++++++
+ src/master/framework.cpp   |  37 ++++------
+ src/master/http.cpp        |  11 +--
+ src/master/master.cpp      |  35 ++++++----
+ src/master/master.hpp      | 169 +++++++++------------------------------------
  src/slave/http.cpp         |   4 +-
  src/slave/slave.cpp        |   2 +-
- src/slave/slave.hpp        |  39 +--------
+ src/slave/slave.hpp        |  39 +----------
  10 files changed, 264 insertions(+), 217 deletions(-)
  create mode 100644 src/common/heartbeater.hpp
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 766bb920c..69df21ec3 100644
+index eb50fc7..17caf02 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
 @@ -989,6 +989,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
@@ -44,7 +44,7 @@ index 766bb920c..69df21ec3 100644
    common/resources.cpp							\
 diff --git a/src/common/heartbeater.hpp b/src/common/heartbeater.hpp
 new file mode 100644
-index 000000000..f7c3a8016
+index 0000000..f7c3a80
 --- /dev/null
 +++ b/src/common/heartbeater.hpp
 @@ -0,0 +1,138 @@
@@ -187,7 +187,7 @@ index 000000000..f7c3a8016
 +
 +#endif // __COMMON_HEARTBEATER_HPP__
 diff --git a/src/common/http.hpp b/src/common/http.hpp
-index cc7f747d1..954508fc3 100644
+index cc7f747..954508f 100644
 --- a/src/common/http.hpp
 +++ b/src/common/http.hpp
 @@ -36,7 +36,11 @@
@@ -251,7 +251,7 @@ index cc7f747d1..954508fc3 100644
  JSON::Object model(const hashmap<std::string, Resources>& roleResources);
  JSON::Object model(const Attributes& attributes);
 diff --git a/src/master/framework.cpp b/src/master/framework.cpp
-index 7cfe9f49c..8589c6ff6 100644
+index 7cfe9f4..8589c6f 100644
 --- a/src/master/framework.cpp
 +++ b/src/master/framework.cpp
 @@ -16,6 +16,7 @@
@@ -332,7 +332,7 @@ index 7cfe9f49c..8589c6ff6 100644
  
  
 diff --git a/src/master/http.cpp b/src/master/http.cpp
-index e2773ed78..0e2c2bb78 100644
+index e2773ed..0e2c2bb 100644
 --- a/src/master/http.cpp
 +++ b/src/master/http.cpp
 @@ -838,7 +838,8 @@ Future<Response> Master::Http::subscribe(
@@ -371,10 +371,10 @@ index e2773ed78..0e2c2bb78 100644
  
      return ok;
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 423bbe533..51ad910d7 100644
+index bb49f10..1ec273b 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -1256,7 +1256,9 @@ void Master::finalize()
+@@ -1250,7 +1250,9 @@ void Master::finalize()
  }
  
  
@@ -385,7 +385,7 @@ index 423bbe533..51ad910d7 100644
  {
    foreachvalue (Framework* framework, frameworks.registered) {
      if (framework->http.isSome() && framework->http->writer == http.writer) {
-@@ -2535,7 +2537,7 @@ void Master::reregisterFramework(
+@@ -2529,7 +2531,7 @@ void Master::reregisterFramework(
  
  
  void Master::subscribe(
@@ -394,7 +394,7 @@ index 423bbe533..51ad910d7 100644
      const scheduler::Call::Subscribe& subscribe)
  {
    // TODO(anand): Authenticate the framework.
-@@ -2635,7 +2637,7 @@ void Master::subscribe(
+@@ -2629,7 +2631,7 @@ void Master::subscribe(
  
    // Need to disambiguate for the compiler.
    void (Master::*_subscribe)(
@@ -403,7 +403,7 @@ index 423bbe533..51ad910d7 100644
        const FrameworkInfo&,
        bool,
        const set<string>&,
-@@ -2653,7 +2655,7 @@ void Master::subscribe(
+@@ -2647,7 +2649,7 @@ void Master::subscribe(
  
  
  void Master::_subscribe(
@@ -412,7 +412,7 @@ index 423bbe533..51ad910d7 100644
      const FrameworkInfo& frameworkInfo,
      bool force,
      const set<string>& suppressedRoles,
-@@ -9977,7 +9979,8 @@ void Master::addFramework(
+@@ -9971,7 +9973,8 @@ void Master::addFramework(
      } else {
        CHECK_SOME(framework->http);
  
@@ -422,7 +422,7 @@ index 423bbe533..51ad910d7 100644
  
        http.closed()
          .onAny(defer(self(), &Self::exited, framework->id(), http));
-@@ -10067,7 +10070,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10061,7 +10064,7 @@ Try<Nothing> Master::activateRecoveredFramework(
      Framework* framework,
      const FrameworkInfo& frameworkInfo,
      const Option<UPID>& pid,
@@ -431,7 +431,7 @@ index 423bbe533..51ad910d7 100644
      const set<string>& suppressedRoles)
  {
    // Exactly one of `pid` or `http` must be provided.
-@@ -10145,7 +10148,9 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10139,7 +10142,9 @@ Try<Nothing> Master::activateRecoveredFramework(
  }
  
  
@@ -442,7 +442,7 @@ index 423bbe533..51ad910d7 100644
  {
    CHECK_NOTNULL(framework);
  
-@@ -12029,7 +12034,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12023,7 +12028,7 @@ void Master::Subscribers::Subscriber::send(
        if (approvers->approved<VIEW_TASK>(
                event->task_added().task(), *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -451,7 +451,7 @@ index 423bbe533..51ad910d7 100644
        }
        break;
      }
-@@ -12039,7 +12044,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12033,7 +12038,7 @@ void Master::Subscribers::Subscriber::send(
  
        if (approvers->approved<VIEW_TASK>(*task, *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -460,7 +460,7 @@ index 423bbe533..51ad910d7 100644
        }
        break;
      }
-@@ -12070,7 +12075,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12064,7 +12069,7 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -469,7 +469,7 @@ index 423bbe533..51ad910d7 100644
        }
        break;
      }
-@@ -12101,14 +12106,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12095,14 +12100,14 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -486,7 +486,7 @@ index 423bbe533..51ad910d7 100644
        }
        break;
      }
-@@ -12126,14 +12131,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12120,14 +12125,14 @@ void Master::Subscribers::Subscriber::send(
          }
        }
  
@@ -503,7 +503,7 @@ index 423bbe533..51ad910d7 100644
        break;
    }
  }
-@@ -12154,7 +12159,7 @@ void Master::exited(const id::UUID& id)
+@@ -12148,7 +12153,7 @@ void Master::exited(const id::UUID& id)
  
  
  void Master::subscribe(
@@ -513,7 +513,7 @@ index 423bbe533..51ad910d7 100644
  {
    LOG(INFO) << "Added subscriber " << http.streamId
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index b367aadde..4118502a4 100644
+index b367aad..4118502 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -75,6 +75,7 @@
@@ -783,7 +783,7 @@ index b367aadde..4118502a4 100644
  
    // This is used for per-framwork metrics.
 diff --git a/src/slave/http.cpp b/src/slave/http.cpp
-index f7be16ebe..94aabba17 100644
+index f7be16e..94aabba 100644
 --- a/src/slave/http.cpp
 +++ b/src/slave/http.cpp
 @@ -837,7 +837,9 @@ Future<Response> Http::executor(
@@ -798,7 +798,7 @@ index f7be16ebe..94aabba17 100644
  
        return ok;
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 07066a79f..ca7d0aa45 100644
+index 07066a7..ca7d0aa 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -4644,7 +4644,7 @@ void Slave::operationStatusAcknowledgement(
@@ -811,7 +811,7 @@ index 07066a79f..ca7d0aa45 100644
      Framework* framework,
      Executor* executor)
 diff --git a/src/slave/slave.hpp b/src/slave/slave.hpp
-index 28d65908b..344e1b2c7 100644
+index 28d6590..344e1b2 100644
 --- a/src/slave/slave.hpp
 +++ b/src/slave/slave.hpp
 @@ -112,7 +112,6 @@ class TaskStatusUpdateManager;
@@ -882,5 +882,5 @@ index 28d65908b..344e1b2c7 100644
  
    // Tasks can be found in one of the following four data structures:
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
+++ b/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
@@ -1,7 +1,7 @@
-From c1e7b7dcc53e9807188286e2597e059f379b9cf7 Mon Sep 17 00:00:00 2001
+From bb1b22349bef6a3685a8586470d6c36c3391bcfd Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:36 -0800
-Subject: [PATCH 11/14] Added heartbeaters for agent and HTTP executors.
+Subject: [PATCH] Added heartbeaters for agent and HTTP executors.
 
 This implements two separate heartbeaters for Executor Events (agent
 to executor) and Executor Calls (executor to agent).  Both are set to
@@ -23,7 +23,7 @@ Review: https://reviews.apache.org/r/69473/
  9 files changed, 61 insertions(+)
 
 diff --git a/src/common/validation.cpp b/src/common/validation.cpp
-index 5f8f2889f..4a64fc8ac 100644
+index 5f8f288..4a64fc8 100644
 --- a/src/common/validation.cpp
 +++ b/src/common/validation.cpp
 @@ -602,6 +602,10 @@ Option<Error> validateExecutorCall(const mesos::executor::Call& call)
@@ -38,7 +38,7 @@ index 5f8f2889f..4a64fc8ac 100644
        return None();
      }
 diff --git a/src/executor/executor.cpp b/src/executor/executor.cpp
-index d00ea32f0..e9439da2a 100644
+index d00ea32..e9439da 100644
 --- a/src/executor/executor.cpp
 +++ b/src/executor/executor.cpp
 @@ -90,6 +90,11 @@ namespace mesos {
@@ -83,7 +83,7 @@ index d00ea32f0..e9439da2a 100644
    struct Callbacks
    {
 diff --git a/src/executor/v0_v1executor.cpp b/src/executor/v0_v1executor.cpp
-index aebdbe705..de73f0ec1 100644
+index aebdbe7..de73f0e 100644
 --- a/src/executor/v0_v1executor.cpp
 +++ b/src/executor/v0_v1executor.cpp
 @@ -229,6 +229,12 @@ public:
@@ -100,7 +100,7 @@ index aebdbe705..de73f0ec1 100644
          EXIT(EXIT_FAILURE) << "Received an unexpected " << call.type()
                             << " call";
 diff --git a/src/launcher/default_executor.cpp b/src/launcher/default_executor.cpp
-index b89b0363d..d32931fba 100644
+index b89b036..d32931f 100644
 --- a/src/launcher/default_executor.cpp
 +++ b/src/launcher/default_executor.cpp
 @@ -295,6 +295,10 @@ public:
@@ -115,7 +115,7 @@ index b89b0363d..d32931fba 100644
          LOG(WARNING) << "Received an UNKNOWN event and ignored";
          break;
 diff --git a/src/launcher/executor.cpp b/src/launcher/executor.cpp
-index 6b1204dc5..f962e800f 100644
+index 6b1204d..f962e80 100644
 --- a/src/launcher/executor.cpp
 +++ b/src/launcher/executor.cpp
 @@ -258,6 +258,10 @@ public:
@@ -130,7 +130,7 @@ index 6b1204dc5..f962e800f 100644
          LOG(WARNING) << "Received an UNKNOWN event and ignored";
          break;
 diff --git a/src/slave/constants.hpp b/src/slave/constants.hpp
-index fdc21a35b..1a201138e 100644
+index fdc21a3..1a20113 100644
 --- a/src/slave/constants.hpp
 +++ b/src/slave/constants.hpp
 @@ -48,6 +48,9 @@ constexpr Duration MAX_EXECUTOR_REREGISTRATION_TIMEOUT = Seconds(15);
@@ -144,7 +144,7 @@ index fdc21a35b..1a201138e 100644
  
  // TODO(gkleiman): Move this to a different file once `TaskStatusUpdateManager`
 diff --git a/src/slave/http.cpp b/src/slave/http.cpp
-index 94aabba17..aae030469 100644
+index 94aabba..aae0304 100644
 --- a/src/slave/http.cpp
 +++ b/src/slave/http.cpp
 @@ -865,6 +865,10 @@ Future<Response> Http::executor(
@@ -159,7 +159,7 @@ index 94aabba17..aae030469 100644
        LOG(WARNING) << "Received 'UNKNOWN' call";
        return NotImplemented();
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index ca7d0aa45..b39294ad6 100644
+index ca7d0aa..b39294a 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -4705,6 +4705,18 @@ void Slave::subscribe(
@@ -182,7 +182,7 @@ index ca7d0aa45..b39294ad6 100644
          // Write a marker file to indicate that this executor
          // is HTTP based.
 diff --git a/src/slave/slave.hpp b/src/slave/slave.hpp
-index 344e1b2c7..13d63872a 100644
+index 344e1b2..13d6387 100644
 --- a/src/slave/slave.hpp
 +++ b/src/slave/slave.hpp
 @@ -69,6 +69,7 @@
@@ -204,5 +204,5 @@ index 344e1b2c7..13d63872a 100644
  
    // Tasks can be found in one of the following four data structures:
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
+++ b/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
@@ -1,7 +1,7 @@
-From d02bfbc8a2964c8222a3bd06237aa3264a43ae30 Mon Sep 17 00:00:00 2001
+From 4e327f511152c422e44d216dae325bbb9f6128ed Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:43 -0800
-Subject: [PATCH 12/14] Added tests for agent/executor heartbeating.
+Subject: [PATCH] Added tests for agent/executor heartbeating.
 
 This adds two separate tests which check if the Agent sends heartbeats
 to HTTP executors, and if the HTTP executor driver sends heartbeats
@@ -11,12 +11,12 @@ Review: https://reviews.apache.org/r/69474/
 ---
  src/examples/long_lived_executor.cpp  |   1 +
  src/examples/test_http_executor.cpp   |   4 +
- src/tests/executor_http_api_tests.cpp | 308 ++++++++++++++++++++++++++
+ src/tests/executor_http_api_tests.cpp | 308 ++++++++++++++++++++++++++++++++++
  src/tests/mesos.hpp                   |   2 +
  4 files changed, 315 insertions(+)
 
 diff --git a/src/examples/long_lived_executor.cpp b/src/examples/long_lived_executor.cpp
-index b87a80698..868287060 100644
+index b87a806..8682870 100644
 --- a/src/examples/long_lived_executor.cpp
 +++ b/src/examples/long_lived_executor.cpp
 @@ -132,6 +132,7 @@ protected:
@@ -28,7 +28,7 @@ index b87a80698..868287060 100644
            break;
          }
 diff --git a/src/examples/test_http_executor.cpp b/src/examples/test_http_executor.cpp
-index e5f7cbb3b..0689c1072 100644
+index e5f7cbb..0689c10 100644
 --- a/src/examples/test_http_executor.cpp
 +++ b/src/examples/test_http_executor.cpp
 @@ -195,6 +195,10 @@ public:
@@ -43,7 +43,7 @@ index e5f7cbb3b..0689c1072 100644
            LOG(WARNING) << "Received an UNKNOWN event and ignored";
            break;
 diff --git a/src/tests/executor_http_api_tests.cpp b/src/tests/executor_http_api_tests.cpp
-index a635e1a3c..99bcafb65 100644
+index a635e1a..99bcafb 100644
 --- a/src/tests/executor_http_api_tests.cpp
 +++ b/src/tests/executor_http_api_tests.cpp
 @@ -74,10 +74,22 @@ using recordio::Decoder;
@@ -373,7 +373,7 @@ index a635e1a3c..99bcafb65 100644
  } // namespace internal {
  } // namespace mesos {
 diff --git a/src/tests/mesos.hpp b/src/tests/mesos.hpp
-index 60bd6e098..f965ef2fd 100644
+index 60bd6e0..f965ef2 100644
 --- a/src/tests/mesos.hpp
 +++ b/src/tests/mesos.hpp
 @@ -2780,6 +2780,8 @@ public:
@@ -386,5 +386,5 @@ index 60bd6e098..f965ef2fd 100644
            LOG(FATAL) << "Received unexpected UNKNOWN event";
            break;
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
+++ b/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
@@ -1,8 +1,7 @@
-From b4b363a7f9ea76b98a6fad1f486f2d873563b9a8 Mon Sep 17 00:00:00 2001
+From 406baa060b5d5f7e1e703f9c20705b2a7bea72d8 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:35:03 -0800
-Subject: [PATCH 13/14] Changed master to hold subscribers in a circular
- buffer.
+Subject: [PATCH] Changed master to hold subscribers in a circular buffer.
 
 This adds a flag (--max_operator_event_stream_subscribers) to the
 master which controls how many active subscribers on the Master's
@@ -15,20 +14,20 @@ option of lowering this flag.
 
 Review: https://reviews.apache.org/r/69307/
 ---
- docs/configuration/master.md |  16 ++++
- src/master/constants.hpp     |   4 +
+ docs/configuration/master.md |  16 +++++
+ src/master/constants.hpp     |   4 ++
  src/master/flags.cpp         |  11 +++
  src/master/flags.hpp         |   1 +
- src/master/master.cpp        |  17 +++-
+ src/master/master.cpp        |  17 ++++-
  src/master/master.hpp        |   6 +-
- src/tests/api_tests.cpp      | 167 +++++++++++++++++++++++++++++++++++
+ src/tests/api_tests.cpp      | 167 +++++++++++++++++++++++++++++++++++++++++++
  7 files changed, 217 insertions(+), 5 deletions(-)
 
 diff --git a/docs/configuration/master.md b/docs/configuration/master.md
-index f290e377b..48ffe3822 100644
+index 883bc61..5319f7f 100644
 --- a/docs/configuration/master.md
 +++ b/docs/configuration/master.md
-@@ -444,6 +444,22 @@ Maximum number of completed tasks per framework to store in memory. (default: 10
+@@ -448,6 +448,22 @@ Maximum number of completed tasks per framework to store in memory. (default: 10
    </td>
  </tr>
  
@@ -52,7 +51,7 @@ index f290e377b..48ffe3822 100644
    <td>
      --max_unreachable_tasks_per_framework=VALUE
 diff --git a/src/master/constants.hpp b/src/master/constants.hpp
-index 76ad0c3b1..b0ab9187b 100644
+index 76ad0c3..b0ab918 100644
 --- a/src/master/constants.hpp
 +++ b/src/master/constants.hpp
 @@ -91,6 +91,10 @@ constexpr double RECOVERY_AGENT_REMOVAL_PERCENT_LIMIT = 1.0; // 100%.
@@ -67,10 +66,10 @@ index 76ad0c3b1..b0ab9187b 100644
  constexpr size_t DEFAULT_MAX_COMPLETED_FRAMEWORKS = 50;
  
 diff --git a/src/master/flags.cpp b/src/master/flags.cpp
-index 6ad53ed44..96ba3c59a 100644
+index 38ba888..e76acd6 100644
 --- a/src/master/flags.cpp
 +++ b/src/master/flags.cpp
-@@ -572,6 +572,17 @@ mesos::internal::master::Flags::Flags()
+@@ -578,6 +578,17 @@ mesos::internal::master::Flags::Flags()
        "Currently there is no support for multiple HTTP framework\n"
        "authenticators.");
  
@@ -89,7 +88,7 @@ index 6ad53ed44..96ba3c59a 100644
        "max_completed_frameworks",
        "Maximum number of completed frameworks to store in memory.",
 diff --git a/src/master/flags.hpp b/src/master/flags.hpp
-index 4a260155b..c29cebf7b 100644
+index 4a26015..c29cebf 100644
 --- a/src/master/flags.hpp
 +++ b/src/master/flags.hpp
 @@ -90,6 +90,7 @@ public:
@@ -101,10 +100,10 @@ index 4a260155b..c29cebf7b 100644
    size_t max_completed_tasks_per_framework;
    size_t max_unreachable_tasks_per_framework;
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 51ad910d7..56189807e 100644
+index 1ec273b..0f7a84b 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -324,7 +324,7 @@ Master::Master(
+@@ -326,7 +326,7 @@ Master::Master(
      detector(_detector),
      authorizer(_authorizer),
      frameworks(flags),
@@ -113,7 +112,7 @@ index 51ad910d7..56189807e 100644
      authenticator(None()),
      metrics(new Metrics(*this)),
      electedTime(None())
-@@ -12147,7 +12147,9 @@ void Master::Subscribers::Subscriber::send(
+@@ -12141,7 +12141,9 @@ void Master::Subscribers::Subscriber::send(
  void Master::exited(const id::UUID& id)
  {
    if (!subscribers.subscribed.contains(id)) {
@@ -124,7 +123,7 @@ index 51ad910d7..56189807e 100644
      return;
    }
  
-@@ -12171,7 +12173,16 @@ void Master::subscribe(
+@@ -12165,7 +12167,16 @@ void Master::subscribe(
               exited(http.streamId);
             }));
  
@@ -143,7 +142,7 @@ index 51ad910d7..56189807e 100644
        Owned<Subscribers::Subscriber>(
            new Subscribers::Subscriber{http, principal}));
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 4118502a4..150e791de 100644
+index 4118502..150e791 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
 @@ -1999,7 +1999,9 @@ private:
@@ -167,7 +166,7 @@ index 4118502a4..150e791de 100644
  
    Subscribers subscribers;
 diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
-index b42628ac9..9d61ff59d 100644
+index b42628a..9d61ff5 100644
 --- a/src/tests/api_tests.cpp
 +++ b/src/tests/api_tests.cpp
 @@ -36,6 +36,7 @@
@@ -352,5 +351,5 @@ index b42628ac9..9d61ff59d 100644
  // `GET_QUOTA` call, after we set quota resources through `SET_QUOTA` call.
  TEST_P(MasterAPITest, GetQuota)
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
+++ b/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
@@ -1,8 +1,7 @@
-From 2810ae2801f8a32aaa80f24af496a51e4c66de48 Mon Sep 17 00:00:00 2001
+From f42ad4abfbe7542106f9a164950072fe6104c022 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:35:12 -0800
-Subject: [PATCH 14/14] Added gauge metric for operator event stream
- subscribers.
+Subject: [PATCH] Added gauge metric for operator event stream subscribers.
 
 This metric "master/operator_event_stream_subscribers" returns
 the total number of subscribers to the master's operator event stream.
@@ -19,7 +18,7 @@ Review: https://reviews.apache.org/r/69514/
  7 files changed, 37 insertions(+)
 
 diff --git a/docs/monitoring.md b/docs/monitoring.md
-index 00c6ea94b..2c2320ad0 100644
+index 00c6ea9..2c2320a 100644
 --- a/docs/monitoring.md
 +++ b/docs/monitoring.md
 @@ -979,6 +979,13 @@ event queue.
@@ -37,25 +36,25 @@ index 00c6ea94b..2c2320ad0 100644
  
  #### Registrar
 diff --git a/docs/operator-http-api.md b/docs/operator-http-api.md
-index 6edf36104..2d4a9b66e 100644
+index 6edf361..2d4a9b6 100644
 --- a/docs/operator-http-api.md
 +++ b/docs/operator-http-api.md
-@@ -716,6 +716,10 @@ Content-Type: application/json
-         "name": "master/outstanding_offers",
+@@ -717,6 +717,10 @@ Content-Type: application/json
          "value": 0.0
        },
-+      {
+       {
 +        "name": "master/operator_event_stream_subscribers",
 +        "value": 0.0
 +      },
-       {
++      {
          "name": "master/frameworks_active",
          "value": 0.0
+       },
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 56189807e..13ba4a42e 100644
+index 0f7a84b..6fd2b01 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -12157,6 +12157,9 @@ void Master::exited(const id::UUID& id)
+@@ -12151,6 +12151,9 @@ void Master::exited(const id::UUID& id)
              << " from the list of active subscribers";
  
    subscribers.subscribed.erase(id);
@@ -65,7 +64,7 @@ index 56189807e..13ba4a42e 100644
  }
  
  
-@@ -12186,6 +12189,9 @@ void Master::subscribe(
+@@ -12180,6 +12183,9 @@ void Master::subscribe(
        http.streamId,
        Owned<Subscribers::Subscriber>(
            new Subscribers::Subscriber{http, principal}));
@@ -76,7 +75,7 @@ index 56189807e..13ba4a42e 100644
  
  
 diff --git a/src/master/metrics.cpp b/src/master/metrics.cpp
-index 56a7eef2d..3ed0827ad 100644
+index 56a7eef..3ed0827 100644
 --- a/src/master/metrics.cpp
 +++ b/src/master/metrics.cpp
 @@ -80,6 +80,8 @@ Metrics::Metrics(const Master& master)
@@ -107,7 +106,7 @@ index 56a7eef2d..3ed0827ad 100644
    process::metrics::remove(tasks_starting);
    process::metrics::remove(tasks_running);
 diff --git a/src/master/metrics.hpp b/src/master/metrics.hpp
-index a8055159b..1cf03301e 100644
+index a805515..1cf0330 100644
 --- a/src/master/metrics.hpp
 +++ b/src/master/metrics.hpp
 @@ -60,6 +60,8 @@ struct Metrics
@@ -120,7 +119,7 @@ index a8055159b..1cf03301e 100644
    process::metrics::PullGauge tasks_staging;
    process::metrics::PullGauge tasks_starting;
 diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
-index 9d61ff59d..00c2ce77f 100644
+index 9d61ff5..00c2ce7 100644
 --- a/src/tests/api_tests.cpp
 +++ b/src/tests/api_tests.cpp
 @@ -3527,6 +3527,7 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
@@ -154,7 +153,7 @@ index 9d61ff59d..00c2ce77f 100644
    // and should not cause any disconnections.
    Future<http::Response> response4 = http::streaming::post(
 diff --git a/src/tests/master_tests.cpp b/src/tests/master_tests.cpp
-index 9d5d5a3bd..1e840c478 100644
+index 9d5d5a3..1e840c4 100644
 --- a/src/tests/master_tests.cpp
 +++ b/src/tests/master_tests.cpp
 @@ -2265,6 +2265,9 @@ TEST_F(MasterTest, MetricsInMetricsEndpoint)
@@ -168,5 +167,5 @@ index 9d5d5a3bd..1e840c478 100644
    EXPECT_EQ(1u, snapshot.values.count("master/tasks_starting"));
    EXPECT_EQ(1u, snapshot.values.count("master/tasks_running"));
 -- 
-2.17.0
+2.5.1
 

--- a/packages/mesos/extra/patches/0015-Reverted-the-container-sandbox-permission-from-0750-.patch
+++ b/packages/mesos/extra/patches/0015-Reverted-the-container-sandbox-permission-from-0750-.patch
@@ -1,0 +1,45 @@
+From 5755a3bb48b0e4fbd562ce1bb7cb82f1ae456811 Mon Sep 17 00:00:00 2001
+From: Gilbert Song <songzihao1990@gmail.com>
+Date: Fri, 25 Jan 2019 10:40:07 -0800
+Subject: [PATCH] Reverted the container sandbox permission from 0750 back to
+ 0755.
+
+This patch is used to revert the sandbox permission semantic change
+in Mesos 1.6.0 (caused by this commit 04dd7f32). 04dd7f32 caused
+nestd container could not traverse its parent container's sandbox
+if the nested container user is an arbitrary non-root user and
+different from its parent's user.
+
+Without this revert, there will be two issues:
+1. Some modules may not be able to create files under the sandbox
+   as a non-root user.
+2. Task launched as non-root users may not be able to open files
+   under the sandbox if the task is launched as a non-root user.
+
+This patch could be removed once DCOS-47501 and MESOS-9536 are
+landed.
+---
+ src/slave/paths.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/src/slave/paths.cpp b/src/slave/paths.cpp
+index ed0b127..cbce598 100644
+--- a/src/slave/paths.cpp
++++ b/src/slave/paths.cpp
+@@ -789,13 +789,6 @@ Try<Nothing> createSandboxDirectory(
+   }
+ 
+ #ifndef __WINDOWS__
+-  // Since this is a sandbox directory containing private task data,
+-  // we want to ensure that it is not accessible to "others".
+-  Try<Nothing> chmod = os::chmod(directory, 0750);
+-  if (mkdir.isError()) {
+-    return Error("Failed to chmod directory: " + chmod.error());
+-  }
+-
+   if (user.isSome()) {
+     Try<Nothing> chown = os::chown(user.get(), directory);
+     if (chown.isError()) {
+-- 
+2.5.1
+


### PR DESCRIPTION
This patch is used to revert the sandbox permission semantic change
in Mesos 1.6.0 (caused by this commit 04dd7f32). 04dd7f32 caused
nestd container could not traverse its parent container's sandbox
if the nested container user is an arbitrary non-root user and
different from its parent's user.

Without this revert, there will be two issues:
1. Some modules may not be able to create files under the sandbox
   as a non-root user.
2. Task launched as non-root users may not be able to open files
   under the sandbox if the task is launched as a non-root user.

This patch could be removed once DCOS-47501 and MESOS-9536 are
landed.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-47699](https://jira.mesosphere.com/browse/DCOS-47699) Revert the 1.12 sandbox permission change back to 0755.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
