### PR TITLE
Update DC/OS version to 1.10.11

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -83,7 +83,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.10.10.1',
+        'version': '1.10.11',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -984,7 +984,7 @@ entry = {
         'mesos_dns_resolvers_str': calculate_mesos_dns_resolvers_str,
         'mesos_log_retention_count': calculate_mesos_log_retention_count,
         'mesos_log_directory_max_files': calculate_mesos_log_directory_max_files,
-        'dcos_version': '1.10.10.1',
+        'dcos_version': '1.10.11',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'config_package_ids': calculate_config_package_ids,


### PR DESCRIPTION
## High-level description

https://jira.mesosphere.com/browse/DCOS-48228 - Update the next release of 1.10 DC/OS version to 1.10.11

* Go to https://dcos.io/releases/ and make sure the version mentioned in this change is the next version of DC/OS for 1.10 release
* The target branch will be renamed to `1.10.11` after we merge this PR.