### PR TITLE
DCOS-16098 - Correct filename in dcos_generate_config.ee.sh help

### DIFF
--- a/gen/build_deploy/bash/installer_internal_wrapper.in
+++ b/gen/build_deploy/bash/installer_internal_wrapper.in
@@ -16,6 +16,11 @@ export BOOTSTRAP_VARIANT={variant}
 # ash exec inside busybox doesn't have an equivalent to `-a` letting us set argv0
 # directly, and python also doesn't have a way of setting it, so we pass argv0
 # out of line and have it picked up by the installer
-export INSTALLER_ARGV0="dcos_generate_config.sh"
+if [[ -z $BOOTSTRAP_VARIANT ]];
+then
+  export INSTALLER_ARGV0="dcos_generate_config.sh"
+else
+  export INSTALLER_ARGV0="dcos_generate_config.${{BOOTSTRAP_VARIANT}}.sh"
+fi
 
 exec /opt/mesosphere/bin/python3 /opt/mesosphere/bin/dcos_installer "$@"


### PR DESCRIPTION
## High-level description

Before this change the ARGV0 that's used by `dcos_install` when printing the `--help` output was always `dcos_generate_config.sh`, even when it was built for another variant. In the case of the ticket: `ee`.

This change checks whether `$BOOTSTRAP_VARIANT` is empty or not. And if it's not empty, it uses it to construct the correct filename.

And just to make sure that my shell/ash scripting is up to the task, I tried the `-z` switch etc. in a busybox container with ash:

```
$ docker run -it --rm busybox
/ # export BOOTSTRAP_VARIANT=

/ # if [[ -z $BOOTSTRAP_VARIANT ]];
> then
>   export INSTALLER_ARGV0="dcos_generate_config.sh"
> else
>   export INSTALLER_ARGV0="dcos_generate_config.${BOOTSTRAP_VARIANT}.sh"
> fi

/ # echo $INSTALLER_ARGV0
dcos_generate_config.sh


/ # export BOOTSTRAP_VARIANT=ee

/ # if [[ -z $BOOTSTRAP_VARIANT ]];
> then
>   export INSTALLER_ARGV0="dcos_generate_config.sh"
> else
>   export INSTALLER_ARGV0="dcos_generate_config.${BOOTSTRAP_VARIANT}.sh"
> fi

/ # echo $INSTALLER_ARGV0
dcos_generate_config.ee.sh
```

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS-16098] Installer help displays wrong filename - JIRA](https://jira.mesosphere.com/browse/DCOS-16098)


## Related tickets (optional)

Other tickets related to this change:

  - 


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: test driving it in busybox
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
