### PR TITLE
[BACKPORT] [1.10] DCOS-50823 - Mute frequently flakey tests.

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -308,6 +308,11 @@ def vip_workload_test(dcos_api_session, container, vip_net, proxy_net, named_vip
     return (vip, hosts, cmd, origin_app, proxy_app)
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-19790',
+    reason='test_if_overlay_ok fails with STATUS_FAILED',
+    since='2019-03-15'
+)
 @retrying.retry(wait_fixed=2000,
                 stop_max_delay=120 * 1000,
                 retry_on_exception=lambda x: True)

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -7,6 +7,11 @@ import pytest
 from test_helpers import get_expanded_config
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4922',
+    reason='test_move_external_volume_to_new_agent application deployment fails',
+    since='2019-03-15'
+)
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 


### PR DESCRIPTION
## High-level description

This mutes tests that are known to be flakey.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50823](https://jira.mesosphere.com/browse/DCOS-50823) Mute flakey tests.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-19790](https://jira.mesosphere.com/browse/DCOS-19790) Flaky Test For DCOS Release: test_networking.test_if_overlay_ok
  - [DCOS-47438](https://jira.mesosphere.com/browse/DCOS-47438) test_networking.test_dcos_net_cluster_identity[true] non-zero exit status 1
  - [DCOS_OSS-4922](https://jira.mesosphere.com/browse/DCOS_OSS-4922) test_rexray.test_move_external_volume_to_new_agent fails on master.
  - [DCOS-50156](https://jira.mesosphere.com/browse/DCOS-50156) flaky test_clusterstate.test_ee_systemd_units_are_healthy
  - [DCOS-46578](https://jira.mesosphere.com/browse/DCOS-46578) DC/OS Enterprise - test_metronome.test_metronome flake - Exception: Job run failed - operation was not completed in 300 seconds.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: muting tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A muting tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)