### PR TITLE
[1.11] Improve gen validate AssertionError

### DIFF
--- a/gen/tests/__init__.py
+++ b/gen/tests/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite('gen.tests.utils')


### PR DESCRIPTION
## High-level description

Backport of #4336

This PR adds proper AssertionError reporting with the full output why the assert failed.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4742](https://jira.mesosphere.com/browse/DCOS_OSS-4742) Failed gen validate does not show reason for failure of assertions.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
