### PR TITLE
(1.11) Unmute test_metrics_containers

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -111,11 +111,6 @@ def test_metrics_node(dcos_api_session):
         assert expected_dimension_response(response.json())
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS_OSS-4486',
-    reason='test_metrics_containers fails with container metrics response status 204',
-    since='2018-11-20',
-)
 def test_metrics_containers(dcos_api_session):
     """If there's a deployed container on the slave, iterate through them to check for
     the statsd-emitter executor. When found, query it's /app endpoint to test that


### PR DESCRIPTION
## High-level description

This unmutes `test_metrics.test_metrics_containers`, which was muted with #3836. There are no overrides for this test on the 1.11 branch in the ticket linked in the decorator. This test hasn't failed on the 1.11 branch in its available history, going back to September at the time of this writing: https://teamcity.mesosphere.io/project.html?tab=testDetails&projectId=DcOs_Open_Test_IntegrationTest&testNameId=-4813183735307993658&branch_DcOs_Open_Test_IntegrationTest=1.11.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4486](https://jira.mesosphere.com/browse/DCOS_OSS-4486) test_metrics.test_metrics_containers / test_metrics_containers_app fails with container metrics response status 204


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Only affects tests.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Unmuting a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]