### PR TITLE
Metronome PID is not written to this location

### DIFF
--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 pushd "/pkg/src/metronome"
-rm -rf bin/metronome.bat README.md RUNNING_PID share/ logs/
+rm -rf bin/metronome.bat README.md share/ logs/
 cp -an * "$PKG_PATH/"
 cp -f /pkg/extra/logback.xml "$PKG_PATH/conf/"
 
@@ -28,6 +28,5 @@ ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metronome
 ExecStartPre=/bin/bash -c 'mkdir -p /run/dcos/etc/metronome'
 ExecStartPre=/bin/bash -c 'echo "METRONOME_LEADER_ELECTION_HOSTNAME=\$(\$MESOS_IP_DISCOVERY_COMMAND)" > /run/dcos/etc/metronome/service.env'
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=\$(\$MESOS_IP_DISCOVERY_COMMAND)" >> /run/dcos/etc/metronome/service.env'
-ExecStartPre=-/usr/bin/env rm -f /opt/mesosphere/active/metronome/RUNNING_PID
 ExecStart=/opt/mesosphere/bin/metronome
 EOF


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Remove redundant code in the build script


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45513](https://jira.mesosphere.com/browse/DCOS-45513) packages/metronome: metronome incorrectly writes its PID into /opt/mesosphere location


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
