### PR TITLE
Use Python's tarfile in make_tar to avoid Linux/macOS difference in tar distributions

### DIFF
--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -3,6 +3,7 @@
     "boto",
     "dnspython",
     "flask",
+    "liblzma",
     "pytest",
     "python",
     "python-certifi",

--- a/packages/liblzma/build
+++ b/packages/liblzma/build
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+mkdir -p build
+pushd build
+
+export CFLAGS=-I/opt/mesosphere/include
+export LDFLAGS="-L/opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
+export CPPFLAGS=-I/opt/mesosphere/include
+
+cd /pkg/src/liblzma
+./autogen.sh
+./configure --prefix="$PKG_PATH"
+make
+make install

--- a/packages/liblzma/buildinfo.json
+++ b/packages/liblzma/buildinfo.json
@@ -1,0 +1,8 @@
+{
+  "requires": ["openssl"],
+  "single_source": {
+    "kind": "url_extract",
+    "url": "https://sourceforge.net/projects/lzmautils/files/xz-5.2.4.tar.gz",
+    "sha1": "63ca380029597b951ce9afc6dec28f44f70bb5bd"
+  }
+}

--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -1,5 +1,5 @@
 {
-  "requires": ["openssl"],
+  "requires": ["openssl", "liblzma"],
   "environment": {
     "PYTHONPATH": "/opt/mesosphere/lib/python3.6/site-packages",
     "PYTHONUNBUFFERED": "true"

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -9,20 +9,11 @@ Each package contains a pkginfo.json. That contains a list of requires as well a
 environment variables from the package.
 
 """
-try:
-    import grp
-except ImportError:
-    pass
 import json
 import os
 import os.path
-try:
-    import pwd
-except ImportError:
-    pass
 import re
 import shutil
-import sys
 import tempfile
 from collections import Iterable
 from itertools import chain
@@ -38,8 +29,8 @@ from pkgpanda.util import (download, extract_tarball, if_exists, is_windows,
                            load_json, make_directory, remove_directory, write_json, write_string)
 
 if not is_windows:
-    assert 'grp' in sys.modules
-    assert 'pwd' in sys.modules
+    import grp
+    import pwd
 
 # TODO(cmaloney): Can we switch to something like a PKGBUILD from ArchLinux and
 # then just do the mutli-version stuff ourself and save a lot of re-implementation?

--- a/pkgpanda/docker/dcos-builder/Dockerfile
+++ b/pkgpanda/docker/dcos-builder/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER help@dcos.io
 RUN apt-get -qq update && apt-get -y install \
   autoconf \
   automake \
+  autopoint \
   cmake \
   cpp \
   curl \

--- a/pkgpanda/test_util.py
+++ b/pkgpanda/test_util.py
@@ -302,10 +302,15 @@ def test_validate_username():
     bad('dcos3_foobar')
 
 
-@pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows does not have a root group")
+@pytest.mark.skipif(
+    pkgpanda.util.is_windows,
+    reason="Windows does not have Unix groups",
+)
 def test_validate_group():
-    # assuming linux distributions have `root` group.
-    UserManagement.validate_group('root')
+    # We import grp here so that this module can be imported on Windows.
+    import grp
+    group_name_which_exists = grp.getgrall()[0].gr_name
+    UserManagement.validate_group(group_name_which_exists)
 
     with pytest.raises(ValidationError):
         UserManagement.validate_group('group-should-not-exist')


### PR DESCRIPTION
## High-level description

This PR removes operating system specific tar commands in favor of Python's built-in `tarfile` module. It adds a new DC/OS package `liblzma` which is used by `tarfile` to do `lzma` compression for `xz` archives.

This was a collaborative effort together with @adamtheturtle. It enables running DC/OS OSS unit tests natively on macOS.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4764](https://jira.mesosphere.com/browse/DCOS_OSS-4764) Make it possible/documented to run unit tests on macOS.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)