### PR TITLE
update the version of DC/OS to 1.11.10

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -83,7 +83,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.11.9.1',
+        'version': '1.11.10',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1093,7 +1093,7 @@ entry = {
         'mesos_agent_log_file': '/var/log/mesos/mesos-agent.log',
         'mesos_master_log_file': '/var/lib/dcos/mesos/log/mesos-master.log',
         'marathon_port': '8080',
-        'dcos_version': '1.11.9.1',
+        'dcos_version': '1.11.10',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,


### PR DESCRIPTION
## High-level description

https://jira.mesosphere.com/browse/DCOS-48228 - Update the next release of 1.11 DC/OS version to 1.11.10

### How to review

* Go to https://dcos.io/releases/ and make sure the version mentioned in this change is the next version of DC/OS for 1.11 release
* The target branch `1.11.9.1` will be renamed to `1.11.10` after we merge this PR.
