### PR TITLE
DCOS-46615 - Make pkgpanda resistant to missing content-length

### DIFF
--- a/pkgpanda/test_util.py
+++ b/pkgpanda/test_util.py
@@ -422,8 +422,11 @@ class MockDownloadServerRequestHandler(BaseHTTPRequestHandler):
         body = b'foobar'
 
         self.send_response(requests.codes.ok)
-        self.send_header('Content-Length', '6')
         self.send_header('Content-Type', 'text/plain')
+
+        if 'no_content_length' not in self.path:
+            self.send_header('Content-Length', '6')
+
         self.end_headers()
 
         if self.server.requests_received == 0:
@@ -439,17 +442,24 @@ class MockDownloadServerRequestHandler(BaseHTTPRequestHandler):
 class MockHTTPDownloadServer(HTTPServer):
     requests_received = 0
 
+    def reset_requests_received(self):
+        self.requests_received = 0
 
-def test_stream_remote_file_with_retries(tmpdir):
+
+@pytest.fixture(scope='module')
+def mock_download_server():
     mock_server = MockHTTPDownloadServer(('localhost', 0), MockDownloadServerRequestHandler)
-    mock_server_port = mock_server.server_port
 
-    mock_server_thread = Thread(
-        target=mock_server.serve_forever,
-        daemon=True)
+    mock_server_thread = Thread(target=mock_server.serve_forever, daemon=True)
     mock_server_thread.start()
 
-    url = 'http://localhost:{port}/foobar.txt'.format(port=mock_server_port)
+    return mock_server
+
+
+def test_download_remote_file(tmpdir, mock_download_server):
+    mock_download_server.reset_requests_received()
+
+    url = 'http://localhost:{port}/foobar.txt'.format(port=mock_download_server.server_port)
 
     out_file = os.path.join(str(tmpdir), 'foobar.txt')
     response = pkgpanda.util._download_remote_file(out_file, url)
@@ -457,7 +467,25 @@ def test_stream_remote_file_with_retries(tmpdir):
     response_is_ok = response.ok
     assert response_is_ok
 
-    assert mock_server.requests_received == 2
+    assert mock_download_server.requests_received == 2
 
     with open(out_file, 'rb') as f:
         assert f.read() == b'foobar'
+
+
+def test_download_remote_file_without_content_length(tmpdir, mock_download_server):
+    mock_download_server.reset_requests_received()
+
+    url = 'http://localhost:{port}/foobar.txt?no_content_length=true'.format(
+        port=mock_download_server.server_port)
+
+    out_file = os.path.join(str(tmpdir), 'foobar.txt')
+    response = pkgpanda.util._download_remote_file(out_file, url)
+
+    response_is_ok = response.ok
+    assert response_is_ok
+
+    assert mock_download_server.requests_received == 1
+
+    with open(out_file, 'rb') as f:
+        assert f.read() == b'fooba'

--- a/pkgpanda/util.py
+++ b/pkgpanda/util.py
@@ -160,20 +160,20 @@ def _is_incomplete_download_error(exception):
     wait_random_min=1000,
     wait_random_max=2000,
     retry_on_exception=_is_incomplete_download_error)
-def _download_remote_file(out_filename, url, retries=4):
+def _download_remote_file(out_filename, url):
     with open(out_filename, "wb") as f:
         r = get_requests_retry_session().get(url, stream=True)
         r.raise_for_status()
-
-        content_length = int(r.headers['content-length'])
 
         total_bytes_read = 0
         for chunk in r.iter_content(chunk_size=4096):
             f.write(chunk)
             total_bytes_read += len(chunk)
 
-        if total_bytes_read != content_length:
-            raise IncompleteDownloadError(url, total_bytes_read, content_length)
+        if 'content-length' in r.headers:
+            content_length = int(r.headers['content-length'])
+            if total_bytes_read != content_length:
+                raise IncompleteDownloadError(url, total_bytes_read, content_length)
 
         return r
 


### PR DESCRIPTION
## High-level description

This fixes an issue that [popped up when making an uncached build of DC/OS](https://jira.mesosphere.com/browse/DCOS-46615?focusedCommentId=222075&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-222075) where pkgpanda was downloading files that didn't come with a `Content-Length` header in their HTTP responses. Example:

```
$ curl -I -L https://github.com/pallets/flask/archive/0.11.1.tar.gz
HTTP/1.1 302 Found
Server: GitHub.com
Date: Thu, 28 Feb 2019 07:59:14 GMT
Content-Type: text/html; charset=utf-8
Status: 302 Found
Location: https://codeload.github.com/pallets/flask/tar.gz/0.11.1
[...]

HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://render.githubusercontent.com
ETag: "d1d82ca8ce7262ad9d27245ce44f86571287810e"
Content-Type: application/x-gzip
Content-Disposition: attachment; filename=flask-0.11.1.tar.gz
Date: Thu, 28 Feb 2019 07:59:14 GMT
[...]
```

What this change does it to change the behaviour of the `_download_remote_file` function to only compare the `total_bytes_read` with `content-length` in case the latter is provided.

In order to keep the code still readable and not littered with conditionals I kept the counting of `total_bytes_read` outside of a `if 'content-length' in r.headers` conditional and only wrap the final check in it.

The tests have also been cleaned up and (maybe most importantly for nitpickers like myself) I also removed the unused paramter of the `_download_remote_file` function that I only noticed after it was merged.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS-46615] Pkgpanda - package dcos-image - xz: (stdin): Unexpected end of input - JIRA](https://jira.mesosphere.com/browse/DCOS-46615?focusedCommentId=222075&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-222075)


## Related tickets (optional)


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
