### PR TITLE
[1.12] Fix mesos metrics bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Format of the entries must be.
 
 * * Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
 
+* Telegraf: Fix a bug in the Mesos input plugin that could cause metrics to be mis-tagged (DCOS_OSS-4760)
 
 ### Security Updates
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ Format of the entries must be.
 
 * Improve error message in case Docker is not running at start of installation (DCOS-15890)
 
-* * Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
+* Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
 
 * Telegraf: Fix a bug in the Mesos input plugin that could cause metrics to be mis-tagged (DCOS_OSS-4760)
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "e62db07bc444254df19eed062ad265f2c6b30664",
+    "ref": "e06a185f18201deb875e6fb0bcfaee2ad13fc22d",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

In the last MWST, we discovered a bug in Telegraf's Mesos input plugin that was causing some mesos metrics to be mis-tagged. The bug has been fixed in Telegraf, bumping the version here.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4760](https://jira.mesosphere.com/browse/DCOS_OSS-4760) Some metrics may have wrong tags


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-47991](https://jira.mesosphere.com/browse/DCOS-47991) Gaps in the Mesos MoM dashboards


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: upstream tests in Telegraf should be sufficient. adding an integration test that forces this test case would be difficult.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/e62db07bc444254df19eed062ad265f2c6b30664...dcos:e06a185f18201deb875e6fb0bcfaee2ad13fc22d
  - [x] Test Results: [link to CI job test results for component] https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/178/
  - [ ] Code Coverage (if available): [link to code coverage report]
