### PR TITLE
Fix fault domain metric tags

### DIFF
--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -13,7 +13,7 @@ fi
 cluster_id="$(cat ${cluster_id_file})"
 
 # Retrieve the node's private IP address.
-node_private_ip=$(/opt/mesosphere/bin/detect_ip)
+node_private_ip="$(/opt/mesosphere/bin/detect_ip)"
 
 # Export values to env vars so Telegraf config can reference them.
 export DCOS_CLUSTER_ID="${cluster_id}"
@@ -23,7 +23,7 @@ export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
 fault_domain_extractor="/opt/mesosphere/active/telegraf/tools/extract_fault_domain.py"
 
-if [ -x $fault_domain_script ]; then
+if [ -x "$fault_domain_script" ]; then
   # If a fault domain script exists, export environment variables so that
   # fault_domain_zone and fault_domain_region are added to all tags originating
   # in this machine

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -27,7 +27,8 @@ if [ -x $fault_domain_script ]; then
   # If a fault domain script exists, export environment variables so that
   # fault_domain_zone and fault_domain_region are added to all tags originating
   # in this machine
-  eval `$(fault_domain_script) | $(fault_domain_extractor)`
+  export FAULT_DOMAIN_REGION="$("$fault_domain_script" | "$fault_domain_extractor" region)"
+  export FAULT_DOMAIN_ZONE="$("$fault_domain_script" | "$fault_domain_extractor" zone)"
 fi
 
 # Create containers dir for dcos_statsd input.

--- a/packages/telegraf/extra/start_telegraf.sh
+++ b/packages/telegraf/extra/start_telegraf.sh
@@ -21,7 +21,7 @@ export DCOS_NODE_PRIVATE_IP="${node_private_ip}"
 
 # Retrieve the fault domain for this machine
 fault_domain_script="/opt/mesosphere/bin/detect_fault_domain"
-fault_domain_extractor="$(pwd)/tools/extract_fault_domain.py"
+fault_domain_extractor="/opt/mesosphere/active/telegraf/tools/extract_fault_domain.py"
 
 if [ -x $fault_domain_script ]; then
   # If a fault domain script exists, export environment variables so that

--- a/packages/telegraf/extra/tools/extract_fault_domain.py
+++ b/packages/telegraf/extra/tools/extract_fault_domain.py
@@ -15,7 +15,7 @@ import json
 import sys
 
 
-if (len(sys.argv) != 2) or (sys.argv[1] not in ['region', 'zone']):
+if len(sys.argv) != 2 or sys.argv[1] not in ['region', 'zone']:
     print("usage: {} <region|zone>".format(sys.argv[0]), file=sys.stderr)
     sys.exit(1)
 


### PR DESCRIPTION
## High-level description

The Telegraf startup script intends to run the fault domain detect script and extract the names of the region and zone from its output, in order to set these values in environment variables that can be referenced in Telegraf config. The current implementation is setting these environment variables in a subshell, which is then immediately exited, discarding the environment variables, and causing Telegraf to tag metrics with the names of the env vars it intends to reference.

This commit fixes the startup script by setting these environment variables in the same shell that execs Telegraf. This is accomplished by modifying extract_fault_domain.py to print either the zone or region with each run, and then running it twice to get both the zone and region names and assign them to env vars.

I tested this fix manually by deploying a fault domain aware cluster, running dcos-monitoring on it, and observing fault domain tags on incoming metrics. Our integration tests only test that fault domain tags aren't empty on fault domain aware clusters, since the fault domain values aren't accessible to integration tests.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-50673](https://jira.mesosphere.com/browse/DCOS-50673) fault_domain_* tags should be blank if not set


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This will be backported to 1.12, so no changelog entry is needed.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Tested manually, see description above.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]