### PR TITLE
Pin the dependency for pep8-naming.

### DIFF
--- a/flake8_dcos_lint/setup.py
+++ b/flake8_dcos_lint/setup.py
@@ -19,7 +19,7 @@ setup(
         'pycodestyle==2.2.0',
         'flake8==3.3.0',
         'flake8-import-order==0.9.2',
-        'pep8-naming'
+        'pep8-naming==0.7.0'
     ],
     entry_points={
         'flake8.extension': [


### PR DESCRIPTION
## High-level description

Cherry-pick 7709196

* https://jira.mesosphere.com/browse/DCOS-47755 - tox failing on master - unpinned dependency 
