### PR TITLE
Add AR routing logic support for ip-per-container feature for Marathon 1.5+

### DIFF
--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -7,7 +7,7 @@ local util = require "util"
 -- In order to make caching code testable, these constants need to be
 -- configurable/exposed through env vars.
 --
--- Values assigned to these variable need to fufil following condition:
+-- Values assigned to these variable need to fulfil following condition:
 --
 -- CACHE_FIRST_POLL_DELAY << CACHE_EXPIRATION < CACHE_POLL_PERIOD < CACHE_MAX_AGE_SOFT_LIMIT < CACHE_MAX_AGE_HARD_LIMIT
 --

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -138,8 +138,9 @@ end
 
 local function is_container_network(app)
   -- Networking mode for a Marathon application is defined in
-  -- app["container"]["networks"][1]["mode"].
+  -- app["networks"][1]["mode"].
     local container = app["container"]
+    ngx.log(ngx.NOTICE, "APP: " .. cjson_safe.encode(app))
     local network = app["networks"][1]
     return container and network and (network["mode"] == "container")
 end

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -140,7 +140,6 @@ local function is_container_network(app)
   -- Networking mode for a Marathon application is defined in
   -- app["networks"][1]["mode"].
     local container = app["container"]
-    ngx.log(ngx.NOTICE, "APP: " .. cjson_safe.encode(app))
     local network = app["networks"][1]
     return container and network and (network["mode"] == "container")
 end

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -136,13 +136,12 @@ local function request(url, accept_404_reply, auth_token)
     return res, nil
 end
 
-local function is_ip_per_task(app)
-    return app["ipAddress"] ~= nil and app["ipAddress"] ~= cjson_safe.null
-end
-
-local function is_user_network(app)
+local function is_container_network(app)
+  -- Networking mode for a Marathon application is defined in
+  -- app["container"]["networks"][1]["mode"].
     local container = app["container"]
-    return container and container["type"] == "DOCKER" and container["docker"]["network"] == "USER"
+    local network = app["networks"][1]
+    return container and network and (network["mode"] == "container")
 end
 
 local function fetch_and_store_marathon_apps(auth_token)
@@ -220,8 +219,18 @@ local function fetch_and_store_marathon_apps(auth_token)
           )
 
        local host_or_ip = task["host"] --take host  by default
-       if is_ip_per_task(app) then
-          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is using ip-per-task")
+       -- In "container" networking mode the task/container will get its own IP
+       -- (ip-per-container).
+       -- The task will be reachable:
+       -- 1) through the container port defined in portMappings.
+       -- If the app is using DC/OS overlay network
+       -- it will be also reachable on
+       -- 2) task["host"]:task["ports"][portIdx] (<private agent IP>:<hostPort>).
+       -- However, in case of CNI networks (e.g. Calico), the task might not be
+       -- reachable on task["host"]:task["ports"][portIdx], so we choose option 2)
+       -- for routing.
+       if is_container_network(app) then
+          ngx.log(ngx.NOTICE, "app '" .. appId .. "' is in a container network")
           -- override with the ip of the task
           local task_ip_addresses = task["ipAddresses"]
           if task_ip_addresses then
@@ -237,36 +246,27 @@ local function fetch_and_store_marathon_apps(auth_token)
           goto continue
        end
 
