### PR TITLE
Open-source CockroachDB ranges check

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -861,6 +861,16 @@ def calculate_check_config(check_time):
                     'cmd': ['/opt/mesosphere/bin/dcos-checks', 'journald'],
                     'timeout': instant_check_timeout,
                 },
+                'cockroachdb_replication': {
+                    'description': 'CockroachDB is fully replicated',
+                    'cmd': [
+                        '/opt/mesosphere/bin/dcos-checks',
+                        'cockroachdb',
+                        'ranges',
+                    ],
+                    'timeout': normal_check_timeout,
+                    'roles': ['master']
+                },
             },
             'prestart': [],
             'poststart': [
@@ -875,6 +885,7 @@ def calculate_check_config(check_time):
                 'mesos_master_replog_synchronized',
                 'mesos_agent_registered_with_masters',
                 'journald_dir_permissions',
+                'cockroachdb_replication',
             ],
         },
     }

--- a/packages/dcos-checks/buildinfo.json
+++ b/packages/dcos-checks/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-checks.git",
-    "ref": "c34c5a76bd49bf5df224e0c8abca51a71dece475",
+    "ref": "81bc1973ec1a86a6f3b77ebe86af98985ba12a23",
     "ref_origin": "master"
   }
 }

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,5 +1,6 @@
 git+https://github.com/dcos/dcos-e2e.git@2019.01.05.0
 cryptography==2.5
+docker==3.7.0
 jwt==0.5.4
 pytest==4.1.1
 requests==2.21.0

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -53,3 +53,4 @@
 groups:
     group_1:
         - test_service_account.py
+        - test_master_node_replacement.py

