### PR TITLE
[master] Bump Marathon to 1.8.161-804653491

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -1,9 +1,11 @@
 {
-  "requires": ["java"],
+  "requires": [
+    "java"
+  ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.172-bb9e87da2/marathon-1.8.172-bb9e87da2.tgz",
-    "sha1": "8311de741179d2aec2a695f27fde8781661f5741"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.161-804653491/marathon-1.8.161-804653491.tgz",
+    "sha1": "fd72463c343feb0715881c7f6103ba267ecbef3e"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION

## High-level description

This is automatic bump to the latest Marathon.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
