### PR TITLE
(1.12) Telegraf scale tuning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Format of the entries must be.
 
 ### Fixed and improved
 
+* Telegraf is tuned for workloads that emit a large number of metrics (DCOS-50994)
+
 * Prefix illegal prometheus metric names with an underscore (DCOS_OSS-4899)
 
 * Fix dcos-net-setup.py failing when systemd network directory did not exist (DCOS-49711)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1291,7 +1291,7 @@ package:
         dcos_cluster_id="$DCOS_CLUSTER_ID"
       [agent]
         ## Default data collection interval for all inputs
-        interval = "20s"
+        interval = "10s"
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
         round_interval = true
@@ -1303,7 +1303,7 @@ package:
         ## output, and will flush this buffer on a successful write. Oldest metrics
         ## are dropped first when this buffer fills.
         ## This buffer only fills when writes fail to output plugin(s).
-        metric_buffer_limit = 20000
+        metric_buffer_limit = 90000
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the
@@ -1422,6 +1422,8 @@ package:
         user_agent = "Telegraf-dcos-containers"
       # Plugin for monitoring statsd metrics from mesos tasks
       [[inputs.dcos_statsd]]
+        ## The interval at which to collect metrics
+        interval = "30s"
         ## The address on which the command API should listen
         listen = "/run/dcos/telegraf/dcos_statsd.sock"
         ## The directory in which container information is stored

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1366,6 +1366,8 @@ package:
       [[outputs.prometheus_client]]
         ## Address to listen on
         listen = ":61091"
+        ## Expiration interval for each metric before it's evicted from cache.
+        expiration_interval = "60s"
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters


### PR DESCRIPTION
## High-level description

This is a 1.12 backport of #4939.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50994](https://jira.mesosphere.com/browse/DCOS-50994) Telegraf started to drop metrics on some agents

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This solves a problem that only appears at scale, which our integration tests don't cover.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]