### PR TITLE
[1.11] DCOS_OSS-4613 - Use default `ssh_user` in deprecated CLI installer validations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Format of the entries must be.
 
 * Improve error message in case Docker is not running at start of installation (DCOS-15890)
 
+* Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
+
 ### Security Updates
 
 

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -158,7 +158,6 @@ def test_do_validate_config(tmpdir, monkeypatch):
     create_fake_build_artifacts(tmpdir)
     expected_output = {
         'ip_detect_contents': 'ip-detect script `genconf/ip-detect` must exist',
-        'ssh_user': 'Must set ssh_user, no way to calculate value.',
         'master_list': 'Must set master_list, no way to calculate value.',
         'ssh_key_path': 'could not find ssh private key: genconf/ssh_key'
     }

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -45,6 +45,7 @@ source = Source({
         'ssh_key_path': 'genconf/ssh_key',
         'agent_list': '[]',
         'public_agent_list': '[]',
+        'ssh_user': 'centos',
         'ssh_port': '22',
         'process_timeout': '120',
         'ssh_parallelism': '20'


### PR DESCRIPTION
This backports https://github.com/dcos/dcos/pull/4414