### PR TITLE
[1.13] Use prometheus parser for metrics tests

### DIFF
--- a/packages/dcos-integration-test/buildinfo.json
+++ b/packages/dcos-integration-test/buildinfo.json
@@ -5,5 +5,6 @@
       "pytest",
       "python",
       "python-kazoo",
+      "python-prometheus_client",
       "python-requests"]
 }

--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -13,3 +13,6 @@ dnspython3==1.12.0
 kazoo==2.4.0
 # /packages/dcos-test-utils/buildinfo.json
 git+https://github.com/dcos/dcos-test-utils.git@ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8
+
+# /packages/python-prometheus_client/buildinfo.json
+prometheus_client==0.5.0

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1,9 +1,11 @@
 import contextlib
+import copy
 import logging
 import uuid
 
 import pytest
 import retrying
+from prometheus_client.parser import text_string_to_metric_families
 
 from test_helpers import get_expanded_config
 
@@ -79,7 +81,11 @@ def test_metrics_agents_mesos(dcos_api_session):
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_mesos_metrics():
             response = get_metrics_prom(dcos_api_session, node)
-            assert 'mesos_slave_uptime_secs' in response.text
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[0] == 'mesos_slave_uptime_secs':
+                        return
+            raise Exception('Expected Mesos mesos_slave_uptime_secs metric not found')
         check_mesos_metrics()
 
 
@@ -88,46 +94,53 @@ def test_metrics_master_mesos(dcos_api_session):
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_mesos_metrics():
         response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
-        assert 'mesos_master_uptime_secs' in response.text
+        for family in text_string_to_metric_families(response.text):
+            for sample in family.samples:
+                if sample[0] == 'mesos_master_uptime_secs':
+                    return
+        raise Exception('Expected Mesos mesos_master_uptime_secs metric not found')
     check_mesos_metrics()
 
 
 def test_metrics_master_zookeeper(dcos_api_session):
     """Assert that ZooKeeper metrics on master are present."""
-    expected_metrics = ['ZooKeeper', 'zookeeper_avg_latency']
-
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_zookeeper_metrics():
         response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
-        for metric_name in expected_metrics:
-            assert metric_name in response.text
+        for family in text_string_to_metric_families(response.text):
+            for sample in family.samples:
+                if sample[0] == 'zookeeper_avg_latency':
+                    assert sample[1]['dcos_component_name'] == 'ZooKeeper'
+                    return
+        raise Exception('Expected ZooKeeper zookeeper_avg_latency metric not found')
     check_zookeeper_metrics()
 
 
 def test_metrics_master_cockroachdb(dcos_api_session):
     """Assert that CockroachDB metrics on master are present."""
-    expected_metrics = ['CockroachDB', 'ranges_underreplicated']
-
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_cockroachdb_metrics():
         response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
-        for metric_name in expected_metrics:
-            assert metric_name in response.text
+        for family in text_string_to_metric_families(response.text):
+            for sample in family.samples:
+                if sample[0] == 'ranges_underreplicated':
+                    assert sample[1]['dcos_component_name'] == 'CockroachDB'
+                    return
+        raise Exception('Expected CockroachDB ranges_underreplicated metric not found')
     check_cockroachdb_metrics()
 
 
 def test_metrics_master_adminrouter(dcos_api_session):
     """Assert that Admin Router metrics on master are present."""
-    expected_metrics = [
-        'dcos_component_name="Admin Router"',
-        'nginx_vts',
-    ]
-
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_adminrouter_metrics():
         response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
-        for metric_name in expected_metrics:
-            assert metric_name in response.text
+        for family in text_string_to_metric_families(response.text):
+            for sample in family.samples:
+                if sample[0].startswith('nginx_vts_'):
+                    assert sample[1]['dcos_component_name'] == 'Admin Router'
+                    return
+        raise Exception('Expected Admin Router nginx_vts_* metrics not found')
     check_adminrouter_metrics()
 
 
@@ -139,16 +152,16 @@ def test_metrics_agents_adminrouter(dcos_api_session):
     if dcos_api_session.public_slaves:
         nodes.append(dcos_api_session.public_slaves[0])
 
-    expected_metrics = [
-        'dcos_component_name="Admin Router Agent"',
-        'nginx_vts',
-    ]
     for node in nodes:
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_adminrouter_metrics():
             response = get_metrics_prom(dcos_api_session, node)
-            for metric_name in expected_metrics:
-                assert metric_name in response.text
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[0].startswith('nginx_vts_'):
+                        assert sample[1]['dcos_component_name'] == 'Admin Router Agent'
+                        return
+            raise Exception('Expected Admin Router nginx_vts_* metrics not found')
         check_adminrouter_metrics()
 
 
