### PR TITLE
[1.12] Check that DNS is ready before starting checks

### DIFF
--- a/packages/dcos-check-runner/extra/dcos-checks-api.service
+++ b/packages/dcos-check-runner/extra/dcos-checks-api.service
@@ -3,6 +3,7 @@ Description=DC/OS Checks API: Provides node and cluster checks
 
 [Service]
 Restart=always
+RestartSec=5
 StartLimitInterval=0
 
 LimitNOFILE=16384

--- a/packages/dcos-check-runner/extra/dcos-checks-api.service
+++ b/packages/dcos-check-runner/extra/dcos-checks-api.service
@@ -15,4 +15,6 @@ User=dcos_check_runner
 SupplementaryGroups=dcos_adminrouter
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-check-runner.env
+# Ensure dns is ready
+ExecStartPre=/bin/ping -c1 ready.spartan
 ExecStart=/opt/mesosphere/bin/dcos-check-runner http-server --config ${DCOS_DIAGNOSTICS_CONFIG_PATH}


### PR DESCRIPTION
See: https://github.com/dcos/dcos/pull/4884

## High-level description

This PR fixes a bug where dcos-checks-runner would start before DNS is ready, causing lookups to fail and breaking some builds. 

[This](https://jira.mesosphere.com/browse/DCOS-47608?focusedCommentId=252609&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-252609) comment on the ticket explains the issue further.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-47608](https://jira.mesosphere.com/browse/DCOS-47608)


## Related tickets (optional)

Other tickets related to this change: N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).