### PR TITLE
DCOS-18825- Update CORE OS AMI used in CloudFormation templates.

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -32,7 +32,7 @@
     "DefaultInstanceType" : {
       "Description" : "default instance",
       "Type" : "String",
-      "Default" : "m4.xlarge"
+      "Default" : "m5.large"
     }
 {% switch oauth_available %}
 {% case "true" %}
@@ -71,17 +71,7 @@
       },
       "StackCreationTimeout": {
           "default": "PT45M"
-      }},
-    "RegionMap" : {
-        "us-east-1" : { "AZ" : "us-east-1a" },
-        "us-west-1" : { "AZ" : "us-west-1a" },
-        "us-west-2" : { "AZ" : "us-west-2a" },
-        "sa-east-1" : { "AZ" : "sa-east-1a" },
-        "eu-west-1" : { "AZ" : "eu-west-1a" },
-        "eu-central-1" : { "AZ" : "eu-central-1a" },
-        "ap-northeast-1" : { "AZ" : "ap-northeast-1a" },
-        "ap-southeast-1" : { "AZ" : "ap-southeast-1a" },
-        "ap-southeast-2" : { "AZ" : "ap-southeast-2a" }}
+      }}
   },
 
   "Conditions" : {
@@ -111,7 +101,6 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
-        "AvailabilityZone": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "Vpc" },
         "CidrBlock" : { "Fn::FindInMap" : [ "Parameters", "PublicSubnetRange", "default" ] },
         "Tags" : [

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -126,75 +126,71 @@ aws_region_names = [
         'id': 'ap-southeast-2'
     }]
 
