### PR TITLE
DCOS-50823 - Mute test_checks_cli and test_vip_ipv6.

### DIFF
--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -2,10 +2,18 @@ import logging
 import random
 import uuid
 
+import pytest
+
+
 __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-50400',
+    reason='fails with metronome exception.',
+    since='2019-03-19'
+)
 def test_checks_cli(dcos_api_session):
     base_cmd = [
         '/opt/mesosphere/bin/dcos-shell',

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -265,6 +265,11 @@ def test_ipv6(dcos_api_session, same_host):
         proxy_app.purge(dcos_api_session)
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-50427',
+    reason='fails with read timeout.',
+    since='2019-03-19'
+)
 @pytest.mark.slow
 def test_vip_ipv6(dcos_api_session):
     return test_vip(dcos_api_session, marathon.Container.DOCKER,


### PR DESCRIPTION
## High-level description

This mutes tests that are known to be flakey.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50823](https://jira.mesosphere.com/browse/DCOS-50823) Mute flakey tests.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-50427](https://jira.mesosphere.com/browse/DCOS-50427) test_networking.test_vip_ipv6 fails on an unrelated change
  - [DCOS-50400](https://jira.mesosphere.com/browse/DCOS-50400) test_checks.test_checks_cli  failed with a Metronome Exception

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: muting tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A muting tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)