-       local ports = task["ports"] --task host port mapping by default
-       if is_ip_per_task(app) then
-         ports = {}
-         if is_user_network(app) then
-            -- override with ports from the container's portMappings
-            local port_mappings = app["container"]["docker"]["portMappings"] or app["portDefinitions"] or {}
-            local port_attr = app["container"]["docker"]["portMappings"] and "containerPort" or "port"
-            for _, port_mapping in ipairs(port_mappings) do
-               table.insert(ports, port_mapping[port_attr])
-            end
-         else
-            --override with the discovery ports
-            local discovery_ports = app["ipAddress"]["discovery"]["ports"]
-            for _, discovery_port in ipairs(discovery_ports) do
-                table.insert(ports, discovery_port["number"])
-            end
-         end
+       -- In "container" mode we find the container port out from portMappings array
+       -- for the case when container port is fixed (non-zero value specified).
+       -- When container port is specified as 0 it will be set the same as the host port:
+       -- https://mesosphere.github.io/marathon/docs/ports.html#random-port-assignment
+       -- We do not override it with container port from the portMappings array
+       -- in that case.
+       -- In "container/bridge" and "host" networking modes we need to use the
+       -- host port for routing (available via task's ports array)
+       if is_container_network(app) and app["container"]["portMappings"][portIdx]["containerPort"] ~= 0 then
+         port = app["container"]["portMappings"][portIdx]["containerPort"]
+       else
+         port = task["ports"][portIdx]
        end
 
-       if not ports then
-          ngx.log(ngx.NOTICE, "Cannot find ports for app '" .. appId .. "'")
-          goto continue
-       end
-
-       local port = ports[portIdx]
        if not port then
           ngx.log(ngx.NOTICE, "Cannot find port at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
           goto continue
        end
 
+       -- Details on how Admin Router interprets DCOS_SERVICE_REWRITE_REQUEST_URLS label:
+       -- https://github.com/dcos/dcos/blob/master/packages/adminrouter/extra/src/README.md#disabling-url-path-rewriting-for-selected-applications
        local do_rewrite_req_url = labels["DCOS_SERVICE_REWRITE_REQUEST_URLS"]
        if do_rewrite_req_url == false or do_rewrite_req_url == 'false' then
           ngx.log(ngx.INFO, "DCOS_SERVICE_REWRITE_REQUEST_URLS for app '" .. appId .. "' set to 'false'")
@@ -279,6 +279,8 @@ local function fetch_and_store_marathon_apps(auth_token)
           do_rewrite_req_url = true
        end
 
+       -- Details on how Admin Router interprets DCOS_SERVICE_REQUEST_BUFFERING label:
+       -- https://github.com/dcos/dcos/blob/master/packages/adminrouter/extra/src/README.md#disabling-request-buffering-for-selected-applications
        local do_request_buffering = labels["DCOS_SERVICE_REQUEST_BUFFERING"]
        if do_request_buffering == false or do_request_buffering == 'false' then
           ngx.log(ngx.INFO, "DCOS_SERVICE_REQUEST_BUFFERING for app '" .. appId .. "' set to 'false'")
@@ -297,7 +299,7 @@ local function fetch_and_store_marathon_apps(auth_token)
          url=url,
          do_rewrite_req_url=do_rewrite_req_url,
          do_request_buffering=do_request_buffering,
-         }
+       }
 
        ::continue::
     end

