### PR TITLE
Add annotations to AR config for static upstreams IAM, Exhibitor, Diagnostics, Log, Net, Pkgpanda, Metrics, Checks, Mesos DNS

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -84,6 +84,11 @@ location /system/checks/v1 {
 
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
+
+    # Annotation for DCOS Checks upstream metrics.
+    set $upstream_tag DCOSChecks;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_checks_api;
 }
 
@@ -316,6 +321,11 @@ location /navstar/lashup/key {
         util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
+
+    # Annotation for DC/OS Net upstream metrics.
+    set $upstream_tag DCOSNet;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_net/lashup/key;
 }
 
@@ -327,6 +337,11 @@ location /net/ {
     }
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
+
+    # Annotation for DC/OS Net upstream metrics.
+    set $upstream_tag DCOSNet;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_net/;
 }
 

--- a/packages/adminrouter/extra/src/includes/server/open/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/agent.conf
@@ -3,6 +3,10 @@
 location /pkgpanda/ {
     include includes/proxy-headers.conf;
 
+    # Annotation for DCOS Component Package Manager upstream metrics.
+    set $upstream_tag Pkgpanda;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://pkgpanda/;
     proxy_redirect http://$http_host/ /pkgpanda/;
 }
@@ -13,6 +17,11 @@ location /system/checks/v1 {
     include includes/proxy-headers.conf;
 
     proxy_set_header Authorization "";
+
+    # Annotation for DCOS Checks upstream metrics.
+    set $upstream_tag DCOSChecks;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_checks_api;
 }
 
@@ -20,6 +29,11 @@ location /system/checks/v1 {
 # Description: Component service status
 location /system/health/v1 {
     include includes/proxy-headers.conf;
+
+    # Annotation for DC/OS diagnostics upstream metrics.
+    set $upstream_tag DCOSDiagnostics;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_diagnostics;
 }
 
@@ -30,6 +44,10 @@ location /system/v1/logs/ {
     include includes/http-11.conf;
     proxy_pass_header X-Accel-Buffering;
 
+    # Annotation for DC/OS log upstream metrics.
+    set $upstream_tag DCOSLog;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://log/;
 }
 
@@ -37,5 +55,10 @@ location /system/v1/logs/ {
 # Description: Node, container, and application metrics
 location /system/v1/metrics/ {
     include includes/proxy-headers.conf;
+
+    # Annotation for DCOS Metrics upstream metrics.
+    set $upstream_tag DCOSMetrics;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://metrics/;
 }

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -7,6 +7,10 @@ location /pkgpanda/ {
     }
     include includes/proxy-headers.conf;
 
+    # Annotation for DCOS Component Package Manager upstream metrics.
+    set $upstream_tag Pkgpanda;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://pkgpanda/;
     proxy_redirect http://$http_host/ /pkgpanda/;
 }
@@ -20,6 +24,11 @@ location /system/health/v1 {
     }
 
     include includes/proxy-headers.conf;
+
+    # Annotation for DC/OS diagnostics upstream metrics.
+    set $upstream_tag DCOSDiagnostics;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://dcos_diagnostics;
 }
 
@@ -34,6 +43,11 @@ location /system/v1/logs/ {
     include includes/proxy-headers.conf;
     include includes/http-11.conf;
     proxy_pass_header X-Accel-Buffering;
+
+    # Annotation for DC/OS log upstream metrics.
+    set $upstream_tag DCOSLog;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://log/;
 }
 
@@ -46,6 +60,11 @@ location /system/v1/metrics/ {
     }
 
     include includes/proxy-headers.conf;
+
+    # Annotation for DCOS Metrics upstream metrics.
+    set $upstream_tag DCOSMetrics;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://metrics/;
 }
 
@@ -58,6 +77,10 @@ location /exhibitor/ {
     }
 
     include includes/proxy-headers.conf;
+
+    # Annotation for Exhibitor upstream metrics.
+    set $upstream_tag Exhibitor;
+    include includes/metrics-location-level.conf;
 
     proxy_pass http://exhibitor/;
     proxy_redirect http://$http_host/ /exhibitor/;
