### PR TITLE
Restore IAM user creation script for adding remote users for Auth0 identity provider in DC/OS 1.13+

### DIFF
--- a/packages/bouncer/build
+++ b/packages/bouncer/build
@@ -31,4 +31,7 @@ envsubst '$PKG_PATH' < "/pkg/extra/${SERVICE_FILE_NAME}" > "${SERVICE_FILE_PATH}
 mkdir -p $PKG_PATH/bin
 install -m 755 /pkg/extra/iam-migrate-users-from-zk.py $PKG_PATH/bin/iam-migrate-users-from-zk.py
 
+# Copy the IAM user creation script
+install -m 755 /pkg/extra/dcos_add_user.py $PKG_PATH/bin/dcos_add_user.py
+
 cp /pkg/extra/dcos-bouncer-migrate-users.service "$PKG_PATH/dcos.target.wants_master/dcos-bouncer-migrate-users.service"

--- a/packages/bouncer/extra/dcos_add_user.py
+++ b/packages/bouncer/extra/dcos_add_user.py
@@ -20,10 +20,7 @@ IAM_BASE_URL = 'http://127.0.0.1:8101'
 
 
 def add_user(uid: str) -> None:
-    """
-    Create a user in DC/OS IAM:
-https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
-    """
+
     url = '{iam}/acs/api/v1/users/{uid}'.format(
         iam=IAM_BASE_URL,
         uid=uid,
@@ -37,7 +34,7 @@ https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packa
     # The 409 response code means that user already exists in the DC/OS IAM
     # service
     if r.status_code == 409:
-        log.info('Skipping existing IAM user `%s`', uid)
+        log.info('User `%s` already exists', uid)
         return
     r.raise_for_status()
     log.info('Created IAM user `%s`', uid)
@@ -62,7 +59,7 @@ def main() -> None:
     if re.match(r'[^@]+@[^@]+\.[^@]+', email):
         add_user(email)
     else:
-        log.error('Provided email `%s` is not valid', email)
+        log.error('Provided uid `%s` does not appear to be an email address', email)
 
 
 if __name__ == "__main__":

--- a/packages/bouncer/extra/dcos_add_user.py
+++ b/packages/bouncer/extra/dcos_add_user.py
@@ -1,17 +1,6 @@
 #!/usr/bin/env python
 """
-Prior to DC/OS version 1.13 a user could directly be created in ZooKeeper by
-utilizing a script ``dcos_add_user.py`` which would be copied to
-``/opt/mesosphere/bin/dcos_add_user.py``:
-https://github.com/dcos/dcos/blob/1d9e6bb2a27daf3dc8ec359e01e2272ec8a09dd0/packages/dcos-oauth/extra/dcos_add_user.py
-
-This script is intended to enable the same functionality for DC/OS 1.13+.
-After installing DC/OS it will be accessible from
-``/opt/mesosphere/bin/dcos_add_user.py``. It is meant to add remote users
-specifically for the Auth0 identity provider.
-
-The script uses legacy user management to create a user in the IAM service:
-https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
+This script adds remote users in DC/OS IAM for the Auth0 identity provider.
 """
 
 import argparse
@@ -32,7 +21,7 @@ IAM_BASE_URL = 'http://127.0.0.1:8101'
 
 def add_user(uid: str) -> None:
     """
-    Create a user in IAM service:
+    Create a user in DC/OS IAM:
 https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
     """
     url = '{iam}/acs/api/v1/users/{uid}'.format(

--- a/packages/bouncer/extra/dcos_add_user.py
+++ b/packages/bouncer/extra/dcos_add_user.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""
+Prior to DC/OS version 1.13 a user could directly be created in ZooKeeper by
+utilizing a script ``dcos_add_user.py`` which would be copied to
+``/opt/mesosphere/bin/dcos_add_user.py``:
+https://github.com/dcos/dcos/blob/1d9e6bb2a27daf3dc8ec359e01e2272ec8a09dd0/packages/dcos-oauth/extra/dcos_add_user.py
+
+This script is intended to enable the same functionality for DC/OS 1.13+.
+After installing DC/OS will be accessible from ``/opt/mesosphere/bin/dcos_add_user.py``.
+
+This script uses legacy user management to create a user in the IAM service:
+
+https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
+"""
+import argparse
+import logging
+
+import requests
+
+
+log = logging.getLogger(__name__)
+logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
+
+
+# To keep this script simple and avoid authentication and authorization this
+# script uses local IAM address instead of going through Admin Router
+IAM_BASE_URL = 'http://127.0.0.1:8101'
+
+
+def add_user(uid: str) -> None:
+    """
+    Create a user in IAM service:
+https://github.com/dcos/dcos/blob/abaeb5cceedd5661b8d96ff47f8bb5ef212afbdc/packages/dcos-integration-test/extra/test_legacy_user_management.py#L96
+    """
+    url = '{iam}/acs/api/v1/users/{uid}'.format(
+        iam=IAM_BASE_URL,
+        uid=uid,
+    )
+    r = requests.put(url, json={})
+
+    # The 409 response code means that user already exists in the DC/OS IAM
+    # service
+    if r.status_code == 409:
+        log.info('Skipping existing IAM user `%s`', uid)
+        return
+    r.raise_for_status()
+    log.info('Created IAM user `%s`', uid)
+
+
+def main() -> None:
+    """
+    Add user to database with email argument as the user ID.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'email',
+        type=str,
+        help='Identity of the user to add.',
+    )
+    args = parser.parse_args()
+    add_user(args.email)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/dcos-integration-test/extra/test_legacy_user_management.py
+++ b/packages/dcos-integration-test/extra/test_legacy_user_management.py
@@ -19,6 +19,7 @@ that first user's point of view. That is, we can not test that a user (e.g.
 user2) which was added by the first user (user1) can add another user (user3).
 """
 import logging
+import os.path
 
 import pytest
 
@@ -185,3 +186,10 @@ def test_dynamic_ui_config(dcos_api_session):
     assert not data['clusterConfiguration']['firstUser']
     assert 'id' in data['clusterConfiguration']
     assert 'uiConfiguration' in data
+
+
+def test_dcos_add_user_script_exists_oss():
+    """
+    dcos_add_user.py script exists in /opt/mesosphere/bin directory.
+    """
+    assert os.path.isfile("/opt/mesosphere/bin/dcos_add_user.py")


### PR DESCRIPTION
Script contributed by @timaa2k: https://github.com/dcos/dcos/commit/c5d20500af61e9b0597c3d982760934c051fe383

## High-level description

Prior to DC/OS version 1.13 a user could directly be created in ZooKeeper by
utilizing a script `dcos_add_user.py`
This script is intended to enable the same functionality for DC/OS 1.13+. It is meant to add remote users
specifically for the Auth0 identity provider.

This script uses legacy user management to create a user in the IAM service.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS-45284

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ x ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ x ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
