### PR TITLE
Add integration test for checking nginx_service_* Telegraf metrics

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -264,7 +264,8 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     node = dcos_api_session.masters[0]
     # Make request to a fine-grained metrics annotated upstream of
     # Admin Router (IAM in this case).
-    dcos_api_session.get('/acs/api/v1/auth/jwks', host=node)
+    dcos_api_session.get('/acs/api/v1/auth/jwks')
+    node = dcos_api_session.masters[0]
 
     @retrying.retry(
         wait_fixed=STD_INTERVAL,

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -267,6 +267,8 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     r = dcos_api_session.get('/acs/api/v1/auth/jwks')
     assert r.status_code == 200
 
+    # Accessing /service/marathon/v2/queue via Admin Router will cause
+    # Telegraf to emit nginx_service_backend and nginx_service_status metrics.
     r = dcos_api_session.get('/service/marathon/v2/queue')
     assert r.status_code == 200
 

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -264,8 +264,11 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     node = dcos_api_session.masters[0]
     # Make request to a fine-grained metrics annotated upstream of
     # Admin Router (IAM in this case).
-    dcos_api_session.get('/acs/api/v1/auth/jwks')
-    node = dcos_api_session.masters[0]
+    r = dcos_api_session.get('/acs/api/v1/auth/jwks')
+    assert r.status_code == 200
+
+    r = dcos_api_session.get('/service/marathon/v2/queue')
+    assert r.status_code == 200
 
     @retrying.retry(
         wait_fixed=STD_INTERVAL,
@@ -297,6 +300,8 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
             'nginx_server_status',
             'nginx_upstream_status',
             'nginx_upstream_backend',
+            'nginx_service_backend',
+            'nginx_service_status',
         ])
 
         difference = expected - measurements


### PR DESCRIPTION
## High-level description

This PR adds an integration test checking that nginx_service_* metrics are reported through Telegraf.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS_OSS-5014

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: 
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)