### PR TITLE
[1.12] Fix lua variable scope bug in service.lua

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Format of the entries must be.
 
 ### Notable changes
 
-* Fix a bug in service.lua which was causing some wrong metrics labels for Admin Router and affecting request buffering by Admin Router. (DCOS_OSS-4950, DCOS_OSS-4999)
+* Fix a bug in Admin Router's service endpoint as of which the DCOS_SERVICE_REQUEST_BUFFERING setting was not adhered to in all cases. (DCOS_OSS-4999)
 
 * Update ZooKeeper to release [3.4.14](https://zookeeper.apache.org/doc/r3.4.14/releasenotes.html). (DCOS_OSS-4988)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,12 +17,12 @@ Format of the entries must be.
 
 ### Notable changes
 
-* Fix a bug in Admin Router's service endpoint as of which the DCOS_SERVICE_REQUEST_BUFFERING setting was not adhered to in all cases. (DCOS_OSS-4999)
-
 * Update ZooKeeper to release [3.4.14](https://zookeeper.apache.org/doc/r3.4.14/releasenotes.html). (DCOS_OSS-4988)
 
 
 ### Fixed and improved
+
+* Fix a bug in Admin Router's service endpoint as of which the DCOS_SERVICE_REQUEST_BUFFERING setting was not adhered to in all cases. (DCOS_OSS-4999)
 
 * Telegraf is tuned for workloads that emit a large number of metrics (DCOS-50994)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Format of the entries must be.
 
 ### Notable changes
 
+* Fix a bug in service.lua which was causing some wrong metrics labels for Admin Router and affecting request buffering by Admin Router. (DCOS_OSS-4950, DCOS_OSS-4999)
+
 * Update ZooKeeper to release [3.4.14](https://zookeeper.apache.org/doc/r3.4.14/releasenotes.html). (DCOS_OSS-4988)
 
 

--- a/packages/adminrouter/extra/src/lib/service.lua
+++ b/packages/adminrouter/extra/src/lib/service.lua
@@ -312,6 +312,7 @@ local function recursive_resolve(auth, path, marathon_cache, mesos_cache)
     local do_request_buffering = true
     local err_code = nil
     local err_text = nil
+    local service_name = ""
 
     -- Resolve all the services!
     for i = 1, RESOLVE_LIMIT do


### PR DESCRIPTION
## High-level description

This PR fixes a bug in service.lua library. See corresponding JIRA ticket for details. This is a backport of a change implemented as part of DCOS_OSS-4950.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS_OSS-4999

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
No test is included since the behaviour of AR resulting from the bug is non-deterministic.

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
