### PR TITLE
Bump ZooKeeper to 3.4.14 [1.12]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,8 @@ Format of the entries must be.
 
 ### Notable changes
 
-### Breaking changes
+* Update ZooKeeper to release [3.4.14](https://zookeeper.apache.org/doc/r3.4.14/releasenotes.html). (DCOS_OSS-4988)
+
 
 ### Fixed and improved
 
@@ -41,9 +42,6 @@ Format of the entries must be.
 ## DC/OS 1.12.3
 
 ### Notable changes
-
-### Breaking changes
-
 
 ### Fixed and improved
 
@@ -72,7 +70,6 @@ Format of the entries must be.
 
 * Add thisnode.thisdcos.directory dns zone (DCOS_OSS-4666)
 
-### Breaking changes
 
 ### Fixed and improved
 
@@ -99,7 +96,6 @@ Format of the entries must be.
 
 * Bumped DC/OS UI to [1.12+v2.25.11](https://github.com/dcos/dcos-ui/releases/tag/1.12%2Bv2.25.11)
 
-### Breaking changes
 
 ### Fixed and improved
 

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,8 +9,8 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz",
-      "sha1": "a989b527f3f990d471e6d47ee410e57d8be7620b"
+      "url": "https://www-us.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz",
+      "sha1": "285a0c85112d9f99d42cbbf8fb750c9aa5474716"
     },
     "log4j": {
         "kind": "url",


### PR DESCRIPTION
## High-level description

This bumps DC/OS' ZooKeeper from version 3.4.13 to version 3.4.14.

## Corresponding DC/OS tickets (obligatory)

https://jira.mesosphere.com/browse/DCOS_OSS-4988

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)