### PR TITLE
dcos-integration-test: skip rexray test in strict mode, unmute it

### DIFF
--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -10,11 +10,6 @@ __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS_OSS-4922',
-    reason='test_move_external_volume_to_new_agent application deployment fails',
-    since='2019-03-15'
-)
 @pytest.mark.supportedwindows
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
@@ -26,6 +21,9 @@ def test_move_external_volume_to_new_agent(dcos_api_session):
     expanded_config = get_expanded_config()
     if not (expanded_config['provider'] == 'aws' or expanded_config['platform'] == 'aws'):
         pytest.skip('Must be run in an AWS environment!')
+
+    if expanded_config.get('security') == 'strict':
+        pytest.skip('See: https://jira.mesosphere.com/browse/DCOS_OSS-4922')
 
     hosts = dcos_api_session.slaves[0], dcos_api_session.slaves[-1]
     test_uuid = uuid.uuid4().hex


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR unmutes the test in `test_rexray.py` but skips it in strict mode.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4922](https://jira.mesosphere.com/browse/DCOS_OSS-4922) test_rexray.test_move_external_volume_to_new_agent fails on master


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___