### PR TITLE
[1.12]  DCOS_OSS-1502 - dcos-docker-gc does not clean leftover volumes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Format of the entries must be.
 
 ### Notable changes
 
+* `docker-gc` now removes unused volumes (DCOS_OSS-1502)
+
 ### Breaking changes
 
 ### Fixed and improved
@@ -31,7 +33,6 @@ Format of the entries must be.
 ## DC/OS 1.12.3
 
 ### Notable changes
-
 
 ### Breaking changes
 

--- a/packages/docker-gc/buildinfo.json
+++ b/packages/docker-gc/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/spotify/docker-gc.git",
-    "ref": "4ee60137cfc76cf568b47f9b459b851d59325311",
+    "ref": "131a786886f571b656e0e4bdda967b7abc1fa7d1",
     "ref_origin": "master"
   },
   "username": "dcos_docker_gc",

--- a/packages/docker-gc/extra/dcos-docker-gc.service
+++ b/packages/docker-gc/extra/dcos-docker-gc.service
@@ -11,4 +11,5 @@ EnvironmentFile=/opt/mesosphere/environment
 Environment=STATE_DIR=/var/lib/dcos/docker-gc
 Environment=PID_DIR=/var/lib/dcos/docker-gc
 Environment=LOG_TO_SYSLOG=0
+Environment=REMOVE_VOLUMES=1
 ExecStart=$PKG_PATH/docker-gc


### PR DESCRIPTION
This is the backport of #4851 