### PR TITLE
[1.10] dcos-metrics: bump to latest commit.

### DIFF
--- a/packages/dcos-metrics/build
+++ b/packages/dcos-metrics/build
@@ -35,7 +35,7 @@ mkdir -p /pkg/src/github.com/dcos
 mv /pkg/src/dcos-metrics /pkg/src/github.com/dcos/dcos-metrics
 
 pushd /pkg/src/github.com/dcos/dcos-metrics
-make build
+make rawbuild
 popd
 
 mkdir -p $PKG_PATH/bin
@@ -44,7 +44,7 @@ mv /pkg/src/github.com/dcos/dcos-metrics/build/collector/dcos-metrics-collector-
 # We build this for integration tests
 mv /pkg/src/github.com/dcos/dcos-metrics/build/statsd-emitter/dcos-metrics-statsd-emitter-* $PKG_PATH/bin/statsd-emitter
 
-# Create the service file for all roles 
+# Create the service file for all roles
 agent_service="$PKG_PATH/dcos.target.wants_slave/dcos-metrics-agent.service"
 mkdir -p "$(dirname "$agent_service")"
 cp /pkg/extra/dcos-metrics-agent.service "$agent_service"

--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "aabb980cf2edc7d53d82025024844cdb92180b17",
+    "ref": "c76327a418ef198bc9cafd0c7dfea31ffeceb295",
     "ref_origin": "1.10.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This bump ensures that containers are tracked in Mesos metrics isolator,
which prevents remove attempts of unknown containers.

## Corresponding DC/OS tickets

  - [DCOS_OSS-4630](https://jira.mesosphere.com/browse/DCOS_OSS-4630) com_mesosphere_MetricsIsolatorModule fails to track individual containers' lifecycle.
  - [COPS-4310](https://jira.mesosphere.com/browse/COPS-4310)

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
      * This has been tested manually on a 1.11.8 cluster, see https://github.com/dcos/dcos-metrics/pull/172
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-metrics/compare/aabb980cf2edc7d53d82025024844cdb92180b17...c76327a418ef198bc9cafd0c7dfea31ffeceb295
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]