### PR TITLE
DCOS-46615 - Retry downloading pkgpanda pkg if file size incorrect

### DIFF
--- a/pkgpanda/exceptions.py
+++ b/pkgpanda/exceptions.py
@@ -16,6 +16,22 @@ class FetchError(Exception):
         return msg
 
 
+class IncompleteDownloadError(Exception):
+
+    def __init__(self, url, total_bytes_read, content_length):
+        self.url = url
+        self.total_bytes_read = total_bytes_read
+        self.content_length = content_length
+
+    def __str__(self):
+        msg = "Problem fetching {} - bytes read {} does not match content-length {}".format(
+            self.url,
+            self.total_bytes_read,
+            self.content_length)
+
+        return msg
+
+
 class InstallError(Exception):
     pass
 

--- a/pkgpanda/test_util.py
+++ b/pkgpanda/test_util.py
@@ -1,8 +1,11 @@
 import os
 import tempfile
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from subprocess import CalledProcessError
+from threading import Thread
 
 import pytest
+import requests
 
 import pkgpanda.util
 from pkgpanda import UserManagement
@@ -412,3 +415,49 @@ def test_write_string(tmpdir):
     st_mode = os.stat(filename).st_mode
     expected_permission = 0o777
     assert (st_mode & 0o777) == expected_permission
+
+
+class MockDownloadServerRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        body = b'foobar'
+
+        self.send_response(requests.codes.ok)
+        self.send_header('Content-Length', '6')
+        self.send_header('Content-Type', 'text/plain')
+        self.end_headers()
+
+        if self.server.requests_received == 0:
+            # Don't send the last byte of the response body.
+            self.wfile.write(body[:len(body) - 1])
+        else:
+            self.wfile.write(body)
+        self.server.requests_received += 1
+
+        return
+
+
+class MockHTTPDownloadServer(HTTPServer):
+    requests_received = 0
+
+
+def test_stream_remote_file_with_retries(tmpdir):
+    mock_server = MockHTTPDownloadServer(('localhost', 0), MockDownloadServerRequestHandler)
+    mock_server_port = mock_server.server_port
+
+    mock_server_thread = Thread(
+        target=mock_server.serve_forever,
+        daemon=True)
+    mock_server_thread.start()
+
+    url = 'http://localhost:{port}/foobar.txt'.format(port=mock_server_port)
+
+    out_file = os.path.join(str(tmpdir), 'foobar.txt')
+    response = pkgpanda.util._download_remote_file(out_file, url)
+
+    response_is_ok = response.ok
+    assert response_is_ok
+
+    assert mock_server.requests_received == 2
+
+    with open(out_file, 'rb') as f:
+        assert f.read() == b'foobar'


### PR DESCRIPTION
## High-level description

AWS S3, from which we download pre-built pkgpanda packages, might sometimes end the connection before the package has been fully downloaded. (See https://github.com/aws/aws-sdk-js/issues/312 and https://github.com/boto/boto3/issues/540 for more context on this)

In our case that leads to invalid `tar.xz` archives which cause `unexpected end of input` errors and result in faulty builds of DC/OS (`dcos_generate_config.sh`) which contain these invalid archives and then result in install-time errors for users. See this comment for an investigation into how this can affect installation errors: https://jira.mesosphere.com/browse/DCOS_OSS-4097?focusedCommentId=219259&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-219259

This change here adds a sanity check to the `download` function used by pkgpanda. It checks whether the final file size (after flushing the file to disk) matches the `Content-Length` we get from S3. If it doesn't match, it sleep for 2, 4, 8, ... seconds and then retries until it either downloads the file completely or the retries are exhausted. In that case, it raises an exception.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS-46615] Pkgpanda - package dcos-image - xz: (stdin): Unexpected end of input - JIRA](https://jira.mesosphere.com/browse/DCOS-46615)

## Related tickets (optional)

Other tickets related to this change:

  - [[DCOS_OSS-4097] pkgpanda: Explicitly create user groups for all users - JIRA](https://jira.mesosphere.com/browse/DCOS_OSS-4097)


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: it's internal behaviour that's not exposed to the user
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: I didn't include a test yet, since that would need to involve setting up a mock http server etc. and I wanted to get input on this first
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
