### PR TITLE
CHANGES.md: editorial update for 1.14.0 development

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,29 +1,10 @@
-## DC/OS 1.14.0
+Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos/dcos/wiki/CHANGES.md-guidelines). Thank you!
 
-```
-* For any significant improvement to DC/OS add an entry to Fixed and Improved section.
-* For Security updates, please call out in Security updates section.
-* Add to the top of the existing list.
-* External Projects like Mesos and Marathon shall provide a link to their published changelogs.
 
-Format of the entries must be.
+## DC/OS 1.14.0 (in development)
 
-* Entry with no-newlines. (DCOS_OSS_JIRA)
-<new-line>
-* Entry two with no-newlines. (DCOS_OSS_JIRA_2)
-```
 
-### Highlights
+### What's new
 
-#### What's new
 
-#### Breaking changes
-
-#### Known limitations
-
-#### Fixed and improved
-
-* DC/OS Diagnostics now applies timeouts when reading systemd journal entries. The timeout that's applied is configured via the `command-exec-timeout` configuration parameter.
-* `docker-gc` now removes unused volumes (DCOS_OSS-1502)
-
-* Use gzip compression for some UI assets (DCOS-5978)
+### Breaking changes


### PR DESCRIPTION
This is an editorial update for `CHANGES.md`.

Part of the 2019 changelog initiative.