### PR TITLE
Enable fluent bit metrics

### DIFF
--- a/docs/admin-ports.md
+++ b/docs/admin-ports.md
@@ -8,6 +8,7 @@ The following is a list of ports used by internal DC/OS services, and their corr
 
  - 53: dcos-net (dns)
  - 61091: telegraf
+ - 62020: fluent-bit
  - 62080: dcos-net (rest)
  - 62501: dcos-net (disterl)
 

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -558,6 +558,7 @@ function check_all() {
             "46839 metronome" \
             "61053 mesos-dns" \
             "61091 telegraf" \
+            "62020 fluent-bit" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do
@@ -570,6 +571,7 @@ function check_all() {
             "5051 mesos-agent" \
             "61001 agent-adminrouter" \
             "61091 telegraf" \
+            "62020 fluent-bit" \
             "62080 dcos-net" \
             "62501 dcos-net"
         do

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2809,9 +2809,9 @@ package:
           # HTTP Server
           # ===========
           # Enable/Disable the built-in HTTP Server for metrics
-          HTTP_Server  Off
-          #HTTP_Listen  0.0.0.0
-          #HTTP_Port    62020
+          HTTP_Server  On
+          HTTP_Listen  127.0.0.1
+          HTTP_Port    62020
       [INPUT]
           Name systemd
           Tag host.*

--- a/packages/fluent-bit/build
+++ b/packages/fluent-bit/build
@@ -7,7 +7,12 @@ set -o nounset
 # Build and install Fluent Bit.
 # https://docs.fluentbit.io/manual/installation/build_install
 pushd "/pkg/src/$PKG_NAME/build"
-cmake -DCMAKE_INSTALL_PREFIX="$PKG_PATH" ../
+# FLB_TLS:         enable TLS support
+# FLB_METRICS:     fluent bit's metrics
+# FLB_HTTP_SERVER: API for metrics collection
+# FLB_SQLDB:       use an SQLite DB to track log cursors
+# FLB_PROXY_GO:    enable proxy plugins support
+cmake -DCMAKE_INSTALL_PREFIX="$PKG_PATH" -DFLB_TLS="On" -DFLB_METRICS="On" -DFLB_HTTP_SERVER="On" -DFLB_SQLDB="On" -DFLB_PROXY_GO="On" ../
 make
 make install
 popd


### PR DESCRIPTION
## High-level description

This PR builds fluent-bit with three extra flags to enable the metrics server, so that we can configure it to be monitored. It enables the fluent bit metrics server in the common configuration file.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-51855](https://jira.mesosphere.com/browse/DCOS-51855) Build fluent bit with metrics support


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: this change is added to the 1.13 changelog already
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: This is a configuration change, no dc/os code is involved
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)