### PR TITLE
Changed order of containerizers on Mesos agents.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1330,7 +1330,10 @@ package:
       GLOG_drop_log_memory=false
       MESOS_CGROUPS_ENABLE_CFS=true
       MESOS_CGROUPS_LIMIT_SWAP=false
-      MESOS_CONTAINERIZERS=docker,mesos
+      # The order of containerizers affects the order of certain operations
+      # on the agent.  See https://github.com/dcos/dcos/pull/4988 before
+      # making any changes to this variable.
+      MESOS_CONTAINERIZERS=mesos,docker
       MESOS_CONTAINER_LOGGER=com_mesosphere_mesos_JournaldLogger
       MESOS_DEFAULT_CONTAINER_DNS=file:///opt/mesosphere/etc/mesos-slave-dns.json
       MESOS_DISALLOW_SHARING_AGENT_PID_NAMESPACE=true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This is a subtle change that changes the processing order for
operations associated with launching, monitoring, or stopping
containers.  Effectively, the Mesos agent will try the Mesos
containerizer before the Docker containerizer.

This change improves performance of launching Mesos containers when
there are a large number of Docker containers running on the same
agent.  The Docker containerizer tends to spend most of its time
waiting on the Docker daemon to respond, sometimes blocking further
progress if there are too many containers.  Sometimes, this waiting
will cause Mesos containers to take excessively long times to launch,
as we get blocked while executing the launch command on each
containerizer, *in order*.  If the Mesos containerizer comes first,
then we skip the wait entirely.

This is unlikely to cause the opposite scenario (too many Mesos
containers blocking a Docker container from launching) because the
Mesos containerizer does not have long blocking sections.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-42757](https://jira.mesosphere.com/browse/DCOS-42757) Switch composing containerizer order in agent flag.


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-3794](https://jira.mesosphere.com/browse/COPS-3794) Tasks stuck in STAGING.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This should be transparent to the user, as we are flipping the order of some operations.  Functionality does not change.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There is no test because this is a performance improvement for an uncommon case (launching ~50 docker containers, then a single UCR container on the same agent).  We can independently check how much time is saved though.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): N/A
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]