### PR TITLE
metronome 0.6.18 bump on dcos 1.11

### DIFF
--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.11-cf8887d/metronome-0.6.11-cf8887d.tgz",
-    "sha1": "ee1db9dae89962a5559d230205eb854efde65201"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.18-b4016b0/metronome-0.6.18-b4016b0.tgz",
+    "sha1": "31e63a5796a0af7840f2f5c882dfbe3fc6dc251b"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4994](https://jira.mesosphere.com/browse/DCOS_OSS-4994) Release Metronome 1.6.18 on Master.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-4636 ](https://jira.mesosphere.com/browse/DCOS_OSS-4636 ) Failure when restart policy is ON_FAILURE. This bug was introduced through the fix of another bug regarding stopping invalid extra instances of a job run. Metronome should not check the launch queue when a restart is invoked.
  - [DCOS_OSS-4636 ](https://jira.mesosphere.com/browse/DCOS_OSS-4978 ) Allow using IS operator when creating jobs. This was broken since introduction of the IS operator, which replaced EQ but was not a valid schema value.
- New Feature:  Added new metric metronome.uptime.gauge.seconds


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/6283014e0a4fa87f4dcbfdc21354223565daa663...b4016b01a349b15df25970877bd62521a49d0cc9)
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/9/consoleFull)
  - [ ] Code Coverage (if available): N/A
