### PR TITLE
DCOS_OSS-4316 REX-Ray: bump to v0.11.4 [1.12 Backport] and unmute test_rexray.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@ Format of the entries must be.
 
 * Telegraf cancels timed out requests for internal Mesos metrics, instead of collecting partial metric data (DCOS-50672)
 
+* Updated REX-Ray version to 0.11.4 (DCOS_OSS-4316) (COPS-3961) [rexray v0.11.4](https://github.com/rexray/rexray/releases/tag/v0.11.4)
+
 ### Security updates
 
 * Update to OpenSSL 1.0.2r. (DCOS_OSS-4868)

--- a/packages/rexray/buildinfo.json
+++ b/packages/rexray/buildinfo.json
@@ -2,7 +2,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/rexray/rexray.git",
-    "ref": "fc8bfbd2d02c2690fc3a755a9560dd12c88e0852",
-    "ref_origin": "v0.11.2"
+    "ref": "e7414eaa971b27977d2283f2882825393493179d",
+    "ref_origin": "v0.11.4"
   }
 }


### PR DESCRIPTION
*Backport of https://github.com/dcos/dcos/pull/4552 to 1.12*

Version bump to the latest release of REX-Ray, which includes support for
AWS NVMe storage. Users will still be required to provide `udev` scripts
and provide the `nvme-cli` package on the host. Details can be found in
the original REX-Ray [pull request](https://github.com/rexray/rexray/pull/1252)

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>
(cherry picked from commit b07fc98a0269f26ac8a027ea6c5c91eae4748cd5)

## High-level description

What features does this change enable? What bugs does this change fix?

Version bump to the latest release of REX-Ray, which includes support for
AWS NVMe storage. Users will still be required to provide udev scripts
and provide the nvme-cli package on the host. Details can be found in
the original REX-Ray [pull request](https://github.com/rexray/rexray/pull/1252)

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4316](https://jira.mesosphere.com/browse/DCOS_OSS-4316) Support NVMe EBS volumes

## Related tickets (optional)

Other tickets related to this change:

  - [COPS-3961](https://jira.mesosphere.com/browse/COPS-3961) Support NVMe EBS volumes

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There is an existing `test_rexray.py` test.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [rexray](https://github.com/rexray/rexray/compare/v0.11.2...v0.11.4)
  - [ ] Test Results: [rexray CI](https://travis-ci.org/rexray/rexray/builds/479962434)
  - [ ] Code Coverage (if available): [link to code coverage report]
___