### PR TITLE
Fix illegal prometheus metric names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### Fixed and improved
 
+* Prefix illegal prometheus metric names with an underscore (DCOS_OSS-4899)
+
 * Fix dcos-net-setup.py failing when systemd network directory did not exist (DCOS-49711)
 * Updated REX-Ray version to 0.11.4 (DCOS_OSS-4316) (COPS-3961) [rexray v0.11.4](https://github.com/rexray/rexray/releases/tag/v0.11.4)
 


### PR DESCRIPTION
## High-level description

This telegraf update prefixes any prometheus metric which starts with a number with an underscore.

So, `123.foo.bar` becomes `_123_foo_bar` instead of `123_foo_bar`

This prevents Prometheus dropping such metrics.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4900](https://jira.mesosphere.com/browse/DCOS_OSS-4900) Metric names can begin with numbers in Telegraf Prometheus output plugin


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/telegraf/compare/8de2b1788dd9d9ea7d89408cfa168f332220d842...381b2febd60ada0f2667b02a6a214c899214d7e4)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/214/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/214/)
