### PR TITLE
Bump Telegraf to include nginx_vts_processor

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2232,6 +2232,24 @@ package:
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "DC/OS Net"
+      # Transform Admin Router metrics from the Nginx VTS module
+      [[processors.nginx_vts_filter]]
+        [[processors.nginx_vts_filter.convert]]
+          measurement = "nginx_vts_filter_requests_total"
+          key_value_delimiter = ":="
+          tag_delimiter = "_._._"
+        [[processors.nginx_vts_filter.convert]]
+          measurement = "nginx_vts_filter_bytes_total"
+          key_value_delimiter = ":="
+          tag_delimiter = "_._._"
+        [[processors.nginx_vts_filter.convert]]
+          measurement = "nginx_vts_filter_request_seconds"
+          key_value_delimiter = ":="
+          tag_delimiter = "_._._"
+        [[processors.nginx_vts_filter.convert]]
+          measurement = "nginx_vts_filter_request_seconds_total"
+          key_value_delimiter = ":="
+          tag_delimiter = "_._._"
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters
@@ -2341,6 +2359,10 @@ package:
         # tls_key = /path/to/keyfile
         ## Use TLS but skip chain & host verification
         insecure_skip_verify = true
+        ## Drop unused Admin Router metrics from the Nginx VTS module
+        namedrop = ["nginx_vts_filter_cache_*"]
+        [inputs.prometheus.tagdrop]
+          direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router"
@@ -2478,6 +2500,10 @@ package:
         # tls_key = /path/to/keyfile
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
+        ## Drop unused Admin Router metrics from the Nginx VTS module
+        namedrop = ["nginx_vts_filter_cache_*"]
+        [inputs.prometheus.tagdrop]
+          direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router Agent"
@@ -2608,6 +2634,10 @@ package:
         # tls_key = /path/to/keyfile
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
+        ## Drop unused Admin Router metrics from the Nginx VTS module
+        namedrop = ["nginx_vts_filter_cache_*"]
+        [inputs.prometheus.tagdrop]
+          direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router Agent"

--- a/packages/adminrouter/extra/src/includes/metrics-http-level.conf
+++ b/packages/adminrouter/extra/src/includes/metrics-http-level.conf
@@ -8,8 +8,8 @@
 # per second over all requests for us. This could potentially be removed once we
 # calculate the average latency ourselves in Grafana.
 # 
-# By supplying no value to http= and all= the keys will only be used by our
+# By supplying no value to http:= and all:= the keys will only be used by our
 # custom relabelling mechanism the metric but will result in empty labels http
-# and all.  Empty labels are dropped by Prometheus and thus they will not show
+# and all. Empty labels are dropped by Prometheus and thus they will not show
 # up in Grafana.
-vhost_traffic_status_filter_by_set_key http= ,all=,;
+vhost_traffic_status_filter_by_set_key http:= all:=;

--- a/packages/adminrouter/extra/src/includes/metrics-location-level.conf
+++ b/packages/adminrouter/extra/src/includes/metrics-location-level.conf
@@ -19,19 +19,19 @@
 #
 # Create a counter for every backend that requests go to when passing this line in a location directive.
 # Tag the counter with the manually set upstream.
-vhost_traffic_status_filter_by_set_key backend=$upstream_addr ,upstream=${upstream_tag},;
+vhost_traffic_status_filter_by_set_key backend:=$upstream_addr upstream:=${upstream_tag};
 
 # Create a counter for every status of requests which matches the location directive that this filter appears in.
 # Tag the counter with the manually set upstream and the backend that the request was passed on to.
-vhost_traffic_status_filter_by_set_key status=$status ,upstream=${upstream_tag},backend=${upstream_addr},;
+vhost_traffic_status_filter_by_set_key status:=$status upstream:=${upstream_tag}_._._backend:=${upstream_addr};
 
 # Create a counter for every URI that requests go to when matching the location directive that this filter appears in.
 # Tag the counter with the manually set upstream, the backend that the request was passed on to and the resulting status code.
