### PR TITLE
Revert "packages/cockroach: improve iam-database-restore script"

### DIFF
--- a/packages/cockroach/extra/iam-database-restore
+++ b/packages/cockroach/extra/iam-database-restore
@@ -82,32 +82,22 @@ def recover_database(my_internal_ip: str, backup_file_path: str, db_suffix: str)
                 log.error('Failed to load data into database `{}`.'.format(dbname))
                 raise
 
-    def _replace_database(source: str, existing: str, backup: str) -> None:
-        transaction = '; '.join([
-            'BEGIN',
-            'SAVEPOINT cockroach_restart',
-            # iam -> iam_old
-            'ALTER DATABASE {} RENAME TO {}'.format(existing, backup),
-            # iam_new -> iam
-            'ALTER DATABASE {} RENAME TO {}'.format(source, existing),
-            'RELEASE SAVEPOINT cockroach_restart',
-            'COMMIT',
-        ])
+    def _rename_database(oldname: str, newname: str) -> None:
         command = [
             '/opt/mesosphere/active/cockroach/bin/cockroach',
             'sql',
             '--insecure',
             '--host={}'.format(my_internal_ip),
             '-e',
-            transaction,
+            'ALTER DATABASE {} RENAME to {}'.format(oldname, newname),
             ]
-        msg = 'Replace database `{}` to `{}` via command `{}`'.format(
-            source, existing, ' '.join(command))
+        msg = 'Rename database `{}` to `{}` via command `{}`'.format(
+            oldname, newname, ' '.join(command))
         log.info(msg)
         try:
             subprocess.run(command, check=True)
         except CalledProcessError:
-            log.error('Failed to replace database `{}` -> `{}`.'.format(source, existing))
+            log.error('Failed to rename database `{}` -> `{}`.'.format(oldname, newname))
             raise
 
     def _drop_database(dbname: str) -> None:
@@ -147,15 +137,25 @@ def recover_database(my_internal_ip: str, backup_file_path: str, db_suffix: str)
         _drop_database(newdbname)
         raise
 
-    # 3. In a single transaction replace original `iam` database with `iam_new`
-    #    and keep original `iam` as `iam_old`.
+    # 3. Then rename the active `iam` database to `iam_old`.
     try:
-        _replace_database(source=newdbname, existing=curdbname, backup=olddbname)
+        _rename_database(oldname=curdbname, newname=olddbname)
     except CalledProcessError:
+        # Renaming the existing database failed, so remove the 'iam_new' database
         _drop_database(newdbname)
         raise
 
-    # 4. Remove the original (old) database that isn't used anymore
+    # 4. Finally, rename the `iam_new` database to `iam`.
+    try:
+        _rename_database(oldname=newdbname, newname=curdbname)
+    except CalledProcessError:
+        # Renaming the new database failed, so rename the old one back and
+        # remove the 'iam_new' database
+        _rename_database(oldname=olddbname, newname=curdbname)
+        _drop_database(newdbname)
+        raise
+
+    # 5. Remove the original (old) database that isn't used anymore
     try:
         _drop_database(olddbname)
     except CalledProcessError:


### PR DESCRIPTION
This reverts commit 0bcab681a26f1e9152c24af320592989a07b2df0.

## High-level description

The #4251 changed `iam-database-restore` script on a false assumption that database renames could be handled transactionally.

After consulting with CockroachDB https://forum.cockroachlabs.com/t/renaming-database-in-a-transaction/2397 I've confirmed that this is not the case and we need to revert to a previous restore script version.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-48182](https://jira.mesosphere.com/browse/DCOS-48182) cockroach: confirm that database renames are transactional

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this fixes a problem of unreleased version
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)