### PR TITLE
DCOS-49963 - Update fetch_cluster_logs.bash to include logs from the beginning of time instead of current reboot.

### DIFF
--- a/fetch_cluster_logs.bash
+++ b/fetch_cluster_logs.bash
@@ -174,7 +174,7 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
 
   if [[ $pid == *"master"* ]]; then
     # get journald logs
-    ssh $ssh_options $master_public_ip -- journalctl -x -b --no-pager > master_journald.log
+    ssh $ssh_options $master_public_ip -- journalctl -x --no-pager > master_journald.log
     check_max_artifact_size "master_journald.log"
 
     # get mesos logs
@@ -198,7 +198,7 @@ for node_info in $(echo "$nodes_info_json" | jq -r '.[] | @base64'); do
     fi
 
     # get journald logs
-    ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- journalctl -x -b --no-pager > agent_${ip_underscores}_journald.log
+    ssh $ssh_options $master_public_ip -- ssh $ssh_options $ip -- journalctl -x --no-pager > agent_${ip_underscores}_journald.log
     check_max_artifact_size "agent_${ip_underscores}_journald.log"
 
     # get mesos logs


### PR DESCRIPTION
## High-level description

This makes it easier to debug integration tests by ensuring we pick up all logs instead of just logs since the most recent reboot.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49963](https://jira.mesosphere.com/browse/DCOS-49963) Collect all systemd logs in integration tests

## Related DC/OS tickets

  - [DCOS-45732](https://jira.mesosphere.com/browse/DCOS-45732) test_if_ucr_app_can_be_deployed fails with Application deployment failed - Agents not reachable

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: change to integration tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)