### PR TITLE
Pass Accept-Encoding header to service backends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,8 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 ### Fixed and improved
 
+* Backends for requests to `/service/<service-name>` may compress responses (DCOS_OSS-4906)
+
 * Fixed issue where Metronome did not handle restart policy is ON_FAILURE correctly, not restarting the task. (DCOS_OSS-4636 )
 
 * Prefix illegal prometheus metric names with an underscore (DCOS_OSS-4899)

--- a/packages/adminrouter/extra/src/includes/service-location.common.conf
+++ b/packages/adminrouter/extra/src/includes/service-location.common.conf
@@ -1,5 +1,3 @@
-    more_clear_input_headers Accept-Encoding;
-
     include includes/proxy-headers.conf;
     include includes/websockets.conf;
 

--- a/packages/adminrouter/extra/src/test-harness/tests/test_master.py
+++ b/packages/adminrouter/extra/src/test-harness/tests/test_master.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 class TestServiceEndpoint:
     # Majority of /service endpoint tests are done with generic tests framework
-    def test_if_accept_encoding_header_is_removed_from_upstream_request(
+    def test_if_accept_encoding_header_is_in_upstream_request(
             self, master_ar_process_perclass, mocker, valid_user_header):
         headers = copy.deepcopy(valid_user_header)
         headers['Accept-Encoding'] = 'gzip'
@@ -31,7 +31,7 @@ class TestServiceEndpoint:
         generic_upstream_headers_verify_test(master_ar_process_perclass,
                                              headers,
                                              '/service/scheduler-alwaysthere/foo/bar/',
-                                             assert_headers_absent=["Accept-Encoding"],
+                                             assert_headers={'Accept-Encoding': 'gzip'},
                                              )
 
 


### PR DESCRIPTION
## High-level description

This PR causes adminrouter to stop stripping the `Accept-Encoding` header from requests to `/service/<service-name>` before it proxies them to service backends. This allows service backends to compress responses.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4906](https://jira.mesosphere.com/browse/DCOS_OSS-4906) Admin Router service endpoint: forward Accept-Encoding header to upstream


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]