### PR TITLE
gen: Make X-Frame-Options configurable for DC/OS UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Add metrics for lashup (DCOS_OSS-4756)
 
+* DC/OS UI X-Frame-Options value can be configured (DCOS-49594)
+
 
 ### Breaking changes
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -608,6 +608,18 @@ def validate_adminrouter_tls_version_present(
     assert enabled_tls_flags_count > 0, msg
 
 
+def validate_adminrouter_x_frame_options(adminrouter_x_frame_options):
+    """
+    Provide a basic validation that checks that provided value starts with
+    one of the supported options: DENY, SAMEORIGIN, ALLOW-FROM
+    See: https://tools.ietf.org/html/rfc7034#section-2.1
+    """
+    msg = 'X-Frame-Options must be set to one of DENY, SAMEORIGIN, ALLOW-FROM'
+    regex = r"^((DENY|SAMEORIGIN)|ALLOW-FROM .+)$"
+    match = re.match(regex, adminrouter_x_frame_options)
+    assert match is not None, msg
+
+
 def validate_s3_prefix(s3_prefix):
     # See DCOS_OSS-1353
     assert not s3_prefix.endswith('/'), "Must be a file path and cannot end in a /"
@@ -1072,6 +1084,7 @@ entry = {
         lambda adminrouter_tls_1_1_enabled: validate_true_false(adminrouter_tls_1_1_enabled),
         lambda adminrouter_tls_1_2_enabled: validate_true_false(adminrouter_tls_1_2_enabled),
         validate_adminrouter_tls_version_present,
+        validate_adminrouter_x_frame_options,
         lambda gpus_are_scarce: validate_true_false(gpus_are_scarce),
         validate_mesos_max_completed_tasks_per_framework,
         validate_mesos_recovery_timeout,
@@ -1105,6 +1118,7 @@ entry = {
         'adminrouter_tls_1_1_enabled': 'false',
         'adminrouter_tls_1_2_enabled': 'true',
         'adminrouter_tls_cipher_suite': '',
+        'adminrouter_x_frame_options': 'DENY',
         'intercom_enabled': 'true',
         'oauth_enabled': 'true',
         'oauth_available': 'true',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -615,8 +615,8 @@ def validate_adminrouter_x_frame_options(adminrouter_x_frame_options):
     See: https://tools.ietf.org/html/rfc7034#section-2.1
     """
     msg = 'X-Frame-Options must be set to one of DENY, SAMEORIGIN, ALLOW-FROM'
-    regex = r"^((DENY|SAMEORIGIN)|ALLOW-FROM .+)$"
-    match = re.match(regex, adminrouter_x_frame_options)
+    regex = r"^(DENY|SAMEORIGIN|ALLOW-FROM[ \t].+)$"
+    match = re.match(regex, adminrouter_x_frame_options, re.IGNORECASE)
     assert match is not None, msg
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2025,6 +2025,10 @@ package:
 
       ssl_certificate includes/snakeoil.crt;
       ssl_certificate_key includes/snakeoil.key;
+  - path: /etc_master/adminrouter-ui-security.conf
+    content: |
+      # Browser security settings for the DC/OS UI
+      add_header X-Frame-Options "{{ adminrouter_x_frame_options }}";
   - path: /etc/adminrouter-tls-master.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf

--- a/gen/tests/test_adminrouter_ui.py
+++ b/gen/tests/test_adminrouter_ui.py
@@ -30,6 +30,10 @@ def test_adminrouter_ui_x_frame_options_default():
     'DENY',
     'SAMEORIGIN',
     'ALLOW-FROM https://example.com',
+    'deny',
+    'sameorigin',
+    'allow-from https://example.com',
+    'allow-from\thttps://example.com',
 ])
 def test_adminrouter_ui_x_frame_options_custom(value):
     """
@@ -59,6 +63,7 @@ def test_adminrouter_ui_x_frame_options_custom(value):
     'DENY bad',
     'SAMEORIGIN bad',
     'ALLOW-FROM',
+    'allow-from',
 ])
 def test_adminrouter_ui_x_frame_options_validation(value):
     new_arguments = {'adminrouter_x_frame_options': value}

--- a/gen/tests/test_adminrouter_ui.py
+++ b/gen/tests/test_adminrouter_ui.py
@@ -1,0 +1,71 @@
+from textwrap import dedent
+
+import pytest
+
+import gen
+from gen.tests.utils import make_arguments
+
+
+def test_adminrouter_ui_x_frame_options_default():
+    """
+    Test that Master Admin Router config file has the correct default
+    `X-Frame-Options` value. Defaults are present in `calc.py`.
+    """
+    config_path = '/etc_master/adminrouter-ui-security.conf'
+    arguments = make_arguments(new_arguments={})
+    generated = gen.generate(arguments=arguments)
+    package = generated.templates['dcos-config.yaml']['package']
+    [config] = [item for item in package if item['path'] == config_path]
+
+    expected_configuration = dedent(
+        """\
+        # Browser security settings for the DC/OS UI
+        add_header X-Frame-Options "DENY";
+        """
+    )
+    assert config['content'] == expected_configuration
+
+
+@pytest.mark.parametrize('value', [
+    'DENY',
+    'SAMEORIGIN',
+    'ALLOW-FROM https://example.com',
+])
+def test_adminrouter_ui_x_frame_options_custom(value):
+    """
+    Test for all 3 allowed values
+    See: https://tools.ietf.org/html/rfc7034#section-2.1
+    """
+    config_path = '/etc_master/adminrouter-ui-security.conf'
+    arguments = make_arguments(new_arguments={
+        'adminrouter_x_frame_options': value,
+    })
+    generated = gen.generate(arguments=arguments)
+    package = generated.templates['dcos-config.yaml']['package']
+    [config] = [item for item in package if item['path'] == config_path]
+
+    expected_configuration = dedent(
+        """\
+        # Browser security settings for the DC/OS UI
+        add_header X-Frame-Options "{value}";
+        """.format(value=value)
+    )
+    assert config['content'] == expected_configuration
+
+
+@pytest.mark.parametrize('value', [
+    'wrong value',
+    'not supported DENY',
+    'DENY bad',
+    'SAMEORIGIN bad',
+    'ALLOW-FROM',
+])
+def test_adminrouter_ui_x_frame_options_validation(value):
+    new_arguments = {'adminrouter_x_frame_options': value}
+    expected_error_msg = (
+        'X-Frame-Options must be set to one of DENY, SAMEORIGIN, ALLOW-FROM'
+    )
+    result = gen.validate(arguments=make_arguments(new_arguments))
+    assert result['status'] == 'errors'
+
+    assert result['errors']['adminrouter_x_frame_options']['message'] == expected_error_msg

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -144,6 +144,7 @@ COPY adminrouter-redirect-http-https.conf \
      adminrouter-listen-agent.conf \
      adminrouter-tls-agent.conf \
      adminrouter-tls-master.conf \
+     adminrouter-ui-security.conf \
         /opt/mesosphere/etc/
 
 # The `ca.crt` file is copied into two places due to the fact that

--- a/packages/adminrouter/docker/adminrouter-ui-security.conf
+++ b/packages/adminrouter/docker/adminrouter-ui-security.conf
@@ -1,0 +1,2 @@
+# Browser security settings for the DC/OS UI
+add_header X-Frame-Options "DENY";

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -20,8 +20,7 @@ location /pkgpanda/active.buildinfo.full.json {
 root /var/lib/dcos/dcos-ui-update-service/dist/ui;
 
 location / {
-    # prevent opening in iframe when not on same origin
-    add_header X-Frame-Options SAMEORIGIN;
+    include /opt/mesosphere/etc/adminrouter-ui-security.conf;
 }
 
 # Group: System

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -306,7 +306,7 @@ class TestUiRoot:
         assert resp.status_code == 200
         resp.encoding = 'utf-8'
         assert resp.text == uniq_content
-        verify_header(resp.headers.items(), 'X-Frame-Options', 'SAMEORIGIN')
+        verify_header(resp.headers.items(), 'X-Frame-Options', 'DENY')
 
 
 class TestMisc:


### PR DESCRIPTION
## High-level description

Provides a new configuration `adminrouter_x_frame_options` that allows configuring `X-Frame-Options` value for DC/OS UI responses.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49594](https://jira.mesosphere.com/browse/DCOS-49594) Allow X-Frame-Options to be set in cluster configuration


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)