### PR TITLE
DCOS-15890 - Check Docker is running before version check 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Fix CLI task metrics summary command which was occasionally failing to find metrics (DCOS_OSS-4679)
 
+* Improve error message in case Docker is not running at start of installation (DCOS-15890)
+
 ### Notable changes
 
 * Bumped DC/OS UI to [master+v2.40.10](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.40.10)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -290,6 +290,16 @@ function check() {
     fi
 }
 
+function check_docker_running() {
+    check_command_exists "docker" "docker"
+    echo -e -n "Checking if Docker is running: "
+    docker info >/dev/null 2>&1
+    RC=$?
+    print_status $RC
+    (( OVERALL_RC += $RC ))
+    return $RC
+}
+
 function check_service() {
   PORT=$1
   NAME=$2
@@ -429,6 +439,8 @@ function check_all() {
     check_preexisting_dcos
     check_selinux
     check_sort_capability
+
+    check_docker_running
 
     local docker_version=$(command -v docker >/dev/null 2>&1 && docker version 2>/dev/null | awk '
         BEGIN {


### PR DESCRIPTION
## High-level description

This adds a proper message in case Docker is not running instead of
telling the user that the Docker version doesn't match.

`docker info` sets its exit-code according to whether Docker is running,
so we can use that in a platform-independent way to make sure it is.
See: https://docs.docker.com/config/daemon/#check-whether-docker-is-running

So before we check the Docker version, we check for the exit code of
`docker info`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS-15890] DCOS advance installer pre-flight check has a wrong error message](https://jira.mesosphere.com/browse/DCOS-15890)


## Related tickets (optional)

Other tickets related to this change:

  - 


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: there are no tests for the preflight checks of the installer, but they will be executed on every CI run
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