-vhost_traffic_status_filter_by_set_key uri=$uri ,upstream=${upstream_tag},backend=${upstream_addr},status=${status},uri;
+#vhost_traffic_status_filter_by_set_key uri:=$uri upstream:=${upstream_tag}_._._backend:=${upstream_addr}_._._status:=${status};
 
-# Create a counter for every client that requests were sent from which match the location directive that this filter appears in.
+# Create a counter for every user agent that requests were sent from which match the location directive that this filter appears in.
 # Tag the counter with the manually set upstream, the backend that the request was passed on to and the resulting status code.
-vhost_traffic_status_filter_by_set_key client=$http_user_agent ,upstream=${upstream_tag},backend=${upstream_addr},status=${status},client;
+#vhost_traffic_status_filter_by_set_key useragent:=$http_user_agent upstream:=${upstream_tag}_._._backend:=${upstream_addr}_._._status:=${status};
 
 # Another thing to keep in mind is the consideration of whether to import this file before
 # or after any Lua auth checks.

--- a/packages/adminrouter/extra/src/includes/metrics-server-level.conf
+++ b/packages/adminrouter/extra/src/includes/metrics-server-level.conf
@@ -7,12 +7,12 @@
 
 # Create a counter for every status of requests going to the server in the server directive that this line is passed in.
 # Tag the counter with the server name.
-vhost_traffic_status_filter_by_set_key status=$status ,server=${server_name},;
+vhost_traffic_status_filter_by_set_key status:=$status server:=${server_name};
 
 # Create a counter for every URI of requests going to the server in the server directive that this line is passed in.
 # Tag the counter with the server name.
-vhost_traffic_status_filter_by_set_key uri=$uri ,server=${server_name},uri;
+#vhost_traffic_status_filter_by_set_key uri:=$uri server:=${server_name};
 
-# Create a counter for every client of requests going to the server in the server directive that this line is passed in.
+# Create a counter for every useragent of requests going to the server in the server directive that this line is passed in.
 # Tag the counter with the server name.
-vhost_traffic_status_filter_by_set_key client=$http_user_agent ,server=${server_name},client;
+#vhost_traffic_status_filter_by_set_key useragent:=$http_user_agent server:=${server_name};

--- a/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
@@ -70,4 +70,4 @@ class TestMetrics:
         # not escaped:
         assert '/service/monitoring/gra"f\\a\nn\ta' not in resp.text
         # correctly escaped:
-        assert '/service/monitoring/gra\\"f\\\\a\\nn\ta' in resp.text
+        # assert '/service/monitoring/gra\\"f\\\\a\\nn\ta' in resp.text

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "8de2b1788dd9d9ea7d89408cfa168f332220d842",
+    "ref": "0b6f2527d1ba0d917953d6f6181d2146259805eb",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

This PR adds fine-grained Admin Router metrics to the Telegraf output. We introduce a `nginx_vts_processor` plugin in Telegraf to transform Prometheus metrics output from the Nginx VTS module which can then be easily parsed in Grafana to build better dashboards.
This greatly reduces the amount of time-series ending up in Prometheus because all unused metrics are dropped on the Telegraf level.

As a follow-up we need to look into long URI and useragent string corrupting the Nginx VTS module Prometheus output. With this PR we deactivated the useragent and URI output for this reason.

Given the experience from SOAK and the MWTs we can now also think about reducing the shared memory region size of the Nginx VTS module.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49589](https://jira.mesosphere.com/browse/DCOS-49589) Adding Nginx/VTS Module metrics processor.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: It's a user facing change but we already have a changelog entry for initial AdminRouter metrics.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Diff](https://github.com/dcos/telegraf/compare/8de2b1788dd9d9ea7d89408cfa168f332220d842...0b6f2527d1ba0d917953d6f6181d2146259805eb)
  - [x] Test Results: [Jenkins](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/213/)
___