### PR TITLE
Send pre-compressed UI assets if possible.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,3 +24,5 @@ Format of the entries must be.
 #### Fixed and improved
 
 * `docker-gc` now removes unused volumes (DCOS_OSS-1502)
+
+* Use gzip compression for some UI assets (DCOS-5978)

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -23,6 +23,25 @@ location / {
     include /opt/mesosphere/etc/adminrouter-ui-security.conf;
 }
 
+location /assets {
+    # Some UI assets are pre-compressed. Serve these compressed if the client
+    # accepts gzip encoding.
+    gzip_static on;
+    # Add a "Vary: Accept-Encoding" header to the response to ensure that
+    # a cached gzip file does not get returned to a client that does not
+    # set "Accept-Encoding: gzip".
+    gzip_vary on;
+    # Send compressed file even for proxied connections. The use of a
+    # "Vary: Accept-Encoding" header should prevent clients mixing compressed
+    # and uncompressed files. This may cause multiple copies of the compressed
+    # file to be cached, if some clients use "Accept-Encoding: gzip, deflate"
+    # and others use "Accept-Encoding: deflate, gzip" for example.
+    gzip_proxied any;
+    # IE6 shouldn't be very common, and later versions support gzip, but let's
+    # be conservative.
+    gzip_disable "msie6";
+}
+
 # Group: System
 # Description: System proxy to the master node with the Mesos leader
 location ~ ^/system/v1/leader/mesos(?<url>.*)$ {

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -24,6 +24,9 @@ location / {
 }
 
 location /assets {
+    # The UI asset filenames are hashed by content. Hence, they can be cached
+    # by the client indefinitely. Currently, we use a more conservative value.
+    expires 10h;
     # Some UI assets are pre-compressed. Serve these compressed if the client
     # accepts gzip encoding.
     gzip_static on;

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -66,6 +66,7 @@ class TestEncodingGzip:
             r.raise_for_status()
             log.info('Response headers: %s', repr(r.headers))
             assert r.headers.get('content-encoding') == 'gzip'
+            assert 'max-age=36000' in r.headers['cache-control']
 
     def test_not_accept_gzip(self, dcos_api_session):
         """
@@ -84,3 +85,4 @@ class TestEncodingGzip:
             r.raise_for_status()
             log.info('Response headers: %s', repr(r.headers))
             assert 'content-encoding' not in r.headers
+            assert 'max-age=36000' in r.headers['cache-control']

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -61,10 +61,10 @@ class TestEncodingGzip:
         filenames = self.pat.findall(r.text)
         assert len(filenames) > 0
         for filename in set(filenames):
-            log.info('Load %s', filename)
-            log.info('%s', repr(r.headers))
-            r = dcos_api_session.get(filename, headers={'Accept-Encoding': 'gzip'})
+            log.info('Load %r', filename)
+            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'gzip'})
             r.raise_for_status()
+            log.info('Response headers: %s', repr(r.headers))
             assert r.headers.get('content-encoding') == 'gzip'
 
     def test_not_accept_gzip(self, dcos_api_session):
@@ -77,10 +77,10 @@ class TestEncodingGzip:
         filenames = self.pat.findall(r.text)
         assert len(filenames) > 0
         for filename in set(filenames):
-            log.info('Load %s', filename)
-            log.info('%s', repr(r.headers))
+            log.info('Load %r', filename)
             # Set a benign `Accept-Encoding` header to prevent underlying
             # libraries setting their own header based on their capabilities.
-            r = dcos_api_session.get(filename, headers={'Accept-Encoding': 'identity'})
+            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'identity'})
             r.raise_for_status()
+            log.info('Response headers: %s', repr(r.headers))
             assert 'content-encoding' not in r.headers


### PR DESCRIPTION
## High-level description

Serve pre-compressed UI assets to clients that provide an `Accept-Encoding` header containing `gzip`.

This also sets a cache header for 10 hours, to helps speed up UI interaction.

Note, this is an alternative solution to #5063 

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-5978](https://jira.mesosphere.com/browse/DCOS-5978) Admin Router: enable gzip compression for relevant MIME types


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
