### PR TITLE
[1.13] Fix prometheus task metrics in bridged and virtual IP mode

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -870,8 +870,8 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
             'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
             'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
 
-            'echo "Serving prometheus metrics on http://localhost:$PORT0"',
-            'python3 -m http.server $PORT0',
+            'echo "Serving prometheus metrics on http://localhost:8000"',
+            'python3 -m http.server 8000',
         ]),
         'networks': {
             'mode': 'container/bridge',
@@ -881,7 +881,7 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
             'docker': {'image': 'library/python:3'}
             'portMappings': [
                 {
-                    'containerPort': 0,
+                    'containerPort': 8000,
                     'hostPort': 0,
                     'protocol': 'tcp',
                     'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -873,9 +873,7 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
             'echo "Serving prometheus metrics on http://localhost:8000"',
             'python3 -m http.server 8000',
         ]),
-        'networks': {
-            'mode': 'container/bridge',
-        },
+        'networks': [{'mode': 'container/bridge'}],
         'container': {
             'type': 'MESOS',
             'docker': {'image': 'library/python:3'},

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -792,10 +792,10 @@ def test_statsd_metrics_containers_app(dcos_api_session):
             assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
 
 
-def test_prom_metrics_containers_app(dcos_api_session):
+def test_prom_metrics_containers_app_host(dcos_api_session):
     """Assert that prometheus app metrics appear in the v0 metrics API."""
-    task_name = 'test-prom-metrics-containers-app'
-    metric_name_pfx = 'test_prom_metrics_containers_app'
+    task_name = 'test-prom-metrics-containers-app-host'
+    metric_name_pfx = 'test_prom_metrics_containers_app_host'
     marathon_app = {
         'id': '/' + task_name,
         'instances': 1,
@@ -828,6 +828,66 @@ def test_prom_metrics_containers_app(dcos_api_session):
             'port': 0,
             'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
         }],
+    }
+
+    logging.debug('Starting marathon app with config: %s', marathon_app)
+    expected_metrics = [
+        # metric_name, metric_value
+        ('_'.join([metric_name_pfx, 'gauge.gauge']), 100),
+        ('_'.join([metric_name_pfx, 'count.counter']), 2),
+        ('_'.join([metric_name_pfx, 'histogram_seconds', 'count']), 4),
+    ]
+
+    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
+        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+        node = endpoints[0].host
+        for metric_name, metric_value in expected_metrics:
+            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+
+
+def test_prom_metrics_containers_app_bridge(dcos_api_session):
+    """Assert that prometheus app metrics appear in the v0 metrics API."""
+    task_name = 'test-prom-metrics-containers-app-bridge'
+    metric_name_pfx = 'test_prom_metrics_containers_app_bridge'
+    marathon_app = {
+        'id': '/' + task_name,
+        'instances': 1,
+        'cpus': 0.1,
+        'mem': 128,
+        'cmd': '\n'.join([
+            'echo "Creating metrics file..."',
+            'touch metrics',
+
+            'echo "# TYPE {}_gauge gauge" >> metrics'.format(metric_name_pfx),
+            'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
+
+            'echo "# TYPE {}_count counter" >> metrics'.format(metric_name_pfx),
+            'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
+
+            'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
+            'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
+
+            'echo "Serving prometheus metrics on http://localhost:$PORT0"',
+            'python3 -m http.server $PORT0',
+        ]),
+        'networks': {
+            'mode': 'container/bridge',
+        },
+        'container': {
+            'type': 'MESOS',
+            'docker': {'image': 'library/python:3'}
+            'portMappings': [
+                {
+                    'containerPort': 0,
+                    'hostPort': 0,
+                    'protocol': 'tcp',
+                    'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
+                }
+            ]
+        },
     }
 
     logging.debug('Starting marathon app with config: %s', marathon_app)

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -878,7 +878,7 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
         },
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'library/python:3'}
+            'docker': {'image': 'library/python:3'},
             'portMappings': [
                 {
                     'containerPort': 8000,

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "50e7f0fb1e2a6bfe270db2d3e83a53c7d11daa3f",
+    "ref": "67c0ee1b643668405979b3b2eff9e8959c5c7916",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

Backports #5141


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5022](https://jira.mesosphere.com/browse/DCOS_OSS-5022) Prometheus task metrics don't work in bridge or virtual IP mode


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: there is already a changelog entry
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/telegraf/compare/50e7f0fb1e2a6bfe270db2d3e83a53c7d11daa3f...67c0ee1b643668405979b3b2eff9e8959c5c7916)
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/227/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/227/)
