### PR TITLE
Catch Additional Azure Exceptions

### DIFF
--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -37,15 +37,27 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
         except (azure.common.AzureException, azure.common.AzureMissingResourceHttpError):
             # Cancel the past copy, make a new copy
-            properties = self.blob_service.get_blob_properties(self.container, destination_path)
-            assert properties.id
-            self.blob_service.abort_copy_blob(self.container, destination_path, properties.id)
+            # copy_blob returns a returns a copy operation properties object, including a copy ID can be used to check
+            # or abort the  copy operation.
 
-            # Try the copy again
-            resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
-        except azure.common.AzureConflictHttpError:
-            pass
+            # copy_blob as per Azure is a best effort operation.
 
+            # If the previous copy failed due to HTTP Connection Error, we can abort it using copy.id and retry.
+            # Otherwise, we simply retry again.
+
+            try:
+                assert resp.id
+                self.blob_service.abort_copy_blob(self.container, destination_path, resp.id)
+            except AttributeError:
+                pass
+
+            try:
+                resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
+            except azure.common.AzureConflictHttpError:
+                # the resource name was already present,
+                # Our assumption is the initial error was due to HTTP connection hanging, and we ignore the
+                # AzureConflictHttpError
+                pass
         # Since we're copying inside of one bucket the copy should always be
         # synchronous and successful.
         assert resp.status == 'success'

--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -35,9 +35,7 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
         resp = None
         try:
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
-        except (azure.common.AzureConflictHttpError,
-                azure.common.AzureException,
-                azure.common.AzureMissingResourceHttpError):
+        except (azure.common.AzureException, azure.common.AzureMissingResourceHttpError):
             # Cancel the past copy, make a new copy
             properties = self.blob_service.get_blob_properties(self.container, destination_path)
             assert properties.id
@@ -45,6 +43,9 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
 
             # Try the copy again
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
+        except azure.common.AzureConflictHttpError:
+            pass
+
         # Since we're copying inside of one bucket the copy should always be
         # synchronous and successful.
         assert resp.status == 'success'

--- a/release/storage/azure.py
+++ b/release/storage/azure.py
@@ -35,7 +35,9 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
         resp = None
         try:
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
-        except (azure.common.AzureConflictHttpError, azure.common.AzureException):
+        except (azure.common.AzureConflictHttpError,
+                azure.common.AzureException,
+                azure.common.AzureMissingResourceHttpError):
             # Cancel the past copy, make a new copy
             properties = self.blob_service.get_blob_properties(self.container, destination_path)
             assert properties.id
@@ -43,7 +45,6 @@ class AzureBlockBlobStorageProvider(AbstractStorageProvider):
 
             # Try the copy again
             resp = self.blob_service.copy_blob(self.container, destination_path, az_blob_url)
-
         # Since we're copying inside of one bucket the copy should always be
         # synchronous and successful.
         assert resp.status == 'success'


### PR DESCRIPTION
In https://github.com/dcos/dcos/pull/3930#pullrequestreview-184440616 we decided that we will expand the scope of Azure Exceptions to catch for Retry.

This change makes sure to catch two additional types of Exception

Added a `azure.common.AzureMissingResourceHttpError` - Which will address https://jira.mesosphere.com/browse/DCOS-46370 on the first attempt.

* On the retry, the a wrong attribute was being looked up that resulted in an error *AttributeError: 'Blob' object has no attribute 'id'* - This was cleared up looking at the Azure Documentation and finding that `.id` is the property of the copy_blob operation (Ref: https://github.com/Azure/azure-storage-python/blob/master/azure-storage-blob/azure/storage/blob/baseblobservice.py#L2947) 

And we need to use the right variable for the abort.

This addresses both

* https://jira.mesosphere.com/browse/DCOS-46370
* https://jira.mesosphere.com/browse/DCOS_OSS-4615 

That we encounter due the Azure Instabilities. 
