### PR TITLE
[1.13.0] Added mesos patch that reverts ContainerInfo protobuf validation.

### DIFF
--- a/packages/mesos/extra/patches/0006-Revert-Validated-the-match-between-Type-and-Infos-in.patch
+++ b/packages/mesos/extra/patches/0006-Revert-Validated-the-match-between-Type-and-Infos-in.patch
@@ -1,0 +1,353 @@
+From d89dc5cebed8497248db1526ee18462a42a530e6 Mon Sep 17 00:00:00 2001
+From: Benno Evers <bevers@mesosphere.com>
+Date: Wed, 24 Apr 2019 09:36:46 +0200
+Subject: [PATCH] Revert "Validated the match between Type and *Infos in the
+ ContainerInfo."
+
+This reverts commit 93aca1eb0efcec941e19e976f683a35ecd9a840b.
+---
+ include/mesos/mesos.proto             |  6 +--
+ src/common/protobuf_utils.cpp         | 56 -----------------------
+ src/common/protobuf_utils.hpp         | 45 ------------------
+ src/common/validation.cpp             |  7 ---
+ src/master/validation.cpp             |  7 ---
+ src/tests/health_check_tests.cpp      | 22 ++-------
+ src/tests/master_validation_tests.cpp | 66 ---------------------------
+ 7 files changed, 5 insertions(+), 204 deletions(-)
+
+diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
+index dc6a87f14..3ec43ed5c 100644
+--- a/include/mesos/mesos.proto
++++ b/include/mesos/mesos.proto
+@@ -3333,8 +3333,6 @@ message TTYInfo {
+  */
+ message ContainerInfo {
+   // All container implementation types.
+-  // For each type there should be a field in the ContainerInfo itself
+-  // with exactly matching name in lowercase.
+   enum Type {
+     DOCKER = 1;
+     MESOS = 2;
+@@ -3388,8 +3386,8 @@ message ContainerInfo {
+   repeated Volume volumes = 2;
+   optional string hostname = 4;
+ 
+-  // At most one of the following *Info messages should be set to match
+-  // the type, i.e. the "protobuf union" in ContainerInfo should be valid.
++  // Only one of the following *Info messages should be set to match
++  // the type.
+   optional DockerInfo docker = 3;
+   optional MesosInfo mesos = 5;
+ 
+diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
+index 8b252cb11..a10d36ef4 100644
+--- a/src/common/protobuf_utils.cpp
++++ b/src/common/protobuf_utils.cpp
+@@ -77,62 +77,6 @@ namespace mesos {
+ namespace internal {
+ namespace protobuf {
+ 
+-// If `descriptor` is not a descriptor of a protobuf union,
+-// this constructor will abort the process.
+-UnionValidator::UnionValidator(const google::protobuf::Descriptor* descriptor)
+-{
+-  const auto* typeFieldDescriptor = descriptor->FindFieldByName("type");
+-  CHECK_NOTNULL(typeFieldDescriptor);
+-
+-  typeDescriptor_ = typeFieldDescriptor->enum_type();
+-  CHECK_NOTNULL(typeDescriptor_);
+-
+-  const auto* unknownTypeValueDescriptor =
+-    typeDescriptor_->FindValueByNumber(0);
+-  if (unknownTypeValueDescriptor != nullptr) {
+-    CHECK_EQ(unknownTypeValueDescriptor->name(), "UNKNOWN");
+-  }
+-
+-  for (int index = 0; index < typeDescriptor_->value_count(); index++) {
+-    const auto* typeValueDescriptor = typeDescriptor_->value(index);
+-    if (typeValueDescriptor->number() == 0) {
+-      // We are skipping the "UNKNOWN" value of the enum.
+-      continue;
+-    }
+-
+-    const auto* fieldDescriptor =
+-      descriptor->FindFieldByName(strings::lower(typeValueDescriptor->name()));
+-
+-    CHECK_NOTNULL(fieldDescriptor);
+-    unionFieldDescriptors_.emplace_back(
+-        typeValueDescriptor->number(), fieldDescriptor);
+-  }
+-}
+-
+-
+-Option<Error> UnionValidator::validate(
+-  const int messageTypeNumber, const google::protobuf::Message& message) const
+-{
+-  const auto* reflection = message.GetReflection();
+-  for (const auto& item : unionFieldDescriptors_) {
+-    const auto typeNumber = item.first;
+-    const auto* fieldDescriptor = item.second;
+-    if (
+-        messageTypeNumber != typeNumber &&
+-        reflection->HasField(message, fieldDescriptor)) {
+-      const auto* descr = typeDescriptor_->FindValueByNumber(messageTypeNumber);
+-      return Error(
+-          "Protobuf union `" + message.GetDescriptor()->full_name() +
+-          "` with `Type == " +
+-          (descr == nullptr ? string("<UNKNOWN>") : descr->name()) +
+-          "` should not have the field `" +
+-          fieldDescriptor->name() + "` set.");
+-    }
+-  }
+-  return None();
+-}
+-
+-
+ bool frameworkHasCapability(
+     const FrameworkInfo& framework,
+     FrameworkInfo::Capability::Type capability)
+diff --git a/src/common/protobuf_utils.hpp b/src/common/protobuf_utils.hpp
+index 273ae2706..1d3dd0b02 100644
+--- a/src/common/protobuf_utils.hpp
++++ b/src/common/protobuf_utils.hpp
+@@ -64,51 +64,6 @@ struct Slave;
+ 
+ namespace protobuf {
+ 
+-// Internal helper class for protobuf union validation.
+-class UnionValidator
+-{
+-public:
+-  UnionValidator(const google::protobuf::Descriptor*);
+-  Option<Error> validate(
+-      const int messageTypeNumber, const google::protobuf::Message&) const;
+-
+-private:
+-  std::vector<std::pair<int, const google::protobuf::FieldDescriptor*>>
+-    unionFieldDescriptors_;
+-  const google::protobuf::EnumDescriptor* typeDescriptor_;
+-};
+-
+-//
+-// A message is a "protobuf union" if, and only if,
+-// the following requirements are satisfied:
+-// 1. It has a required field named `type` of an enum type.
+-// 2. A member of this enum with a number (not index!) of 0
+-//    either is named "UNKNOWN" or does not exist.
+-// 3. For each other member of this enum there is an optional field
+-//    in the message with an exactly matching name in lowercase.
+-// (Being or not being a protobuf uinion depends on a message declaration only.)
+-//
+-// A "protobuf union" is valid if, and only if, all the message fields
+-// which correspond to members of this enum that do not matching the value
+-// of the `type` field, are not set.
+-// (Validity of the protobuf union depends on the message contents.
+-// Note that it does not depend on whether the matching field is set or not.)
+-//
+-// NOTE: If possible, oneof should be used in the new messages instead
+-// of the "protobuf union".
+-//
+-// This function returns None if the protobuf union is valid
+-// and Error otherwise.
+-// In case the ProtobufUnion is not a protobuf union,
+-// this function will abort the process on the first use.
+-template <class ProtobufUnion>
+-Option<Error> validateProtobufUnion(const ProtobufUnion& message)
+-{
+-  static const UnionValidator validator(ProtobufUnion::descriptor());
+-  return validator.validate(message.type(), message);
+-}
+-
+-
+ bool frameworkHasCapability(
+     const FrameworkInfo& framework,
+     FrameworkInfo::Capability::Type capability);
+diff --git a/src/common/validation.cpp b/src/common/validation.cpp
+index 458f2258c..b42053eaa 100644
+--- a/src/common/validation.cpp
++++ b/src/common/validation.cpp
+@@ -32,8 +32,6 @@
+ 
+ #include <stout/os/constants.hpp>
+ 
+-#include "common/protobuf_utils.hpp"
+-
+ using std::string;
+ 
+ using google::protobuf::RepeatedPtrField;
+@@ -266,11 +264,6 @@ Option<Error> validateVolume(const Volume& volume)
+ 
+ Option<Error> validateContainerInfo(const ContainerInfo& containerInfo)
+ {
+-  Option<Error> unionError = protobuf::validateProtobufUnion(containerInfo);
+-  if (unionError.isSome()) {
+-    return unionError;
+-  }
+-
+   foreach (const Volume& volume, containerInfo.volumes()) {
+     Option<Error> error = validateVolume(volume);
+     if (error.isSome()) {
+diff --git a/src/master/validation.cpp b/src/master/validation.cpp
+index d7f210fc1..3f82b1beb 100644
+--- a/src/master/validation.cpp
++++ b/src/master/validation.cpp
+@@ -997,13 +997,6 @@ Option<Error> validateExecutorID(const ExecutorInfo& executor)
+ 
+ Option<Error> validateType(const ExecutorInfo& executor)
+ {
+-  if (executor.has_container()) {
+-    Option<Error> unionError =
+-      protobuf::validateProtobufUnion(executor.container());
+-    if (unionError.isSome()) {
+-      return unionError;
+-    }
+-  }
+   switch (executor.type()) {
+     case ExecutorInfo::DEFAULT:
+       if (executor.has_command()) {
+diff --git a/src/tests/health_check_tests.cpp b/src/tests/health_check_tests.cpp
+index 062357ee6..40ba33e1f 100644
+--- a/src/tests/health_check_tests.cpp
++++ b/src/tests/health_check_tests.cpp
+@@ -1819,11 +1819,11 @@ TEST_F_TEMP_DISABLED_ON_WINDOWS(
+   }
+ }
+ 
+-#ifdef __linux__
++
+ // Tests a healthy docker task via CMD health checks using the
+ // DefaultExecutor.
+ TEST_F_TEMP_DISABLED_ON_WINDOWS(
+-    HealthCheckTest, ROOT_DefaultExecutorWithDockerImageCommandHealthCheck)
++    HealthCheckTest, DefaultExecutorWithDockerImageCommandHealthCheck)
+ {
+   Try<Owned<cluster::Master>> master = StartMaster();
+   ASSERT_SOME(master);
+@@ -1839,17 +1839,6 @@ TEST_F_TEMP_DISABLED_ON_WINDOWS(
+   flags.acls = acls;
+ #endif // USE_SSL_SOCKET
+ 
+-  const string directory = path::join(os::getcwd(), "archives");
+-
+-  Future<Nothing> testImage = DockerArchive::create(directory, "alpine");
+-  AWAIT_READY(testImage);
+-  ASSERT_TRUE(os::exists(path::join(directory, "alpine.tar")));
+-
+-  flags.isolation = "docker/runtime,filesystem/linux";
+-  flags.image_providers = "docker";
+-  flags.docker_registry = directory;
+-  flags.docker_store_dir = path::join(os::getcwd(), "store");
+-
+   Fetcher fetcher(flags);
+ 
+   // We have to explicitly create a `Containerizer` in non-local mode,
+@@ -1900,13 +1889,9 @@ TEST_F_TEMP_DISABLED_ON_WINDOWS(
+   TaskInfo task = createTask(offers->front(), "sleep 120");
+ 
+   // TODO(tnachen): Use local image to test if possible.
+-  Image image;
+-  image.set_type(Image::DOCKER);
+-  image.mutable_docker()->set_name("alpine");
+-
+   ContainerInfo containerInfo;
+   containerInfo.set_type(ContainerInfo::MESOS);
+-  containerInfo.mutable_mesos()->mutable_image()->CopyFrom(image);
++  containerInfo.mutable_docker()->set_image("alpine");
+ 
+   task.mutable_container()->CopyFrom(containerInfo);
+ 
+@@ -1969,7 +1954,6 @@ TEST_F_TEMP_DISABLED_ON_WINDOWS(
+     AWAIT_READY(containerizer->wait(containerId));
+   }
+ }
+-#endif  // __linux__
+ 
+ 
+ // This test verifies that the debug container launched by the command health
+diff --git a/src/tests/master_validation_tests.cpp b/src/tests/master_validation_tests.cpp
+index c98f7517a..6d7069a3a 100644
+--- a/src/tests/master_validation_tests.cpp
++++ b/src/tests/master_validation_tests.cpp
+@@ -3339,57 +3339,6 @@ TEST_F(TaskValidationTest, TaskMissingDockerInfo)
+   driver.join();
+ }
+ 
+-// This test verifies that a task that has `ContainerInfo` set as MESOS
+-// but has a `DockerInfo` is rejected during `TaskInfo` validation.
+-TEST_F(TaskValidationTest, TaskMesosTypeWithDockerInfo)
+-{
+-  Try<Owned<cluster::Master>> master = StartMaster();
+-  ASSERT_SOME(master);
+-
+-  Owned<MasterDetector> detector = master.get()->createDetector();
+-  Try<Owned<cluster::Slave>> slave = StartSlave(detector.get());
+-  ASSERT_SOME(slave);
+-
+-  MockScheduler sched;
+-  MesosSchedulerDriver driver(
+-      &sched, DEFAULT_FRAMEWORK_INFO, master.get()->pid, DEFAULT_CREDENTIAL);
+-
+-  EXPECT_CALL(sched, registered(&driver, _, _));
+-
+-  Future<vector<Offer>> offers;
+-  EXPECT_CALL(sched, resourceOffers(&driver, _))
+-    .WillOnce(FutureArg<1>(&offers))
+-    .WillRepeatedly(Return()); // Ignore subsequent offers.
+-
+-  driver.start();
+-
+-  AWAIT_READY(offers);
+-  ASSERT_FALSE(offers->empty());
+-
+-  Future<TaskStatus> status;
+-  EXPECT_CALL(sched, statusUpdate(&driver, _))
+-    .WillOnce(FutureArg<1>(&status));
+-
+-  // Create an invalid task that has `ContainerInfo` set
+-  // as MESOS and has a `DockerInfo` set.
+-  TaskInfo task = createTask(offers.get()[0], "exit 0");
+-  task.mutable_container()->set_type(ContainerInfo::MESOS);
+-  task.mutable_container()->mutable_docker()->set_image("alpine");
+-
+-  driver.launchTasks(offers.get()[0].id(), {task});
+-
+-  AWAIT_READY(status);
+-  EXPECT_EQ(TASK_ERROR, status->state());
+-  EXPECT_EQ(
+-    "Task's `ContainerInfo` is invalid: "
+-    "Protobuf union `mesos.ContainerInfo` with `Type == MESOS` "
+-    "should not have the field `docker` set.",
+-    status->message());
+-
+-  driver.stop();
+-  driver.join();
+-}
+-
+ 
+ // This test verifies that a task that has `name` parameter set
+ // in `DockerInfo` is rejected during `TaskInfo` validation.
+@@ -3548,21 +3497,6 @@ TEST_F(ExecutorValidationTest, ExecutorType)
+         "'ExecutorInfo.container.mesos.image' must not be set for "
+         "'DEFAULT' executor"));
+   }
+-  {
+-    // Invalid protobuf union in ContainerInfo.
+-    executorInfo.set_type(ExecutorInfo::CUSTOM);
+-    executorInfo.mutable_command();
+-    executorInfo.mutable_container()->set_type(ContainerInfo::DOCKER);
+-    executorInfo.mutable_container()->mutable_mesos();
+-
+-    Option<Error> error = ::executor::internal::validateType(executorInfo);
+-
+-    EXPECT_SOME(error);
+-    EXPECT_TRUE(strings::contains(
+-      error->message,
+-      "Protobuf union `mesos.ContainerInfo` with `Type == DOCKER` "
+-      "should not have the field `mesos` set."));
+-  }
+ }
+ 
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
## High-level description

During the Mesos 1.8 development cycle, an additional validation check was
added to the Mesos master that verifies that the protobuf union inside
a `ContainerInfo` is set correctly, i.e. `DOCKER`-type messages should
have their `docker` field set and `MESOS`-type message should have
their `mesos` field set.

However, during a MWT15 pre-test we found that 13 out of 17 agents
were running tasks that violate these constraints.

Therefore, we disable this validation inside DC/OS for now.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-55219](https://jira.mesosphere.com/browse/DCOS-52219) premwt15 agents wont re-register with cluster after 1.13 upgrade.


## Related tickets (optional)

Other tickets related to this change:

  - [MESOS-9740](https://issues.apache.org/jira/browse/MESOS-9740) Invalid protobuf unions in ExecutorInfo::ContainerInfo will prevent agents from reregistering with 1.8+ masters.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a hotfix which will be removed once the issue is fixed upstream.
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
This is a hotfix which will be removed once the issue is fixed upstream.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
