### PR TITLE
DCOS-52191 - Mute flaky test test_dcos_diagnostics_bundle_create_download_delete

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -319,6 +319,11 @@ def test_dcos_diagnostics_report(dcos_api_session):
         assert len(report_response['Nodes']) > 0
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-52191',
+    reason='test_dcos_diagnostics_bundle_create_download_delete is flaky.',
+    since='2019-04-26'
+)
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
     """
     test bundle create, read, delete workflow


### PR DESCRIPTION
## High-level description

test_dcos_diagnostics_bundle_create_download_delete is a flaky test and should be muted.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-52191](https://jira.mesosphere.com/browse/DCOS-52191) test_dcos_diagnostics_bundle_create_download_delete failing with Timeout errors