### PR TITLE
Fix tests for schema 0.7.0

### DIFF
--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -341,12 +341,12 @@ def test_validate_check_config():
     validate_error(
         {'check_config': json.dumps({'cluster_checks': {}})},
         'check_config',
-        "Key 'cluster_checks' error: Missing keys: Check name must be a nonzero length string with no whitespace",
+        "Key 'cluster_checks' error: Missing key: Check name must be a nonzero length string with no whitespace",
     )
     validate_error(
         {'check_config': json.dumps({'node_checks': {}})},
         'check_config',
-        "Key 'node_checks' error: Missing keys: 'checks'",
+        "Key 'node_checks' error: Missing key: 'checks'",
     )
     validate_error(
         {
@@ -358,7 +358,7 @@ def test_validate_check_config():
         },
         'check_config',
         (
-            "Key 'node_checks' error: Key 'checks' error: Missing keys: Check name must be a nonzero length string "
+            "Key 'node_checks' error: Key 'checks' error: Missing key: Check name must be a nonzero length string "
             "with no whitespace"
         ),
     )
@@ -377,7 +377,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'cluster_checks' error: Missing keys: Check name must be a nonzero length string with no whitespace",
+        "Key 'cluster_checks' error: Missing key: Check name must be a nonzero length string with no whitespace",
     )
     validate_error(
         {
@@ -396,7 +396,7 @@ def test_validate_check_config():
         },
         'check_config',
         (
-            "Key 'node_checks' error: Key 'checks' error: Missing keys: Check name must be a nonzero length string "
+            "Key 'node_checks' error: Key 'checks' error: Missing key: Check name must be a nonzero length string "
             "with no whitespace"
         ),
     )
@@ -485,7 +485,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'cluster_checks' error: Key 'cluster-check-1' error: Missing keys: 'description'",
+        "Key 'cluster_checks' error: Key 'cluster-check-1' error: Missing key: 'description'",
     )
     validate_error(
         {
@@ -502,7 +502,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'node_checks' error: Key 'checks' error: Key 'node-check-1' error: Missing keys: 'description'",
+        "Key 'node_checks' error: Key 'checks' error: Key 'node-check-1' error: Missing key: 'description'",
     )
 
     # Check cmd is wrong type.


### PR DESCRIPTION
## High-level description

The 0.7.0 release of the schema package changed the wording in some error messages. This updates tests to reflect the change.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4829](https://jira.mesosphere.com/browse/DCOS_OSS-4829) tox failure: test_config.test_validate_check_config


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This updates a test to reflect a slight change in user-facing error messages.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This fixes a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]