### PR TITLE
Write override config for fault domain tags

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1313,6 +1313,12 @@ package:
         # Tags to be applied to all metrics.
         dcos_cluster_name="{{ cluster_name }}"
         dcos_cluster_id="$DCOS_CLUSTER_ID"
+{% switch fault_domain_enabled %}
+{% case "true" %}
+        fault_domain_zone="$FAULT_DOMAIN_ZONE"
+        fault_domain_region="$FAULT_DOMAIN_REGION"
+{% case "false" %}
+{% endswitch %}
       [agent]
         ## Default data collection interval for all inputs
         interval = "10s"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -17,6 +17,8 @@ METRICS_INTERVAL = 2 * 1000
 STD_WAITTIME = 15 * 60 * 1000
 STD_INTERVAL = 5 * 1000
 
+# tags added if a fault domain is present
+FAULT_DOMAIN_TAGS={'fault_domain_zone', 'fault_domain_region',}
 
 def check_tags(tags: dict, required_tag_names: set, optional_tag_names: set=set()):
     """Assert that tags contains only expected keys with nonempty values."""
@@ -410,7 +412,7 @@ def test_metrics_containers(dcos_api_session):
                 if dp['name'].startswith('blkio.'):
                     # blkio stats have 'blkio_device' tags.
                     expected_tag_names.add('blkio_device')
-                check_tags(dp['tags'], expected_tag_names)
+                check_tags(dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
 
                 # Ensure all container ID's in the container/<id> endpoint are
                 # the same.
@@ -439,7 +441,7 @@ def test_metrics_containers(dcos_api_session):
                 'dcos_cluster_name',
                 'host'
             }
-            check_tags(uptime_dp['tags'], expected_tag_names)
+            check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
             assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
             assert uptime_dp['value'] > 0
 
@@ -857,7 +859,7 @@ def test_standalone_container_metrics(dcos_api_session):
             'dcos_cluster_name',
             'host'
         }
-        check_tags(uptime_dp['tags'], expected_tag_names)
+        check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
         assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
         assert uptime_dp['value'] > 0
 
@@ -986,7 +988,7 @@ def test_pod_application_metrics(dcos_api_session):
                     'dcos_cluster_name',
                     'host'
                 }
-                check_tags(uptime_dp['tags'], expected_tag_names)
+                check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
                 assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
                 assert uptime_dp['value'] > 0
 
@@ -1019,7 +1021,7 @@ def test_pod_application_metrics(dcos_api_session):
                     if dp['name'].startswith('blkio.'):
                         # blkio stats have 'blkio_device' tags.
                         expected_tag_names.add('blkio_device')
-                    check_tags(dp['tags'], expected_tag_names)
+                    check_tags(dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
 
                     # Ensure all container IDs in the response from the
                     # containers/<id> endpoint are the same.

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -18,9 +18,11 @@ STD_WAITTIME = 15 * 60 * 1000
 STD_INTERVAL = 5 * 1000
 
 
-def check_tags(tags: dict, expected_tag_names: set):
+def check_tags(tags: dict, required_tag_names: set, optional_tag_names: set=set()):
     """Assert that tags contains only expected keys with nonempty values."""
-    assert set(tags.keys()) == expected_tag_names
+    keys = set(tags.keys())
+    assert keys & required_tag_names == required_tag_names, 'Not all required tags were set'
+    assert keys - required_tag_names - optional_tag_names == set(), 'Encountered unexpected tags'
     for tag_name, tag_val in tags.items():
         assert tag_val != '', 'Value for tag "%s" must not be empty'.format(tag_name)
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -1072,3 +1072,22 @@ def test_pod_application_metrics(dcos_api_session):
             data['instances'][0]['agentHostname'],
             data['instances'][0]['agentId'],
             marathon_pod_config['containers'][0]['name'], 2)
