### PR TITLE
gen/dcos-config.yaml: Remove nginx_vts_upstream and nginx_vts_server metrics

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2368,7 +2368,7 @@ package:
         ## Use TLS but skip chain & host verification
         insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
@@ -2509,7 +2509,7 @@ package:
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
@@ -2643,7 +2643,7 @@ package:
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -208,6 +208,8 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
         measurements = set()
         expect_dropped = set([
             'nginx_vts_filter',
+            'nginx_vts_upstream',
+            'nginx_vts_server',
         ])
         unexpected_samples = []
 
@@ -227,8 +229,6 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
             'nginx_server_status',
             'nginx_upstream_status',
             'nginx_upstream_backend',
-            'nginx_vts_upstream',
-            'nginx_vts_server',
         ])
 
         difference = expected - measurements
@@ -282,6 +282,8 @@ def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
             measurements = set()
             expect_dropped = set([
                 'nginx_vts_filter',
+                'nginx_vts_upstream',
+                'nginx_vts_server',
             ])
             unexpected_samples = []
 


### PR DESCRIPTION
## High-level description

Changes `dcos-telegraf` to drop unnecessary metrics reported by NGINX `vts` module. The removed metrics are `nginx_vts_server_*` and `nginx_vts_upstream_*`.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4960](https://jira.mesosphere.com/browse/DCOS_OSS-4960) Drop default VTS module metrics

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this is a new work that is already captured in changelog
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)