### PR TITLE
[BACKPORT] [1.11] DCOS-46439 - Move xfailflake collection to dcos-test-utils.

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import os
 
@@ -11,48 +10,6 @@ from dcos_test_utils.diagnostics import Diagnostics
 
 logger.setup(os.getenv('TEST_LOG_LEVEL', 'INFO'))
 log = logging.getLogger(__name__)
-
-
-def _add_xfail_markers(item):
-    """
-    Mute flaky Integration Tests with custom pytest marker.
-    Rationale for doing this is mentioned at DCOS-45308.
-    """
-    xfailflake_markers = [
-        marker for marker in item.iter_markers() if marker.name == 'xfailflake'
-    ]
-    for xfailflake_marker in xfailflake_markers:
-        assert 'reason' in xfailflake_marker.kwargs
-        assert 'jira' in xfailflake_marker.kwargs
-        assert xfailflake_marker.kwargs['jira'].startswith('DCOS')
-        # Show the JIRA in the printed reason.
-        xfailflake_marker.kwargs['reason'] = '{jira} - {reason}'.format(
-            jira=xfailflake_marker.kwargs['jira'],
-            reason=xfailflake_marker.kwargs['reason'],
-        )
-        date_text = xfailflake_marker.kwargs['since']
-        try:
-            datetime.datetime.strptime(date_text, '%Y-%m-%d')
-        except ValueError:
-            message = (
-                'Incorrect date format for "since", should be YYYY-MM-DD'
-            )
-            raise ValueError(message)
-
-        # The marker is not "strict" unless that is explicitly stated.
-        # That means that by default, no error is raised if the test passes or
-        # fails.
-        strict = xfailflake_marker.kwargs.get('strict', False)
-        xfailflake_marker.kwargs['strict'] = strict
-        xfail_marker = pytest.mark.xfail(
-            *xfailflake_marker.args,
-            **xfailflake_marker.kwargs,
-        )
-        item.add_marker(xfail_marker)
-
-
-def pytest_runtest_setup(item):
-    _add_xfail_markers(item)
 
 
 def pytest_configure(config):

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "c1608590e010ca08c418f8bd9d9ebd764d511d57",
+    "ref": "9850e69c680f89082dd88f9df1310f6a0f544c09",
     "ref_origin": "master"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "9850e69c680f89082dd88f9df1310f6a0f544c09",
+    "ref": "ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
Original PR: #4320 

## High-level description

This moves the xfailflake plugin code into dcos-test-utils so that it does not need to be duplicated for every branch and repository. It also adds a pytest hook to write out a report of all tests that are marked flakey.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  -  [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) xfailflake dashboard - collect marked issues without a cluster and without regex

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: changes to test library only
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: code will run on all dcos-integration-test runs, so the unit test is sufficient as it will always be exercised.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [my PR](https://github.com/dcos/dcos-test-utils/pull/77)
  - [x] Test Results: https://teamcity.mesosphere.io/viewLog.html?buildId=1516218&buildTypeId=DcosIo_DcosTestUtils_ToxDcosTestUtils&tab=buildResultsDiv