### PR TITLE
Send task logs to Fluent Bit

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -48,3 +48,4 @@ The following is a list of ports used by internal DC/OS services, and their corr
 
  - 5051: dcos-mesos-slave
  - 61001: dcos-adminrouter-agent
+ - 61092: dcos-fluent-bit

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1146,7 +1146,7 @@ entry = {
         'mesos_dns_set_truncate_bit': 'true',
         'master_external_loadbalancer': '',
         'mesos_log_retention_mb': '4000',
-        'mesos_container_log_sink': 'logrotate',
+        'mesos_container_log_sink': 'fluentbit+logrotate',
         'mesos_max_completed_tasks_per_framework': '',
         'mesos_recovery_timeout': '24hrs',
         'mesos_seccomp_enabled': 'false',

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -196,8 +196,13 @@ def validate_mesos_log_retention_mb(mesos_log_retention_mb):
 
 
 def validate_mesos_container_log_sink(mesos_container_log_sink):
-    assert mesos_container_log_sink in ['journald', 'logrotate', 'journald+logrotate'], \
-        "Container logs must go to 'journald', 'logrotate', or 'journald+logrotate'."
+    assert mesos_container_log_sink in [
+        'fluentbit',
+        'journald',
+        'logrotate',
+        'fluentbit+logrotate',
+        'journald+logrotate',
+    ], "Container logs must go to 'fluentbit', 'journald', 'logrotate', 'fluentbit+logrotate', or 'journald+logrotate'."
 
 
 def validate_metronome_gpu_scheduling_behavior(metronome_gpu_scheduling_behavior):

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2718,10 +2718,16 @@ package:
       DCOS_UI_UPDATE_DIST_PATH=/var/lib/dcos/dcos-ui-update-service/dist
       DCOS_UI_UPDATE_DIST_LINK=/var/lib/dcos/dcos-ui-update-service/dist/ui
       DCOS_UI_UPDATE_STAGE_LINK=/var/lib/dcos/dcos-ui-update-service/dist/new-ui
-  - path: /etc/fluent-bit.env
+  - path: /etc_master/fluent-bit.env
     content: |
-      FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/fluent-bit.conf
-  - path: /etc/fluent-bit/fluent-bit.conf
+      FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/master.conf
+  - path: /etc_slave/fluent-bit.env
+    content: |
+      FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/agent.conf
+  - path: /etc_slave_public/fluent-bit.env
+    content: |
+      FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/agent.conf
+  - path: /etc/fluent-bit/common.conf
     content: |
       [SERVICE]
           # Flush
@@ -2764,4 +2770,15 @@ package:
       [OUTPUT]
           Name  null
           Match *
-
+  - path: /etc/fluent-bit/master.conf
+    content: |
+      @INCLUDE /opt/mesosphere/etc/fluent-bit/common.conf
+  - path: /etc/fluent-bit/agent.conf
+    content: |
+      @INCLUDE /opt/mesosphere/etc/fluent-bit/common.conf
+      [INPUT]
+          Name tcp
+          Listen 127.0.0.1
+          Port 61092
+          Chunk_Size 32
+          Buffer_Size 64

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -409,6 +409,12 @@ package:
                   }, {
                     "key": "logrotate_stderr_options",
                     "value": "rotate 9"
+                  }, {
+                    "key": "fluentbit_ip",
+                    "value": "127.0.0.1"
+                  }, {
+                    "key": "fluentbit_port",
+                    "value": "61092"
                   }
                 ]
               }

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2727,12 +2727,15 @@ package:
   - path: /etc_master/fluent-bit.env
     content: |
       FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/master.conf
+      FLUENT_BIT_SERVICE=dcos-fluent-bit-master
   - path: /etc_slave/fluent-bit.env
     content: |
       FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/agent.conf
