### PR TITLE
Use systemd to manage Telegraf's dcos_statsd socket

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2326,6 +2326,8 @@ package:
           dcos-component-name = "Admin Router"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
+        # The systemd socket on which to listen
+        systemd_socket_name = "dcos-telegraf-dcos_metrics.socket"
         dcos_node_role = "master"
         # Duration to cache metrics in memory.
         cache_expiry = "2m"
@@ -2348,8 +2350,8 @@ package:
         user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
-        ## The address on which the command API should listen
-        listen = "/run/dcos/telegraf/dcos_statsd.sock"
+        ## The systemd socket on which the command API should listen
+        systemd_socket_name = "dcos-telegraf-dcos_statsd.socket"
         ## The directory in which container information is stored
         containers_dir = "/run/dcos/telegraf/dcos_statsd/containers"
         ## The period after which requests to the API should time out
@@ -2448,6 +2450,8 @@ package:
         user_agent = "Telegraf-dcos-metadata"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
+        # The systemd socket on which to listen
+        systemd_socket_name = "dcos-telegraf-dcos_metrics.socket"
         dcos_node_role = "agent"
         # Duration to cache metrics in memory.
         cache_expiry = "2m"
@@ -2470,8 +2474,8 @@ package:
         user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
-        ## The address on which the command API should listen
-        listen = "/run/dcos/telegraf/dcos_statsd.sock"
+        ## The systemd socket on which the command API should listen
+        systemd_socket_name = "dcos-telegraf-dcos_statsd.socket"
         ## The directory in which container information is stored
         containers_dir = "/run/dcos/telegraf/dcos_statsd/containers"
         ## The period after which requests to the API should time out

--- a/packages/telegraf/build
+++ b/packages/telegraf/build
@@ -44,10 +44,18 @@ for unit in $agent_unit $agent_public_unit; do
   SERVICE="dcos-telegraf-agent" envsubst '${SERVICE} ${PKG_PATH}' < $unit_template > $unit
 done
 
-# Add the socket unit to the package for all roles.
-socket_unit="$PKG_PATH/dcos.target.wants/dcos-telegraf.socket"
-mkdir -p $(dirname $socket_unit)
-cp /pkg/extra/dcos-telegraf.socket $socket_unit
+# Add the dcos_metrics socket unit to the package for all roles.
+dcos_metrics_socket_unit="$PKG_PATH/dcos.target.wants/dcos-telegraf-dcos_metrics.socket"
+mkdir -p $(dirname $dcos_metrics_socket_unit)
+cp /pkg/extra/dcos-telegraf-dcos_metrics.socket $dcos_metrics_socket_unit
+
+# Add the dcos_statsd socket unit to the package for agents and public agents.
+dcos_statsd_socket_unit_agent="$PKG_PATH/dcos.target.wants_slave/dcos-telegraf-dcos_statsd.socket"
+dcos_statsd_socket_unit_agent_public="$PKG_PATH/dcos.target.wants_slave_public/dcos-telegraf-dcos_statsd.socket"
+for unit in $dcos_statsd_socket_unit_agent $dcos_statsd_socket_unit_agent_public; do
+  mkdir -p $(dirname $unit)
+  cp /pkg/extra/dcos-telegraf-dcos_statsd.socket $unit
+done
 
 # Add tools to the package.
 cp -r /pkg/extra/tools/ "${PKG_PATH}"

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -2,9 +2,9 @@
   "docker": "golang:1.11-stretch",
   "single_source" : {
     "kind": "git",
-    "git": "https://github.com/dcos/telegraf.git",
-    "ref": "8de2b1788dd9d9ea7d89408cfa168f332220d842",
-    "ref_origin": "1.9.4-dcos"
+    "git": "https://github.com/branden/telegraf.git",
+    "ref": "59a8bbfcab90c163393ef80ab82f60469d90435a",
+    "ref_origin": "dcos_statsd-systemd-socket"
   },
   "environment": {
     "STATSD_UDP_HOST": "localhost",

--- a/packages/telegraf/extra/dcos-telegraf-dcos_metrics.socket
+++ b/packages/telegraf/extra/dcos-telegraf-dcos_metrics.socket
@@ -1,6 +1,7 @@
 [Unit]
-Description=Telegraf Socket: socket for Telegraf
+Description=Telegraf dcos_metrics Socket: socket for Telegraf's dcos_metrics plugin
 [Socket]
+Service=dcos-telegraf.service
 ListenStream=/run/dcos/telegraf-dcos-metrics.sock
 SocketUser=root
 SocketGroup=dcos_adminrouter

--- a/packages/telegraf/extra/dcos-telegraf-dcos_statsd.socket
+++ b/packages/telegraf/extra/dcos-telegraf-dcos_statsd.socket
@@ -1,0 +1,15 @@
+[Unit]
+Description=Telegraf dcos_statsd Socket: socket for Telegraf's dcos_statsd plugin
+
+[Socket]
+Service=dcos-telegraf.service
+
+ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
+ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
+
+SocketUser=root
+SocketGroup=dcos_telegraf
+SocketMode=0660
+
+ListenStream=/run/dcos/telegraf/dcos_statsd.sock

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -35,9 +35,5 @@ mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
 # Migrate old containers dir to new location in case the cluster was upgraded.
 /opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
 
-# Ensure that old socket file is removed, if present
-# TODO(philipnrmn): investigate whether moving to a systemd-managed socket
-# would be a better solution than manually creating and removing this file.
-rm -f /run/dcos/telegraf/dcos_statsd.sock
 # Start telegraf.
 exec /opt/mesosphere/bin/telegraf "$@"


### PR DESCRIPTION
## High-level description

This PR makes the socket for the command API for Telegraf's dcos_statsd plugin the responsibility of systemd, rather than leaving Telegraf to manage it.

This depends on a systemd API that was added with version 227: https://lwn.net/Articles/660733/

> File descriptors passed during socket activation may now be named. A new API sd_listen_fds_with_names() is added to access the names. The default names may be overriden, either in the .socket file using the FileDescriptorName= parameter, or by passing FDNAME= when storing the file descriptors using sd_notify().



## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4465](https://jira.mesosphere.com/browse/DCOS_OSS-4465) dcos_statsd API socket should be managed by systemd


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a refactor with no change to external behavior.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Covered by existing tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]