### PR TITLE
Open /package/describe and /package/resource to any authenticated user

### DIFF
--- a/packages/adminrouter/extra/src/docs/api/nginx.master.html
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.html
@@ -1052,6 +1052,42 @@
             </table>
           </div>
         </li>
+        <li class="route route-type-proxy">
+          <div class="heading">
+            <h3>
+              <span class="route-type">Proxy</span>
+              <span class="route-path"><code>/net/</code></span>
+            </h3>
+          </div>
+          <div class="route-meta" style="display:none">
+            <table>
+              <tr>
+                <td>
+                  Path:
+                </td>
+                <td>
+                  <code>http://$backend/</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Server:
+                </td>
+                <td>
+                  <code>127.0.0.1:62080</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Backend:
+                </td>
+                <td>
+                  DC/OS Net
+                </td>
+              </tr>
+            </table>
+          </div>
+        </li>
       </ul>
     </li>
     <li id="resource-exhibitor" class="resource">
@@ -1720,7 +1756,7 @@
           <div class="heading">
             <h3>
               <span class="route-type">Proxy</span>
-              <span class="route-path"><code>/package/</code></span>
+              <span class="route-path"><code>/package/(?&lt;package_path&gt;.*)</code></span>
             </h3>
             <span class="route-desc">Package Management</span>
           </div>

--- a/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
+++ b/packages/adminrouter/extra/src/docs/api/nginx.master.yaml
@@ -301,13 +301,13 @@ routes:
     proxy:
       path: $upstream_url
     path: '@service_requnbuffered'
-  /package/:
+  /package/(?<package_path>.*):
     group: Package
-    matcher: path
+    matcher: regex
     description: Package Management
     proxy:
       path: $upstream_cosmos
-    path: /package/
+    path: /package/(?<package_path>.*)
   /pkgpanda/:
     group: Pkgpanda
     matcher: path

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -413,9 +413,9 @@ location /cosmos/service/ {
 
 # Group: Package
 # Description: Package Management
-location /package/ {
+location ~ ^/package/(?<package_path>.*) {
     access_by_lua_block {
-        auth.access_package_endpoint();
+        auth.access_package_endpoint(ngx.var.package_path);
         util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;

--- a/packages/adminrouter/extra/src/lib/auth/open.lua
+++ b/packages/adminrouter/extra/src/lib/auth/open.lua
@@ -159,7 +159,7 @@ function _M.init(use_auth)
     end
 
     -- /package/
-    res.access_package_endpoint = function()
+    res.access_package_endpoint = function(package_path)
         return res.do_authn_and_authz_or_exit()
     end
 


### PR DESCRIPTION
These endpoints are used to install CLI extensions through the `dcos
package install` subcommand (eg. `dcos package install
dcos-enterprise-cli`) and currently require the full
dcos:adminrouter:package permission even though they do not install
anything on the cluster side.

This change opens these endpoints to all authenticated users, making it
easier for unprivileged CLI users to install package subcommands.

https://jira.mesosphere.com/browse/DCOS_OSS-4651