### PR TITLE
Re-enable test_checks_cli test

### DIFF
--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -8,11 +8,6 @@ __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-45278',
-    reason='test_checks_cli _wait_for_run_completion',
-    since='2018-11-20',
-)
 def test_checks_cli(dcos_api_session):
     base_cmd = [
         '/opt/mesosphere/bin/dcos-shell',

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -2,8 +2,6 @@ import logging
 import random
 import uuid
 
-import pytest
-
 __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Re-enable the test. I did not see it fail in last 20 runs of ARM build. Also we were not able to reproduce locally and there were many metronome fixes in last X months.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45278](https://jira.mesosphere.com/browse/DCOS-45278) teamcity/dcos/test/azure/arm: Metronome error 'history for that job run is not available'

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]