### PR TITLE
Specifying ec2:InstanceType instead of InstanceType.

### DIFF
--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -317,7 +317,7 @@
         "SourceDestCheck" : "false",
         "KeyName" : { "Ref" : "KeyName" },
         "ImageId" : { "Fn::FindInMap" : [ "NATAmi", { "Ref" : "AWS::Region" }, "default" ] },
-        "InstanceType" : "m5.large",
+        "ec2:InstanceType" : "m5.large",
         "NetworkInterfaces" : [
           {
             "SubnetId" : { "Ref" : "PublicSubnet" },


### PR DESCRIPTION
## High-level description

* DCOS-51332 - Specifying ec2:InstanceType instead of InstanceType. 