--- a/test-e2e/test_master_node_replacement.py
+++ b/test-e2e/test_master_node_replacement.py
@@ -1,0 +1,209 @@
+"""
+Tests for replacing master nodes.
+"""
+
+import textwrap
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+import docker
+import pytest
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
+from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Role
+from docker.models.networks import Network
+
+
+@pytest.fixture()
+def docker_network_three_available_addresses() -> Iterator[Network]:
+    """
+    Return a custom Docker network with 3 assignable IP addresses.
+    """
+    # We want to return a Docker network with only three assignable IP
+    # addresses.
+    # To do this, we create a network with 8 IP addresses, where 5 are
+    # reserved.
+    #
+    # Why we have 8 IP addresses available:
+    # * The IP range is "172.28.0.0/29"
+    # * We get 2 ^ (32 - 29) = 8 IP addresses
+    #
+    # The 8 IP addresses in the IPAM Pool are:
+    # * 172.28.0.0 (reserved because this is the subnet identifier)
+    # * 172.28.0.1 (reserved because this is the gateway address)
+    # * 172.28.0.2 (available)
+    # * 172.28.0.3 (available)
+    # * 172.28.0.4 (available)
+    # * 172.28.0.5 (reserved because we reserve this with `aux_addresses`)
+    # * 172.28.0.6 (reserved because we reserve this with `aux_addresses`)
+    # * 172.28.0.7 (reserved because this is the broadcast address)
+    client = docker.from_env(version='auto')
+    aux_addresses = {
+        'reserved_address_0': '172.28.0.5',
+        'reserved_address_1': '172.28.0.6',
+    }
+    ipam_pool = docker.types.IPAMPool(
+        subnet='172.28.0.0/29',
+        iprange='172.28.0.0/29',
+        gateway='172.28.0.1',
+        aux_addresses=aux_addresses,
+    )
+    network = client.networks.create(
+        name='dcos-e2e-network-{random}'.format(random=uuid.uuid4()),
+        driver='bridge',
+        ipam=docker.types.IPAMConfig(pool_configs=[ipam_pool]),
+        attachable=False,
+    )
+    try:
+        yield network
+    finally:
+        network.remove()
+
+
+def test_replace_all_static(
+    artifact_path: Path,
+    docker_network_three_available_addresses: Network,
+    tmp_path: Path,
+    request: SubRequest,
+    log_dir: Path,
+) -> None:
+    """
+    In a cluster with an Exhibitor backend consisting of a static ZooKeeper
+    ensemble, after removing one master, and then adding another master with
+    the same IP address, the cluster will get to a healthy state. This is
+    repeated until all masters in the original cluster have been replaced.
+    The purpose of this test is to assert that the ``node-poststart``
+    procedure correctly prevents a master node replacement from being performed
+    too quickly. A new master node should only become part of the cluster if
+    there are no more underreplicated ranges reported by CockroachDB.
+
+    Permanent CockroachDB data loss and a potential breakage of DC/OS occurs
+    when a second master node is taken down for replacement while CockroachDB
+    is recovering and there are still underreplicated ranges due to a recent
+    other master node replacement.
+    """
+    docker_backend = Docker(network=docker_network_three_available_addresses)
+
+    with Cluster(
+        cluster_backend=docker_backend,
+        # Allocate all 3 available IP addresses in the subnet.
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as original_cluster:
+        master = next(iter(original_cluster.masters))
+        result = master.run(
+            args=[
+                'ifconfig',
+                '|', 'grep', '-B1', str(master.public_ip_address),
+                '|', 'grep', '-o', '"^\w*"',
+            ],
+            shell=True,
+        )
+        interface = result.stdout.strip().decode()
+        ip_detect_contents = textwrap.dedent(
+            """\
+            #!/bin/bash -e
+            if [ -f /sbin/ip ]; then
+               IP_CMD=/sbin/ip
+            else
+               IP_CMD=/bin/ip
+            fi
+
+            $IP_CMD -4 -o addr show dev {interface} | awk '{{split($4,a,"/");print a[1]}}'
+            """.format(interface=interface),
+        )
+        ip_detect_path = tmp_path / 'ip-detect'
+        ip_detect_path.write_text(data=ip_detect_contents)
+        static_config = {
+            'master_discovery': 'static',
+            'master_list': [str(master.private_ip_address)
+                            for master in original_cluster.masters],
+        }
+        dcos_config = {
+            **original_cluster.base_config,
+            **static_config,
+        }
+        original_cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=dcos_config,
+            ip_detect_path=ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=original_cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        current_cluster = original_cluster
+        tmp_clusters = set([])
+
+        original_masters = original_cluster.masters
+
+        try:
+            for master_to_be_replaced in original_masters:
+                # Destroy a master and free one IP address.
+                original_cluster.destroy_node(node=master_to_be_replaced)
+
+                temporary_cluster = Cluster(
+                    cluster_backend=docker_backend,
+                    # Allocate one container with the now free IP address.
+                    masters=1,
+                    agents=0,
+                    public_agents=0,
+                )
+                tmp_clusters.add(temporary_cluster)
+
+                # Install a new master on a new container with the same IP address.
+                (new_master, ) = temporary_cluster.masters
+                new_master.install_dcos_from_path(
+                    dcos_installer=artifact_path,
+                    dcos_config=dcos_config,
+                    role=Role.MASTER,
+                    ip_detect_path=ip_detect_path,
+                )
+                # Form a new cluster with the newly create master node.
+                new_cluster = Cluster.from_nodes(
+                    masters=current_cluster.masters.union(set([new_master])),
+                    agents=current_cluster.agents,
+                    public_agents=current_cluster.public_agents,
+                )
+                # The `wait_for_dcos_oss` function waits until the new master has
+                # joined the cluster and all masters are healthy. Without the
+                # cockroachdb check, this succeeds before all cockroachdb ranges
+                # have finished replicating to the new master. That meant that the
+                # next master would be replaced too quickly, while it had data that
+                # was not present elsewhere in the cluster. This lead to
+                # irrecoverable dataloss.  This function waits until the node is
+                # "healthy". It is assumed that this performs the same diagnostics
+                # we instruct operators to perform when we tell them to "wait until
+                # the cluster becomes healthy before replacing the next master
+                # node."
+                #
+                # We don't call the cockroachdb ranges check directly as the
+                # purpose of this test is to ensure that when an operator follows
+                # our documented procedure for replacing a master node multiple
+                # times in a row then his cluster remains healthy throughout and
+                # afterwards. If we called the check directly here, we would be
+                # sure the check is being called, but we would not be sure that
+                # "wait_for_dcos_oss", i.e., the standard procedure for determining
+                # whether a node is healthy, is sufficient to prevent the cluster
+                # from breaking.
+                #
+                # We perform this check after every master is replaced, as that is
+                # what we tell operators to do: "After installing the new master
+                # node, wait until it becomes healthy before proceeding to the
+                # next."
+                wait_for_dcos_oss(
+                    cluster=new_cluster,
+                    request=request,
+                    log_dir=log_dir,
+                )
+                # Use the new cluster object in the next replacement iteration.
+                current_cluster = new_cluster
+
+        finally:
+            for cluster in tmp_clusters:
+                cluster.destroy()


### PR DESCRIPTION
## High-level description

CockroachDB is introduced to DC/OS in version 1.13. To make sure that no master node replacements/upgrades can happen too quickly for CockroachDB nodes to rebalance their data we introduce also this dcos-check from DC/OS Enterprise.

This PR adds the dcos-check for CockroachDB underreplicated ranges to DC/OS from DC/OS Enterprise. It also adds a test that replaces all master nodes in 3 master cluster one after another to test that the check works correctly.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4753](https://jira.mesosphere.com/browse/DCOS_OSS-4753) Add dcos-check fo cockroachdb replication to DC/OS.

The plan is to have a follow-up PR for Enterprise that incorporates this check from dcos-checks.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is considered part of the CockroachDB open-sourcing effort.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___