@@ -159,9 +172,16 @@ def check_statsd_app_metrics(dcos_api_session, marathon_app, node, expected_metr
 
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_statsd_metrics():
+            expected_copy = copy.deepcopy(expected_metrics)
             response = get_metrics_prom(dcos_api_session, node)
-            for metric_name in expected_metrics:
-                assert metric_name in response.text
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[0] in expected_copy:
+                        val = expected_copy.pop(sample[0])
+                        assert sample[2] == val
+                        if len(expected_copy) == 0:
+                            return
+            raise Exception('Expected statsd metrics not found')
         check_statsd_metrics()
 
 
@@ -207,12 +227,15 @@ def test_metrics_agent_statsd(dcos_api_session):
         },
         'networks': [{'mode': 'host'}],
     }
-    expected_metrics = [
-        ('TYPE ' + '_'.join([metric_name_pfx, 'gauge']) + ' gauge'),
-        ('TYPE ' + '_'.join([metric_name_pfx, 'count']) + ' counter'),
-        ('TYPE ' + '_'.join([metric_name_pfx, 'timing', 'count']) + ' untyped'),
-        ('TYPE ' + '_'.join([metric_name_pfx, 'histogram', 'count']) + ' untyped'),
-    ]
+    expected_metrics = {
+        metric_name_pfx + '_gauge': 100.0,
+        # NOTE: prometheus_client appends _total to counter-type metrics if they don't already have the suffix
+        # ref: https://github.com/prometheus/client_python/blob/master/prometheus_client/parser.py#L169
+        # (the raw prometheus output here omits _total)
+        metric_name_pfx + '_count_total': 1.0,
+        metric_name_pfx + '_timing_count': 1.0,
+        metric_name_pfx + '_histogram_count': 1.0,
+    }
 
     if dcos_api_session.slaves:
         marathon_app['constraints'] = [['hostname', 'LIKE', dcos_api_session.slaves[0]]]
@@ -289,13 +312,14 @@ def test_task_metrics_metadata(dcos_api_session):
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
-            for line in response.text.splitlines():
-                if '#' in line:
-                    continue
-                if 'task_name="marathon-user"' in line:
-                    assert 'service_name="marathon"' in line
-                    # check for whitelisted label
-                    assert 'DCOS_SERVICE_NAME="marathon-user"' in line
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[1].get('task_name') == 'marathon-user':
+                        assert sample[1]['service_name'] == 'marathon'
+                        # check for whitelisted label
+                        assert sample[1]['DCOS_SERVICE_NAME'] == 'marathon-user'
+                        return
+            raise Exception('Expected marathon task metrics not found')
         check_metrics_metadata()
 
 
@@ -311,16 +335,14 @@ def test_executor_metrics_metadata(dcos_api_session):
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
         def check_executor_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
-            for line in response.text.splitlines():
-                if '#' in line:
-                    continue
-                # ignore metrics from hello-world task started by marathon by checking
-                # for absence of 'marathon' string.
-                if 'cpus_nr_periods' in line and 'marathon' not in line:
-                    assert 'service_name="hello-world"' in line
-                    assert 'task_name=""' in line  # this is an executor, not a task
-                    # hello-world executors can be named "hello" or "world"
-                    assert ('executor_name="hello"' in line or 'executor_name="world"' in line)
+            for family in text_string_to_metric_families(response.text):
+                for sample in family.samples:
+                    if sample[0] == 'cpus_nr_periods' and sample[1].get('service_name') == 'hello-world':
+                        assert sample[1]['task_name'] == ''
+                        # hello-world executors can be named "hello" or "world"
+                        assert (sample[1]['executor_name'] == 'hello' or sample[1]['executor_name'] == 'world')
+                        return
+            raise Exception('Expected hello-world executor metrics not found')
         check_executor_metrics_metadata()
 
 

--- a/packages/python-prometheus_client/build
+++ b/packages/python-prometheus_client/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+source /opt/mesosphere/environment.export
+export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
+mkdir -p "$LIB_INSTALL_DIR"
+
+pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$PKG_NAME

--- a/packages/python-prometheus_client/buildinfo.json
+++ b/packages/python-prometheus_client/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["python"],
+  "single_source": {
+    "kind": "url_extract",
+    "url": "https://files.pythonhosted.org/packages/bc/e1/3cddac03c8992815519c5f50493097f6508fa153d067b494db8ab5e9c4ce/prometheus_client-0.5.0.tar.gz",
+    "sha1": "885ba6707492d8ff97e3f612ed266f0273ee8363"
+  }
+}

--- a/packages/windows.treeinfo.json
+++ b/packages/windows.treeinfo.json
@@ -67,6 +67,7 @@
     "python-kazoo",
     "python-markupsafe",
     "python-passlib",
+    "python-prometheus_client",
     "python-pycparser",
     "python-pyyaml",
     "python-requests",


### PR DESCRIPTION
## High-level description

Improve metrics integration tests by using the `prometheus_client` python library to parse prom responses for expected metrics instead of checking for substrings in the response string.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4572](https://jira.mesosphere.com/browse/DCOS_OSS-4572) Parse Prometheus exporter responses in integration tests


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: integration test changes only
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
