### PR TITLE
gen: remove `disk:32` from min allocatable rez

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1299,7 +1299,7 @@ package:
       # hostname in the resource offer to be reachable.
       MESOS_HOSTNAME_LOOKUP=false
       MESOS_MAX_SLAVE_PING_TIMEOUTS=20
-      MESOS_MIN_ALLOCATABLE_RESOURCES=cpus:0.01;mem:32;ports:1|disk:32
+      MESOS_MIN_ALLOCATABLE_RESOURCES=cpus:0.01;mem:32;ports:1
       MESOS_MEMORY_PROFILING=true
       MESOS_MODULES_DIR=/opt/mesosphere/etc/mesos-master-modules
       MESOS_OFFER_TIMEOUT=2mins


### PR DESCRIPTION
## High-level description

DSS (master, and soon the 0.5.x series) has been upgraded to leverage the new FrameworkInfo.OfferFilters API in order to explicitly set its own min-allocatable-resources. Thus, this global setting is no longer needed.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
  - [DCOS-49202](https://jira.mesosphere.com/browse/DCOS-49202) Remove "|disk:32" from the min_allocatable_resources flag.

## Related tickets (optional)

Other tickets related to this change:
  - [DCOS-47867](https://jira.mesosphere.com/browse/DCOS-47867) Update DSS to specify the resources that it's interested in.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
    * DSS is the only consumer of disk-only offers
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
    * Now that DSS has been upgraded, this global change is no longer needed. Nothing else should break, no additional test needed.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