+
+
+def test_fault_domain(dcos_api_session):
+    """Check that fault domain tags are present in metrics on each node type.
+    Skip if no fault domain is set in this test scenario."""
+    expanded_config = get_expanded_config()
+    if expanded_config['fault_domain_enabled'] == 'false':
+        pytest.skip('fault domain is not set')
+
+    nodes = [dcos_api_session.masters[0]]
+    if dcos_api_session.slaves:
+        nodes.append(dcos_api_session.slaves[0])
+    if dcos_api_session.public_slaves:
+        nodes.append(dcos_api_session.public_slaves[0])
+
+    for node in nodes:
+        response = get_metrics_prom(dcos_api_session, node)
+        assert 'fault_domain_zone' in response.text, 'Fault domain zone tag was not set.'
+        assert 'fault_domain_region' in response.text, 'Fault domain region tag was not set.'

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -18,7 +18,8 @@ STD_WAITTIME = 15 * 60 * 1000
 STD_INTERVAL = 5 * 1000
 
 # tags added if a fault domain is present
-FAULT_DOMAIN_TAGS={'fault_domain_zone', 'fault_domain_region',}
+FAULT_DOMAIN_TAGS = {'fault_domain_zone', 'fault_domain_region'}
+
 
 def check_tags(tags: dict, required_tag_names: set, optional_tag_names: set=set()):
     """Assert that tags contains only expected keys with nonempty values."""
@@ -441,7 +442,13 @@ def test_metrics_containers(dcos_api_session):
                 'dcos_cluster_name',
                 'host'
             }
-            check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
+
+            # If fault domain is enabled, ensure that fault domain tags are present
+            expanded_config = get_expanded_config()
+            if expanded_config.get('fault_domain_enabled') == 'true':
+                expected_tag_names |= FAULT_DOMAIN_TAGS
+
+            check_tags(uptime_dp['tags'], expected_tag_names)
             assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
             assert uptime_dp['value'] > 0
 
@@ -1076,22 +1083,3 @@ def test_pod_application_metrics(dcos_api_session):
             data['instances'][0]['agentHostname'],
             data['instances'][0]['agentId'],
             marathon_pod_config['containers'][0]['name'], 2)
-
-
-def test_fault_domain(dcos_api_session):
-    """Check that fault domain tags are present in metrics on each node type.
-    Skip if no fault domain is set in this test scenario."""
-    expanded_config = get_expanded_config()
-    if expanded_config['fault_domain_enabled'] == 'false':
-        pytest.skip('fault domain is not set')
-
-    nodes = [dcos_api_session.masters[0]]
-    if dcos_api_session.slaves:
-        nodes.append(dcos_api_session.slaves[0])
-    if dcos_api_session.public_slaves:
-        nodes.append(dcos_api_session.public_slaves[0])
-
-    for node in nodes:
-        response = get_metrics_prom(dcos_api_session, node)
-        assert 'fault_domain_zone' in response.text, 'Fault domain zone tag was not set.'
-        assert 'fault_domain_region' in response.text, 'Fault domain region tag was not set.'

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -21,6 +21,8 @@ ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
 
 ExecStartPre=/bin/bash -c "mkdir -p ${TELEGRAF_USER_CONFIG_DIR}"
+ExecStartPre=/bin/bash -c "chmod 775 ${TELEGRAF_USER_CONFIG_DIR}"
+ExecStartPre=/bin/bash -c "chown root:dcos_telegraf ${TELEGRAF_USER_CONFIG_DIR}"
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR},${TELEGRAF_USER_CONFIG_DIR}

--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -21,8 +21,6 @@ ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
 
 ExecStartPre=/bin/bash -c "mkdir -p ${TELEGRAF_USER_CONFIG_DIR}"
-ExecStartPre=/bin/bash -c "chmod 775 ${TELEGRAF_USER_CONFIG_DIR}"
-ExecStartPre=/bin/bash -c "chown root:dcos_telegraf ${TELEGRAF_USER_CONFIG_DIR}"
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR},${TELEGRAF_USER_CONFIG_DIR}

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -24,9 +24,9 @@ fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
 fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
 
 if [ -x $fault_domain_script ]; then
