### PR TITLE
CHANGES.md: Improve X-Frame-Options note

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,8 +75,6 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Add metrics for lashup (DCOS_OSS-4756)
 
-* DC/OS UI X-Frame-Options value can be configured (DCOS-49594)
-
 
 ### Breaking changes
 
@@ -126,6 +124,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 * Fix a race condition in L4LB (DCOS_OSS-4939)
 
 * Fix IPv6 VIP support in L4LB (DCOS-50427)
+
+* DC/OS UI X-Frame-Options default value has been changed from `SAMEORIGIN` to `DENY`. This is now configurable using the `adminrouter_x_frame_options` configuration value (DCOS-49594)
 
 ### Notable changes
 


### PR DESCRIPTION
## High-level description

Change the release note for `X-Frame-Options` config option default value, which has been changed from `SAMEORIGIN` to `DENY`.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-49594](https://jira.mesosphere.com/browse/DCOS-49594) Allow X-Frame-Options to be set in cluster configuration

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Not a testable change
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)