### PR TITLE
Update NAT AMIS to address CloudFormation Resource Errors

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -44,8 +44,8 @@
     },
     "MasterInstanceType": {
       "Type": "String",
-      "Default": "m4.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+      "Default": "m5.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/advanced-priv-agent.json
+++ b/gen/aws/templates/advanced/advanced-priv-agent.json
@@ -187,8 +187,8 @@
     },
     "PrivateAgentInstanceType": {
       "Type": "String",
-      "Default": "m4.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+      "Default": "m5.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/advanced-pub-agent.json
+++ b/gen/aws/templates/advanced/advanced-pub-agent.json
@@ -179,8 +179,8 @@
     },
     "PublicAgentInstanceType": {
       "Type": "String",
-      "Default": "m4.xlarge",
-      "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+      "Default": "m5.xlarge",
+      "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
     },
     "CustomAMI": {
       "Default": "default",

--- a/gen/aws/templates/advanced/infra.json
+++ b/gen/aws/templates/advanced/infra.json
@@ -348,7 +348,7 @@
         "SourceDestCheck" : "false",
         "KeyName" : { "Ref" : "KeyName" },
         "ImageId" : { "Fn::FindInMap" : [ "NATAmi", { "Ref" : "AWS::Region" }, "default" ] },
-        "InstanceType" : "m4.large",
+        "InstanceType" : "m5.large",
         "Tags" : [
           {
             "Key" : "role",

--- a/gen/aws/templates/advanced/zen.json
+++ b/gen/aws/templates/advanced/zen.json
@@ -37,18 +37,18 @@
         },
         "MasterInstanceType": {
           "Type": "String",
-          "Default": "m4.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+          "Default": "m5.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
         },
         "PublicAgentInstanceType": {
           "Type": "String",
-          "Default": "m4.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+          "Default": "m5.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
         },
         "PrivateAgentInstanceType": {
           "Type": "String",
-          "Default": "m4.xlarge",
-          "Description" : "\nRegion-specific instance type. E.g. m4.xlarge"
+          "Default": "m5.xlarge",
+          "Description" : "\nRegion-specific instance type. E.g. m5.xlarge"
         },
         "CustomAMI": {
           "Default": "default",

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -317,7 +317,7 @@
         "SourceDestCheck" : "false",
         "KeyName" : { "Ref" : "KeyName" },
         "ImageId" : { "Fn::FindInMap" : [ "NATAmi", { "Ref" : "AWS::Region" }, "default" ] },
-        "InstanceType" : "m4.large",
+        "InstanceType" : "m5.large",
         "NetworkInterfaces" : [
           {
             "SubnetId" : { "Ref" : "PublicSubnet" },

--- a/gen/build_deploy/aws.py
+++ b/gen/build_deploy/aws.py
@@ -128,6 +128,7 @@ aws_region_names = [
 
 # Core OS AMIS from: https://github.com/dcos/dcos-images/blob/62f97aa3cada6d29356003ee6a01c7c94a5f5433/coreos/1967.6.0/aws/DCOS-1.12.2/docker-18.06.1/dcos_images.yaml # noqa
 # RHEL 7 AMIS from: https://github.com/dcos/dcos-images/blob/9c231811a8d7f5b925ea405f928b7c2b3182bae6/rhel/7.6/aws/DCOS-1.12.0/docker-1.13.1.git8633870/selinux_disabled/dcos_images.yaml # noqa
+# natami is from: https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/ instances labelled amzn-ami-vpc-nat-hvm
 
 region_to_ami_map = {
     'ap-northeast-1': {
@@ -135,63 +136,63 @@ region_to_ami_map = {
         'stable': 'ami-0ffd2ee15ceabef65',
         'el7': 'ami-0bfe52d6d145c674e',
         'el7prereq': 'ami-0bfe52d6d145c674e',
-        'natami': 'ami-55c29e54'
+        'natami': 'ami-00d29e4cb217ae06b'
     },
     'ap-southeast-1': {
         'coreos': 'ami-02e06ba544feb3f51',
         'stable': 'ami-02e06ba544feb3f51',
         'el7': 'ami-024ac75903e3114f1',
         'el7prereq': 'ami-024ac75903e3114f1',
-        'natami': 'ami-b082dae2'
+        'natami': 'ami-01514bb1776d5c018'
     },
     'ap-southeast-2': {
         'coreos': 'ami-07809279cd1e43478',
         'stable': 'ami-07809279cd1e43478',
         'el7': 'ami-0a81a425ed8ebf3c9',
         'el7prereq': 'ami-0a81a425ed8ebf3c9',
-        'natami': 'ami-996402a3'
+        'natami': 'ami-062c04ec46aecd204'
     },
     'eu-central-1': {
         'coreos': 'ami-0285f4197bb94b5b0',
         'stable': 'ami-0285f4197bb94b5b0',
         'el7': 'ami-0e6000758f18fb6be',
         'el7prereq': 'ami-0e6000758f18fb6be',
-        'natami': 'ami-204c7a3d'
+        'natami': 'ami-06a5303d47fbd8c60'
     },
     'eu-west-1': {
         'coreos': 'ami-0539ccccd1e371d4b',
         'stable': 'ami-0539ccccd1e371d4b',
         'el7': 'ami-0569e7216584320c6',
         'el7prereq': 'ami-0569e7216584320c6',
-        'natami': 'ami-3760b040'
+        'natami': 'ami-024107e3e3217a248'
     },
     'sa-east-1': {
         'coreos': 'ami-0af8dc7533e9698e2',
         'stable': 'ami-0af8dc7533e9698e2',
         'el7': 'ami-0b34096d89569829a',
         'el7prereq': 'ami-0b34096d89569829a',
-        'natami': 'ami-b972dba4'
+        'natami': 'ami-057f5d52ff7ae75ae'
     },
     'us-east-1': {
         'coreos': 'ami-08511d0b9ed33a795',
         'stable': 'ami-08511d0b9ed33a795',
         'el7': 'ami-0da3316c3c6eb42b0',
         'el7prereq': 'ami-0da3316c3c6eb42b0',
-        'natami': 'ami-4c9e4b24'
+        'natami': 'ami-00a9d4a05375b2763'
     },
     'us-west-1': {
         'coreos': 'ami-08bcbb80bb680b5f2',
         'stable': 'ami-08bcbb80bb680b5f2',
         'el7': 'ami-074a555b65ca3c76e',
         'el7prereq': 'ami-074a555b65ca3c76e',
-        'natami': 'ami-2b2b296e'
+        'natami': 'ami-097ad469381034fa2'
     },
     'us-west-2': {
         'coreos': 'ami-0235ac99b19539293',
         'stable': 'ami-0235ac99b19539293',
         'el7': 'ami-093949a7969be18da',
         'el7prereq': 'ami-093949a7969be18da',
-        'natami': 'ami-bb69128b'
+        'natami': 'ami-0b840e8a1ce4cdf15'
     }
 }
 


### PR DESCRIPTION
## High-level description


#### StackStatus changed unexpectedly to: ROLLBACK_IN_PROGRESS - Resource unavailability issue

was observed due to resource unavailability of the NAT AMI. The error message in the console had this errror

```
Your requested instance type (m3.medium) is not supported in your requested Availability Zone (us-west-2d). Please retry your request by not specifying an Availability Zone or choosing us-west-2c, us-west-2b, us-west-2a. (Service: AmazonEC2; Status Code: 400; Error Code: Unsupported; Request ID: 11bba17d-87a4-4e7c-a0b1-3d3c09257a4a)
```
Attempting to resolve this issue by upgrading the NAT AMI provided by Amazon to the latest version (https://aws.amazon.com/amazon-linux-ami/2018.03-release-notes/) 

* https://jira.mesosphere.com/browse/DCOS-18825 

