### PR TITLE
[1.13] Use configured timeout in http client instead of mesos query param

### DIFF
--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "0b6f2527d1ba0d917953d6f6181d2146259805eb",
+    "ref": "50e7f0fb1e2a6bfe270db2d3e83a53c7d11daa3f",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

The HTTP client used in the Mesos input plugin was setting its own timeout to 4s, which was effectively taking precedent over the timeout configured in DCOS (30s). We are now using the configured timeout in the http client and have removed the timeout query param from the mesos snapshot request altogether to avoid emitting partial metrics if a timeout were hit in mesos.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50672](https://jira.mesosphere.com/browse/DCOS-50672) Mesos metrics dropping due to snapshots timeout

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: 1.12 changelog updated
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/0b6f2527d1ba0d917953d6f6181d2146259805eb...50e7f0fb1e2a6bfe270db2d3e83a53c7d11daa3f
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/218/
  - [ ] Code Coverage (if available): [link to code coverage report]
