### PR TITLE
Revert back to platform-dependent tar decompression

### DIFF
--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager, ExitStack
 from itertools import chain
 from multiprocessing import Process
 from shutil import rmtree
+from subprocess import check_call
 from typing import List
 
 import requests
@@ -218,8 +219,13 @@ def extract_tarball(path, target):
         assert os.path.exists(path), "Path doesn't exist but should: {}".format(path)
         make_directory(target)
 
-        with tarfile.open(name=str(path), mode='r') as tar:
-            tar.extractall(path=str(target), numeric_owner=True)
+        # TODO(tweidner): https://jira.mesosphere.com/browse/DCOS-48220
+        # Make this cross-platform via Python's tarfile module once
+        # https://bugs.python.org/issue21872 is fixed.
+        if is_windows:
+            check_call(['bsdtar', '-xf', path, '-C', target])
+        else:
+            check_call(['tar', '-xf', path, '-C', target])
 
     except:
         # If there are errors, we can't really cope since we are already in an error state.


### PR DESCRIPTION
## High-level description

This PR reverts the decompression part of: [#4388](https://github.com/dcos/dcos/pull/4388/files)
After the aforementioned PR was merged we noticed that the CI runs into this Python bug:
https://bugs.python.org/issue21872

Due to complications to reproduce the issue locally this should be reverted to the old functionality for now.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-48220](https://jira.mesosphere.com/browse/DCOS-48220) pkgpanda: Compressed file ended before the end-of-stream marker was reached.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)