+      FLUENT_BIT_SERVICE=dcos-fluent-bit-agent
   - path: /etc_slave_public/fluent-bit.env
     content: |
       FLUENT_BIT_CONFIG_FILE=/opt/mesosphere/etc/fluent-bit/agent.conf
+      FLUENT_BIT_SERVICE=dcos-fluent-bit-agent
   - path: /etc/fluent-bit/common.conf
     content: |
       [SERVICE]

--- a/packages/fluent-bit/build
+++ b/packages/fluent-bit/build
@@ -14,20 +14,7 @@ popd
 # Remove Fluent Bit's default config.
 rm -rf "$PKG_PATH/etc"
 
-# Add systemd unit files.
-# We use different unit files per role because Fluent Bit uses one service account on masters and another on agents.
-unit_template="/pkg/extra/dcos-fluent-bit.service"
-master_unit="$PKG_PATH/dcos.target.wants_master/dcos-fluent-bit.service"
-agent_unit="$PKG_PATH/dcos.target.wants_slave/dcos-fluent-bit.service"
-agent_public_unit="$PKG_PATH/dcos.target.wants_slave_public/dcos-fluent-bit.service"
-
-# Add the master unit file to the package.
-mkdir -p $(dirname "$master_unit")
-SERVICE="dcos-fluent-bit-master" envsubst '${SERVICE} ${PKG_PATH}' < "$unit_template" > "$master_unit"
-
-# Add the agent unit files to the package.
-# Agents and public agents have the same unit file contents.
-for unit in "$agent_unit" "$agent_public_unit"; do
-  mkdir -p $(dirname "$unit")
-  SERVICE="dcos-fluent-bit-agent" envsubst '${SERVICE} ${PKG_PATH}' < "$unit_template" > "$unit"
-done
+# Add systemd unit file.
+unit_file="$PKG_PATH/dcos.target.wants/dcos-fluent-bit.service"
+mkdir -p "$(dirname "$unit_file")"
+cp "/pkg/extra/dcos-fluent-bit.service" "$unit_file"

--- a/packages/fluent-bit/extra/dcos-fluent-bit.service
+++ b/packages/fluent-bit/extra/dcos-fluent-bit.service
@@ -14,5 +14,5 @@ EnvironmentFile=/opt/mesosphere/etc/fluent-bit.env
 
 LimitNOFILE=16384
 
-ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
+ExecStartPre=/opt/mesosphere/bin/bootstrap ${FLUENT_BIT_SERVICE}
 ExecStart=/opt/mesosphere/bin/fluent-bit --config ${FLUENT_BIT_CONFIG_FILE}

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "2ac2fcebe7872da05571078d68207c2d622e3acd",
+    "ref": "2633cb7135c978f640d08819f2408c541d6dedb2",
     "ref_origin": "1.13"
   }
 }


### PR DESCRIPTION
## High-level description

This PR bumps mesos-modules to pull in https://github.com/dcos/dcos-mesos-modules/pull/105, and adds configuration that directs Mesos agents to send task logs to Fluent Bit.

This also simplifies the Fluent Bit build script by moving the logic for defining Fluent Bit's service name to dcos-config.yaml.

I manually tested that task logs are being sent to Fluent Bit. I launched a Marathon app where tasks echo on a loop, configured dcos-fluent-bit.service on an agent to output logs to stdout, and observed task logs in dcos-fluent-bit.service's journal.

## Corresponding DC/OS tickets (obligatory)

- [DCOS-50078](https://jira.mesosphere.com/browse/DCOS-50078) Integrate Mesos task log module changes with DC/OS

## Related tickets (optional)

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Fluent Bit isn't yet configured to do anything useful, so this has no user-facing impact.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually, see description above.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-mesos-modules/compare/2ac2fcebe7872da05571078d68207c2d622e3acd...2633cb7135c978f640d08819f2408c541d6dedb2
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/modules/job/DCOS_OSS_Mesos_Modules-pr/158/)
  - [x] Code Coverage (if available): N/A