### PR TITLE
[1.12] Enabled mesos launcher sealing.

### DIFF
--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -19,6 +19,7 @@ pushd build
 LDFLAGS="-Wl,-rpath,/opt/mesosphere/lib" "/pkg/src/mesos/configure" \
   --prefix="$PKG_PATH" --enable-optimize --disable-python \
   --enable-libevent --enable-ssl \
+  --enable-launcher-sealing \
   --enable-install-module-dependencies \
   --enable-grpc \
   --enable-jemalloc-allocator \


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This is a cherry pick of 32a013a , which landed on the 1.12.2 tag only.  The reason for the disjointed merge was to maintain secrecy of the security hole prior to fixing it immediately once the CVE's embargo was lifted.

This is the 1.12 version of #4620.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

 - [DCOS-49211](https://jira.mesosphere.com/browse/DCOS-49211) Enable mesos launcher sealing for upstream branches.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-48052](https://jira.mesosphere.com/browse/DCOS-48052) Mesos containerizer launch binary and command executor are under the risk of being overwritten.
  - [CVE-2019-5736](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736) Runc at risk of being overwritten by containers.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This should be transparent to the user, as the user is not expected to try to overwrite a host binary to escape the container.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a cherry-pick.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A
  - [ ] Test Results: N/A
  - [x] Code Coverage (if available): N/A