### PR TITLE
Remove dcos-history usage form dcos-diagnostics.

### DIFF
--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "1389e1499b0790a9bdf041514fe173a395a4b7b8",
+    "ref": "3e43a43178906202a340b9341380119b98f084cd",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-diagnostics/buildinfo.json
+++ b/packages/dcos-diagnostics/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-diagnostics.git",
-    "ref": "3e43a43178906202a340b9341380119b98f084cd",
+    "ref": "f741a79bac1b4841f5c33e12e2dc99c4f1e9d1f5",
     "ref_origin": "master"
   },
   "username": "dcos_diagnostics",

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -306,19 +306,6 @@ def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
 
 
 @pytest.mark.supportedwindows
-def test_dcos_diagnostics_selftest(dcos_api_session):
-    """
-    test invokes dcos-diagnostics `self test` functionality
-    """
-    for node in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('/selftest/info', node=node))
-        for test_name, attrs in response.items():
-            assert 'Success' in attrs, 'Field `Success` does not exist'
-            assert 'ErrorMessage' in attrs, 'Field `ErrorMessage` does not exist'
-            assert attrs['Success'], '{} failed, error message {}'.format(test_name, attrs['ErrorMessage'])
-
-
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_report(dcos_api_session):
     """
     test dcos-diagnostics report endpoint /system/health/v1/report


### PR DESCRIPTION
## High-level description

Remove dcos-history usage form dcos-diagnostics.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-5104](https://jira.mesosphere.com/browse/DCOS-5104) Remove dcos-history usage form dcos-diagnostics.

## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
