### PR TITLE
Updating invocation of pip upgrade to remove error message.

### DIFF
--- a/prep_local_windows.ps1
+++ b/prep_local_windows.ps1
@@ -10,7 +10,7 @@ if (!$env:VIRTUAL_ENV) {
 }
 
 # Install the latest version of pip
-pip install -U pip
+python -m pip install -U pip
 
 # Install the packages in editable mode to the virtual environment.
 pip install -e $PWD


### PR DESCRIPTION

## High-level description

Fix for DCOS-45501
As noted here:
https://github.com/pypa/pip/issues/5109
there can be an 'Access denied' error message when calling a pip
upgrade directly as this is a known issue with updating binaries
on Windows.

This change removes the potentially confusing error message, but
does not completely fix Windows builds.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.mesosphere.com/browse/DCOS-45501 teamcity/dcos/build/dcos/windows fails at start_dcos_windows_build.ps1 with PermissionError

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: N/A - minor change in invocation for same result.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
