### PR TITLE
DCOS_OSS-4922 - Mute test_rexray.test_move_external_volume_to_new_agent

### DIFF
--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -10,6 +10,11 @@ __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS_OSS-4922',
+    reason='test_move_external_volume_to_new_agent application deployment fails',
+    since='2019-03-22'
+)
 @pytest.mark.supportedwindows
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.


### PR DESCRIPTION
## High-level description


* DCOS_OSS-4922 - Mute test_rexray.test_move_external_volume_to_new_agent

The failure was observed in this train PR - https://github.com/mesosphere/dcos-enterprise/pull/5038