### PR TITLE
Update the cloud-formation templates to use specific Availability Zone

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -73,15 +73,8 @@
           "default": "PT45M"
       }},
     "RegionMap" : {
-        "us-east-1" : { "AZ" : ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e", "us-east-1f"]},
-        "us-west-1" : { "AZ" : ["us-west-1a", "us-west-1b", "us-west-1c"]},
-        "us-west-2" : { "AZ" : ["us-west-2a", "us-west-2b", "us-west-2c"]},
-        "sa-east-1" : { "AZ" : ["sa-east-1a", "sa-east-1b", "sa-east-1c"]},
-        "eu-west-1" : { "AZ" : ["eu-west-1a", "eu-west-1b", "eu-west-1c"]},
-        "eu-central-1" : { "AZ" : ["eu-central-1a", "eu-central-1b", "eu-central-1c"]},
-        "ap-northeast-1" : { "AZ" : ["ap-northeast-1a", "ap-northeast-1b", "ap-northeast-1c", "ap-northeast-1d"]},
-        "ap-southeast-1" : { "AZ" : ["ap-southeast-1a", "ap-southeast-1b", "ap-southeast-1c"]},
-        "ap-southeast-2" : { "AZ" : ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]},
+        "us-east-1" : { "AZ" : "us-east-1a"},
+        "us-west-2" : { "AZ" : "us-west-2a"}
     }
   },
 

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -73,9 +73,15 @@
           "default": "PT45M"
       }},
     "RegionMap" : {
-        "us-east-1" : { "AZ" : "us-east-1a"},
-        "us-west-2" : { "AZ" : "us-west-2a"}
-    }
+        "us-east-1" : { "AZ" : "us-east-1a" },
+        "us-west-1" : { "AZ" : "us-west-1a" },
+        "us-west-2" : { "AZ" : "us-west-2a" },
+        "sa-east-1" : { "AZ" : "sa-east-1a" },
+        "eu-west-1" : { "AZ" : "eu-west-1a" },
+        "eu-central-1" : { "AZ" : "eu-central-1a" },
+        "ap-northeast-1" : { "AZ" : "ap-northeast-1a" },
+        "ap-southeast-1" : { "AZ" : "ap-southeast-1a" },
+        "ap-southeast-2" : { "AZ" : "ap-southeast-2a" }}
   },
 
   "Conditions" : {

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -71,7 +71,17 @@
       },
       "StackCreationTimeout": {
           "default": "PT45M"
-      }
+      }},
+    "RegionMap" : {
+        "us-east-1" : { "AZ" : ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1e", "us-east-1f"]},
+        "us-west-1" : { "AZ" : ["us-west-1a", "us-west-1b", "us-west-1c"]},
+        "us-west-2" : { "AZ" : ["us-west-2a", "us-west-2b", "us-west-2c"]},
+        "sa-east-1" : { "AZ" : ["sa-east-1a", "sa-east-1b", "sa-east-1c"]},
+        "eu-west-1" : { "AZ" : ["eu-west-1a", "eu-west-1b", "eu-west-1c"]},
+        "eu-central-1" : { "AZ" : ["eu-central-1a", "eu-central-1b", "eu-central-1c"]},
+        "ap-northeast-1" : { "AZ" : ["ap-northeast-1a", "ap-northeast-1b", "ap-northeast-1c", "ap-northeast-1d"]},
+        "ap-southeast-1" : { "AZ" : ["ap-southeast-1a", "ap-southeast-1b", "ap-southeast-1c"]},
+        "ap-southeast-2" : { "AZ" : ["ap-southeast-2a", "ap-southeast-2b", "ap-southeast-2c"]},
     }
   },
 
@@ -102,6 +112,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
+        "AvailabilityZone": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "Vpc" },
         "CidrBlock" : { "Fn::FindInMap" : [ "Parameters", "PublicSubnetRange", "default" ] },
         "Tags" : [


### PR DESCRIPTION
DCOS-18825 - Pin the Availability Zone per region for the AWS CF Template

**NOTE** - Cloudformation tests are successful with this change:

1. https://teamcity.mesosphere.io/viewLog.html?buildId=1642996&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsCloudFormationSimple 

2. The list of regions map to the supported ones listed here:
https://github.com/dcos/dcos/blob/master/gen/build_deploy/aws.py#L129

3. If we have to update the instance support from `m4.xlarge` (https://github.com/dcos/dcos/blob/master/gen/aws/templates/cloudformation.json#L35) to something else like m5, we will have to update the list of amis per region that is built for the instance in step 2. That's a larger change, and this change makes sure that our default cloudformation templates will keep working.
