### PR TITLE
test-e2e/cluster_helpers: save cluster log files with log extension

### DIFF
--- a/test-e2e/cluster_helpers.py
+++ b/test-e2e/cluster_helpers.py
@@ -83,7 +83,7 @@ def _dump_node_journals(node: Node, node_dir: Path) -> None:
     LOGGER.info('Dumping journals from {node}'.format(node=node))
     node_dir.mkdir(parents=True)
     try:
-        _dump_stdout_to_file(node, ['journalctl'], node_dir / 'journal')
+        _dump_stdout_to_file(node, ['journalctl'], node_dir / _log_filename('journal'))
     except CalledProcessError as exc:
         # Continue dumping further journals even if an error occurs.
         LOGGER.warn('Unable to dump journalctl: {exc}'.format(exc=str(exc)))
@@ -95,7 +95,7 @@ def _dump_node_journals(node: Node, node_dir: Path) -> None:
                 _dump_stdout_to_file(
                     node=node,
                     cmd=['journalctl', '-u', unit],
-                    file_path=node_dir / name,
+                    file_path=node_dir / _log_filename(name),
                 )
             except CalledProcessError as exc:
                 # Continue dumping further journals even if an error occurs.
@@ -153,3 +153,10 @@ def _dcos_systemd_units(node: Node) -> List[str]:
     )
     systemd_units_string = result.stdout.strip().decode()
     return str(systemd_units_string).split(' ')
+
+
+def _log_filename(name: str) -> Path:
+    """
+    Returns a name of the file with `.log` extension.
+    """
+    return Path(name).with_suffix('.log')


### PR DESCRIPTION
## High-level description

Adds `.log` extension to the log files produced by `wait_for_dcos_oss` test helper.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43359](https://jira.mesosphere.com/browse/DCOS-43359) DC/OS Enterprise test-e2e tests: Use `.log` extensions on logs


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: internal change that isn't being shipped in the end product
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: the test helper itself is being changed
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)