### PR TITLE
DCOS-46608 - docker pull image ahead of usage in test

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import os
-import subprocess
 
 import pytest
 import requests
@@ -149,9 +148,3 @@ def _dump_diagnostics(request, dcos_api_session):
         diagnostics.download_diagnostics_reports(diagnostics_bundles=bundles)
     else:
         log.info('\nNot downloading diagnostics bundle for this session.')
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _docker_pull():
-    log.info("\n Docker pull debian:jessie-slim that is used in integration tests.")
-    subprocess.check_call(["docker", "pull", "debian:jessie-slim"])

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import subprocess
 
 import pytest
 import requests
@@ -148,3 +149,9 @@ def _dump_diagnostics(request, dcos_api_session):
         diagnostics.download_diagnostics_reports(diagnostics_bundles=bundles)
     else:
         log.info('\nNot downloading diagnostics bundle for this session.')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _docker_pull():
+    log.info("\n Docker pull debian:jessie-slim that is used in integration tests.")
+    subprocess.check_call(["docker", "pull", "debian:jessie-slim"])

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -167,7 +167,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
             {
                 'name': 'ct1',
                 'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
+                'image': {'kind': 'DOCKER', 'id': 'alpine:3.4'},
                 'exec': {'command': {'shell': 'touch foo; while true; do sleep 1; done'}},
                 'healthcheck': {'command': {'shell': 'test -f foo'}}
             },

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -167,7 +167,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
             {
                 'name': 'ct1',
                 'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'alpine:3.4'},
+                'image': {'kind': 'DOCKER', 'id': 'debian:jessie-slim'},
                 'exec': {'command': {'shell': 'touch foo; while true; do sleep 1; done'}},
                 'healthcheck': {'command': {'shell': 'test -f foo'}}
             },

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -72,6 +72,11 @@ def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: st
             raise Exception(msg.format(r.status_code, r.reason, r.text))
 
 
