### PR TITLE
DCOS-49088 - Check in installer if DSS kernel modules are loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Stop requiring `ssh_user` attribute in `config.yaml` when using parts of deprecated CLI installer (DCOS_OSS-4613)
 
+* Add a warning to the installer to let the user know if case kernel modules required by DSS are not loaded (DCOS-49088)
+
 ### Notable changes
 
 * Bumped DC/OS UI to [master+v2.40.10](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.40.10)


### PR DESCRIPTION

## High-level description

This adds a check to the installer that checks whether the `raid1` and `dm_raid` kernel modules that are required by DSS are loaded or not.

If they're not loaded, it does _not_ fail the installation. It only prints a warning message to notify the user that usage of DSS depends on `raid1` and `dm_raid` being loaded.

This is what it looks like when a module is not loaded:

<img width="942" alt="kernel_module_warning" src="https://user-images.githubusercontent.com/1185253/53941209-cdf3a380-40b7-11e9-9168-217c144dcbe0.png">

And this is what it looks like when both are loaded:

<img width="708" alt="kernel_module_pass" src="https://user-images.githubusercontent.com/1185253/53941222-d5b34800-40b7-11e9-8a0a-f63643d8c64b.png">


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [[DCOS-49088] Add a new pre-install check for RAID kernel modules to installer bash script - JIRA](https://jira.mesosphere.com/browse/DCOS-49088)

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This will be executed every time we run tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).