### PR TITLE
ZooKeeper backup/restore script E2E tests

### DIFF
--- a/test-e2e/fixtures/zk_scripts/dcos-zk-backup.sh
+++ b/test-e2e/fixtures/zk_scripts/dcos-zk-backup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SSH_USER='root'
+REMOTE_TMP_DIR=/tmp
+
+usage() {
+  echo "Usage: $0 [-h] [-l SSH_USER] [-i SSH_KEY_PATH] [-t REMOTE_TMP_DIR] ZK_BACKUP_DEST_DIR MASTER_HOSTNAME" 1>&2
+}
+exit_abnormal() {
+  usage
+  exit 1
+}
+while getopts ":hl:i:t:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 0
+    ;;
+    l) SSH_USER=$OPTARG
+    ;;
+    i) SSH_KEY_PATH=$OPTARG
+    ;;
+    t) REMOTE_TMP_DIR=$OPTARG
+    ;;
+    \?) echo "Error: Invalid option -$OPTARG" 1>&2
+        exit_abnormal
+    ;;
+    :) echo "Error: -$OPTARG requires an argument." 1>&2
+       exit_abnormal
+    ;;
+    *) exit_abnormal
+    ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+if (($# != 2)); then
+  exit_abnormal
+fi
+
+DESTINATION_DIR=$1
+if [ ! -d "$DESTINATION_DIR" ]; then
+  echo "Error: $DESTINATION_DIR does not exist." 1>&2
+  exit 1
+fi
+
+MASTER_HOST=$2
+REMOTE_BACKUP_DIR=${REMOTE_TMP_DIR}/zk_backup.$$
+KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
+OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
+-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+
+ssh $OPTS $KEY -tt ${SSH_USER}@${MASTER_HOST} << EOF
+  set -euxo pipefail
+  if [ -d "$REMOTE_BACKUP_DIR" ]; then
+    exit 1
+  fi
+  sudo mkdir -p $REMOTE_BACKUP_DIR
+  sudo systemctl stop dcos-exhibitor
+  sudo cp -pr /var/lib/dcos/exhibitor/zookeeper ${REMOTE_BACKUP_DIR}/zookeeper
+  sudo systemctl start dcos-exhibitor
+  sudo tar --exclude 'myid' --exclude 'zookeeper.out' -pcvzf \\
+  ${REMOTE_BACKUP_DIR}/zk_backup-'$(date +%Y-%m-%d_%H-%M-%S)'.tar.gz -C $REMOTE_BACKUP_DIR ./zookeeper
+  sudo rm -rf ${REMOTE_BACKUP_DIR}/zookeeper
+  exit 0
+EOF
+
+scp $OPTS $KEY -r ${SSH_USER}@${MASTER_HOST}:${REMOTE_BACKUP_DIR}/zk_backup-'*'.tar.gz ${DESTINATION_DIR}/ 2> /dev/null
+
+ssh $OPTS $KEY -tt ${SSH_USER}@${MASTER_HOST} << EOF
+  set -euxo pipefail
+  sudo rm -rf $REMOTE_BACKUP_DIR
+  exit 0
+EOF

--- a/test-e2e/fixtures/zk_scripts/dcos-zk-backup.sh
+++ b/test-e2e/fixtures/zk_scripts/dcos-zk-backup.sh
@@ -52,11 +52,11 @@ OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
 
 ssh $OPTS $KEY -tt ${SSH_USER}@${MASTER_HOST} << EOF
-  set -euxo pipefail
+  set -exo pipefail
   if [ -d "$REMOTE_BACKUP_DIR" ]; then
     exit 1
   fi
-  sudo mkdir -p $REMOTE_BACKUP_DIR
+  mkdir -p $REMOTE_BACKUP_DIR
   sudo systemctl stop dcos-exhibitor
   sudo cp -pr /var/lib/dcos/exhibitor/zookeeper ${REMOTE_BACKUP_DIR}/zookeeper
   sudo systemctl start dcos-exhibitor
@@ -69,7 +69,7 @@ EOF
 scp $OPTS $KEY -r ${SSH_USER}@${MASTER_HOST}:${REMOTE_BACKUP_DIR}/zk_backup-'*'.tar.gz ${DESTINATION_DIR}/ 2> /dev/null
 
 ssh $OPTS $KEY -tt ${SSH_USER}@${MASTER_HOST} << EOF
-  set -euxo pipefail
+  set -exo pipefail
   sudo rm -rf $REMOTE_BACKUP_DIR
   exit 0
 EOF

--- a/test-e2e/fixtures/zk_scripts/dcos-zk-restore.sh
+++ b/test-e2e/fixtures/zk_scripts/dcos-zk-restore.sh
@@ -54,11 +54,11 @@ ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
   if [ -d "$REMOTE_BACKUP_DIR" ]; then
     exit 1
   fi
-  sudo mkdir -p $REMOTE_BACKUP_DIR
+  mkdir -p $REMOTE_BACKUP_DIR
   sudo systemctl stop dcos-exhibitor
   exit 0
 EOF
-scp $OPTS $KEY $BACKUP_PATH $SSH_USER@${i}:${REMOTE_BACKUP_DIR}/zk_backup.tar.gz 2> /dev/null
+scp $OPTS $KEY $BACKUP_PATH $SSH_USER@${i}:${REMOTE_BACKUP_DIR}/zk_backup.tar.gz
 done
 
 for i in "$@"

--- a/test-e2e/fixtures/zk_scripts/dcos-zk-restore.sh
+++ b/test-e2e/fixtures/zk_scripts/dcos-zk-restore.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+SSH_USER='root'
+REMOTE_TMP_DIR=/tmp
+
+usage() {
+  echo "Usage: $0 [-h] [-l SSH_USER] [-i SSH_KEY_PATH] [-t REMOTE_TMP_DIR] ZK_BACKUP_PATH MASTER_HOSTNAME..." 1>&2
+}
+exit_abnormal() {
+  usage
+  exit 1
+}
+while getopts ":hl:i:t:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 0
+    ;;
+    l) SSH_USER=$OPTARG
+    ;;
+    i) SSH_KEY_PATH=$OPTARG
+    ;;
+    t) REMOTE_TMP_DIR=$OPTARG
+    ;;
+    \?) echo "Error: Invalid option -$OPTARG" 1>&2
+        exit_abnormal
+    ;;
+    :) echo "Error: -$OPTARG requires an argument." 1>&2
+       exit_abnormal
+    ;;
+    *) exit_abnormal
+    ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+if (($# < 2)); then
+  exit_abnormal
+fi
+
+BACKUP_PATH=$1
+REMOTE_BACKUP_DIR=${REMOTE_TMP_DIR}/zk_backup.$$
+OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
+-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
+
+shift
+
+for i in "$@"
+do
+ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
+  set -euxo pipefail
+  if [ -d "$REMOTE_BACKUP_DIR" ]; then
+    exit 1
+  fi
+  sudo mkdir -p $REMOTE_BACKUP_DIR
+  sudo systemctl stop dcos-exhibitor
+  exit 0
+EOF
+scp $OPTS $KEY $BACKUP_PATH $SSH_USER@${i}:${REMOTE_BACKUP_DIR}/zk_backup.tar.gz 2> /dev/null
+done
+
+for i in "$@"
+do
+ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
+  set -euxo pipefail
+  sudo mv /var/lib/dcos/exhibitor/zookeeper ${REMOTE_BACKUP_DIR}/zookeeper.old
+  sudo tar -C /var/lib/dcos/exhibitor --same-owner -xzvf ${REMOTE_BACKUP_DIR}/zk_backup.tar.gz
+  sudo systemctl start dcos-exhibitor
+  exit 0
+EOF
+done
+
+for i in "$@"
+do
+ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
+  set -euxo pipefail
+  sudo rm -rf $REMOTE_BACKUP_DIR
+  exit 0
+EOF
+done

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -2,6 +2,7 @@ git+https://github.com/dcos/dcos-e2e.git@2019.04.25.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4
+kazoo==2.6.1
 pytest==4.1.1
 requests==2.21.0
 wheel==0.33.1

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -54,3 +54,4 @@ groups:
     group_1:
         - test_service_account.py
         - test_master_node_replacement.py
+        - test_zookeeper_backup.py::TestZooKeeperBackup

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -3,13 +3,12 @@ Tests for the ZooKeeper backup/restore scripts.
 """
 
 import logging
+import shlex
 import subprocess
-import textwrap
 import uuid
 from pathlib import Path
 from typing import List
 
-import pytest
 from _pytest.fixtures import SubRequest
 from cluster_helpers import wait_for_dcos_oss
 from dcos_e2e.backends import Docker
@@ -32,21 +31,27 @@ def _zk_set_flag(hosts: str, ephemeral: bool = False) -> str:
     znode = '/{}'.format(uuid.uuid4())
     zk_client = KazooClient(hosts=hosts)
     zk_client.start()
-    zk_client.create(znode, makepath=True, ephemeral=ephemeral)
-    zk_client.set(znode, FLAG)
-    zk_client.stop()
+    try:
+        zk_client.create(znode, makepath=True, ephemeral=ephemeral)
+        zk_client.set(znode, FLAG)
+    finally:
+        zk_client.stop()
     return znode
 
 
-def _zk_check_flag(hosts: str, znode: str) -> None:
+def _zk_flag_exists(hosts: str, znode: str) -> bool:
     """
-    The `FLAG` value is found in ZooKeeper at the `znode` path.
+    The `FLAG` value exists in ZooKeeper at the `znode` path.
     """
     zk_client = KazooClient(hosts=hosts, read_only=True)
     zk_client.start()
-    value = zk_client.get(znode)
-    zk_client.stop()
-    assert value[0] == FLAG
+    try:
+        value = zk_client.get(znode)
+    except NoNodeError:
+        return False
+    finally:
+        zk_client.stop()
+    return bool(value[0] == FLAG)
 
 
 def _bash(cmd: List[str]) -> None:
@@ -56,7 +61,7 @@ def _bash(cmd: List[str]) -> None:
     LOGGER.debug('BASH ARGS: {}'.format(' '.join(cmd)))
     try:
         result = subprocess.check_output(
-            args=' '.join(cmd),
+            args=' '.join(shlex.quote(arg) for arg in cmd),
             stderr=subprocess.STDOUT,
             shell=True,
         )
@@ -66,154 +71,11 @@ def _bash(cmd: List[str]) -> None:
         raise
 
 
-BACKUP_SCRIPT = textwrap.dedent(
-    """\
-#!/bin/bash -e
-
-DESTINATION_DIR=$PWD
-REMOTE_TMP_DIR=/tmp/zk_backup
-
-usage() {
-  echo "Usage: $0 [-h] [-p ZK_BACKUP_DEST_DIR] [-i SSH_KEY_PATH] [-t REMOTE_TMP_DIR] SSH_USER@MASTER_HOST" 1>&2
-}
-exit_abnormal() {
-  usage
-  exit 1
-}
-while getopts ":hp:t:i:" opt; do
-  case $opt in
-    h)
-      usage
-      exit 0
-    ;;
-    p) DESTINATION_DIR=$OPTARG
-    ;;
-    t) REMOTE_TMP_DIR=$OPTARG
-    ;;
-    i) SSH_KEY_PATH=$OPTARG
-    ;;
-    \\?) echo "Invalid option -$OPTARG" 1>&2
-        exit_abnormal
-    ;;
-    :) echo "Error: -$OPTARG requires an argument." 1>&2
-       exit_abnormal
-    ;;
-    *) exit_abnormal
-    ;;
-  esac
-done
-
-shift $((OPTIND - 1))
-if (($# != 1)); then
-  exit_abnormal
-fi
-
-CONN=$1
-KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
-OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
--o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
-
-ssh $OPTS $KEY -tt $CONN << EOF
-  set -e
-  sudo mkdir -p $REMOTE_TMP_DIR
-  sudo systemctl stop dcos-exhibitor
-  sudo cp -pr /var/lib/dcos/exhibitor/zookeeper ${REMOTE_TMP_DIR}/zookeeper
-  sudo systemctl start dcos-exhibitor
-  sudo tar --exclude 'myid' --exclude 'zookeeper.out' -pcvzf \\
-  ${REMOTE_TMP_DIR}/zk_backup-'$(date +%Y-%m-%d_%H-%M-%S)'.tar.gz -C $REMOTE_TMP_DIR ./zookeeper
-  sudo rm -rf ${REMOTE_TMP_DIR}/zookeeper
-  exit 0
-EOF
-
-scp $OPTS $KEY -r ${CONN}:${REMOTE_TMP_DIR}/zk_backup-'*'.tar.gz ${DESTINATION_DIR}/ 2> /dev/null
-
-ssh $OPTS $KEY -tt $CONN << EOF
-  set -e
-  sudo rm -rf $REMOTE_TMP_DIR
-  exit 0
-EOF
-exit 0
-    """
-)
-
-
-RESTORE_SCRIPT = textwrap.dedent(
-    """\
-#!/bin/bash -e
-
-SSH_USER='root'
-REMOTE_TMP_DIR=/tmp/zk_restore
-
-usage() {
-  echo "Usage: $0 [-h] [-i SSH_KEY_PATH] [-l SSH_USER] [-t REMOTE_TMP_DIR] ZK_BACKUP_PATH MASTER_HOSTNAME..." 1>&2
-}
-exit_abnormal() {
-  usage
-  exit 1
-}
-while getopts ":ht:i:l:" opt; do
-  case $opt in
-    h)
-      usage
-      exit 0
-    ;;
-    t) REMOTE_TMP_DIR=$OPTARG
-    ;;
-    i) SSH_KEY_PATH=$OPTARG
-    ;;
-    l) SSH_USER=$OPTARG
-    ;;
-    \\?) echo "Invalid option -$OPTARG" 1>&2
-        exit_abnormal
-    ;;
-    :) echo "Error: -$OPTARG requires an argument." 1>&2
-       exit_abnormal
-    ;;
-    *) exit_abnormal
-    ;;
-  esac
-done
-
-shift $((OPTIND - 1))
-if (($# < 2)); then
-  exit_abnormal
-fi
-
-BACKUP_PATH=$1
-shift
-
-OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
--o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
-KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
-
-for i in "$@"
-do
-ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
-  set -e
-  sudo systemctl stop dcos-exhibitor
-  sudo mkdir -p $REMOTE_TMP_DIR
-  exit 0
-EOF
-scp $OPTS $KEY $BACKUP_PATH $SSH_USER@${i}:${REMOTE_TMP_DIR}/zk_backup.tar.gz 2> /dev/null
-done
-
-for i in "$@"
-do
-ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
-  set -e
-  sudo rm -rf /var/lib/dcos/exhibitor/zookeeper
-  sudo tar -C /var/lib/dcos/exhibitor --same-owner -xzvf ${REMOTE_TMP_DIR}/zk_backup.tar.gz
-  sudo systemctl start dcos-exhibitor
-  sudo rm -rf $REMOTE_TMP_DIR
-  exit 0
-EOF
-done
-exit 0
-    """
-)
-
-
 class TestZooKeeperBackup:
+    """
+    Within the context of DC/OS ZooKeeper can be backed up on a running
+    cluster and a previous state can be restored with minimal downtime.
+    """
 
     def test_transaction_log_backup_and_restore(
         self,
@@ -228,6 +90,9 @@ class TestZooKeeperBackup:
         one node and restoring from the backup on all master results in a
         functioning DC/OS cluster with previously backed up Znodes restored.
         """
+        fixture_root = Path('fixtures').absolute()
+        fixture_dir = fixture_root / 'zk_scripts'
+
         with Cluster(
             cluster_backend=docker_backend,
             masters=3,
@@ -244,42 +109,38 @@ class TestZooKeeperBackup:
                 request=request,
                 log_dir=log_dir,
             )
-            masters = cluster.masters
+            ssh_key_path = next(iter(cluster.masters))._ssh_key_path
+            master_ips = [str(m.public_ip_address) for m in cluster.masters]
+            zk_hostports = ','.join([m + ':2181' for m in master_ips])
 
             # Write to ZooKeeper before backup
-            zk_hostports = ','.join([str(m.public_ip_address) + ':2181' for m in masters])
             persistent_flag = _zk_set_flag(zk_hostports)
             ephemeral_flag = _zk_set_flag(zk_hostports, ephemeral=True)
 
-            # Backup ZooKeeper state from single master node
-            script_path = tmp_path / 'dcos-zk-backup'
-            script_path.write_text(BACKUP_SCRIPT)
-            script_path.chmod(0o755)
-            master = next(iter(masters))
+            # Generate and download ZooKeeper backup
             _bash(cmd=[
-                str(script_path),
-                '-i', str(master._ssh_key_path),
-                '-p', str(tmp_path),
-                'root@{}'.format(master.public_ip_address),
+                str(fixture_dir / 'dcos-zk-backup.sh'),
+                '-l', 'root',
+                '-i', str(ssh_key_path),
+                str(tmp_path),
+                next(iter(master_ips)),
             ])
 
             # Store a datapoint which we expect to be lost.
             not_backed_up_flag = _zk_set_flag(zk_hostports)
 
-            # Restore ZooKeeper state from backup to all master nodes
-            script_path = tmp_path / 'dcos-zk-restore'
+            # Find ZooKeeper backup filename
             result = subprocess.check_output(
-                args='ls {} | grep zk_backup'.format(tmp_path),
+                args='ls {} | grep zk_backup'.format(shlex.quote(str(tmp_path))),
                 shell=True,
             )
             backup_filename = result.decode().strip('\n')
-            script_path.write_text(RESTORE_SCRIPT)
-            script_path.chmod(0o755)
-            master_ips = [str(m.public_ip_address) for m in masters]
+
+            # Restore ZooKeeper state from backup to all master nodes
             _bash(cmd=[
-                str(script_path),
-                '-i', str(master._ssh_key_path),
+                str(fixture_dir / 'dcos-zk-restore.sh'),
                 '-l', 'root',
+                '-i', str(ssh_key_path),
                 str(tmp_path / backup_filename),
             ] + master_ips)
 
@@ -291,11 +152,9 @@ class TestZooKeeperBackup:
             )
 
             # Read from ZooKeeper after restore
-            _zk_check_flag(zk_hostports, persistent_flag)
-            with pytest.raises(NoNodeError):
-                _zk_check_flag(zk_hostports, ephemeral_flag)
-            with pytest.raises(NoNodeError):
-                _zk_check_flag(zk_hostports, not_backed_up_flag)
+            assert _zk_flag_exists(zk_hostports, persistent_flag)
+            assert not _zk_flag_exists(zk_hostports, ephemeral_flag)
+            assert not _zk_flag_exists(zk_hostports, not_backed_up_flag)
 
     def test_snapshot_backup_and_restore(
         self,
@@ -310,6 +169,9 @@ class TestZooKeeperBackup:
         one node and restoring from the backup on all master results in a
         functioning DC/OS cluster with previously backed up Znodes restored.
         """
+        fixture_root = Path('fixtures').absolute()
+        fixture_dir = fixture_root / 'zk_scripts'
+
         with Cluster(
             cluster_backend=docker_backend,
             masters=3,
@@ -328,8 +190,10 @@ class TestZooKeeperBackup:
             )
             masters = cluster.masters
 
+            # Modify Exhibitor conf, generating ZooKeeper conf (set `snapCount=1`).
+            # This config change instructs ZooKeeper to generate a new snapshot for
+            # every single transaction.
             for master in masters:
-                # Modify Exhibitor conf, generating ZooKeeper conf (set `snapCount=1`)
                 master.run(
                     args=[
                         'sed',
@@ -349,8 +213,12 @@ class TestZooKeeperBackup:
                 log_dir=log_dir,
             )
 
+            # Begin the backup/restore test procedure
+            ssh_key_path = next(iter(masters))._ssh_key_path
+            master_ips = [str(m.public_ip_address) for m in masters]
+            zk_hostports = ','.join([m + ':2181' for m in master_ips])
+
             # Write to ZooKeeper multiple times before backup
-            zk_hostports = ','.join([str(m.public_ip_address) + ':2181' for m in masters])
             persistent_flag = _zk_set_flag(zk_hostports)
             ephemeral_flag = _zk_set_flag(zk_hostports, ephemeral=True)
 
@@ -360,34 +228,29 @@ class TestZooKeeperBackup:
             _zk_set_flag(zk_hostports)
 
             # Backup ZooKeeper state from single master node
-            script_path = tmp_path / 'dcos-zk-backup'
-            script_path.write_text(BACKUP_SCRIPT)
-            script_path.chmod(0o755)
-            master = next(iter(masters))
             _bash(cmd=[
-                str(script_path),
-                '-i', str(master._ssh_key_path),
-                '-p', str(tmp_path),
-                'root@{}'.format(master.public_ip_address),
+                str(fixture_dir / 'dcos-zk-backup.sh'),
+                '-l', 'root',
+                '-i', str(ssh_key_path),
+                str(tmp_path),
+                next(iter(master_ips)),
             ])
 
             # Store a datapoint which we expect to be lost.
             not_backed_up_flag = _zk_set_flag(zk_hostports)
 
-            # Restore ZooKeeper state from backup to all master nodes
-            script_path = tmp_path / 'dcos-zk-restore'
+            # Find generated ZooKeeper backup file name
             result = subprocess.check_output(
-                args='ls {} | grep zk_backup'.format(tmp_path),
+                args='ls {} | grep zk_backup'.format(shlex.quote(str(tmp_path))),
                 shell=True,
             )
             backup_filename = result.decode().strip('\n')
-            script_path.write_text(RESTORE_SCRIPT)
-            script_path.chmod(0o755)
-            master_ips = [str(m.public_ip_address) for m in masters]
+
+            # Restore ZooKeeper state from backup to all master nodes
             _bash(cmd=[
-                str(script_path),
-                '-i', str(master._ssh_key_path),
+                str(fixture_dir / 'dcos-zk-restore.sh'),
                 '-l', 'root',
+                '-i', str(ssh_key_path),
                 str(tmp_path / backup_filename),
             ] + master_ips)
 
@@ -399,9 +262,6 @@ class TestZooKeeperBackup:
             )
 
             # Read from ZooKeeper after restore
-            _zk_check_flag(zk_hostports, persistent_flag)
-            with pytest.raises(NoNodeError):
-                _zk_check_flag(zk_hostports, ephemeral_flag)
-            with pytest.raises(NoNodeError):
-                _zk_check_flag(zk_hostports, not_backed_up_flag)
-
+            assert _zk_flag_exists(zk_hostports, persistent_flag)
+            assert not _zk_flag_exists(zk_hostports, ephemeral_flag)
+            assert not _zk_flag_exists(zk_hostports, not_backed_up_flag)

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -1,0 +1,394 @@
+"""
+Tests for the ZooKeeper backup/restore scripts.
+"""
+
+import logging
+import subprocess
+import textwrap
+import uuid
+from pathlib import Path
+from typing import List
+
+import pytest
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
+from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Output
+from kazoo.client import KazooClient
+from kazoo.exceptions import NoNodeError
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Arbitrary value written to ZooKeeper.
+FLAG = b'flag'
+
+
+def _zk_set_flag(hosts: str, ephemeral: bool = False) -> str:
+    """
+    Store the `FLAG` value in ZooKeeper in a random Znode.
+    """
+    znode = '/{}'.format(uuid.uuid4())
+    zk_client = KazooClient(hosts=hosts)
+    zk_client.start()
+    zk_client.create(znode, makepath=True, ephemeral=ephemeral)
+    zk_client.set(znode, FLAG)
+    zk_client.stop()
+    return znode
+
+
+def _zk_check_flag(hosts: str, znode: str) -> None:
+    """
+    The `FLAG` value is found in ZooKeeper at the `znode` path.
+    """
+    zk_client = KazooClient(hosts=hosts, read_only=True)
+    zk_client.start()
+    value = zk_client.get(znode)
+    zk_client.stop()
+    assert value[0] == FLAG
+
+
+def _bash(cmd: List[str]) -> None:
+    """
+    Execute `cmd` in a subprocess, log potential errors.
+    """
+    LOGGER.debug('BASH ARGS: {}'.format(' '.join(cmd)))
+    try:
+        result = subprocess.check_output(
+            args=' '.join(cmd),
+            stderr=subprocess.STDOUT,
+            shell=True,
+        )
+        LOGGER.debug(result.decode())
+    except subprocess.CalledProcessError as exc:
+        LOGGER.error(exc.output.decode())
+        raise
+
+
+BACKUP_SCRIPT = textwrap.dedent(
+    """\
+#!/bin/bash -e
+
+DESTINATION_DIR=$PWD
+REMOTE_TMP_DIR=/tmp/zk_backup
+
+usage() {
+  echo "Usage: $0 [-h] [-p ZK_BACKUP_DEST_DIR] [-i SSH_KEY_PATH] [-t REMOTE_TMP_DIR] SSH_USER@MASTER_HOST" 1>&2
+}
+exit_abnormal() {
+  usage
+  exit 1
+}
+while getopts ":hp:t:i:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 0
+    ;;
+    p) DESTINATION_DIR=$OPTARG
+    ;;
+    t) REMOTE_TMP_DIR=$OPTARG
+    ;;
+    i) SSH_KEY_PATH=$OPTARG
+    ;;
+    \\?) echo "Invalid option -$OPTARG" 1>&2
+        exit_abnormal
+    ;;
+    :) echo "Error: -$OPTARG requires an argument." 1>&2
+       exit_abnormal
+    ;;
+    *) exit_abnormal
+    ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+if (($# != 1)); then
+  exit_abnormal
+fi
+
+CONN=$1
+KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
+OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
+-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+
+ssh $OPTS $KEY -tt $CONN << EOF
+  set -e
+  sudo mkdir -p $REMOTE_TMP_DIR
+  sudo systemctl stop dcos-exhibitor
+  sudo cp -pr /var/lib/dcos/exhibitor/zookeeper ${REMOTE_TMP_DIR}/zookeeper
+  sudo systemctl start dcos-exhibitor
+  sudo tar --exclude 'myid' --exclude 'zookeeper.out' -pcvzf \\
+  ${REMOTE_TMP_DIR}/zk_backup-'$(date +%Y-%m-%d_%H-%M-%S)'.tar.gz -C $REMOTE_TMP_DIR ./zookeeper
+  sudo rm -rf ${REMOTE_TMP_DIR}/zookeeper
+  exit 0
+EOF
+
+scp $OPTS $KEY -r ${CONN}:${REMOTE_TMP_DIR}/zk_backup-'*'.tar.gz ${DESTINATION_DIR}/ 2> /dev/null
+
+ssh $OPTS $KEY -tt $CONN << EOF
+  set -e
+  sudo rm -rf $REMOTE_TMP_DIR
+  exit 0
+EOF
+exit 0
+    """
+)
+
+
+RESTORE_SCRIPT = textwrap.dedent(
+    """\
+#!/bin/bash -e
+
+SSH_USER='root'
+REMOTE_TMP_DIR=/tmp/zk_restore
+
+usage() {
+  echo "Usage: $0 [-h] [-i SSH_KEY_PATH] [-l SSH_USER] [-t REMOTE_TMP_DIR] ZK_BACKUP_PATH MASTER_HOSTNAME..." 1>&2
+}
+exit_abnormal() {
+  usage
+  exit 1
+}
+while getopts ":ht:i:l:" opt; do
+  case $opt in
+    h)
+      usage
+      exit 0
+    ;;
+    t) REMOTE_TMP_DIR=$OPTARG
+    ;;
+    i) SSH_KEY_PATH=$OPTARG
+    ;;
+    l) SSH_USER=$OPTARG
+    ;;
+    \\?) echo "Invalid option -$OPTARG" 1>&2
+        exit_abnormal
+    ;;
+    :) echo "Error: -$OPTARG requires an argument." 1>&2
+       exit_abnormal
+    ;;
+    *) exit_abnormal
+    ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+if (($# < 2)); then
+  exit_abnormal
+fi
+
+BACKUP_PATH=$1
+shift
+
+OPTS='-o ConnectTimeout=3 -o ConnectionAttempts=1
+-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+KEY=${SSH_KEY_PATH:+"-i $SSH_KEY_PATH"}
+
+for i in "$@"
+do
+ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
+  set -e
+  sudo systemctl stop dcos-exhibitor
+  sudo mkdir -p $REMOTE_TMP_DIR
+  exit 0
+EOF
+scp $OPTS $KEY $BACKUP_PATH $SSH_USER@${i}:${REMOTE_TMP_DIR}/zk_backup.tar.gz 2> /dev/null
+done
+
+for i in "$@"
+do
+ssh $OPTS -tt $KEY ${SSH_USER}@${i} << EOF
+  set -e
+  sudo rm -rf /var/lib/dcos/exhibitor/zookeeper
+  sudo tar -C /var/lib/dcos/exhibitor --same-owner -xzvf ${REMOTE_TMP_DIR}/zk_backup.tar.gz
+  sudo systemctl start dcos-exhibitor
+  sudo rm -rf $REMOTE_TMP_DIR
+  exit 0
+EOF
+done
+exit 0
+    """
+)
+
+
+class TestZooKeeperBackup:
+
+    def test_transaction_log_backup_and_restore(
+        self,
+        artifact_path: Path,
+        docker_backend: Docker,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        In a 3-master cluster, backing up the transaction log of ZooKeeper on
+        one node and restoring from the backup on all master results in a
+        functioning DC/OS cluster with previously backed up Znodes restored.
+        """
+        with Cluster(
+            cluster_backend=docker_backend,
+            masters=3,
+            agents=0,
+            public_agents=0,
+        ) as cluster:
+            cluster.install_dcos_from_path(
+                dcos_installer=artifact_path,
+                dcos_config=cluster.base_config,
+                ip_detect_path=docker_backend.ip_detect_path,
+            )
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+            masters = cluster.masters
+
+            # Write to ZooKeeper before backup
+            zk_hostports = ','.join([str(m.public_ip_address) + ':2181' for m in masters])
+            persistent_flag = _zk_set_flag(zk_hostports)
+            ephemeral_flag = _zk_set_flag(zk_hostports, ephemeral=True)
+
+            # Backup ZooKeeper state from single master node
+            script_path = tmp_path / 'dcos-zk-backup'
+            script_path.write_text(BACKUP_SCRIPT)
+            script_path.chmod(0o755)
+            master = next(iter(masters))
+            _bash(cmd=[
+                str(script_path),
+                '-i', str(master._ssh_key_path),
+                '-p', str(tmp_path),
+                'root@{}'.format(master.public_ip_address),
+            ])
+            # Restore ZooKeeper state from backup to all master nodes
+            script_path = tmp_path / 'dcos-zk-restore'
+            result = subprocess.check_output(
+                args='ls {} | grep zk_backup'.format(tmp_path),
+                shell=True,
+            )
+            backup_filename = result.decode().strip('\n')
+            script_path.write_text(RESTORE_SCRIPT)
+            script_path.chmod(0o755)
+            master_ips = [str(m.public_ip_address) for m in masters]
+            _bash(cmd=[
+                str(script_path),
+                '-i', str(master._ssh_key_path),
+                '-l', 'root',
+                str(tmp_path / backup_filename),
+            ] + master_ips)
+
+            # Assert DC/OS is intact.
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+
+            # Read from ZooKeeper after restore
+            _zk_check_flag(zk_hostports, persistent_flag)
+            with pytest.raises(NoNodeError):
+                _zk_check_flag(zk_hostports, ephemeral_flag)
+
+    def test_snapshot_backup_and_restore(
+        self,
+        artifact_path: Path,
+        docker_backend: Docker,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        In a 3-master cluster, backing up a snapshot of ZooKeeper on
+        one node and restoring from the backup on all master results in a
+        functioning DC/OS cluster with previously backed up Znodes restored.
+        """
+        with Cluster(
+            cluster_backend=docker_backend,
+            masters=3,
+            agents=0,
+            public_agents=0,
+        ) as cluster:
+            cluster.install_dcos_from_path(
+                dcos_installer=artifact_path,
+                dcos_config=cluster.base_config,
+                ip_detect_path=docker_backend.ip_detect_path,
+            )
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+            masters = cluster.masters
+
+            for master in masters:
+                # Modify Exhibitor conf, generating ZooKeeper conf (set `snapCount=1`)
+                master.run(
+                    args=[
+                        'sed',
+                        '-i', "'s/zoo-cfg-extra=/zoo-cfg-extra=snapCount\\\\=1\\&/'",
+                        '/opt/mesosphere/active/exhibitor/usr/exhibitor/start_exhibitor.py',
+                    ],
+                    shell=True,
+                    output=Output.LOG_AND_CAPTURE,
+                )
+            for master in masters:
+                # Restart Exhibitor
+                master.run(['sudo', 'systemctl', 'restart', 'dcos-exhibitor'])
+
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+
+            # Write to ZooKeeper multiple times before backup
+            zk_hostports = ','.join([str(m.public_ip_address) + ':2181' for m in masters])
+            persistent_flag = _zk_set_flag(zk_hostports)
+            ephemeral_flag = _zk_set_flag(zk_hostports, ephemeral=True)
+
+            # Extra ZooKeeper write, triggering snapshot creation due to
+            # `snapCount=1`. After this we can be sure the previous writes are
+            # contained in at least one of the generated snapshots.
+            _zk_set_flag(zk_hostports)
+
+            # Backup ZooKeeper state from single master node
+            script_path = tmp_path / 'dcos-zk-backup'
+            script_path.write_text(BACKUP_SCRIPT)
+            script_path.chmod(0o755)
+            master = next(iter(masters))
+            _bash(cmd=[
+                str(script_path),
+                '-i', str(master._ssh_key_path),
+                '-p', str(tmp_path),
+                'root@{}'.format(master.public_ip_address),
+            ])
+            # Restore ZooKeeper state from backup to all master nodes
+            script_path = tmp_path / 'dcos-zk-restore'
+            result = subprocess.check_output(
+                args='ls {} | grep zk_backup'.format(tmp_path),
+                shell=True,
+            )
+            backup_filename = result.decode().strip('\n')
+            script_path.write_text(RESTORE_SCRIPT)
+            script_path.chmod(0o755)
+            master_ips = [str(m.public_ip_address) for m in masters]
+            _bash(cmd=[
+                str(script_path),
+                '-i', str(master._ssh_key_path),
+                '-l', 'root',
+                str(tmp_path / backup_filename),
+            ] + master_ips)
+
+            # Assert DC/OS is intact.
+            wait_for_dcos_oss(
+                cluster=cluster,
+                request=request,
+                log_dir=log_dir,
+            )
+
+            # Read from ZooKeeper after restore
+            _zk_check_flag(zk_hostports, persistent_flag)
+            with pytest.raises(NoNodeError):
+                _zk_check_flag(zk_hostports, ephemeral_flag)

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -75,6 +75,10 @@ class TestZooKeeperBackup:
     """
     Within the context of DC/OS ZooKeeper can be backed up on a running
     cluster and a previous state can be restored with minimal downtime.
+
+    NOTE: Tests in this class require the following commands to be available
+        in the environment: `bash`, `ssh` and `scp`
+
     """
 
     def test_transaction_log_backup_and_restore(

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -262,6 +262,10 @@ class TestZooKeeperBackup:
                 '-p', str(tmp_path),
                 'root@{}'.format(master.public_ip_address),
             ])
+
+            # Store a datapoint which we expect to be lost.
+            not_backed_up_flag = _zk_set_flag(zk_hostports)
+
             # Restore ZooKeeper state from backup to all master nodes
             script_path = tmp_path / 'dcos-zk-restore'
             result = subprocess.check_output(
@@ -290,6 +294,8 @@ class TestZooKeeperBackup:
             _zk_check_flag(zk_hostports, persistent_flag)
             with pytest.raises(NoNodeError):
                 _zk_check_flag(zk_hostports, ephemeral_flag)
+            with pytest.raises(NoNodeError):
+                _zk_check_flag(zk_hostports, not_backed_up_flag)
 
     def test_snapshot_backup_and_restore(
         self,
@@ -364,6 +370,10 @@ class TestZooKeeperBackup:
                 '-p', str(tmp_path),
                 'root@{}'.format(master.public_ip_address),
             ])
+
+            # Store a datapoint which we expect to be lost.
+            not_backed_up_flag = _zk_set_flag(zk_hostports)
+
             # Restore ZooKeeper state from backup to all master nodes
             script_path = tmp_path / 'dcos-zk-restore'
             result = subprocess.check_output(
@@ -392,3 +402,6 @@ class TestZooKeeperBackup:
             _zk_check_flag(zk_hostports, persistent_flag)
             with pytest.raises(NoNodeError):
                 _zk_check_flag(zk_hostports, ephemeral_flag)
+            with pytest.raises(NoNodeError):
+                _zk_check_flag(zk_hostports, not_backed_up_flag)
+


### PR DESCRIPTION
## High-level description

This PR adds two E2E tests for our ZooKeeper backup/restore procedures.
The actual backup/restore test is split into two because we want to test are two different scenarios:
1. Restore from a ZooKeeper transaction log 
2. Restore from a ZooKeeper snapshot

Normally one would like to test 1. with a snapshot+transaction log but success is difficult to assert in this case. Splitting it into to different test cases gives us confidence that a transaction log is replayed from our backup (1.) and that we could restore from snapshot directly, which limits the fallback of a backup to the `snapCount`. That's not a perfect test but it's reasonably close.

The scripts have been tested manually to work on CCM (AWS) in a non-root environment as well as on an Enterprise strict mode cluster.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53076](https://jira.mesosphere.com/browse/DCOS-53076) Automate ZooKeeper backup and restoration testing with an E2E test.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: It's just a test.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)