### PR TITLE
Start of test that we drop nginx_vts_*_request_seconds* metrics

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2368,7 +2368,7 @@ package:
         ## Use TLS but skip chain & host verification
         insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*", "nginx_vts_*_request_seconds*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
@@ -2509,7 +2509,7 @@ package:
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*", "nginx_vts_*_request_seconds*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.
@@ -2643,7 +2643,7 @@ package:
         ## Use TLS but skip chain & host verification
         # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
-        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*"]
+        namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*", "nginx_vts_*_request_seconds*"]
         [inputs.prometheus.tagdrop]
           direction = ["1xx", "2xx", "3xx", "4xx", "5xx"]
         ## Apply DC/OS component name tag according to the documentation.

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2250,14 +2250,6 @@ package:
           measurement = "nginx_vts_filter_bytes_total"
           key_value_delimiter = ":="
           tag_delimiter = "_._._"
-        [[processors.nginx_vts_filter.convert]]
-          measurement = "nginx_vts_filter_request_seconds"
-          key_value_delimiter = ":="
-          tag_delimiter = "_._._"
-        [[processors.nginx_vts_filter.convert]]
-          measurement = "nginx_vts_filter_request_seconds_total"
-          key_value_delimiter = ":="
-          tag_delimiter = "_._._"
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -197,10 +197,10 @@ def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session
     """
     nginx_vts_*_request_seconds* metrics are not present.
     """
+    node = dcos_api_session.masters[0]
     # Make request to a fine-grained metrics annotated upstream of
     # Admin Router (IAM in this case).
-    dcos_api_session.get('/acs/api/v1/auth/jwks')
-    node = dcos_api_session.masters[0]
+    dcos_api_session.get('/acs/api/v1/auth/jwks', host=node)
 
     @retrying.retry(
         wait_fixed=STD_INTERVAL,
@@ -261,10 +261,10 @@ def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(dcos_api_session)
 
 def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     """Assert that processed Admin Router metrics on master are present."""
+    node = dcos_api_session.masters[0]
     # Make request to a fine-grained metrics annotated upstream of
     # Admin Router (IAM in this case).
-    dcos_api_session.get('/acs/api/v1/auth/jwks')
-    node = dcos_api_session.masters[0]
+    dcos_api_session.get('/acs/api/v1/auth/jwks', host=node)
 
     @retrying.retry(
         wait_fixed=STD_INTERVAL,


### PR DESCRIPTION
## High-level description

This was a collaborative effort with @mhrabovcin .

This drops some inaccurate measurements from Telegraf.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4959](https://jira.mesosphere.com/browse/DCOS_OSS-4959) Drop latency measurements


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: Users have never seen these metrics represented in a dashboard
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)