### PR TITLE
[DCOS_OSS-4844] Fix master node replacement test

### DIFF
--- a/test-e2e/test_master_node_replacement.py
+++ b/test-e2e/test_master_node_replacement.py
@@ -166,7 +166,7 @@ def test_replace_all_static(
                 )
                 # Form a new cluster with the newly create master node.
                 new_cluster = Cluster.from_nodes(
-                    masters=current_cluster.masters.add(new_master),
+                    masters=current_cluster.masters.union({new_master}),
                     agents=current_cluster.agents,
                     public_agents=current_cluster.public_agents,
                 )

--- a/test-e2e/test_master_node_replacement.py
+++ b/test-e2e/test_master_node_replacement.py
@@ -145,7 +145,7 @@ def test_replace_all_static(
         try:
             for master_to_be_replaced in original_masters:
                 # Destroy a master and free one IP address.
-                current_cluster.destroy_node(node=master_to_be_replaced)
+                original_cluster.destroy_node(node=master_to_be_replaced)
 
                 temporary_cluster = Cluster(
                     cluster_backend=docker_backend,


### PR DESCRIPTION
## High-level description

This PR fixes the broken master node replacement E2E test by reverting changes applied after moving it over from Enterprise.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS_OSS-4844](https://jira.mesosphere.com/browse/DCOS_OSS-4844) test_master_node_replacement.test_replace_all_static is failing on master.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)