### PR TITLE
Migrate telegraf containers dir as root

### DIFF
--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -20,6 +20,9 @@ ExecStartPre=/bin/bash -c "mkdir -p /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chmod 775 /run/dcos/telegraf"
 ExecStartPre=/bin/bash -c "chown root:dcos_telegraf /run/dcos/telegraf"
 
+# Migrate old containers dir to new location in case the cluster was upgraded.
+ExecStartPre=/opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
+
 ExecStartPre=/bin/bash -c "mkdir -p ${TELEGRAF_USER_CONFIG_DIR}"
 
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -33,8 +33,6 @@ fi
 
 # Create containers dir for dcos_statsd input.
 mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
-# Migrate old containers dir to new location in case the cluster was upgraded.
-/opt/mesosphere/active/telegraf/tools/migrate_containers_dir.sh "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
 
 # Ensure that old socket file is removed, if present
 # TODO(philipnrmn): investigate whether moving to a systemd-managed socket

--- a/packages/telegraf/extra/tools/migrate_containers_dir.sh
+++ b/packages/telegraf/extra/tools/migrate_containers_dir.sh
@@ -38,10 +38,10 @@ if dir_contains_files "${TELEGRAF_CONTAINERS_DIR}"; then
     exit 1
 fi
 
-# Delete destination dir if it exists, so we don't move the legacy dir *into* it.
-if [ -d "${TELEGRAF_CONTAINERS_DIR}" ]; then
-    rmdir "${TELEGRAF_CONTAINERS_DIR}"
-fi
+# Ensure that the full path to the destination dir exists
+mkdir -p "${TELEGRAF_CONTAINERS_DIR}"
+# Delete destination dir, so we don't move the legacy dir *into* it.
+rmdir "${TELEGRAF_CONTAINERS_DIR}"
 
 echo "Migrating ${LEGACY_CONTAINERS_DIR} to ${TELEGRAF_CONTAINERS_DIR}..."
 mv "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"

--- a/packages/telegraf/extra/tools/migrate_containers_dir.sh
+++ b/packages/telegraf/extra/tools/migrate_containers_dir.sh
@@ -45,4 +45,8 @@ rmdir "${TELEGRAF_CONTAINERS_DIR}"
 
 echo "Migrating ${LEGACY_CONTAINERS_DIR} to ${TELEGRAF_CONTAINERS_DIR}..."
 mv "${LEGACY_CONTAINERS_DIR}" "${TELEGRAF_CONTAINERS_DIR}"
+echo "Granting dcos_telegraf user permissions on ${TELEGRAF_CONTAINERS_DIR}..."
+chmod 775 "${TELEGRAF_CONTAINERS_DIR}"
+chmod 664 "${TELEGRAF_CONTAINERS_DIR}/*"
+chown -R root:dcos_telegraf "${TELEGRAF_CONTAINERS_DIR}"
 echo "Done."


### PR DESCRIPTION
The mesos module's containers directory is owned by root. We therefore migrate
its contents in an ExecPre step, instead of in Exec using the dcos_telegraf
user.

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50697](https://jira.mesosphere.com/browse/DCOS-50697) Evidence of Telegraf failures after upgrading from 1.11 to 1.13.0-alpha


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this stops the 1.11->1.13 upgrade breaking, and changes nothing else
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is covered by upgrade tests (which discovered the issue in the first place)
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
