### PR TITLE
[1.10] Fix lua variable scope bug in service.lua

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,15 @@ Format of the entries must be.
 * Entry two with no-newlines. (DCOS_OSS_JIRA_2)
 ```
 
+## DC/OS 1.10.12 (in development)
+
+### Notable changes
+
+### Fixed and improved
+
+* Fix a bug in service.lua which was causing some wrong metrics labels for Admin Router and affecting request buffering by Admin Router (DCOS_OSS-4950, DCOS_OSS-4999)
+
+
 ### Notable changes
 
 ### Fixed and improved

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Format of the entries must be.
 
 ### Fixed and improved
 
-* Fix a bug in service.lua which was causing some wrong metrics labels for Admin Router and affecting request buffering by Admin Router (DCOS_OSS-4950, DCOS_OSS-4999)
+* Fix a bug in Admin Router's service endpoint as of which the DCOS_SERVICE_REQUEST_BUFFERING setting was not adhered to in all cases. (DCOS_OSS-4999)
 
 
 ### Notable changes

--- a/packages/adminrouter/extra/src/lib/service.lua
+++ b/packages/adminrouter/extra/src/lib/service.lua
@@ -237,6 +237,7 @@ local function recursive_resolve(auth, path)
     local service_realpath = ""
     local err_code = nil
     local err_text = nil
+    local service_name = ""
 
     -- Acquire cache data:
     -- On one hand we want to fetch cache only once no matter the number of


### PR DESCRIPTION
## High-level description

This PR fixes a bug in service.lua library. See corresponding JIRA ticket for details. This is a backport of a change implemented as part of DCOS_OSS-4950.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
https://jira.mesosphere.com/browse/DCOS_OSS-4999

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
No test is included since the behaviour of AR resulting from the bug is non-deterministic.

  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)