### PR TITLE
Update 1.12.2 version to 1.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## DC/OS 1.12-dev
+## DC/OS 1.12.2
 
 ```
 * For any significant improvement to DC/OS add an entry to Fixed and Improved section.

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -86,7 +86,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.12.1',
+        'version': '1.12.2',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.12.1'
+DCOS_VERSION = '1.12.2'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 


### PR DESCRIPTION
## High-level description

DCOS-47790 - DC/OS v1.12.2 is marked as 1.12.1

* Update DC/OS version for 1.12.2 to DC/OS 1.12.2
