### PR TITLE
Add pid to bootstrap logs to distinguish concurrent runs

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -145,7 +145,9 @@ def get_roles():
 def main():
     opts = parse_args()
 
-    logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
+    # Display the pid in each log message to distinguish concurrent runs
+    log_format = '{}:[%(levelname)s] %(message)s'.format(os.getpid())
+    logging.basicConfig(format=log_format, level='INFO')
     log.setLevel(logging.DEBUG)
 
     log.info('Clearing proxy environment variables')
@@ -163,7 +165,7 @@ def main():
             log.error('Unknown service: {}'.format(service))
             sys.exit(1)
         apply_service_configuration(service)
-        log.debug('bootstrapping {}'.format(service))
+        log.info('bootstrapping {}'.format(service))
         bootstrappers[service](b, opts)
 
 


### PR DESCRIPTION
## High-level description

Add the pid to bootstrap logs. Bootstrap runs concurrently on start-up, and sometimes we get logs that have not been separated by unit, especially if they come from the `dcos node log` command. Adding the pid disambiguates these cases.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [https://jira.mesosphere.com/browse/DCOS-48768](https://jira.mesosphere.com/browse/DCOS-48768) Add component name to bootstrap logs


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
Change to log format
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
Change to log format
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
