### PR TITLE
[BACKPORT][1.12] dcos-net: ensure the desination directory exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Fix dcos-net-setup.py failing when systemd network directory did not exist (DCOS-49711)
+
 ### Security updates
 
 * Update to OpenSSL 1.0.2r. (DCOS_OSS-4868)

--- a/packages/dcos-net/extra/dcos-net-setup.py
+++ b/packages/dcos-net/extra/dcos-net-setup.py
@@ -52,6 +52,7 @@ def main():
 
 def add_networkd_config(src):
     networkd = b'systemd-networkd.service'
+    networkd_path = '/etc/systemd/network'
 
     # Check if there is networkd
     result = subprocess.run(['systemctl', 'list-unit-files', networkd],
@@ -63,8 +64,10 @@ def add_networkd_config(src):
 
     # Copy the configuration
     bname = os.path.basename(src)
-    dst = os.path.join('/etc/systemd/network', bname)
+    dst = os.path.join(networkd_path, bname)
 
+    # Ensure the destination directory exists
+    os.makedirs(networkd_path, mode=0o755, exist_ok=True)
     if not safe_filecmp(src, dst):
         shutil.copyfile(src, dst)
 


### PR DESCRIPTION
## High-level description

Makes the systemd network configuration directory (`/etc/systemd/network`) if it does not already exists.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49711](https://jira.mesosphere.com/browse/DCOS-49711) COPS-4621: dcos-net-setup.py fails if systemd-networkd is installed but not active.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: test would just end up testing `os.makedirs`
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]