### PR TITLE
[1.13] Decrease default Telegraf polling frequency

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2126,7 +2126,7 @@ package:
 {% endswitch %}
       [agent]
         ## Default data collection interval for all inputs
-        interval = "10s"
+        interval = "20s"
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
         round_interval = true


### PR DESCRIPTION
## High-level description

In the last MWT, we saw many metrics getting dropped (e.g. internal plugin) while mesos/containers metrics were getting reported in the prom output. We noticed that these two plugins override the default polling interval (defaulted to 10s) to 60s. We should change the default polling interval to 20s and monitor in the next MWT to see if it improves performance and lowers the amount of dropped metrics.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49301](https://jira.mesosphere.com/browse/DCOS-49301) Decrease default Telegraf polling interval

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: added in 1.12 changelog
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: hard to test (comes up in MWT environment)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
