### PR TITLE
DCOS_OSS-4877 - Bump dcos-test-utils to latest.

### DIFF
--- a/packages/dcos-integration-test/extra/requirements.txt
+++ b/packages/dcos-integration-test/extra/requirements.txt
@@ -12,7 +12,7 @@ dnspython3==1.12.0
 # /packages/python-kazoo/buildinfo.json
 kazoo==2.4.0
 # /packages/dcos-test-utils/buildinfo.json
-git+https://github.com/dcos/dcos-test-utils.git@ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8
+git+https://github.com/dcos/dcos-test-utils.git@e8519d9c20c4f0859d90a0a1d7eeae5c3c52fe5d
 
 # /packages/python-prometheus_client/buildinfo.json
 prometheus_client==0.5.0

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "74a1b6d184eff18002ff576b774ff59b589a0739",
+    "ref": "e8519d9c20c4f0859d90a0a1d7eeae5c3c52fe5d",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

Previously, dcos-test-utils would raise an exception if jobs results were not yet ready, but exceptions are not retried, so we instead log and return False.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4877](https://jira.mesosphere.com/browse/DCOS_OSS-4877) Waiting for job run to be finished, but history for that job run is not available

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: dcos-test-utils change
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: dcos-test-utils change has unit tests and will be exercised by integration tests.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [dcos-test-utils](https://github.com/dcos/dcos-test-utils/compare/ea663ac9f905f7ed489bf3fc2861dabcc94b1ea8...3f907b797dbf80c1246140367bec19ce240283d9)
  - [x] Test Results: [PR with test results](https://github.com/dcos/dcos-test-utils/pull/80)