+# Core OS AMIS from: https://github.com/dcos/dcos-images/blob/62f97aa3cada6d29356003ee6a01c7c94a5f5433/coreos/1967.6.0/aws/DCOS-1.12.2/docker-18.06.1/dcos_images.yaml # noqa
+# RHEL 7 AMIS from: https://github.com/dcos/dcos-images/blob/9c231811a8d7f5b925ea405f928b7c2b3182bae6/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/selinux_disabled/dcos_images.yaml # noqa
+
 region_to_ami_map = {
     'ap-northeast-1': {
-        'coreos': 'ami-93f2baf4',
-        'stable': 'ami-93f2baf4',
-        'el7': 'ami-965345f8',
-        'el7prereq': 'ami-f1aee697',
+        'coreos': 'ami-0ffd2ee15ceabef65',
+        'stable': 'ami-0ffd2ee15ceabef65',
+        'el7': 'ami-0bfe52d6d145c674e',
+        'el7prereq': 'ami-0bfe52d6d145c674e',
         'natami': 'ami-55c29e54'
     },
     'ap-southeast-1': {
-        'coreos': 'ami-aacc7dc9',
-        'stable': 'ami-aacc7dc9',
-        'el7': 'ami-8af586e9',
-        'el7prereq': 'ami-a55504d9',
+        'coreos': 'ami-02e06ba544feb3f51',
+        'stable': 'ami-02e06ba544feb3f51',
+        'el7': 'ami-024ac75903e3114f1',
+        'el7prereq': 'ami-024ac75903e3114f1',
         'natami': 'ami-b082dae2'
     },
     'ap-southeast-2': {
-        'coreos': 'ami-9db0b0fe',
-        'stable': 'ami-9db0b0fe',
-        'el7': 'ami-427d9c20',
-        'el7prereq': 'ami-5ba66539',
+        'coreos': 'ami-07809279cd1e43478',
+        'stable': 'ami-07809279cd1e43478',
+        'el7': 'ami-0a81a425ed8ebf3c9',
+        'el7prereq': 'ami-0a81a425ed8ebf3c9',
         'natami': 'ami-996402a3'
     },
     'eu-central-1': {
-        'coreos': 'ami-903df7ff',
-        'stable': 'ami-903df7ff',
-        'el7': 'ami-2d0cbc42',
-        'el7prereq': 'ami-6a610905',
+        'coreos': 'ami-0285f4197bb94b5b0',
+        'stable': 'ami-0285f4197bb94b5b0',
+        'el7': 'ami-0e6000758f18fb6be',
+        'el7prereq': 'ami-0e6000758f18fb6be',
         'natami': 'ami-204c7a3d'
     },
     'eu-west-1': {
-        'coreos': 'ami-abcde0cd',
-        'stable': 'ami-abcde0cd',
-        'el7': 'ami-e46ea69d',
-        'el7prereq': 'ami-c51a54bc',
+        'coreos': 'ami-0539ccccd1e371d4b',
+        'stable': 'ami-0539ccccd1e371d4b',
+        'el7': 'ami-0569e7216584320c6',
+        'el7prereq': 'ami-0569e7216584320c6',
         'natami': 'ami-3760b040'
     },
     'sa-east-1': {
-        'coreos': 'ami-c11573ad',
-        'stable': 'ami-c11573ad',
-        'el7': 'ami-a5acd0c9',
-        'el7prereq': 'ami-f8f2b894',
+        'coreos': 'ami-0af8dc7533e9698e2',
+        'stable': 'ami-0af8dc7533e9698e2',
+        'el7': 'ami-0b34096d89569829a',
+        'el7prereq': 'ami-0b34096d89569829a',
         'natami': 'ami-b972dba4'
     },
     'us-east-1': {
-        'coreos': 'ami-1ad0000c',
-        'stable': 'ami-1ad0000c',
-        'el7': 'ami-771beb0d',
-        'el7prereq': 'ami-27e5235a',
+        'coreos': 'ami-08511d0b9ed33a795',
+        'stable': 'ami-08511d0b9ed33a795',
+        'el7': 'ami-0da3316c3c6eb42b0',
+        'el7prereq': 'ami-0da3316c3c6eb42b0',
         'natami': 'ami-4c9e4b24'
     },
-    'us-gov-west-1': {
-        'coreos': 'ami-e441fb85',
-        'stable': 'ami-e441fb85',
-        'el7': 'ami-9923a1f8',
-        'el7prereq': 'ami-9923a1f8',
-        'natami': 'ami-fe991b9f'
-    },
     'us-west-1': {
-        'coreos': 'ami-b31d43d3',
-        'stable': 'ami-b31d43d3',
-        'el7': 'ami-866151e6',
-        'el7prereq': 'ami-03bbae63',
+        'coreos': 'ami-08bcbb80bb680b5f2',
+        'stable': 'ami-08bcbb80bb680b5f2',
+        'el7': 'ami-074a555b65ca3c76e',
+        'el7prereq': 'ami-074a555b65ca3c76e',
         'natami': 'ami-2b2b296e'
     },
     'us-west-2': {
-        'coreos': 'ami-444dcd24',
-        'stable': 'ami-444dcd24',
-        'el7': 'ami-a9b24bd1',
-        'el7prereq': 'ami-845acbfc',
+        'coreos': 'ami-0235ac99b19539293',
+        'stable': 'ami-0235ac99b19539293',
+        'el7': 'ami-093949a7969be18da',
+        'el7prereq': 'ami-093949a7969be18da',
         'natami': 'ami-bb69128b'
     }
 }

--- a/gen/tests/test_installer_aws.py
+++ b/gen/tests/test_installer_aws.py
@@ -6,6 +6,6 @@ import gen.build_deploy.aws
 def test_gen_aws_mapping():
     result = json.loads(gen.build_deploy.aws.gen_ami_mapping({"stable"}))
     # check number of regions
-    assert len(result) == 10
+    assert len(result) == 9
     # check format of response
     assert result["ap-northeast-1"] == {'stable': gen.build_deploy.aws.region_to_ami_map['ap-northeast-1']['stable']}


### PR DESCRIPTION
* Use m5.large as the default instance type.
* Update CoreOS AMI used from the AMI in dcos-images.