### PR TITLE
Update CHANGES.md for 1.12-dev

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,27 @@ Format of the entries must be.
 * Entry two with no-newlines. (DCOS_OSS_JIRA_2)
 ```
 
+## DC/OS 1.12.3 (Next Release. Please Update News Entries in this Section).
+
+### Notable changes
+
+
+### Breaking changes
+
+
+### Fixed and improved
+
+* Include additional container metrics if provided (DCOS_OSS-4624)
+
+* Tighten permissions on ZooKeeper directories (DCOS-47687)
+
+
+
+### Security Updates
+
+
+
+## DC/OS 1.12.2
 
 ### Notable changes
 
@@ -33,10 +54,6 @@ Format of the entries must be.
 * Fix CLI task metrics summary command which was occasionally failing to find metrics (DCOS_OSS-4679)
 
 * Make cluster identity configurable in dcos-net (DCOS_OSS-4620)
-
-* Include additional container metrics if provided (DCOS_OSS-4624)
-
-* Tighten permissions on ZooKeeper directories (DCOS-47687)
 
 ### Security Updates
 

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -86,7 +86,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.12.1',
+        'version': '1.12-dev',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.12.1'
+DCOS_VERSION = '1.12-dev'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 


### PR DESCRIPTION
## High-level description

Fixes changes.md and let's the development version of 1.12 as 1.12-dev