### PR TITLE
Annotate all upstreams including original URI

### DIFF
--- a/packages/adminrouter/extra/src/includes/metrics-upstream-location-level.conf
+++ b/packages/adminrouter/extra/src/includes/metrics-upstream-location-level.conf
@@ -1,4 +1,4 @@
-# Output fine-grained location directive level metrics using the VTS module.
+# Output fine-grained location directive level metrics for upstreams using the VTS module.
 #
 # Caution:
 # A request which matches a location that has a VTS module filter defined will be
@@ -14,8 +14,9 @@
 # directive and continue to be dynamically resolved.
 # https://tenzer.dk/nginx-with-dynamic-upstreams/
 #
-# Before including this file, a Nginx variable $upstream_tag must be set like this:
+# Before including this file, Nginx variables $upstream_tag and $original_uri must be set like this:
 # set $upstream_tag <CUSTOM_UPSTREAM_TAG>;
+# set $original_uri <ORIGINAL_URI>;
 #
 # Create a counter for every backend that requests go to when passing this line in a location directive.
 # Tag the counter with the manually set upstream.
@@ -27,7 +28,7 @@ vhost_traffic_status_filter_by_set_key status:=$status upstream:=${upstream_tag}
 
 # Create a counter for every URI that requests go to when matching the location directive that this filter appears in.
 # Tag the counter with the manually set upstream, the backend that the request was passed on to and the resulting status code.
