### PR TITLE
DCOS_OSS-4316 REX-Ray: bump to v0.11.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,7 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 ### Fixed and improved
 
 * Fix dcos-net-setup.py failing when systemd network directory did not exist (DCOS-49711)
+* Updated REX-Ray version to 0.11.4 (DCOS_OSS-4316) (COPS-3961) [rexray v0.11.4](https://github.com/rexray/rexray/releases/tag/v0.11.4)
 
 * Telegraf is upgraded to 1.9.4. (DCOS_OSS-4675)
 

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/rexray/rexray.git",
-    "ref": "fc8bfbd2d02c2690fc3a755a9560dd12c88e0852",
-    "ref_origin": "v0.11.2"
+    "ref": "e7414eaa971b27977d2283f2882825393493179d",
+    "ref_origin": "v0.11.4"
   }
 }


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>

## High-level description

Version bump to the latest release of REX-Ray, which includes support for
AWS NVMe storage. Users will still be required to provide `udev` scripts
and provide the `nvme-cli` package on the host. Details can be found in
the original REX-Ray [pull request](https://github.com/rexray/rexray/pull/1252)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4316](https://jira.mesosphere.com/browse/DCOS_OSS-4316) Support NVMe EBS volumes


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-3961](https://jira.mesosphere.com/browse/COPS-3961) Support NVMe EBS volumes


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: *ref bump in JSON, previous commits didn't include one*
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [rexray](https://github.com/rexray/rexray/compare/v0.11.2...v0.11.4)
  - [x] Test Results: [https://travis-ci.org/rexray/rexray/builds/479962434]
  - [ ] Code Coverage (if available): [link to code coverage report]