-  # If a fault domain script exists, write a corresponding Telegraf configuration
-  # so that fault_domain_zone and fault_domain_region are added to all tags
-  # originating in this machine
+  # If a fault domain script exists, export environment variables so that
+  # fault_domain_zone and fault_domain_region are added to all tags originating
+  # in this machine
   eval `$(fault_domain_script) | $(fault_domain_extractor)`
 fi
 

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -22,13 +22,12 @@ export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 # Retrieve the fault domain for this machine
 fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
 fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
-fault_domain_override_path="/opt/mesosphere/etc/telegraf/telegraf.d/fault_domain.conf"
 
 if [ -x $fault_domain_script ]; then
   # If a fault domain script exists, write a corresponding Telegraf configuration
   # so that fault_domain_zone and fault_domain_region are added to all tags
   # originating in this machine
-  $(fault_domain_script) | $(fault_domain_extractor) > $fault_domain_override_path
+  eval `$(fault_domain_script) | $(fault_domain_extractor)`
 fi
 
 # Create containers dir for dcos_statsd input.

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -21,13 +21,14 @@ export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 
 # Retrieve the fault domain for this machine
 fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
-fault_domain_extractor="/opt/mesosphere/active/telegraf/tools/extract_fault_domain.py"
+fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
+fault_domain_override_path="/opt/mesosphere/etc/telegraf/telegraf.d/fault_domain.conf"
 
 if [ -x $fault_domain_script ]; then
   # If a fault domain script exists, write a corresponding Telegraf configuration
   # so that fault_domain_zone and fault_domain_region are added to all tags
   # originating in this machine
-  "$fault_domain_script" | "$fault_domain_extractor" > "${TELEGRAF_USER_CONFIG_DIR}/fault_domain.conf"
+  $(fault_domain_script) | $(fault_domain_extractor) > $fault_domain_override_path
 fi
 
 # Create containers dir for dcos_statsd input.

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -19,6 +19,18 @@ node_private_ip=$(/opt/mesosphere/bin/detect_ip)
 export DCOS_CLUSTER_ID="${cluster_id}"
 export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 
+# Retrieve the fault domain for this machine
+fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
+fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
+fault_domain_override_path="/opt/mesosphere/etc/telegraf/telegraf.d/fault_domain.conf"
+
+if [ -x $fault_domain_script ]; then
+  # If a fault domain script exists, write a corresponding Telegraf configuration
+  # so that fault_domain_zone and fault_domain_region are added to all tags
+  # originating in this machine
+  $(fault_domain_script) | $(fault_domain_extractor) > $fault_domain_override_path
+fi
+
 # Create containers dir for dcos_statsd input.
 mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
 # Migrate old containers dir to new location in case the cluster was upgraded.

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -21,14 +21,13 @@ export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 
 # Retrieve the fault domain for this machine
 fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
-fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
-fault_domain_override_path="/opt/mesosphere/etc/telegraf/telegraf.d/fault_domain.conf"
+fault_domain_extractor="/opt/mesosphere/active/telegraf/tools/extract_fault_domain.py"
 
 if [ -x $fault_domain_script ]; then
   # If a fault domain script exists, write a corresponding Telegraf configuration
   # so that fault_domain_zone and fault_domain_region are added to all tags
   # originating in this machine
-  $(fault_domain_script) | $(fault_domain_extractor) > $fault_domain_override_path
+  "$fault_domain_script" | "$fault_domain_extractor" > "${TELEGRAF_USER_CONFIG_DIR}/fault_domain.conf"
 fi
 
 # Create containers dir for dcos_statsd input.

--- a/packages/telegraf/extra/tools/extract_fault_domain.py
+++ b/packages/telegraf/extra/tools/extract_fault_domain.py
@@ -3,9 +3,11 @@
 # telegraf. It expects a JSON input corresponding to the format detailed here:
 # https://docs.mesosphere.com/1.12/deploying-services/fault-domain-awareness/
 #