--- a/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
+++ b/packages/adminrouter/extra/src/test-harness/modules/mocker/endpoints/marathon.py
@@ -50,7 +50,6 @@ SCHEDULER_APP_TEMPLATE = {
         "volumes": [],
         "docker": {
             "image": "bitnami/nginx:1.10.2-r0",
-            "network": "BRIDGE",
             "portMappings": [
                 {
                     "containerPort": 80,
@@ -72,6 +71,11 @@ SCHEDULER_APP_TEMPLATE = {
             "forcePullImage": False
         }
     },
+    "networks": [
+        {
+            "mode": "container/bridge"
+        }
+    ],
     "healthChecks": [
         {
             "gracePeriodSeconds": 300,

--- a/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_cache.py
@@ -948,74 +948,23 @@ class TestCacheMesosLeader:
 
 
 class TestCacheMarathon:
-
-    def test_ip_per_task_app_with_user_networking_and_portmappings(
-            self, nginx_class, mocker, valid_user_header):
+    @pytest.mark.parametrize('host_port', [12345, 0, None])
+    def test_app_with_container_networking_and_defined_container_port(
+            self, nginx_class, mocker, valid_user_header, host_port):
+        # Testing the case when a non-zero container port is specified
+        # in Marathon app definition with networking mode 'container'.
+        # It does not matter if the host port is fixed (non-zero),
+        # randomly assigned by Marathon (0) or is not present at all:
+        # Admin Router must route the request to the specified container port.
         app = self._scheduler_alwaysthere_app()
-        app['ipAddress'] = {'networkName': 'samplenet'}
-        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
-        app['container']['docker']['network'] = "USER"
-        app['container']['docker']['portMappings'][0]['containerPort'] = '80'
-
-        ar = nginx_class()
-
-        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
-                            func_name='set_apps_response',
-                            aux_data={"apps": [app]})
-
-        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
-        with GuardedSubprocess(ar):
-            # Trigger cache update by issuing request:
-            resp = requests.get(url,
-                                allow_redirects=False,
-                                headers=valid_user_header)
-
-            assert resp.status_code == 200
-            req_data = resp.json()
-            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
-
-    def test_ip_per_task_app_with_user_networking_and_portdefinitions(
-            self, nginx_class, mocker, valid_user_header):
-        app = self._scheduler_alwaysthere_app()
-        app['ipAddress'] = {'networkName': 'samplenet'}
-        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
-        app['container']['docker']['network'] = "USER"
-        app['portDefinitions'] = [
-            {
-                "port": 80,
-                "protocol": "tcp",
-                "labels": {}
-            },
-        ]
-
-        ar = nginx_class()
-
-        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
-                            func_name='set_apps_response',
-                            aux_data={"apps": [app]})
-
-        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
-        with GuardedSubprocess(ar):
-            # Trigger cache update by issuing request:
-            resp = requests.get(url,
-                                allow_redirects=False,
-                                headers=valid_user_header)
-
-            assert resp.status_code == 200
-            req_data = resp.json()
-            assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
-
-    def test_ip_per_task_app_without_user_networking(
-            self, nginx_class, mocker, valid_user_header):
-        app = self._scheduler_alwaysthere_app()
-        app['ipAddress'] = {
-            'networkName': 'samplenet',
-            'discovery': {
-                "ports": [
-                    {"number": 80, "name": "http", "protocol": "tcp"}
-                ]
-            }
-        }
+        app['networks'] = [{
+            'mode': 'container',
+            'name': 'samplenet'
+        }]
+        if host_port is not None:
+            app['container']['portMappings'] = [{'containerPort': 80, 'hostPort': host_port}]
+        else:
+            app['container']['portMappings'] = [{'containerPort': 80}]
         app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.2'
 
         ar = nginx_class()
@@ -1035,16 +984,68 @@ class TestCacheMarathon:
             req_data = resp.json()
             assert req_data['endpoint_id'] == 'http://127.0.0.2:80'
 
-    def test_ip_per_task_app_with_unspecified_ip_address_DCOS_OSS_1366(
-            self, nginx_class, mocker, valid_user_header):
-        """
-        Test that an app that, instead of specifying 'ipAddress: null' does not
-        specify 'ipAddress' at all, is successfully cached.
-        """
+    @pytest.mark.parametrize('host_port', [12345, 0, None])
+    def test_app_with_container_networking_and_random_container_port(
+            self, nginx_class, mocker, valid_user_header, host_port):
+        # Testing the case when container port is specified as 0
+        # in Marathon app definition with networking mode 'container'.
+        # This means that the Marathon app container port is randomly assigned
+        # by Marathon. We are reusing port 16000 on 127.0.0.1 exposed by the
+        # mock server, as the one randomly chosen by Marathon.
+        # It does not matter if the host port is fixed (non-zero),
+        # randomly assigned by Marathon (0) or is not present at all:
+        # Admin Router must route the request to the specified container port.
         app = self._scheduler_alwaysthere_app()
+        app['networks'] = [{
+            'mode': 'container',
+            'name': 'samplenet'
+        }]
+        if host_port is not None:
+            app['container']['portMappings'] = [{'containerPort': 0, 'hostPort': host_port}]
+        else:
+            app['container']['portMappings'] = [{'containerPort': 0}]
+        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.1'
+        app['tasks'][0]['ports'][0] = '16000'
 
-        # Remove the 'ipAddress' key completely, thereby triggering DCOS_OSS-1366.
-        del(app["ipAddress"])
+        ar = nginx_class()
+
+        mocker.send_command(endpoint_id='http://127.0.0.1:8080',
+                            func_name='set_apps_response',
+                            aux_data={"apps": [app]})
+
+        url = ar.make_url_from_path('/service/scheduler-alwaysthere/foo/bar/')
+        with GuardedSubprocess(ar):
+            # Trigger cache update by issuing request:
+            resp = requests.get(url,
+                                allow_redirects=False,
+                                headers=valid_user_header)
+
+            assert resp.status_code == 200
+            req_data = resp.json()
+            assert req_data['endpoint_id'] == 'http://127.0.0.1:16000'
+
+    @pytest.mark.parametrize(
+        'networking_mode, container_port',
+        [['container/bridge', '80'], ['container/bridge', '0'], ['host', '80'], ['host', '0']]
+        )
+    def test_app_with_bridge_and_host_networking(
+            self, nginx_class, mocker, valid_user_header, container_port, networking_mode):
+        # Testing the cases when networking mode is either 'container' or 'host'.
+        # The host port can be non-zero or 0. In the latter case Marathon will
+        # randomly choose the host port. For simplicity in this test we are
+        # reusing port 16000 on 127.0.0.1 exposed by the mock server, as both
+        # the fixed (non-zero) one and the one randomly chosen by Marathon.
+        # It does not matter if the container port is fixed (non-zero) or
+        # randomly assigned by Marathon (0) or: Admin Router must route the
+        # request to the host port.
+        app = self._scheduler_alwaysthere_app()
+        app['networks'] = [{
+            'mode': networking_mode
+        }]
+
+        app['container']['portMappings'] = [
+            {'containerPort': container_port, 'hostPort': 16000}]
+        app['tasks'][0]['ipAddresses'][0]['ipAddress'] = '127.0.0.1'
 
         ar = nginx_class()
 
@@ -1177,19 +1178,6 @@ class TestCacheMarathon:
 
         filter_regexp = {
             "Cannot find host or ip for app '{}'".format(app["id"]):
-                SearchCriteria(1, True),
-        }
-
-        self._assert_filter_regexp_for_invalid_app(
-            filter_regexp, app, nginx_class, mocker, valid_user_header)
-
-    def test_app_without_task_ports(
-            self, nginx_class, mocker, valid_user_header):
-        app = self._scheduler_alwaysthere_app()
-        app["tasks"][0].pop("ports", None)
-
-        filter_regexp = {
-            "Cannot find ports for app '{}'".format(app["id"]):
                 SearchCriteria(1, True),
         }
 

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess
 import threading
+import time
 import uuid
 from collections import deque
 
@@ -410,6 +411,65 @@ def test_ip_per_container(dcos_api_session):
         app_port = app_definition['container']['portMappings'][0]['containerPort']
         cmd = '/opt/mesosphere/bin/curl -s -f -m 5 http://{}:{}/ping'.format(service_points[1].ip, app_port)
         ensure_routable(cmd, service_points[0].host, service_points[0].port)
+
+
+@pytest.mark.parametrize('host_port', [9999, 0])
+def test_app_with_container_mode_with_defined_container_port(dcos_api_session, host_port):
+    '''Testing the case when a non-zero container port is specified
+       in Marathon app definition with networking mode 'container'.
+       It does not matter if the host port is fixed (non-zero),
+       randomly assigned by Marathon (0): Admin Router must route the request
+       to the specified container port.
+    '''
+
+    app_definition, test_uuid = test_helpers.marathon_test_app(
+        healthcheck_protocol=marathon.Healthcheck.MESOS_HTTP,
+        container_type=marathon.Container.DOCKER,
+        network=marathon.Network.USER,
+        host_port=host_port)
+
+    dcos_service_name = uuid.uuid4().hex
+
+    app_definition['labels'] = {
+        'DCOS_SERVICE_NAME': dcos_service_name,
+        'DCOS_SERVICE_PORT_INDEX': '0',
+        'DCOS_SERVICE_SCHEME': 'http',
+    }
+
+    #  Arbitrary buffer time, accounting for propagation/processing delay.
+    buffer_time = 5
+
+    #  Cache refresh in Adminrouter takes 30 seconds at most.
+    #  CACHE_POLL_PERIOD=25s + valid=5s Nginx resolver DNS entry TTL
+    #  https://github.com/dcos/dcos/blob/cb9105ee537cc44cbe63cc7c53b3b01b764703a0/
+    #  packages/adminrouter/extra/src/includes/http/master.conf#L21
+    adminrouter_default_refresh = 25 + 5 + buffer_time
+    app_id = app_definition['id']
+    app_instances = app_definition['instances']
+    app_definition['constraints'] = [['hostname', 'UNIQUE']]
+
+    # For the routing check to work, two conditions must be true:
+    #
+    # 1. The application must be deployed, so that `/ping` responds with 200.
+    # 2. The Admin Router routing layer must not be using an outdated
+    #    version of the Nginx resolver cache.
+    #
+    # We therefore wait until these conditions have certainly been met.
+    # We wait for the Admin Router cache refresh first so that there is
+    # unlikely to be much double-waiting. That is, we do not want to be waiting
+    # for the cache to refresh when it already refreshed while we were waiting
+    # for the app to become healthy.
+    with dcos_api_session.marathon.deploy_and_cleanup(app_definition, check_health=False):
+        time.sleep(adminrouter_default_refresh)
+        dcos_api_session.marathon.wait_for_app_deployment(
+            app_id=app_id,
+            app_instances=app_instances,
+            check_health=False,
+            ignore_failed_tasks=False,
+            timeout=1200,
+        )
+        r = dcos_api_session.get('/service/' + dcos_service_name + '/ping')
+    assert r.status_code == 200
 
 
 @retrying.retry(wait_fixed=2000,


### PR DESCRIPTION
## High-level description

Adds support for latest Marathon networking modes to Admin Router `/service` proxying endpoint.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-48134](https://jira.mesosphere.com/browse/DCOS-48134) Add supporting endpoints for services running in CNI (e.g. Calico) to AdminRouter

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This was already fixed in 1.12 branch.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)