### PR TITLE
marathon 1.5.13 bump on dcos 1.10

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,11 +17,16 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* [MARATHON-8493](https://jira.mesosphere.com/browse/MARATHON-8493) Fixed precision bug associated with summing pod resources.
+* [MARATHON-8498](https://jira.mesosphere.com/browse/MARATHON-8498) Fixed secrets validator when changing secret env.
+* [MARATHON-8466](https://jira.mesosphere.com/browse/MARATHON-8466) Prohibit the use of reserve words in app and pod ids
+* [COPS-4483](https://jira.mesosphere.com/browse/COPS-4483) Provide backward compatible way to produce container ports for text/plain GET requests against /v2/tasks when using USER networking consistent with Marathon 1.4.
+
 * Docker-GC will now log to journald. (COPS-4044)
 
 * Minuteman routes traffic until the first failed health check (DCOS_OSS-1954)
 
-* Added support CoreOS 1800.6.0 1800.7.0, & 1855.4.0. (DCOS_43865) 
+* Added support CoreOS 1800.6.0 1800.7.0, & 1855.4.0. (DCOS_43865)
 
 * Expose a Mesos flag to allow the network CNI root directory to be persisted across host reboot. (DCOS_OSS-4667)
 
@@ -36,7 +41,7 @@ Format of the entries must be.
 
 * Updated DC/OS UI to [v1.10.9](https://github.com/dcos/dcos-ui/releases/tag/v1.10+v1.10.9)
 
-* Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861) 
+* Get timestamp on dmesg, timedatectl, distro version, systemd unit status and pods endpoint in diagnostics bundle. (DCOS_OSS-3861)
 
 
 ### Security Updates

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.12/marathon-1.5.12.tgz",
-    "sha1" : "89e5ede385019c0d854b3e8427dd7b90c92bfee0"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/releases/1.5.13/marathon-1.5.13.tgz",
+    "sha1" : "37edc22a164e8d13069424c149074a163a68d023"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [MARATHON-8574](https://jira.mesosphere.com/browse/MARATHON-8574) Release Marathon 1.5.13.


## Related tickets (optional)

Other tickets related to this change:

[MARATHON-8493](https://jira.mesosphere.com/browse/MARATHON-8493) Fixed precision bug associated with summing pod resources.
[MARATHON-8498](https://jira.mesosphere.com/browse/MARATHON-8498) Fixed secrets validator when changing secret env.
[MARATHON-8466](https://jira.mesosphere.com/browse/MARATHON-8466) Prohibit the use of reserve words in app and pod ids
[COPS-4483](https://jira.mesosphere.com/browse/COPS-4483) Provide backward compatible way to produce container ports for text/plain GET requests against /v2/tasks when using USER networking consistent with Marathon 1.4.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/v1.5.12...v1.5.13)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-team-releases/job/marathon-community-release-1.5/93/)
  - [x] Code Coverage (if available):  N/A
