### PR TITLE
[BACKPORT] [1.10] DCOS-46438 - Support collecting integration tests locally without a cluster.

### DIFF
--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -1,9 +1,15 @@
-dnspython==1.16.0
 pytest==4.2.0
 PyYAML==4.2b4
 webtest==2.0.32
 webtest-aiohttp==1.1.0
 schema==0.6.8
 pytest-catchlog==1.2.2
-kazoo==2.6.1
+
+# The following should be kept in sync with their panda packages. Don't forget to update enterprise as well.
+
+# /packages/dnspython/buildinfo.json:
+dnspython3==1.12.0
+# /packages/python-kazoo/buildinfo.json
+kazoo==2.2.1
+# /packages/dcos-test-utils/buildinfo.json
 git+https://github.com/dcos/dcos-test-utils.git@ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8

--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -1,6 +1,6 @@
 dnspython==1.16.0
 pytest==4.2.0
-PyYAML==3.13
+PyYAML==4.2b4
 webtest==2.0.32
 webtest-aiohttp==1.1.0
 schema==0.6.8

--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -1,0 +1,9 @@
+dnspython==1.16.0
+pytest==4.2.0
+PyYAML==3.13
+webtest==2.0.32
+webtest-aiohttp==1.1.0
+schema==0.6.8
+pytest-catchlog==1.2.2
+kazoo==2.6.1
+git+https://github.com/dcos/dcos-test-utils.git@ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -319,7 +319,6 @@ def test_if_overlay_ok(dcos_api_session):
         _check_overlay(slave, 5051)
 
 
-@pytest.mark.skipif(lb_enabled(), reason='Load Balancer enabled')
 def test_if_navstar_l4lb_disabled(dcos_api_session):
     '''Test to make sure navstar_l4lb is disabled'''
     if lb_enabled():

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,7 @@ commands=
 
 [testenv:collect-integration-tests]
 platform=linux|darwin
+basepython=python3.5
 deps= -rpackages/dcos-integration-test/extra/requirements.txt
 commands=
   py.test --xfailflake-report --collect-only packages/dcos-integration-test/extra/

--- a/tox.ini
+++ b/tox.ini
@@ -83,3 +83,9 @@ changedir=packages/bootstrap/extra
 commands=
   pip install .
   py.test --basetemp={envtmpdir} {posargs}
+
+[testenv:collect-integration-tests]
+platform=linux|darwin
+deps= -rpackages/dcos-integration-test/extra/requirements.txt
+commands=
+  py.test --xfailflake-report --collect-only packages/dcos-integration-test/extra/


### PR DESCRIPTION
## High-level description

Adds a tox target and requirements.txt that allows the integration tests to be collected locally without needing to be run inside of a cluster.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46438](https://jira.mesosphere.com/browse/DCOS-46438) Make it possible to collect DC/OS integration tests without a running cluster


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)