### PR TITLE
Introduce test-e2e to dcos/dcos 1.10

### DIFF
--- a/test-e2e/README.md
+++ b/test-e2e/README.md
@@ -1,0 +1,28 @@
+This directory contains end to end tests.
+
+To run these tests, create an environment which can run DC/OS E2E with Docker nodes as per the [requirements documentation](https://dcos-e2e.readthedocs.io/en/latest/docker-backend.html#requirements).
+
+Then, download the relevant build artifact and set various environment variables.
+For example:
+
+```sh
+ARTIFACT_URL=https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
+export DCOS_E2E_GENCONF_PATH=/tmp/dcos_generate_config.sh
+export DCOS_E2E_TMP_DIR_PATH=/tmp
+export DCOS_E2E_LOG_DIR=/tmp/logs
+
+rm -rf $DCOS_E2E_GENCONF_PATH
+curl -o $DCOS_E2E_GENCONF_PATH $ARTIFACT_URL
+```
+
+Then, install the test dependencies, preferably in a virtual environment:
+
+```sh
+pip3 install -r requirements.txt
+```
+
+and run the tests:
+
+```sh
+pytest --confcutdir .
+```

--- a/test-e2e/cluster_helpers.py
+++ b/test-e2e/cluster_helpers.py
@@ -1,0 +1,155 @@
+"""
+Helpers for working with DC/OS E2E clusters.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import List
+
+from _pytest.fixtures import SubRequest
+
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.exceptions import DCOSTimeoutError
+from dcos_e2e.node import Node
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_for_dcos_oss(
+    cluster: Cluster,
+    request: SubRequest,
+    log_dir: Path,
+) -> None:
+    """
+    Helper for ``wait_for_dcos_oss`` that automatically dumps the journal of
+    every cluster node if a ``DCOSTimeoutError`` is hit.
+    """
+    try:
+        cluster.wait_for_dcos_oss()
+    except DCOSTimeoutError:
+        # Dumping the logs on timeout only works if DC/OS has already started
+        # the systemd units that the logs are retrieved from.
+        # This does currently not pose a problem since the ``wait_for_dcos_ee``
+        # timeout is set to one hour. We expect the systemd units to have
+        # started by then.
+        dump_cluster_journals(
+            cluster=cluster,
+            target_dir=log_dir / artifact_dir_format(request.node.name),
+        )
+        raise
+
+
+def artifact_dir_format(test_name: str) -> str:
+    """
+    Create a common target test directory name format.
+    """
+    return test_name + '_' + str(datetime.now().isoformat().split('.')[0])
+
+
+def dump_cluster_journals(cluster: Cluster, target_dir: Path) -> None:
+    """
+    Dump logs for each cluster node to the ``target_dir``. Logs are separated into directories per node.
+    """
+    target_dir.mkdir(parents=True)
+    for role, nodes in (
+        ('master', cluster.masters),
+        ('agent', cluster.agents),
+        ('public_agent', cluster.public_agents),
+    ):
+        for index, node in enumerate(nodes):
+            node_str = (
+                '{role}-{index}_{private_ip}'
+            ).format(
+                role=role,
+                index=index,
+                private_ip=node.private_ip_address,
+            )
+            node_dir = Path(target_dir) / node_str
+            _dump_node_journals(node, node_dir)
+
+
+def _dump_node_journals(node: Node, node_dir: Path) -> None:
+    """
+    Dump logs from the given cluster node to the ``node_dir``.
+
+    Dumping the diagnostics bundle is unreliable in case that DC/OS
+    components are broken. This is likely if ``wait_for_dcos_ee``
+    times out. Instead this dumps the journal for each systemd unit
+    started by DC/OS.
+    """
+    LOGGER.info('Dumping journals from {node}'.format(node=node))
+    node_dir.mkdir(parents=True)
+    try:
+        _dump_stdout_to_file(node, ['journalctl'], node_dir / 'journal')
+    except CalledProcessError as exc:
+        # Continue dumping further journals even if an error occurs.
+        LOGGER.warn('Unable to dump journalctl: {exc}'.format(exc=str(exc)))
+
+    for unit in _dcos_systemd_units(node):
+        if unit.endswith('.service'):
+            name = unit.split('.')[0]
+            try:
+                _dump_stdout_to_file(
+                    node=node,
+                    cmd=['journalctl', '-u', unit],
+                    file_path=node_dir / name,
+                )
+            except CalledProcessError as exc:
+                # Continue dumping further journals even if an error occurs.
+                message = 'Unable to dump {unit} journal: {exc}'.format(
+                    unit=unit,
+                    exc=str(exc),
+                )
+                LOGGER.warn(message)
+
+
+def _dump_stdout_to_file(node: Node, cmd: List[str], file_path: Path) -> None:
+    """
+    Dump ``stdout`` of the given command to ``file_path``.
+
+    Raises:
+        CalledProcessError: If an error occurs when running the given command.
+    """
+    chunk_size = 2048
+    proc = node.popen(args=cmd)
+    with open(str(file_path), 'wb') as dumpfile:
+        while True:
+            chunk = proc.stdout.read(chunk_size)
+            if chunk:
+                dumpfile.write(chunk)
+            else:
+                break
+    proc.wait()
+    if proc.returncode != 0:
+        exception = CalledProcessError(
+            returncode=proc.returncode,
+            cmd=cmd,
+            output=bytes(proc.stdout),
+            stderr=bytes(proc.stderr),
+        )
+        message = (
+            'Failed to complete "{cmd}": {exception}'
+        ).format(
+            cmd=cmd,
+            exception=exception,
+        )
+        LOGGER.warn(message)
+        raise exception
+
+
+def _dcos_systemd_units(node: Node) -> List[str]:
+    """
+    Return all systemd services that are started up by DC/OS.
+    """
+    result = node.run(
+        args=[
+            'sudo', 'systemctl', 'show', '-p', 'Wants', 'dcos.target', '|',
+            'cut', '-d=', '-f2'
+        ],
+        shell=True,
+    )
+    systemd_units_string = result.stdout.strip().decode()
+    return str(systemd_units_string).split(' ')

--- a/test-e2e/conftest.py
+++ b/test-e2e/conftest.py
@@ -1,0 +1,4 @@
+# Hack to exclude test-e2e/conftest.py from the top-level tox config py35-unittests.
+# https://stackoverflow.com/a/37493203
+pytest_plugins = ['test_e2e_module']
+# Actual content of conftest.py can be found in test_e2e_module.py.

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,0 +1,4 @@
+git+https://github.com/dcos/dcos-e2e.git@2019.01.05.0
+git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
+pytest==4.1.1
+requests==2.21.0

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -1,0 +1,38 @@
+"""
+Surrogate conftest.py contents loaded by the conftest.py file.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from dcos_e2e.backends import Docker
+
+
+@pytest.fixture(scope='session')
+def docker_backend() -> Docker:
+    """
+    Creates a common Docker backend configuration that works within the pytest
+    environment directory.
+    """
+    tmp_dir_path = Path(os.environ['DCOS_E2E_TMP_DIR_PATH'])
+    assert tmp_dir_path.exists() and tmp_dir_path.is_dir()
+
+    return Docker(workspace_dir=tmp_dir_path)
+
+
+@pytest.fixture(scope='session')
+def artifact_path() -> Path:
+    """
+    Return the path to a DC/OS build artifact to test against.
+    """
+    generate_config_path = Path(os.environ['DCOS_E2E_GENCONF_PATH'])
+    return generate_config_path
+
+
+@pytest.fixture(scope='session')
+def log_dir() -> Path:
+    """
+    Return the path to a directory which logs should be stored in.
+    """
+    return Path(os.environ['DCOS_E2E_LOG_DIR'])

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -1,0 +1,55 @@
+# Purpose of this file
+# ====================
+#
+# We split E2E tests into groups so that the test suite can be run in
+# parallel on CI.
+# We could split these tests arbitrarily using, for example,
+# https://pypi.org/project/pytest-test-groups/.
+# However, a downside of this is that tests may move between groups as the test
+# suite size changes.
+# When a test moves between groups, we lose data from TeamCity, such as
+# statistics on test success rate.
+#
+# Details of this file
+# ====================
+#
+# The number of groups matches the number of TeamCity jobs for this test suite.
+# That is, if there are three groups, there must be three CI jobs, one for each
+# group.
+#
+# Each item in a group is a pytest pattern.
+# That means, when collected by pytest in the E2E tests directory, this
+# must collect some tests.
+# For example, the following might be valid patterns:
+# * test_filename.py
+# * test_filename.py::TestClassName
+# * test_filename.py::TestClassName::test_function_name
+#
+# Changing test groupings
+# =======================
+#
+# A goal is to have roughly even run time on each test group.
+# The test suite's run length is the length of time it takes to run the longest
+# group.
+#
+# In conflict with this goal is the cost of moving tests around.
+# Any developer moving a test from one group to the other, to decreate the test
+# suite's run length, must consider this trade-off.
+#
+# ``test_meta.py`` includes a test which asserts that the groups defined here
+# account for each test.
+#
+# Changing the number of groups
+# =============================
+#
+# The number of groups here must be reflected in TeamCity.
+# That is, there must be a builder which runs each group.
+#
+# **IMPORTANT** If a group is added or renamed and no change is made to TeamCity, 
+# tests in that group will not be run on CI.
+#
+# If a group is removed and no change is made to TeamCity, a CI builder will
+# fail.
+groups:
+    group_1:
+        - test_make_disk_resources.py

--- a/test-e2e/test_make_disk_resources.py
+++ b/test-e2e/test_make_disk_resources.py
@@ -1,0 +1,169 @@
+import json
+import logging
+from pathlib import Path
+
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
+from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Output
+from dcos_test_utils.dcos_api import DcosApiSession, DcosUser
+from dcos_test_utils.helpers import CI_CREDENTIALS
+from docker.types import Mount
+from py.path import local  # pylint: disable=no-name-in-module, import-error
+
+
+def extract_mounts(mesos_resources: str) -> dict:
+    """
+    Read the Mesos resources file and return the mount volume (name + disk space).
+    The file is not standard JSON thus parsing it is a cumbersome process.
+    """
+    cache_mounts = {}
+    for line in str(mesos_resources).splitlines():
+        if line.startswith('MESOS_RESOURCES'):
+            data = json.loads(line[len('MESOS_RESOURCES=\''):-1])
+            for item in data:
+                if item["name"] == "disk" and "disk" in item and "source" in item["disk"]:
+                    mount_volume = item["disk"]["source"]["mount"]["root"]
+                    cache_mounts[mount_volume] = item["scalar"]["value"]
+    return cache_mounts
+
+
+class TestMakeDiskResources:
+    """
+    Tests for functionality specific to the make_disk_resources.py script.
+    """
+    def test_make_disk_resources(
+        self,
+        artifact_path: Path,
+        tmpdir: local,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        We check that make_disk_resources creates a mesos resources file with the
+        previously available amount of space of the mount volume after the restart
+        of an agent. If this was not the case and a task used one of the mount
+        volumes, the Mesos agent process would refuse to restart as we can see in
+        https://jira.mesosphere.com/browse/COPS-3527
+        """
+        custom_agent_mount = Mount(
+            source=str(tmpdir.mkdir("mount")),
+            target=str("/dcos/volume1"),
+            type='bind',
+        )
+
+        mount_and_write_app = {
+            "id": "/mount-test",
+            "instances": 1,
+            "cpus": 0.1,
+            "mem": 128,
+            "cmd": "head -c1000k </dev/urandom >$MESOS_SANDBOX/volume1/a.txt && sleep 1000",
+            "container": {
+                "type": "DOCKER",
+                "volumes": [{
+                    "persistent": {
+                        "size": 10,
+                        "type": "mount",
+                        "constraints": [["path", "LIKE", "/dcos/volume1"]]
+                    },
+                    "mode": "RW",
+                    "containerPath": "volume1"
+                }],
+                "docker": {
+                    "image": "alpine",
+                    "privileged": False,
+                    "forcePullImage": False
+                }
+            },
+            "upgradeStrategy": {
+                "minimumHealthCapacity": 0.5,
+                "maximumOverCapacity": 0
+            },
+            "unreachableStrategy": "disabled"
+        }
+
+        deploy_kwargs = {
+            'check_health': False,
+            'ignore_failed_tasks': True,
+            'timeout': 600
+        }
+
+        backend = Docker(custom_agent_mounts=[custom_agent_mount])
+
+        with Cluster(masters=1, agents=1, public_agents=0, cluster_backend=backend) as cluster:
+
+            cluster.install_dcos_from_path(
+                dcos_installer=artifact_path,
+                dcos_config={
+                    **cluster.base_config
+                },
+                ip_detect_path=backend.ip_detect_path,
+            )
+
+            # Wait for DC/OS to be ready for testing.
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+
+            # albert@bekstil.net is test user recognized by dcos-test-utils library.
+            create_user_args = ['.', '/opt/mesosphere/environment.export', '&&',
+                                'python /opt/mesosphere/active/dcos-oauth/bin/dcos_add_user.py albert@bekstil.net']
+
+            any_master = next(iter(cluster.masters))
+
+            any_master.run(
+                args=create_user_args,
+                shell=True,
+                output=Output.CAPTURE,
+            )
+
+            auth_user = DcosUser(CI_CREDENTIALS)
+
+            scheme = 'http://'
+
+            dcos_url = scheme + str(any_master.public_ip_address)
+
+            dcos_api_session = DcosApiSession(
+                dcos_url=dcos_url,
+                masters=[str(n.public_ip_address) for n in cluster.masters],
+                slaves=[str(n.public_ip_address) for n in cluster.agents],
+                public_slaves=[
+                    str(n.public_ip_address) for n in cluster.public_agents
+                ],
+                auth_user=auth_user
+            )
+
+            # Quirks of dcos-test-utils. This is required to get a authenticated user.
+            dcos_api_session = dcos_api_session.get_user_session(auth_user)
+
+            with dcos_api_session.marathon.deploy_and_cleanup(mount_and_write_app, **deploy_kwargs):
+                logging.info('Successfully created task using mount volume')
+                (agent, ) = cluster.agents
+
+                cat_initial_mesos_resources = agent.run(args=['cat', '/var/lib/dcos/mesos-resources'])
+                initial_mesos_resources = cat_initial_mesos_resources.stdout.decode("utf-8")
+                initial_mount_volumes = extract_mounts(initial_mesos_resources)
+                assert initial_mount_volumes != {}
+
+                # Stop the Mesos agent process.
+                agent.run(args=['systemctl', 'stop', 'dcos-mesos-slave'])
+                # Move the mesos-resources to the cache as recommended in the docs.
+                # We were previously simply deleting the file but we can now use it as a cache.
+                agent.run(args=['mv', '-f', '/var/lib/dcos/mesos-resources', '/var/lib/dcos/mesos-resources.cache'])
+                # Remove the agent checkpoint state as recommended in the docs.
+                agent.run(args=['rm', '-f', '/var/lib/mesos/slave/meta/slaves/latest'])
+                # Restart the Mesos agent process.
+                agent.run(args=['systemctl', 'start', 'dcos-mesos-slave'])
+
+                cat_new_mesos_resources = agent.run(args=['cat', '/var/lib/dcos/mesos-resources'])
+                new_mesos_resources = cat_new_mesos_resources.stdout.decode("utf-8")
+                new_mount_volumes = extract_mounts(new_mesos_resources)
+                assert new_mount_volumes != {}
+
+                # If make_disk_resources.py worked as expected, the mount
+                # volumes will be the same even if the mount volume has
+                # been used by mount_and_write_app.
+                assert new_mount_volumes == initial_mount_volumes

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,12 @@ deps =
   webtest
   webtest-aiohttp==1.1.0
   schema
+# Hack to stop pytest from collecting test-e2e tests.
+# Simpler ways of achieving this would not work.
+# https://stackoverflow.com/a/37493203
+# TODO(tweidner): Set pytest collect directories explicitly.
 commands=
-  py.test --basetemp={envtmpdir} {posargs}
+  pytest -p no:test_e2e_module --basetemp={envtmpdir} {posargs}
 
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a


### PR DESCRIPTION
## High-level description

* DCOS_OSS-2032 - Add ability to run E2E tests in DC/OS Open version


This is a backport of https://github.com/dcos/dcos/pull/4445 to 1.12 branch.
This also brings one enterprise test from EE branch to Open (after minor customization for dcos-test-utils) - https://github.com/mesosphere/dcos-enterprise/pull/3255/

This will make sure that we will have at-least one test and a group to exercise against in Teamcity CI and we can enable the status check.

How to review:

Please make sure there is  a status called *teamcity/dcos/test/test-e2e/group1* and you can visit the teamcity details link from that status.

