### PR TITLE
Upgrade Telegraf to 1.9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### Fixed and improved
 
+* Telegraf is upgraded to 1.9.4. (DCOS_OSS-4675)
+
 * Add SELinux details to diagnostics bundle (DCOS_OSS-4123)
 
 * Add external Mesos master/agent logs in the diagnostic bundle (DCOS_OSS-4283)

--- a/packages/telegraf/build
+++ b/packages/telegraf/build
@@ -8,6 +8,11 @@ set -o nounset
 apt-get update && apt-get install gettext-base
 which envsubst
 
+# Install dep to enable the deps target in Telegraf's Makefile.
+dep_version=0.5.0
+curl -L -s https://github.com/golang/dep/releases/download/v$dep_version/dep-linux-amd64 -o $GOPATH/bin/dep
+chmod a+x $GOPATH/bin/dep
+
 project="github.com/influxdata/telegraf"
 project_src_path="$GOPATH/src/$project"
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -1,10 +1,10 @@
 {
-  "docker": "golang:1.10-stretch",
+  "docker": "golang:1.11-stretch",
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "e62db07bc444254df19eed062ad265f2c6b30664",
-    "ref_origin": "1.7.2-dcos"
+    "ref": "38f75ea3af33dbc3a8ae1e74c65908d458d8f7a7",
+    "ref_origin": "1.9.4-dcos"
   },
   "environment": {
     "STATSD_UDP_HOST": "localhost",


### PR DESCRIPTION
## High-level description

This upgrades Telegraf from 1.7.2 to 1.9.4.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4675](https://jira.mesosphere.com/browse/DCOS_OSS-4675) Rebase DC/OS Telegraf against upstream Telegraf


## Related tickets (optional)

Other tickets related to this change:

  - N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Covered by existing tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/e62db07bc444254df19eed062ad265f2c6b30664...38f75ea3af33dbc3a8ae1e74c65908d458d8f7a7
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/200/)
  - [x] Code Coverage (if available): N/A