-# It outputs a Telegraf configuration which activates the processor override
-# plugin, adding a fault_domain_region and fault_domain_zone tag to every
-# metric which passes through the telegraf pipeline.
+# It outputs a shell script which sets two environment variables called
+# FAULT_DOMAIN_REGION and FAULT_DOMAIN_ZONE. These are then included in the
+# global tags in the telegraf config, so adding a fault_domain_region and
+# fault_domain_zone tag to every metric which passes through the telegraf
+# pipeline.
 #
 # If the input is not valid JSON, or is not structured as expected, nothing
 # will be output and an error message will be logged.
@@ -13,11 +15,9 @@
 import json
 import sys
 
-telegraf_template = '''
-[[processors.override]]
-  [processors.override.tags]
-    fault_domain_region = "{region}"
-    fault_domain_zone = "{zone}"
+env_var_template = '''
+export FAULT_DOMAIN_REGION="{region}"
+export FAULT_DOMAIN_ZONE="{zone}"
 '''
 
 fd = {}
@@ -29,4 +29,4 @@ except:
 region = fd.get("region", {}).get("name", "")
 zone = fd.get("zone", {}).get("name", "")
 
-print(telegraf_template.format(zone=zone, region=region))
+print(env_var_template.format(zone=zone, region=region))

--- a/packages/telegraf/extra/tools/extract_fault_domain.py
+++ b/packages/telegraf/extra/tools/extract_fault_domain.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-# import argparse
+# This file is a utility for adding fault domain tags to metrics produced by
+# telegraf. It expects a JSON input corresponding to the format detailed here:
+# https://docs.mesosphere.com/1.12/deploying-services/fault-domain-awareness/
+#
+# It outputs a Telegraf configuration which activates the processor override
+# plugin, adding a fault_domain_region and fault_domain_zone tag to every
+# metric which passes through the telegraf pipeline.
+#
+# If the input is not valid JSON, or is not structured as expected, nothing
+# will be output and an error message will be logged.
+
 import json
 import sys
 
@@ -11,13 +21,12 @@ telegraf_template = '''
 '''
 
 fd = {}
-region = ""
-zone = ""
 try:
     fd = json.load(sys.stdin).get("fault_domain", {})
-    region = fd.get("region", {}).get("name", "")
-    zone = fd.get("zone", {}).get("name", "")
 except:
     exit("Could not parse fault domain json")
+
+region = fd.get("region", {}).get("name", "")
+zone = fd.get("zone", {}).get("name", "")
 
 print(telegraf_template.format(zone=zone, region=region))

--- a/packages/telegraf/extra/tools/extract_fault_domain.py
+++ b/packages/telegraf/extra/tools/extract_fault_domain.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# import argparse
+import json
+import sys
+
+telegraf_template = '''
+[[processors.override]]
+  [processors.override.tags]
+    fault_domain_region = "{region}"
+    fault_domain_zone = "{zone}"
+'''
+
+fd = {}
+region = ""
+zone = ""
+try:
+    fd = json.load(sys.stdin).get("fault_domain", {})
+    region = fd.get("region", {}).get("name", "")
+    zone = fd.get("zone", {}).get("name", "")
+except:
+    exit("Could not parse fault domain json")
+
+print(telegraf_template.format(zone=zone, region=region))


### PR DESCRIPTION
## High-level description

This PR introduces an additional step to the telegraf startup script. If the fault domain script (see https://docs.mesosphere.com/1.12/deploying-services/fault-domain-awareness/#installation-steps) is present, it is executed to yield the fault domain region and zone. These are then written to the telegraf configuration directory in an override configuration (see https://github.com/influxdata/telegraf/tree/master/plugins/processors/override).

This means that:-

 - if no fault domain script is set, no tags will be added
 - if a fault domain script is set, tags will be added
 - if a fault domain script is set but cannot be parsed, no tags will be added

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-16570](https://jira.mesosphere.com/browse/DCOS-16570) Add tags for fault domain to metrics

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: fault domain is an EE feature so I have added a changelog entry downstream
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
