### PR TITLE
DC/OS 1.12.3-fips with OpenSSL 1.0.2r-fips.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## DC/OS 1.12.3
+## DC/OS 1.12.3-fips
 
 ```
 * For any significant improvement to DC/OS add an entry to Fixed and Improved section.
@@ -16,6 +16,9 @@ Format of the entries must be.
 ## DC/OS 1.12.3 (Next Release. Please Update News Entries in this Section).
 
 ### Notable changes
+
+* Update to OpenSSL 1.0.2r. (DCOS_OSS-4868)
+* Build DC/OS with FIPS Compliant OpenSSL (DCOS-50051)
 
 
 ### Breaking changes

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -86,7 +86,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.12.3',
+        'version': '1.12.3-fips',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.12.3'
+DCOS_VERSION = '1.12.3-fips'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 

--- a/packages/openssl/build
+++ b/packages/openssl/build
@@ -3,10 +3,20 @@
 mkdir -p "/build"
 mkdir -p "$PKG_PATH/etc"
 
+pushd "/pkg/src/openssl-fips"
+  export FIPSDIR="$PKG_PATH/etc/fips"
+  ./config
+  make
+  make install
+popd
+
+
 # TODO(cmaloney): Fix the rpath
 pushd "/pkg/src/openssl"
 ./Configure "--prefix=$PKG_PATH" \
   --openssldir="$PKG_PATH/etc/ssl" \
+  --with-fipsdir="$PKG_PATH/etc/fips" \
+  fips \
   shared \
   linux-x86_64 \
   no-krb5 \

--- a/packages/openssl/buildinfo.json
+++ b/packages/openssl/buildinfo.json
@@ -1,7 +1,14 @@
 {
-  "single_source" : {
-    "kind": "url_extract",
-    "url": "https://openssl.org/source/openssl-1.0.2p.tar.gz",
-    "sha1": "f34b5322e92415755c7d58bf5d0d5cf37666382c"
-  }
+  "sources" : {
+    "openssl": {
+      "kind": "url_extract",
+      "url": "https://www.openssl.org/source/openssl-1.0.2r.tar.gz",
+      "sha1": "b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d"
+    },
+    "openssl-fips": {
+      "kind": "url_extract",
+      "url": "https://www.openssl.org/source/openssl-fips-2.0.16.tar.gz",
+      "sha1": "6bf6503339aed2c7fe0aa233a059c7cf49ce94b4"
+    }
+   }
 }


### PR DESCRIPTION
## High-level description

* DCOS-50051 - FIPS complaint DC/OS build on top of stable DC/OS 1.12.3 

This PR is to create the FIPS compliant DC/OS build. The Open DC/OS and Enterprise DC/OS artifacts can be utilized for creating a release.


### Testing Done

```
[centos@ip-10-10-0-101 openssl--805434a819503df1af1d2a999c2a04a24f092654]$ OPENSSL_FIPS=1 LD_LIBRARY_PATH=lib bin/openssl version
OpenSSL 1.0.2r-fips  26 Feb 2019

```