### PR TITLE
[1.12] Add pid to bootstrap logs to distinguish concurrent runs

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -100,6 +100,9 @@ def get_roles():
 def main():
     opts = parse_args()
 
+    # Display the pid in each log message to distinguish concurrent runs
+    log_format = 'pid={}:[%(levelname)s] %(message)s'.format(os.getpid())
+    logging.basicConfig(format=log_format, level='INFO')
     logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
     log.setLevel(logging.DEBUG)
 
@@ -115,7 +118,7 @@ def main():
 
     for service in opts.services:
         if service not in bootstrappers:
-            log.error('Unknown service: {}'.format(service))
+            log.info('Unknown service: {}'.format(service))
             sys.exit(1)
         apply_service_configuration(service)
         log.debug('bootstrapping {}'.format(service))

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -109,8 +109,9 @@ def wait(master_count_filename):
         "Serving hosts: `%s`, leader: `%s`", ','.join(serving), ','.join(leaders))
 
     if len(serving) != cluster_size or len(leaders) != 1:
-        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders'
-        raise Exception(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders\n'
+        log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+        sys.exit(1)
 
     # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
     # there is a restart we can come up quickly without requiring a new zookeeper quorum.

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -49,9 +49,9 @@ def try_shortcut():
     zk_pid = get_zk_pid()
     cmdline_path = '/proc/{}/cmdline'.format(zk_pid)
     try:
-        # Custom because the command line is ascii with `\0` as separator.
+        # Custom because the command line is ascii with `\x00` as separator.
         with open(cmdline_path, 'rb') as f:
-            cmd_line = f.read().split(b'\0')[:-1]
+            cmd_line = f.read().split(b'\x00')[:-1]
     except FileNotFoundError:
         log.info('Process no longer running (couldn\'t read the cmdline at: %s)', zk_pid)
         return False
@@ -109,7 +109,7 @@ def wait(master_count_filename):
         "Serving hosts: `%s`, leader: `%s`", ','.join(serving), ','.join(leaders))
 
     if len(serving) != cluster_size or len(leaders) != 1:
-        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders\n'
+        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders'
         log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
         sys.exit(1)
 


### PR DESCRIPTION
## High-level description

Back-port to 1.12. Includes change suggested by @mhrabovcin in #4658

Add the pid to bootstrap logs. Bootstrap runs concurrently on start-up, and sometimes we get logs that have not been separated by unit, especially if they come from the `dcos node log` command. Adding the pid disambiguates these cases.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [https://jira.mesosphere.com/browse/DCOS-48768](https://jira.mesosphere.com/browse/DCOS-48768) Add component name to bootstrap logs


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
Change to log format
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
Change to log format
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
