### PR TITLE
DCOS_OSS-4613 - Use default `ssh_user` in deprecated CLI installer validations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Improve error message in case Docker is not running at start of installation (DCOS-15890)
 
+* Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
+
 ### Notable changes
 
 * Bumped DC/OS UI to [master+v2.40.10](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.40.10)

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -162,7 +162,6 @@ def test_do_validate_config(tmpdir, monkeypatch):
     create_fake_build_artifacts(tmpdir)
     expected_output = {
         'ip_detect_contents': 'ip-detect script `genconf/ip-detect` must exist',
-        'ssh_user': 'Must set ssh_user, no way to calculate value.',
         'master_list': 'Must set master_list, no way to calculate value.',
         'ssh_key_path': 'could not find ssh private key: genconf/ssh_key'
     }

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -45,6 +45,7 @@ source = Source({
         'ssh_key_path': 'genconf/ssh_key',
         'agent_list': '[]',
         'public_agent_list': '[]',
+        'ssh_user': 'centos',
         'ssh_port': '22',
         'process_timeout': '120',
         'ssh_parallelism': '20'


### PR DESCRIPTION
## High-level description

Requiring the `ssh_user` attribute in `config.yaml` was part of the CLI installer.

But even though the CLI installer was deprecated, users now run into validation errors when they run `./dcos_generate_config.sh` without specifying a `ssh_user` in their `config.yaml`, even though we explictly say in our documentation that the field is not required.

This is now the first step to fix the ticket and resolve the issue for the customer: by setting a default value for `ssh_user` users won't run into a validation error, but if they change the value, we still validate it.

It's the smallest possible fix.

The proper solution would be to remove the deprecated code and rip out the the parts of the CLI installer that are not needed anymore (I did a first spike for this in https://github.com/dcos/dcos/pull/4377 and could remove ~1000 lines of code without breaking the officially supported behaviour)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS_OSS-4613] Modify dcos-installer not to warn on missing optional ssh_user key in dcos-config.yml - JIRA](https://jira.mesosphere.com/browse/DCOS_OSS-4613)


## Related tickets (optional)

Other tickets related to this change:

  - [[COPS-4282] dcos_generate_config --validate complains about deprecated/unused fields - JIRA](https://jira.mesosphere.com/browse/COPS-4282)


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
