### PR TITLE
DCOS-50823 - Mute flaky test_rexray.

### DIFF
--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -7,6 +7,11 @@ import pytest
 from test_helpers import get_expanded_config
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4922',
+    reason='test_move_external_volume_to_new_agent application deployment fails',
+    since='2019-03-20'
+)
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 


### PR DESCRIPTION
## High-level description

This mutes tests that are known to be flakey.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50823](https://jira.mesosphere.com/browse/DCOS-50823) Mute flakey tests.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-4922](https://jira.mesosphere.com/browse/DCOS_OSS-4922) test_rexray.test_move_external_volume_to_new_agent fails on master.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: muting tests
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A muting tests
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)