### PR TITLE
[1.13] Add dcos_fluent_bit user to systemd-journal group

### DIFF
--- a/packages/fluent-bit/buildinfo.json
+++ b/packages/fluent-bit/buildinfo.json
@@ -4,5 +4,6 @@
     "url": "https://fluentbit.io/releases/1.0/fluent-bit-1.0.4.tar.gz",
     "sha1": "63c38fb107c1b6e409e89850fabfaeb84bc95d23"
   },
-  "username": "dcos_fluent_bit"
+  "username": "dcos_fluent_bit",
+  "group": "systemd-journal"
 }


### PR DESCRIPTION
## High-level description

Fluent Bit in EE and EE strict modes currently does not have the permissions to read `/var/log/journal` which belongs to the `systemd-journal` group. This adds the Fluent Bit user `dcos_fluent_bit` to the group, which allows it to access the journald logs. I've tested this on a cluster. Without this update, Fluent Bit was not collecting any logs from journald. With the fix, I saw that `dcos_fluent_bit` belonged to the `systemd-journal` group, and saw journald logs coming in.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5004](https://jira.mesosphere.com/browse/DCOS_OSS-5004) Add dcos_fluent_bit user to systemd-journal group



## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: not a user-facing change as fluent bit is not yet configured to output logs anywhere
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: tested on a cluster
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
