### PR TITLE
[1.12] Increase Telegraf buffer size limit to 20K

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@ Format of the entries must be.
 
 * Telegraf: Fix a bug in the Mesos input plugin that could cause metrics to be mis-tagged (DCOS_OSS-4760)
 
+* Telegraf: Doubled the buffer limit to drop fewer metrics (DCOS-49277)
+
 ### Security Updates
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1299,7 +1299,7 @@ package:
         ## output, and will flush this buffer on a successful write. Oldest metrics
         ## are dropped first when this buffer fills.
         ## This buffer only fills when writes fail to output plugin(s).
-        metric_buffer_limit = 10000
+        metric_buffer_limit = 20000
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the


### PR DESCRIPTION
## High-level description

Increased Telegraf's buffer limit to 20K (doubled from previous 10K) to avoid dropping massive amounts of metrics (bug surfaced from MWST13)


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49277](https://jira.mesosphere.com/browse/DCOS-49277) Dropped Telegraf metrics


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: hard to test this (only seen under very high load such as in MWSTs)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
