### PR TITLE
[1.12] Use configured timeout in http client instead of mesos query param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ Format of the entries must be.
 
 * DC/OS UI X-Frame-Options value can be configured (DCOS-49594)
 
+* Telegraf cancels timed out requests for internal Mesos metrics, instead of collecting partial metric data (DCOS-50672)
+
 ### Security updates
 
 * Update to OpenSSL 1.0.2r. (DCOS_OSS-4868)

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "d40b9e5b69b83b8554c52afd0e0d3149b29a1815",
+    "ref": "42d1e113f141a57be0cc8b5ebaed53b88a5c3850",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

(backport of #4928) The HTTP client used in the Mesos input plugin was setting its own timeout to 4s, which was effectively taking precedent over the timeout configured in DCOS (30s). We are now using the configured timeout in the http client and have removed the timeout query param from the mesos snapshot request altogether to avoid emitting partial metrics if a timeout were hit in mesos.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50672](https://jira.mesosphere.com/browse/DCOS-50672) Mesos metrics dropping due to snapshots timeout

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/d40b9e5b69b83b8554c52afd0e0d3149b29a1815...42d1e113f141a57be0cc8b5ebaed53b88a5c3850
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/218/
  - [ ] Code Coverage (if available): [link to code coverage report]
