### PR TITLE
Telegraf scale tuning

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2130,7 +2130,7 @@ package:
 {% endswitch %}
       [agent]
         ## Default data collection interval for all inputs
-        interval = "20s"
+        interval = "10s"
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
         round_interval = true
@@ -2142,7 +2142,7 @@ package:
         ## output, and will flush this buffer on a successful write. Oldest metrics
         ## are dropped first when this buffer fills.
         ## This buffer only fills when writes fail to output plugin(s).
-        metric_buffer_limit = 20000
+        metric_buffer_limit = 90000
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the
@@ -2431,6 +2431,8 @@ package:
         user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
+        ## The interval at which to collect metrics
+        interval = "30s"
         ## The address on which the command API should listen
         listen = "/run/dcos/telegraf/dcos_statsd.sock"
         ## The directory in which container information is stored

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2211,6 +2211,8 @@ package:
       [[outputs.prometheus_client]]
         ## Address to listen on
         listen = ":61091"
+        ## Expiration interval for each metric before it's evicted from cache.
+        expiration_interval = "60s"
       # Read metrics from DC/OS Net Prometheus endpoint.
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.


### PR DESCRIPTION
## High-level description

This PR edits Telegraf config to help prevent dropped metrics on busy agents. This is accomplished by increasing the number of metrics output pluggins can buffer before they start dropping metrics (`metric_buffer_limit`), and by increasing the collection `interval` for the `dcos_statsd` input plugin, which reduces the rate at which it collects metrics, thus reducing pressure on output buffers.

This PR also reduces the default `interval` for all input plugins to 10s. Most inputs don't need to be throttled on a busy agent, since they emit a consistent number of metrics that doesn't increase as workloads are executed on an agent.

Last, this PR sets `expiration_interval` for the `prometheus_client` output to its default value, instead of using it implicitly.

I'll backport this fix to 1.12, so no changelog update is necessary.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50994](https://jira.mesosphere.com/browse/DCOS-50994) Telegraf started to drop metrics on some agents.

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This will be backported to 1.12, so it won't be a change for 1.13.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This solves a problem that only appears at scale, which our integration tests don't cover.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]