### PR TITLE
bumping marathon to 1.8 on dcos 1.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### What's new
 
+* Release of Marathon 1.8 with refactored Task Instance management.
+
 * Telegraf's statsd input plugin reports additional internal metrics. (DCOS_OSS-4759)
 
 * Admin Router Nginx Virtual Hosts metrics are now collected by default. An Nginx instance metrics display is available on `/nginx/status` on each DC/OS master node. (DCOS_OSS-4562)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.7.189-48bfd6000/marathon-1.7.189-48bfd6000.tgz",
-    "sha1": "d5219d80fb549bfd935a1403239262ac00dc40c5"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.143-7c07b88f9/marathon-1.8.143-7c07b88f9.tgz",
+    "sha1": "e379e9d3a05ed86763e20a20e4d4f55717416942"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4563](https://jira.mesosphere.com/browse/DCOS_OSS-4563) Bump Marathon 1.8.x on DCOS 1.13


## Related tickets (optional)

Other tickets related to this change:

- [DCOS_OSS-4325](https://jira.mesosphere.com/browse/DCOS_OSS-4325) Allow operator to reset Marathon task launch delay.
- [MARATHON-8587](https://jira.mesosphere.com/browse/MARATHON-8587) Marathon metrics HTTP handler exception
- [MARATHON-8431](https://jira.mesosphere.com/browse/MARATHON-8431) Remove sync proxy
- [MARATHON-8485](https://jira.mesosphere.com/browse/MARATHON-8485) GroupsResource should Creation of a group with same path as an existing app should be prohibited
- [MARATHON-8527](https://jira.mesosphere.com/browse/MARATHON-8527) SI Open tests Fixes
- [MARATHON-8498](https://jira.mesosphere.com/browse/MARATHON-8498) Remove validation for app updates and validate the whole app instead.
- [MARATHON-8222](https://jira.mesosphere.com/browse/MARATHON-8222) Remove `listWithStatistics` from LaunchQueue
- [MARATHON-8564](https://jira.mesosphere.com/browse/MARATHON-8564) Remove specByVersion in AppInfoBaseData
- [MARATHON-8554](https://jira.mesosphere.com/browse/MARATHON-8554) Resolved over-scaling issue for resident instances
- [MARATHON-8452](https://jira.mesosphere.com/browse/MARATHON-8452) Only log zero-value offers if they have a scalar value set
- [MARATHON-8516](https://jira.mesosphere.com/browse/MARATHON-8516) Race condition when provisioning an instance while changing a goal.
- [MARATHON-8416](https://jira.mesosphere.com/browse/MARATHON-8416) Replace all print calls with logger calls
- [MARATHON-8470](https://jira.mesosphere.com/browse/MARATHON-8470) Remove InstanceUpdateActor.
- [MARATHON-8388](https://jira.mesosphere.com/browse/MARATHON-8388) Import Matchers from Marathon
- [MARATHON-8479](https://jira.mesosphere.com/browse/MARATHON-8479) SI cluster failures 
- [MARATHON-8524](https://jira.mesosphere.com/browse/MARATHON-8524) Fix raml spec for Pods API
- [MARATHON-8577](https://jira.mesosphere.com/browse/MARATHON-8577) Illegal state exception when task hostPorts don't match runSpec portMappings should include the appId
- [MARATHON-8296](https://jira.mesosphere.com/browse/MARATHON-8296) Kill tasks in Decommissioned or Stopped goals
- [MARATHON-8373](https://jira.mesosphere.com/browse/MARATHON-8373) Reschedule Instances with Incarnation Count
- [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) Deployments endpoint containing no deployment after HTTP 201
- [MARATHON-8541](https://jira.mesosphere.com/browse/MARATHON-8541) Kill & wipe might hang forever in case of kill & wipe
- [MARATHON-8581](https://jira.mesosphere.com/browse/MARATHON-8581) Allow any UID to launch Marathon in a Docker container
- [MARATHON-8539](https://jira.mesosphere.com/browse/MARATHON-8539) Marathon drops on recognized fields for volume sources on offer reply
- [MARATHON-8562](https://jira.mesosphere.com/browse/MARATHON-8562) Remove RestResource.result and use asyncResponse.
- [MARATHON-8221](https://jira.mesosphere.com/browse/MARATHON-8221) Remove LaunchEphemeral
- [MARATHON-8563](https://jira.mesosphere.com/browse/MARATHON-8563) Replace Akka stream in PodsResource.allStatus and reuse newBaseData to get caching effects.
- [MARATHON-8423](https://jira.mesosphere.com/browse/MARATHON-8423) Use cacert file for HTTPS calls.
- [MARATHON-8223](https://jira.mesosphere.com/browse/MARATHON-8223) Remove LaunchQueue.purge calls from the code base
- [MARATHON-8140](https://jira.mesosphere.com/browse/MARATHON-8140) Enduring instanceIds
- [MARATHON-8466](https://jira.mesosphere.com/browse/MARATHON-8466) Fixed Issue with apps with specific names.
- [MARATHON-8133](https://jira.mesosphere.com/browse/MARATHON-8133) Drop connection for slow event consumers.
- [MARATHON-8167](https://jira.mesosphere.com/browse/MARATHON-8167) Instance Goal Phase 2
- [MARATHON-8515](https://jira.mesosphere.com/browse/MARATHON-8515) Don't lock on non-killing, non-scaling kill operations
- [MARATHON-8325](https://jira.mesosphere.com/browse/MARATHON-8325) Attach runspec to Instance
- [MARATHON-8429](https://jira.mesosphere.com/browse/MARATHON-8429) Marathon unable to replace failing tasks because it was stuck killing a task
- [MARATHON-8459](https://jira.mesosphere.com/browse/MARATHON-8459) Expunge Kamon from the Marathon code base
- [MARATHON-8240](https://jira.mesosphere.com/browse/MARATHON-8240) Remove Created condition
- [MARATHON-8555](https://jira.mesosphere.com/browse/MARATHON-8555) Parameter --leader_proxy_max_open_connections does not actually allow more concurrent connections
- [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) Fix application of timeouts in OverdueInstancesActor.
- [MARATHON-8457](https://jira.mesosphere.com/browse/MARATHON-8457) Remove JSON Schema Resources from 1.8
- [MARATHON-8503](https://jira.mesosphere.com/browse/MARATHON-8503) Marathon should run on Java 9.
- [MARATHON-8594](https://jira.mesosphere.com/browse/MARATHON-8594) 1.8 regression: apps include "$anon" in task id, causing compatibility issues
- [MARATHON-8374](https://jira.mesosphere.com/browse/MARATHON-8374) Get rid of the Reserved state
- [MARATHON-8460](https://jira.mesosphere.com/browse/MARATHON-8460) Expunge proxyEvents code and logic from Marathon
- [MARATHON-8413](https://jira.mesosphere.com/browse/MARATHON-8413) Cannot retrieve AppDefinition via a listed version
- [MARATHON-8532](https://jira.mesosphere.com/browse/MARATHON-8532) Scheduled instances does not get expunged
- [MARATHON-8453](https://jira.mesosphere.com/browse/MARATHON-8453) Respect Kill Timeout for sending Kill Requests to Mesos
- [MARATHON-8493](https://jira.mesosphere.com/browse/MARATHON-8493) Incorrect handling of double precision for pods
- [DCOS-41405](https://jira.mesosphere.com/browse/DCOS-41405) Enablement: Initialize CuratorFramework in CoreModuleImpl
- [MARATHON-8505](https://jira.mesosphere.com/browse/MARATHON-8505) Default backoff changed from 1 hour to 5 mins.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/mesosphere/marathon/compare/releases/1.7...7c07b88f9c7f232ce1c04401a441e68590ad382b)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/1234/)
  - [] Code Coverage (if available): N/A
