### PR TITLE
telegraf: add exhibitor status metrics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * ZooKeeper metrics are now collected by Telegraf (DCOS_OSS-4477).
 
+* Exhibitor metrics are now collected by Telegraf (DCOS-45353).
+
 * Marathon and Metronome have DC/OS install flag to configure GPU support.  "restricted", "unrestricted", "undefined" and "" are valid.
 
 * Mesos metrics are now available by default. (DCOS_OSS-3815)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2336,12 +2336,36 @@ package:
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router"
       # Read metrics from DC/OS Diagnostics Prometheus endpoint.
-        [[inputs.prometheus]]
+      [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:1050/metrics"]
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "DC/OS Diagnostics"
+      # Read exhibitor status metrics from HTTP endpoint
+      [[inputs.http]]
+        name_override = "exhibitor_status"
+        urls = ["http://localhost:8181/exhibitor/v1/cluster/status"]
+        data_format = "json"
+        tag_keys = ["hostname"]
+        json_string_fields = ["isLeader"]
+        tagexclude = ["url"]
+        [inputs.http.tags]
+          dcos-component-name = "Exhibitor"
+      [[processors.converter]]
+        order = 1
+        namepass = ["exhibitor_status"]
+        [processors.converter.fields]
+          integer = ["isLeader"]
+      [[processors.rename]]
+        order = 2
+        namepass = ["exhibitor_status"]
+        [[processors.rename.replace]]
+          tag = "hostname"
+          dest = "exhibitor_address"
+        [[processors.rename.replace]]
+          field = "isLeader"
+          dest = "isleader"
       # Expose metrics via the dcos-metrics v0 API.
       [[outputs.dcos_metrics]]
         dcos_node_role = "master"


### PR DESCRIPTION
## High-level description

Exposes result of exhibitor status endpoint as a telegraf metric.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-45353](https://jira.mesosphere.com/browse/DCOS-45353) Exhibitor instrumentation

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)