### PR TITLE
[BACKPORT] [1.11] DCOS-50823 - Mute frequently flakey tests.

### DIFF
--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -1,3 +1,11 @@
+import pytest
+
+
+@pytest.mark.xfailflake(
+    jira='DCOS-46578',
+    reason='test_metronome job run fails',
+    since='2019-03-15'
+)
 def test_metronome(dcos_api_session):
     job = {
         'description': 'Test Metronome API regressions',

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -7,6 +7,11 @@ import pytest
 from test_helpers import get_expanded_config
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4922',
+    reason='test_rexray.test_move_external_volume_to_new_agent fails',
+    since='2019-03-18'
+)
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 


### PR DESCRIPTION
## High-level description

This mutes tests that are known to be flakey.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50823](https://jira.mesosphere.com/browse/DCOS-50823) Mute flakey tests.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-46578](https://jira.mesosphere.com/browse/DCOS-46578) DC/OS Enterprise - test_metronome.test_metronome flake - Exception: Job run failed - operation was not completed in 300 seconds.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: muting tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A muting tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)