### PR TITLE
DCOS-50201 - Add Justin Barrick to DC/OS owners.json.

### DIFF
--- a/owners.json
+++ b/owners.json
@@ -11,6 +11,8 @@
   "greggomann": {"slack": "greg", "jira": "greg"},
   "jgehrcke": {"slack": "jp", "jira": "jp"},
   "jongiddy": {"slack": "jongiddy", "jira": "jonathangiddy"},
+  "juliangieseke": {"slack": "Julian", "jira": "juliangieseke"},
+  "jbarrick": {"slack": "Justin Taylor-Barrick", "jira": "jbarrick"},
   "meichstedt": {"slack": "matthias.eichstedt", "jira": "matthias.eichstedt"},
   "mesosphere-mergebot": {"slack": "mergebot", "jira": "svc.mergebot"},
   "nLight": {"slack": "drozhkov", "jira": "drozhkov"},
@@ -20,6 +22,5 @@
   "rukletsov": {"slack": "alexr", "jira": "alex"},
   "tillt": {"slack": "till", "jira": "till"},
   "timaa2k": {"slack": "tweidner", "jira": "timweidner"},
-  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"},
-  "juliangieseke": {"slack": "Julian", "jira": "juliangieseke"}
+  "urbanserj": {"slack": "urbanserj", "jira": "sergeyurbanovich"}
 }


### PR DESCRIPTION
## High-level description

Grants Justin Barrick access to DC/OS owners.json to assist with Tools Infra on-call.

## Tickets

* [DCOS-50201](https://jira.mesosphere.com/browse/DCOS-50201) Add Justin Barrick to DC/OS owners