### PR TITLE
Upgrade OTP version

### DIFF
--- a/packages/erlang/buildinfo.json
+++ b/packages/erlang/buildinfo.json
@@ -4,7 +4,7 @@
     "erlang": {
       "kind": "git",
       "git": "https://github.com/erlang/otp.git",
-      "ref": "620ac3e68c5bc8b36143965fcf2892a07dc005c4",
+      "ref": "04c57e50c50d167b65c625d6a9fece8d7b4c7954",
       "ref_origin": "maint-21"
     }
   }


### PR DESCRIPTION
## High-level description

Upgrade OTP version to 21.3.3 w/ ERL-900

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4943](https://jira.mesosphere.com/browse/DCOS_OSS-4943) Driver gone away without deselecting

## Related tickets (optional)

Other tickets related to this change:

  - [ERL-900](https://bugs.erlang.org/browse/ERL-900) procket: driver gone away without deselecting

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: no user facing changes
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: none
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
https://github.com/erlang/otp/compare/620ac3e68c5bc8b36143965fcf2892a07dc005c4...04c57e50c50d167b65c625d6a9fece8d7b4c7954
https://github.com/erlang/otp/commit/04c57e50c50d167b65c625d6a9fece8d7b4c7954

___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).