### PR TITLE
Bump dcos-metrics

### DIFF
--- a/packages/dcos-metrics/buildinfo.json
+++ b/packages/dcos-metrics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-metrics.git",
-    "ref": "606ebcf702f2fafa0b9db6a545d9d905d32023e7",
+    "ref": "7d64a97637d3cc5cd34db0a5cc575f13af7129b5",
     "ref_origin": "1.11.x"
   },
   "username": "dcos_metrics"


### PR DESCRIPTION
## High-level description

This bumps dcos-metrics to keep it in sync with the 1.11 branch. This pulls in a new configuration parameter that is unused on DC/OS 1.11.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4465](https://jira.mesosphere.com/browse/DCOS_OSS-4465) dcos_statsd API socket should be managed by systemd


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This pulls in a feature that's unused on 1.11. This bump is just to keep DC/OS 1.11 in sync with the dcos-metrics 1.11 branch.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Not adding any new functionality.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]