### PR TITLE
Bump Telegraf to add internal metrics for statsd plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
+* Telegraf's statsd input plugin reports additional internal metrics. (DCOS_OSS-4759)
+
 * Admin Router Nginx Virtual Hosts metrics are now collected by default. An Nginx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)
 
 * CockroachDB metrics are now collected by Telegraf (DCOS_OSS-4529).

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "38f75ea3af33dbc3a8ae1e74c65908d458d8f7a7",
+    "ref": "8de2b1788dd9d9ea7d89408cfa168f332220d842",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

This adds an internal metric to Telegraf's statsd input plugin: `internal_statsd_dropped_messages`. This metric reports the number of incoming metric messages that have been dropped due to a full queue.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4759](https://jira.mesosphere.com/browse/DCOS_OSS-4759) Telegraf statsd input plugin: report UDP metrics

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually. Deployed Grafana to a cluster built from this PR, created a dashboard with a panel observing `internal_statsd_dropped_messages`, manually set `allowed_pending_messages` to 1 on a master to provoke dropped messages, then watched the count grow in Grafana.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review):https://github.com/dcos/telegraf/compare/38f75ea3af33dbc3a8ae1e74c65908d458d8f7a7...8de2b1788dd9d9ea7d89408cfa168f332220d842
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/204/)
  - [x] Code Coverage (if available): N/A