### PR TITLE
bump of metronome 0.6.11 on dcos 1.13 master

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.10-391637c/metronome-0.6.10-391637c.tgz",
-    "sha1": "38fa4a2c3d281935d0fb123bdfdf64b0df7b48ae"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.11-cf8887d/metronome-0.6.11-cf8887d.tgz",
+    "sha1": "ee1db9dae89962a5559d230205eb854efde65201"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-48948](https://jira.mesosphere.com/browse/DCOS-48948) Bump DC/OS 1.13 to latest Metronome


## Related tickets (optional)

Other tickets related to this change:

* [MARATHON-8555](https://jira.mesosphere.com/browse/MARATHON-8555) Parameter --leader_proxy_max_open_connections does not actually allow more concurrent connections
* [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) Fix race condition causing deployment info to not be available
* [MARATHON-8555](https://jira.mesosphere.com/browse/MARATHON-8577) Include app-id in illegal-state-exception


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/391637cc19cd6136e8733ff8b684aed31b2cf672...cf8887dd836d3629e3f5ac071624e055bdffcec8)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/2/consoleFull)
  - [ ] Code Coverage (if available): N/A
