### PR TITLE
[1.12] Use prometheus parser for metrics tests

### DIFF
--- a/packages/dcos-integration-test/buildinfo.json
+++ b/packages/dcos-integration-test/buildinfo.json
@@ -3,5 +3,6 @@
       "dcos-image-deps",
       "dcos-test-utils",
       "pytest",
-      "python"]
+      "python",
+      "python-prometheus_client"]
 }

--- a/packages/python-prometheus_client/build
+++ b/packages/python-prometheus_client/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-prometheus_client/buildinfo.json
+++ b/packages/python-prometheus_client/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "url_extract",
+    "url": "https://files.pythonhosted.org/packages/bc/e1/3cddac03c8992815519c5f50493097f6508fa153d067b494db8ab5e9c4ce/prometheus_client-0.5.0.tar.gz",
+    "sha1": "885ba6707492d8ff97e3f612ed266f0273ee8363"
+  }
+}


### PR DESCRIPTION
## High-level description

Improve metrics integration tests by using the `prometheus_client` python library to parse prom responses for expected metrics instead of checking for substrings in the response string.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4572](https://jira.mesosphere.com/browse/DCOS_OSS-4572) Parse Prometheus exporter responses in integration tests


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration test changes only
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