-vhost_traffic_status_filter_by_set_key uri:=$uri upstream:=${upstream_tag}_._._backend:=${upstream_addr}_._._status:=${status};
+vhost_traffic_status_filter_by_set_key uri:=$original_uri upstream:=${upstream_tag}_._._backend:=${upstream_addr}_._._status:=${status};
 
 # Create a counter for every user agent that requests were sent from which match the location directive that this filter appears in.
 # Tag the counter with the manually set upstream, the backend that the request was passed on to and the resulting status code.

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -76,6 +76,11 @@ location ~ ^/system/v1/agent/(?<agentid>[0-9a-zA-Z-]+)(?<url>/logs.*|/metrics/v0
 # Group: System
 # Description: Node and cluster checks
 location /system/checks/v1 {
+    # Annotation for DCOS Checks upstream metrics.
+    set $upstream_tag DCOSChecks;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_system_checks_endpoint();
         util.clear_dcos_cookies();
@@ -84,16 +89,17 @@ location /system/checks/v1 {
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
 
-    # Annotation for DCOS Checks upstream metrics.
-    set $upstream_tag DCOSChecks;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://dcos_checks_api;
 }
 
 # Group: Mesos DNS
 # Description: Domain-based service discovery
 location /mesos_dns/ {
+    # Annotation for MesosDNS upstream metrics.
+    set $upstream_tag MesosDNS;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_mesosdns_endpoint();
         util.clear_dcos_cookies();
@@ -101,14 +107,15 @@ location /mesos_dns/ {
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
 
-    # Annotation for MesosDNS upstream metrics.
-    set $upstream_tag MesosDNS;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://mesos_dns/;
 }
 
 location /internal/mesos_dns/ {
+    # Annotation for MesosDNS upstream metrics.
+    set $upstream_tag MesosDNS;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     # This location is meant to be used internally in order to resolve
     # MesosDNS SRV records:
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#internal
@@ -126,16 +133,17 @@ location /internal/mesos_dns/ {
     proxy_connect_timeout 2s;
     proxy_read_timeout 3s;
 
-    # Annotation for MesosDNS upstream metrics.
-    set $upstream_tag MesosDNS;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://mesos_dns/;
 }
 
 # Group: Authentication
 # Description: Access Control Service policy query (unauthenticated, internal-only)
 location /internal/acs/api/v1/ {
+    # Annotation for IAM upstream metrics.
+    set $upstream_tag IAM;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     # This location does not require authentication. It is
     # meant to serve only nginx' subrequests, via the 'internal' directive.
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#internal
@@ -149,10 +157,6 @@ location /internal/acs/api/v1/ {
     include includes/proxy-headers.conf;
 
     rewrite ^/internal/(.*) /$1 break;
-
-    # Annotation for IAM upstream metrics.
-    set $upstream_tag IAM;
-    include includes/metrics-location-level.conf;
 
     proxy_pass http://iam;
 }
@@ -315,21 +319,27 @@ location ~ ^/(slave|agent)/(?<agentid>[0-9a-zA-Z-]+)(?<url>.+)$ {
 
 # Group: DC/OS Net
 location /navstar/lashup/key {
+    # Annotation for DC/OS Net upstream metrics.
+    set $upstream_tag DCOSNet;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_lashupkey_endpoint();
         util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
 
-    # Annotation for DC/OS Net upstream metrics.
-    set $upstream_tag DCOSNet;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://dcos_net/lashup/key;
 }
 
 # Group: DC/OS Net
 location /net/ {
+    # Annotation for DC/OS Net upstream metrics.
+    set $upstream_tag DCOSNet;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_net_endpoint();
         util.clear_dcos_cookies();
@@ -337,16 +347,17 @@ location /net/ {
     include includes/proxy-headers.conf;
     proxy_set_header Authorization "";
 
-    # Annotation for DC/OS Net upstream metrics.
-    set $upstream_tag DCOSNet;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://dcos_net/;
 }
 
 # Group: Mesos
 # Description: Apache Mesos
 location /mesos/ {
+    # Annotation for Mesos upstream metrics.
+    set $upstream_tag Mesos;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_mesos_endpoint();
         util.clear_dcos_cookies();
@@ -386,6 +397,11 @@ location /mesos/ {
 # Group: Cosmos
 # Description: Start a DC/OS service from a DC/OS package
 location /cosmos/service/ {
+    # Annotation for Cosmos upstream metrics.
+    set $upstream_tag Cosmos;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_cosmosservice_endpoint();
         util.clear_dcos_cookies();
@@ -400,6 +416,11 @@ location /cosmos/service/ {
 # Group: Package
 # Description: Package Management
 location ~ ^/package/(?<package_path>.*) {
+    # Annotation for Cosmos upstream metrics.
+    set $upstream_tag Cosmos;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_package_endpoint(ngx.var.package_path);
         util.clear_dcos_cookies();
@@ -421,6 +442,11 @@ location ~ ^/package/(?<package_path>.*) {
 # Group: Capabilities
 # Description: List of capabilities supported by DC/OS
 location /capabilities {
+    # Annotation for Cosmos upstream metrics.
+    set $upstream_tag Cosmos;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_capabilities_endpoint();
         util.clear_dcos_cookies();
@@ -434,6 +460,11 @@ location /capabilities {
 # Group: Authentication
 # Description: Access Control Service
 location /acs/api/v1 {
+    # Annotation for IAM upstream metrics.
+    set $upstream_tag IAM;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     # Enforce access restriction to Auth API. Due to the fact that we need to
     # issue a subrequest in auth.access_acsapi_endpoint(), this block needs to
     # be access_by_lua_block instead of rewrite_by_lua_block
@@ -444,16 +475,17 @@ location /acs/api/v1 {
     include includes/proxy-headers.conf;
     include includes/disable-response_caching.conf;
 
-    # Annotation for IAM upstream metrics.
-    set $upstream_tag IAM;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://iam;
 }
 
 # Group: DC/OS UI Update Service
 # Description: DC/OS UI Update Service Version API
 location = /dcos-ui-update-service/api/v1/version/ {
+    # Annotation for DC/OS UI Update Service upstream metrics.
+    set $upstream_tag DCOSUIUpdateService;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_dcos_ui_update_service_version_api_endpoint();
         util.clear_dcos_cookies();
@@ -468,6 +500,11 @@ location = /dcos-ui-update-service/api/v1/version/ {
 # Group: DC/OS UI Update Service
 # Description: DC/OS UI Update Service API
 location ~ ^/dcos-ui-update-service/api/(?<api_path>.*)$ {
+    # Annotation for DC/OS UI Update Service upstream metrics.
+    set $upstream_tag DCOSUIUpdateService;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_dcos_ui_update_service_api_endpoint();
         util.clear_dcos_cookies();

--- a/packages/adminrouter/extra/src/includes/server/open/agent.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/agent.conf
@@ -1,11 +1,16 @@
 # Group: Pkgpanda
 # Description: DC/OS component package management
 location /pkgpanda/ {
+    # Annotation for DCOS Component Package Manager upstream metrics.
+    set $upstream_tag Pkgpanda;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     include includes/proxy-headers.conf;
 
     # Annotation for DCOS Component Package Manager upstream metrics.
     set $upstream_tag Pkgpanda;
-    include includes/metrics-location-level.conf;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://pkgpanda/;
     proxy_redirect http://$http_host/ /pkgpanda/;
@@ -14,13 +19,18 @@ location /pkgpanda/ {
 # Group: System
 # Description: Node and cluster checks
 location /system/checks/v1 {
+    # Annotation for DCOS Checks upstream metrics.
+    set $upstream_tag DCOSChecks;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     include includes/proxy-headers.conf;
 
     proxy_set_header Authorization "";
 
     # Annotation for DCOS Checks upstream metrics.
     set $upstream_tag DCOSChecks;
-    include includes/metrics-location-level.conf;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://dcos_checks_api;
 }
@@ -28,11 +38,12 @@ location /system/checks/v1 {
 # Group: System
 # Description: Component service status
 location /system/health/v1 {
-    include includes/proxy-headers.conf;
-
     # Annotation for DC/OS diagnostics upstream metrics.
     set $upstream_tag DCOSDiagnostics;
-    include includes/metrics-location-level.conf;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
+    include includes/proxy-headers.conf;
 
     proxy_pass http://dcos_diagnostics;
 }
@@ -40,13 +51,18 @@ location /system/health/v1 {
 # Group: System
 # Description: Node, component service, and container (task) logs
 location /system/v1/logs/ {
+    # Annotation for DC/OS log upstream metrics.
+    set $upstream_tag DCOSLog;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     include includes/proxy-headers.conf;
     include includes/http-11.conf;
     proxy_pass_header X-Accel-Buffering;
 
     # Annotation for DC/OS log upstream metrics.
     set $upstream_tag DCOSLog;
-    include includes/metrics-location-level.conf;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://log/;
 }
@@ -54,11 +70,12 @@ location /system/v1/logs/ {
 # Group: System
 # Description: Node, container, and application metrics
 location /system/v1/metrics/ {
-    include includes/proxy-headers.conf;
-
     # Annotation for DCOS Metrics upstream metrics.
     set $upstream_tag DCOSMetrics;
-    include includes/metrics-location-level.conf;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
+    include includes/proxy-headers.conf;
 
     proxy_pass http://metrics/;
 }

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -1,6 +1,11 @@
-# Group: Pkgpanda
+#IAtrea Group: Pkgpanda
 # Description: DC/OS component package management
 location /pkgpanda/ {
+    # Annotation for DCOS Component Package Manager upstream metrics.
+    set $upstream_tag Pkgpanda;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_pkgpanda_endpoint();
         util.clear_dcos_cookies();
@@ -9,7 +14,7 @@ location /pkgpanda/ {
 
     # Annotation for DCOS Component Package Manager upstream metrics.
     set $upstream_tag Pkgpanda;
-    include includes/metrics-location-level.conf;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://pkgpanda/;
     proxy_redirect http://$http_host/ /pkgpanda/;
@@ -18,6 +23,11 @@ location /pkgpanda/ {
 # Group: System
 # Description: Component service status
 location /system/health/v1 {
+    # Annotation for DC/OS diagnostics upstream metrics.
+    set $upstream_tag DCOSDiagnostics;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_system_health_endpoint();
         util.clear_dcos_cookies();
@@ -25,16 +35,17 @@ location /system/health/v1 {
 
     include includes/proxy-headers.conf;
 
-    # Annotation for DC/OS diagnostics upstream metrics.
-    set $upstream_tag DCOSDiagnostics;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://dcos_diagnostics;
 }
 
 # Group: System
 # Description: Node, component service, and container (task) logs
 location /system/v1/logs/ {
+    # Annotation for DC/OS log upstream metrics.
+    set $upstream_tag DCOSLog;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_system_logs_endpoint();
         util.clear_dcos_cookies();
@@ -44,16 +55,17 @@ location /system/v1/logs/ {
     include includes/http-11.conf;
     proxy_pass_header X-Accel-Buffering;
 
-    # Annotation for DC/OS log upstream metrics.
-    set $upstream_tag DCOSLog;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://log/;
 }
 
 # Group: System
 # Description: Node, container, and application metrics
 location /system/v1/metrics/ {
+    # Annotation for DCOS Metrics upstream metrics.
+    set $upstream_tag DCOSMetrics;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_system_metrics_endpoint();
         util.clear_dcos_cookies();
@@ -61,16 +73,17 @@ location /system/v1/metrics/ {
 
     include includes/proxy-headers.conf;
 
-    # Annotation for DCOS Metrics upstream metrics.
-    set $upstream_tag DCOSMetrics;
-    include includes/metrics-location-level.conf;
-
     proxy_pass http://metrics/;
 }
 
 # Group: Exhibitor
 # Description: Manage Zookeeper
 location /exhibitor/ {
+    # Annotation for Exhibitor upstream metrics.
+    set $upstream_tag Exhibitor;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         auth.access_exhibitor_endpoint();
         util.clear_dcos_cookies();
@@ -80,7 +93,7 @@ location /exhibitor/ {
 
     # Annotation for Exhibitor upstream metrics.
     set $upstream_tag Exhibitor;
-    include includes/metrics-location-level.conf;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://exhibitor/;
     proxy_redirect http://$http_host/ /exhibitor/;
@@ -90,6 +103,11 @@ location /exhibitor/ {
 # Cache: 5 seconds
 # Description: Cache of the Mesos master API
 location /cache/master/ {
+    # Annotation for Mesos upstream metrics.
+    set $upstream_tag Mesos;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     add_header X-Cache-Status $upstream_cache_status;
     rewrite ^/cache/(.*) /$1 break;
     proxy_pass $upstream_mesos;
@@ -121,14 +139,15 @@ location = /login {
 # Group: Authentication
 # Description: Access Control Service (unauthenticated)
 location /acs/api/v1/auth/ {
+    # Annotation for IAM upstream metrics.
+    set $upstream_tag IAM;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
-
-    # Annotation for IAM upstream metrics.
-    set $upstream_tag IAM;
-    include includes/metrics-location-level.conf;
 
     proxy_pass http://iam;
 }
@@ -137,14 +156,15 @@ location /acs/api/v1/auth/ {
 # Group: Metadata
 # Description: DC/OS GUI configuration (unauthenticated)
 location /dcos-metadata/ui-config.json {
+    # Annotation for IAM upstream metrics.
+    set $upstream_tag IAM;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
+
     access_by_lua_block {
         util.clear_dcos_cookies();
     }
     include includes/proxy-headers.conf;
-
-    # Annotation for IAM upstream metrics.
-    set $upstream_tag IAM;
-    include includes/metrics-location-level.conf;
 
     # The trailing slash is critical for upstream to
     # not see the original request URL.
@@ -159,10 +179,10 @@ location /dcos-metadata/ui-config.json {
 ##
 ## https://github.com/dcos/dcos/pull/2098
 location = /exhibitor/exhibitor/v1/cluster/status {
-
-    # Annotation for IAM upstream metrics.
+    # Annotation for Exhibitor upstream metrics.
     set $upstream_tag Exhibitor;
-    include includes/metrics-location-level.conf;
+    set $original_uri $uri;
+    include includes/metrics-upstream-location-level.conf;
 
     proxy_pass http://exhibitor;
     rewrite ^/exhibitor/(.*) /$1 break;

--- a/packages/adminrouter/extra/src/includes/server/open/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/open/master.conf
@@ -1,4 +1,4 @@
-#IAtrea Group: Pkgpanda
+# Group: Pkgpanda
 # Description: DC/OS component package management
 location /pkgpanda/ {
     # Annotation for DCOS Component Package Manager upstream metrics.

--- a/packages/adminrouter/extra/src/test-harness/tests/open/test_metrics.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/open/test_metrics.py
@@ -4,6 +4,9 @@ import requests
 
 def get_static_upstream_annotations() -> dict:
     static_upstream_annotations = {
+        '/mesos/': 'Mesos',
+        '/cosmos/service/': 'Cosmos',
+        '/dcos-ui-update-service/api/v1/version/': 'DCOSUIUpdateService',
         '/acs/api/v1': 'IAM',
         '/system/health/v1': 'DCOSDiagnostics',
         '/system/checks/v1': 'DCOSChecks',
@@ -12,7 +15,7 @@ def get_static_upstream_annotations() -> dict:
         '/system/v1/logs/': 'DCOSLog',
         '/system/v1/metrics/': 'DCOSMetrics',
         '/mesos_dns/': 'MesosDNS',
-        '/pkgpanda': 'Pkgpanda',
+        '/pkgpanda/': 'Pkgpanda',
         '/exhibitor/exhibitor/v1/cluster/status': 'Exhibitor',
     }
     return static_upstream_annotations
@@ -52,3 +55,4 @@ class TestMetrics:
         assert resp.status_code == 200
         assert resp.headers['Content-Type'] == 'text/plain'
         assert annotation in resp.text
+        assert location in resp.text


### PR DESCRIPTION
## High-level description

This PR annotates all Admin Router location directives that include a `proxy_pass` other than
agent proxy locations or locations under `/service`. We refer to the currently annotated set of locations as Upstreams (apart from Mesos all of the annotated requests are handled locally on a master node).
Each Upstream is given an `$upstream_tag` that identifies it in terms of DC/OS terminology. Each location annotation also makes sure that Upstream metrics are tagged with the `$original_uri` to Admin Router rather than the rewritten `$uri` that was actually used in the `proxy_pass`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4945](https://jira.mesosphere.com/browse/DCOS_OSS-4945) Annotate all upstreams including original URI for Admin Router metrics.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: We have had an entry for collecting Admin Router metrics.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

___