### PR TITLE
Re-enable test_metronome

### DIFF
--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -1,5 +1,3 @@
-import pytest
-
 __maintainer__ = 'ichernetsky'
 __contact__ = 'marathon-team@mesosphere.io'
 

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -4,11 +4,6 @@ __maintainer__ = 'ichernetsky'
 __contact__ = 'marathon-team@mesosphere.io'
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-40611',
-    reason="test_metronome.test_metronome failed sporadically on Azure ARM platform.",
-    since='2018-11-20',
-)
 def test_metronome(dcos_api_session):
     job = {
         'description': 'Test Metronome API regressions',


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Re-enable the test. I looked into last ~20 runs on ARM and no failure. Also this is pretty much the ONLY test that covers metronome so it should NEVER be muted.
It's possible that it's fixed already. We had problems with Metronome on ARM that we solved by bumping the marathon dependency.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-40611](https://jira.mesosphere.com/browse/DCOS-40611) test_metronome.test_metronome failed sporadically on Azure ARM platform.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