@@ -136,6 +159,11 @@ location /dcos-metadata/ui-config.json {
 ##
 ## https://github.com/dcos/dcos/pull/2098
 location = /exhibitor/exhibitor/v1/cluster/status {
+
+    # Annotation for IAM upstream metrics.
+    set $upstream_tag Exhibitor;
+    include includes/metrics-location-level.conf;
+
     proxy_pass http://exhibitor;
     rewrite ^/exhibitor/(.*) /$1 break;
 }

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_metrics.py
@@ -1,0 +1,54 @@
+import pytest
+import requests
+
+
+def get_static_upstream_annotations() -> dict:
+    static_upstream_annotations = {
+        '/acs/api/v1': 'IAM',
+        '/system/health/v1': 'DCOSDiagnostics',
+        '/system/checks/v1': 'DCOSChecks',
+        '/navstar/lashup/key': 'DCOSNet',
+        '/net/': 'DCOSNet',
+        '/system/v1/logs/': 'DCOSLog',
+        '/system/v1/metrics/': 'DCOSMetrics',
+        '/mesos_dns/': 'MesosDNS',
+        '/pkgpanda': 'Pkgpanda',
+        '/exhibitor/exhibitor/v1/cluster/status': 'Exhibitor',
+    }
+    return static_upstream_annotations
+
+
+class TestMetrics:
+
+    @pytest.mark.parametrize(
+        'location,annotation', get_static_upstream_annotations().items(),
+        ids=list(get_static_upstream_annotations().values())
+        )
+    def test_metrics_prometheus_static_upstreams_annotated(
+            self, master_ar_process, location, annotation):
+        """
+        /nginx/metrics returns metrics in Prometheus format that are properly
+        annotated for static upstreams
+        """
+
+        url = master_ar_process.make_url_from_path('/nginx/metrics')
+
+        # We are making an HTTP(s) request to a fixed upstream location.
+        # This will cause nginx to apply corresponding annotation
+        # label to the upstream metric, regardless of the status of the
+        # call. As we are interested only in the label here, we are not
+        # checking the status code.
+        upstream_url = master_ar_process.make_url_from_path(location)
+        requests.get(
+            upstream_url,
+            allow_redirects=True,
+        )
+
+        resp = requests.get(
+            url,
+            allow_redirects=False,
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'text/plain'
+        assert annotation in resp.text

--- a/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
@@ -1,6 +1,5 @@
 import urllib.parse
 
-import pytest
 import requests
 
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
@@ -3,31 +3,6 @@ import urllib.parse
 import pytest
 import requests
 
-from generic_test_code.common import repo_is_ee
-
-
-def get_static_upstream_annotations() -> dict:
-    static_upstream_annotations = {
-        '/acs/api/v1': 'IAM',
-        '/system/health/v1': 'DCOSDiagnostics',
-        '/system/checks/v1': 'DCOSChecks',
-        '/navstar/lashup/key': 'DCOSNet',
-        '/net/': 'DCOSNet',
-        '/system/v1/logs/': 'DCOSLog',
-        '/system/v1/metrics/': 'DCOSMetrics',
-        '/mesos_dns/': 'MesosDNS',
-    }
-
-    # Adding upstreams available only in Open DC/OS
-    if not repo_is_ee:
-        static_upstream_annotations.update(
-            {
-                '/pkgpanda': 'Pkgpanda',
-                '/exhibitor/exhibitor/v1/cluster/status': 'Exhibitor',
-            }
-        )
-    return static_upstream_annotations
-
 
 class TestMetrics:
 
@@ -84,39 +59,6 @@ class TestMetrics:
         assert resp.status_code == 200
         assert resp.headers['Content-Type'] == 'text/plain'
         assert url_path in resp.text
-
-    @pytest.mark.parametrize(
-        'location,annotation', get_static_upstream_annotations().items(),
-        ids=list(get_static_upstream_annotations().values())
-        )
-    def test_metrics_prometheus_static_upstreams_annotated(
-            self, master_ar_process, location, annotation):
-        """
-        /nginx/metrics returns metrics in Prometheus format that are properly
-        annotated for static upstreams
-        """
-
-        url = master_ar_process.make_url_from_path('/nginx/metrics')
-
-        # We are making an HTTP(s) request to a fixed upstream location.
-        # This will cause nginx to apply corresponding annotation
-        # label to the upstream metric, regardless of the status of the
-        # call. As we are interested only in the label here, we are not
-        # checking the status code.
-        upstream_url = master_ar_process.make_url_from_path(location)
-        requests.get(
-            upstream_url,
-            allow_redirects=True,
-        )
-
-        resp = requests.get(
-            url,
-            allow_redirects=False,
-        )
-
-        assert resp.status_code == 200
-        assert resp.headers['Content-Type'] == 'text/plain'
-        assert annotation in resp.text
 
     def test_metrics_prometheus_escape(self, master_ar_process, valid_user_header):
         """

--- a/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
@@ -1,4 +1,3 @@
-
 import urllib.parse
 
 import requests

--- a/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_metrics.py
@@ -1,8 +1,32 @@
 import urllib.parse
 
+import pytest
 import requests
 
 from generic_test_code.common import repo_is_ee
+
+
+def get_static_upstream_annotations() -> dict:
+    static_upstream_annotations = {
+        '/acs/api/v1': 'IAM',
+        '/system/health/v1': 'DCOSDiagnostics',
+        '/system/checks/v1': 'DCOSChecks',
+        '/navstar/lashup/key': 'DCOSNet',
+        '/net/': 'DCOSNet',
+        '/system/v1/logs/': 'DCOSLog',
+        '/system/v1/metrics/': 'DCOSMetrics',
+        '/mesos_dns/': 'MesosDNS',
+    }
+
+    # Adding upstreams available only in Open DC/OS
+    if not repo_is_ee:
+        static_upstream_annotations.update(
+            {
+                '/pkgpanda': 'Pkgpanda',
+                '/exhibitor/exhibitor/v1/cluster/status': 'Exhibitor',
+            }
+        )
+    return static_upstream_annotations
 
 
 class TestMetrics:
@@ -61,54 +85,38 @@ class TestMetrics:
         assert resp.headers['Content-Type'] == 'text/plain'
         assert url_path in resp.text
 
-    def test_metrics_prometheus_static_upstreams_annotated(self, master_ar_process):
+    @pytest.mark.parametrize(
+        'location,annotation', get_static_upstream_annotations().items(),
+        ids=list(get_static_upstream_annotations().values())
+        )
+    def test_metrics_prometheus_static_upstreams_annotated(
+            self, master_ar_process, location, annotation):
         """
         /nginx/metrics returns metrics in Prometheus format that are properly
         annotated for static upstreams
         """
-        # Adding upstreams present in both Open and EE DC/OS
-        static_upstream_annotations = {
-            '/acs/api/v1': 'IAM',
-            '/system/health/v1': 'DCOSDiagnostics',
-            '/system/checks/v1': 'DCOSChecks',
-            '/navstar/lashup/key': 'DCOSNet',
-            '/net/': 'DCOSNet',
-            '/system/v1/logs/': 'DCOSLog',
-            '/system/v1/metrics/': 'DCOSMetrics',
-            '/mesos_dns/': 'MesosDNS',
-            }
-
-        # Adding upstreams available only in Open DC/OS
-        if not repo_is_ee:
-            static_upstream_annotations.update(
-                {
-                    '/pkgpanda': 'Pkgpanda',
-                    '/exhibitor/exhibitor/v1/cluster/status': 'Exhibitor',
-                }
-            )
 
         url = master_ar_process.make_url_from_path('/nginx/metrics')
 
-        # We are iterating over the fixed upstream locations and issuing HTTP(s)
-        # request to them.
+        # We are making an HTTP(s) request to a fixed upstream location.
         # This will cause nginx to apply corresponding annotation
         # label to the upstream metric, regardless of the status of the
         # call. As we are interested only in the label here, we are not
         # checking the status code.
-        for upstream, label in static_upstream_annotations.items():
-            upstream_url = master_ar_process.make_url_from_path(upstream)
-            requests.get(
-                upstream_url,
-                allow_redirects=True,
-            )
+        upstream_url = master_ar_process.make_url_from_path(location)
+        requests.get(
+            upstream_url,
+            allow_redirects=True,
+        )
 
-            resp = requests.get(
-                url,
-                allow_redirects=False,
-            )
-            assert resp.status_code == 200
-            assert resp.headers['Content-Type'] == 'text/plain'
-            assert label in resp.text
+        resp = requests.get(
+            url,
+            allow_redirects=False,
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers['Content-Type'] == 'text/plain'
+        assert annotation in resp.text
 
     def test_metrics_prometheus_escape(self, master_ar_process, valid_user_header):
         """


### PR DESCRIPTION
## High-level description
This PR is continuation of the work started earlier: https://github.com/dcos/dcos/pull/3996
It annotates the following upstreams in AR configuration files: Exhibitor, DC/OS Net, DC/OS Log, DC/OS Diagnostics.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS-47256

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)