### PR TITLE
DCOS-46146 - Re-enable test_ipv6 and test_if_overlay_ok

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -218,11 +218,6 @@ def workload_test(dcos_api_session, container, app_net, proxy_net, ipv6, same_ho
     return (hosts, origin_app, proxy_app)
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-46146',
-    reason='Upgrade docker to version 17.12.x.',
-    since='2018-12-11',
-)
 @pytest.mark.slow
 @pytest.mark.parametrize('same_host', [True, False])
 def test_ipv6(dcos_api_session, same_host):
@@ -368,11 +363,6 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, ipv6, nam
     return (vip, hosts, cmd, origin_app, proxy_app)
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-46146',
-    reason='Upgrade docker to version 17.12.x.',
-    since='2018-12-11',
-)
 @retrying.retry(wait_fixed=2000,
                 stop_max_delay=120 * 1000,
                 retry_on_exception=lambda x: True)


### PR DESCRIPTION
## High-level description

Re-enable flakey tests `test_ipv6` and `test_if_overlay_ok` as Docker has been upgraded DCOS-38144

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46146](https://jira.mesosphere.com/browse/DCOS-46146) networking integration test instability, to be fixed by upgrading Docker to version 17.12.x


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-38144](https://jira.mesosphere.com/browse/DCOS-38144) Update Docker on all TeamCity agents to 18.09.1-ce

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A re-enabled test
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A this is a test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)