### PR TITLE
Add HTTP status collection to server level

### DIFF
--- a/packages/adminrouter/extra/src/includes/metrics-server-level.conf
+++ b/packages/adminrouter/extra/src/includes/metrics-server-level.conf
@@ -11,8 +11,8 @@ vhost_traffic_status_filter_by_set_key status:=$status server:=${server_name};
 
 # Create a counter for every URI of requests going to the server in the server directive that this line is passed in.
 # Tag the counter with the server name.
-vhost_traffic_status_filter_by_set_key uri:=$uri server:=${server_name};
+vhost_traffic_status_filter_by_set_key uri:=$uri server:=${server_name}_._._status:=${status};
 
 # Create a counter for every useragent of requests going to the server in the server directive that this line is passed in.
 # Tag the counter with the server name.
-vhost_traffic_status_filter_by_set_key useragent:=$http_user_agent server:=${server_name};
+vhost_traffic_status_filter_by_set_key useragent:=$http_user_agent server:=${server_name}_._._status:=${status};


### PR DESCRIPTION
## High-level description

Small PR that adds collecting HTTP status codes for server level request useragent and URI reporting as well.
I've tested this locally on my machine.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

___