### PR TITLE
[1.13] Send pre-compressed UI assets if possible.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -165,3 +165,4 @@ This change also aligned the authentication architectures between DC/OS Enterpri
 
 * Bumped DC/OS UI to [master+v2.40.10](https://github.com/dcos/dcos-ui/releases/tag/master%2Bv2.40.10)
 
+* Use gzip compression for some UI assets (DCOS-5978)

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -23,6 +23,25 @@ location / {
     include /opt/mesosphere/etc/adminrouter-ui-security.conf;
 }
 
+location /assets {
+    # Some UI assets are pre-compressed. Serve these compressed if the client
+    # accepts gzip encoding.
+    gzip_static on;
+    # Add a "Vary: Accept-Encoding" header to the response to ensure that
+    # a cached gzip file does not get returned to a client that does not
+    # set "Accept-Encoding: gzip".
+    gzip_vary on;
+    # Send compressed file even for proxied connections. The use of a
+    # "Vary: Accept-Encoding" header should prevent clients mixing compressed
+    # and uncompressed files. This may cause multiple copies of the compressed
+    # file to be cached, if some clients use "Accept-Encoding: gzip, deflate"
+    # and others use "Accept-Encoding: deflate, gzip" for example.
+    gzip_proxied any;
+    # IE6 shouldn't be very common, and later versions support gzip, but let's
+    # be conservative.
+    gzip_disable "msie6";
+}
+
 # Group: System
 # Description: System proxy to the master node with the Mesos leader
 location ~ ^/system/v1/leader/mesos(?<url>.*)$ {

--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -20,10 +20,17 @@ location /pkgpanda/active.buildinfo.full.json {
 root /var/lib/dcos/dcos-ui-update-service/dist/ui;
 
 location / {
+    # Frequently check the cache freshness of the top-level file to ensure the
+    # user sees an updated UI.
+    expires 30s;
+    # Include appropriate security headers.
     include /opt/mesosphere/etc/adminrouter-ui-security.conf;
 }
 
 location /assets {
+    # The UI asset filenames are hashed by content. Hence, they can be cached
+    # by the client indefinitely. Currently, we use a more conservative value.
+    expires 2d;
     # Some UI assets are pre-compressed. Serve these compressed if the client
     # accepts gzip encoding.
     gzip_static on;
@@ -33,9 +40,9 @@ location /assets {
     gzip_vary on;
     # Send compressed file even for proxied connections. The use of a
     # "Vary: Accept-Encoding" header should prevent clients mixing compressed
-    # and uncompressed files. This may cause multiple copies of the compressed
-    # file to be cached, if some clients use "Accept-Encoding: gzip, deflate"
-    # and others use "Accept-Encoding: deflate, gzip" for example.
+    # and uncompressed files. However, multiple copies of the compressed file
+    # may be cached, if some clients use "Accept-Encoding: gzip, deflate" and
+    # others use "Accept-Encoding: deflate, gzip" for example.
     gzip_proxied any;
     # IE6 shouldn't be very common, and later versions support gzip, but let's
     # be conservative.

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -49,6 +49,7 @@ class TestRedirectSecurity:
 
 class TestEncodingGzip:
 
+    # This pattern should provide `index.css` and `index.js` files.
     pat = re.compile(r'/assets/index\.[^"]+')
 
     def test_accept_gzip(self, dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -61,10 +61,10 @@ class TestEncodingGzip:
         filenames = self.pat.findall(r.text)
         assert len(filenames) > 0
         for filename in set(filenames):
-            log.info('Load %s', filename)
-            log.info('%s', repr(r.headers))
-            r = dcos_api_session.get(filename, headers={'Accept-Encoding': 'gzip'})
+            log.info('Load %r', filename)
+            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'gzip'})
             r.raise_for_status()
+            log.info('Response headers: %s', repr(r.headers))
             assert r.headers.get('content-encoding') == 'gzip'
 
     def test_not_accept_gzip(self, dcos_api_session):
@@ -77,10 +77,10 @@ class TestEncodingGzip:
         filenames = self.pat.findall(r.text)
         assert len(filenames) > 0
         for filename in set(filenames):
-            log.info('Load %s', filename)
-            log.info('%s', repr(r.headers))
+            log.info('Load %r', filename)
             # Set a benign `Accept-Encoding` header to prevent underlying
             # libraries setting their own header based on their capabilities.
-            r = dcos_api_session.get(filename, headers={'Accept-Encoding': 'identity'})
+            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'identity'})
             r.raise_for_status()
+            log.info('Response headers: %s', repr(r.headers))
             assert 'content-encoding' not in r.headers


### PR DESCRIPTION
## High-level description

Back-port of #5140 - sets more appropriate cache headers based on discussion with @nLight 

Serve pre-compressed UI assets to clients that provide an `Accept-Encoding` header containing `gzip`.

This also sets a cache header for 2 days, to helps speed up UI interaction.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-5978](https://jira.mesosphere.com/browse/DCOS-5978) Admin Router: enable gzip compression for relevant MIME types


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
