### PR TITLE
Grow Telegraf's statsd UDP message queue

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1452,7 +1452,7 @@ package:
         parse_data_dog_tags = false
         ## Number of UDP messages allowed to queue up, once filled,
         ## the statsd server will start dropping packets
-        allowed_pending_messages = 10000
+        allowed_pending_messages = 100000
         ## Number of timing/histogram values to track per-measurement in the
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
@@ -1588,7 +1588,7 @@ package:
         parse_data_dog_tags = false
         ## Number of UDP messages allowed to queue up, once filled,
         ## the statsd server will start dropping packets
-        allowed_pending_messages = 10000
+        allowed_pending_messages = 100000
         ## Number of timing/histogram values to track per-measurement in the
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
@@ -1710,7 +1710,7 @@ package:
         parse_data_dog_tags = false
         ## Number of UDP messages allowed to queue up, once filled,
         ## the statsd server will start dropping packets
-        allowed_pending_messages = 10000
+        allowed_pending_messages = 100000
         ## Number of timing/histogram values to track per-measurement in the
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.


### PR DESCRIPTION
## High-level description

This increases Telegraf's UDP message queue size from 10000 to 100000 to help ensure that messages are not dropped when a cluster is under load.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4761](https://jira.mesosphere.com/browse/DCOS_OSS-4761) Telegraf drops statsd metrics at scale

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This change will be covered by scale testing.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]