### PR TITLE
DCOS-46438 - Do not use vulnerable PyYaml version in tests.

### DIFF
--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -1,6 +1,6 @@
 dnspython==1.16.0
 pytest==4.2.0
-PyYAML==3.13
+PyYAML==4.2b4
 webtest==2.0.32
 webtest-aiohttp==1.1.0
 schema==0.6.8


### PR DESCRIPTION
Bump PyYaml in integration-test requirements.txt to a version not affected by CVE-2017-18342.