### PR TITLE
Log checks API result before status assertion

### DIFF
--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -91,6 +91,9 @@ def test_checks_api(dcos_api_session):
             # check that the returned statuses of each check is 0
             expected_status = {c: 0 for c in checks.keys()}
             response_status = {c: v['status'] for c, v in results['checks'].items()}
+
+            # print out the response for debugging
+            logging.info('Response: {}'.format(results))
             assert expected_status == response_status
 
             # check that overall status is also 0

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -88,10 +88,13 @@ def test_checks_api(dcos_api_session):
             results = r.json()
             assert isinstance(results, dict)
 
-            # check that the returned statuses of each check is 0
-            expected_status = {c: 0 for c in checks.keys()}
-            response_status = {c: v['status'] for c, v in results['checks'].items()}
-            assert expected_status == response_status
+            # check that the returned statuses of each check is 0.
+            # This also duplicates the output from the check so that if the
+            # assert fails, the reason a check failed will be printed but we
+            # have no expectations for what the output should look like so we
+            # duplicate it to prevent failures from that
+            expected_status = {c: {'status': 0, 'output': v['output']} for c, v in results['checks'].items()}
+            assert expected_status == results['checks']
 
             # check that overall status is also 0
             assert results['status'] == 0

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -88,13 +88,10 @@ def test_checks_api(dcos_api_session):
             results = r.json()
             assert isinstance(results, dict)
 
-            # check that the returned statuses of each check is 0.
-            # This also duplicates the output from the check so that if the
-            # assert fails, the reason a check failed will be printed but we
-            # have no expectations for what the output should look like so we
-            # duplicate it to prevent failures from that
-            expected_status = {c: {'status': 0, 'output': v['output']} for c, v in results['checks'].items()}
-            assert expected_status == results['checks']
+            # check that the returned statuses of each check is 0
+            expected_status = {c: 0 for c in checks.keys()}
+            response_status = {c: v['status'] for c, v in results['checks'].items()}
+            assert expected_status == response_status
 
             # check that overall status is also 0
             assert results['status'] == 0


### PR DESCRIPTION
## High-level description

This changes the checks API test to log the result before it attempts to assert on the statuses of the checks. If there are any issues, this makes it possible to look at the logs and see the output of any failed checks.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-51593](https://jira.mesosphere.com/browse/DCOS-51593)


## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
