### PR TITLE
Revert "Merge #4484" -DCOS_OSS-4097 - Explicitly create user groups in pkgpanda

### DIFF
--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -624,10 +624,6 @@ class UserManagement:
             add_user_cmd += [
                 '-g', groupname
             ]
-        else:
-            add_user_cmd += [
-                '--user-group'
-            ]
 
         add_user_cmd += [username]
 


### PR DESCRIPTION
This change reverts [1.11] DCOS_OSS-4097 - Explicitly create user groups in pkgpanda #4484

---- 

This reverts commit c2693ce845c44b9e20fa0f96cd761857402128d7, reversing
changes made to 52ab76e615d150589bc1207fed8a8f6ebd691096.

It looks like #4484
broke 1.11 Enterprise DC/OS branch
https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcOs_Enterprise_Test_DockerBased_E2eGroup4&page=2&tab=buildTypeHistoryList&branch_DcOs_Enterprise_Test_DockerBased=1.11 
