### PR TITLE
[1.12] Exclude prometheus_client from windows build

### DIFF
--- a/packages/windows.treeinfo.json
+++ b/packages/windows.treeinfo.json
@@ -67,6 +67,7 @@
     "python-kazoo",
     "python-markupsafe",
     "python-passlib",
+    "python-prometheus_client",
     "python-pycparser",
     "python-pyyaml",
     "python-requests",


### PR DESCRIPTION
## High-level description

Exclude the newly added prometheus_client python dependency from windows build to prevent windows builds from failing.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

N/A


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
