### PR TITLE
Metronome / Marathon need to be prepared for GPU by default on DCOS 1.13

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -201,13 +201,13 @@ def validate_mesos_container_log_sink(mesos_container_log_sink):
 
 
 def validate_metronome_gpu_scheduling_behavior(metronome_gpu_scheduling_behavior):
-    assert metronome_gpu_scheduling_behavior in ['restricted', 'unrestricted', 'undefined', ''], \
-        "metronome_gpu_scheduling_behavior must be 'restricted', 'unrestricted', 'undefined' or ''"
+    assert metronome_gpu_scheduling_behavior in ['restricted', 'unrestricted', ''], \
+        "metronome_gpu_scheduling_behavior must be 'restricted', 'unrestricted' or ''"
 
 
 def validate_marathon_gpu_scheduling_behavior(marathon_gpu_scheduling_behavior):
-    assert marathon_gpu_scheduling_behavior in ['restricted', 'unrestricted', 'undefined', ''], \
-        "marathon_gpu_scheduling_behavior must be 'restricted', 'unrestricted', 'undefined' or ''"
+    assert marathon_gpu_scheduling_behavior in ['restricted', 'unrestricted', ''], \
+        "marathon_gpu_scheduling_behavior must be 'restricted', 'unrestricted' or ''"
 
 
 def calculate_mesos_log_retention_count(mesos_log_retention_mb):


### PR DESCRIPTION

## High-level description

What features does this change enable? What bugs does this change fix?

- adding install controllable capabilities for turning on gpu support i…n marathon and metronome, along with validation

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4824](https://jira.mesosphere.com/browse/DCOS_OSS-4824) Metronome needs to be prepared for GPU by default on DCOS 1.13.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