+@pytest.mark.first
+def test_docker_image_availablity():
+    assert test_helpers.docker_pull_debian_jessie(), "docker pull failed the images used in the test"
+
+
 def test_if_marathon_app_can_be_deployed(dcos_api_session):
     """Marathon app deployment integration test
 
@@ -167,7 +172,7 @@ def test_if_marathon_pods_can_be_deployed_with_mesos_containerizer(dcos_api_sess
             {
                 'name': 'ct1',
                 'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'debian:jessie-slim'},
+                'image': {'kind': 'DOCKER', 'id': 'debian:jessie'},
                 'exec': {'command': {'shell': 'touch foo; while true; do sleep 1; done'}},
                 'healthcheck': {'command': {'shell': 'test -f foo'}}
             },

--- a/packages/dcos-integration-test/extra/test_applications.py
+++ b/packages/dcos-integration-test/extra/test_applications.py
@@ -74,7 +74,7 @@ def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: st
 
 @pytest.mark.first
 def test_docker_image_availablity():
-    assert test_helpers.docker_pull_debian_jessie(), "docker pull failed the images used in the test"
+    assert test_helpers.docker_pull_image("debian:jessie"), "docker pull failed for image used in the test"
 
 
 def test_if_marathon_app_can_be_deployed(dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -1,6 +1,10 @@
 import copy
 import json
+import logging
+import subprocess
 import uuid
+
+import retrying
 
 from dcos_test_utils import marathon
 
@@ -8,6 +12,8 @@ __maintainer__ = 'mellenburg'
 __contact__ = 'tools-infra-team@mesosphere.io'
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
+
+log = logging.getLogger(__name__)
 
 
 def get_exhibitor_admin_password():
@@ -33,6 +39,18 @@ def get_expanded_config():
         # TODO: Remove this hack. https://jira.mesosphere.com/browse/QUALITY-1611
         expanded_config['exhibitor_admin_password'] = get_exhibitor_admin_password()
     return expanded_config
+
+
+@retrying.retry(wait_fixed=60 * 1000,       # wait for 60 seconds
+                retry_on_exception=lambda exc: isinstance(exc, subprocess.CalledProcessError), # Called Process Error
+                stop_max_attempt_number=3)  # retry 3 times
+def docker_pull_debian_jessie():
+    log.info("\n Docker pull debian:jessie that is used in integration tests.")
+    try:
+        subprocess.run(["docker", "pull", "debian:jessie"], check=True)
+        return True
+    except retrying.RetryError:
+        return False
 
 
 def marathon_test_app_linux(
@@ -114,7 +132,7 @@ def marathon_test_app_linux(
     if container_type != marathon.Container.NONE:
         app['container'] = {
             'type': container_type.value,
-            'docker': {'image': 'debian:jessie-slim'},
+            'docker': {'image': 'debian:jessie'},
             'volumes': [{
                 'containerPath': '/opt/mesosphere',
                 'hostPath': '/opt/mesosphere',

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -8,7 +8,7 @@ import retrying
 
 from dcos_test_utils import marathon
 
-__maintainer__ = 'mellenburg'
+__maintainer__ = 'orsenthil'
 __contact__ = 'tools-infra-team@mesosphere.io'
 
 TEST_APP_NAME_FMT = 'integration-test-{}'
@@ -44,10 +44,10 @@ def get_expanded_config():
 @retrying.retry(wait_fixed=60 * 1000,       # wait for 60 seconds
                 retry_on_exception=lambda exc: isinstance(exc, subprocess.CalledProcessError),  # Called Process Error
                 stop_max_attempt_number=3)  # retry 3 times
-def docker_pull_debian_jessie():
-    log.info("\n Docker pull debian:jessie that is used in integration tests.")
+def docker_pull_image(image: str) -> bool:
+    log.info("\n Ensure docker image is available, and cached locally before its usage in tests.")
     try:
-        subprocess.run(["docker", "pull", "debian:jessie"], check=True)
+        subprocess.run(["sudo", "docker", "pull", image], check=True)
         return True
     except retrying.RetryError:
         return False

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -45,7 +45,7 @@ def get_expanded_config():
                 retry_on_exception=lambda exc: isinstance(exc, subprocess.CalledProcessError),  # Called Process Error
                 stop_max_attempt_number=3)  # retry 3 times
 def docker_pull_image(image: str) -> bool:
-    log.info("\n Ensure docker image is available, and cached locally before its usage in tests.")
+    log.info("\n Ensure docker image availability ahead of tests.")
     try:
         subprocess.run(["sudo", "docker", "pull", image], check=True)
         return True

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -114,7 +114,7 @@ def marathon_test_app_linux(
     if container_type != marathon.Container.NONE:
         app['container'] = {
             'type': container_type.value,
-            'docker': {'image': 'debian:jessie'},
+            'docker': {'image': 'alpine:3.4'},
             'volumes': [{
                 'containerPath': '/opt/mesosphere',
                 'hostPath': '/opt/mesosphere',

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -114,7 +114,7 @@ def marathon_test_app_linux(
     if container_type != marathon.Container.NONE:
         app['container'] = {
             'type': container_type.value,
-            'docker': {'image': 'alpine:3.4'},
+            'docker': {'image': 'debian:jessie-slim'},
             'volumes': [{
                 'containerPath': '/opt/mesosphere',
                 'hostPath': '/opt/mesosphere',

--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -42,7 +42,7 @@ def get_expanded_config():
 
 
 @retrying.retry(wait_fixed=60 * 1000,       # wait for 60 seconds
-                retry_on_exception=lambda exc: isinstance(exc, subprocess.CalledProcessError), # Called Process Error
+                retry_on_exception=lambda exc: isinstance(exc, subprocess.CalledProcessError),  # Called Process Error
                 stop_max_attempt_number=3)  # retry 3 times
 def docker_pull_debian_jessie():
     log.info("\n Docker pull debian:jessie that is used in integration tests.")

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -218,6 +218,11 @@ def workload_test(dcos_api_session, container, app_net, proxy_net, ipv6, same_ho
     return (hosts, origin_app, proxy_app)
 
 
+@pytest.mark.first
+def test_docker_image_availablity():
+    assert test_helpers.docker_pull_image("debian:jessie"), "docker pull failed for image used in the test"
+
+
 @pytest.mark.xfailflake(
     jira='DCOS-46146',
     reason='Upgrade docker to version 17.12.x.',


### PR DESCRIPTION
## High-level description

DCOS-46608 - Docker pull instabilities. 

This PR adds a helper which will do a docker pull of the image before we use in the integration test.
