### PR TITLE
[1.13][DCOS_OSS-5088] test-e2e: remove unnecessary debug logging

### DIFF
--- a/test-e2e/conftest.py
+++ b/test-e2e/conftest.py
@@ -1,4 +1,9 @@
+import logging
+
 # Hack to exclude test-e2e/conftest.py from the top-level tox config py35-unittests.
 # https://stackoverflow.com/a/37493203
 pytest_plugins = ['test_e2e_module']
 # Actual content of conftest.py can be found in test_e2e_module.py.
+
+# Configures logging level to DEBUG
+logging.basicConfig(level=logging.DEBUG)

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.04.23.0
+git+https://github.com/dcos/dcos-e2e.git@2019.04.23.1
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -5,3 +5,4 @@ jwt==0.5.4
 pytest==4.1.1
 requests==2.21.0
 wheel==0.33.1
+teamcity-messages==1.25

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.01.05.0
+git+https://github.com/dcos/dcos-e2e.git@2019.04.23.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -5,4 +5,4 @@ jwt==0.5.4
 pytest==4.1.1
 requests==2.21.0
 wheel==0.33.1
-teamcity-messages==1.25
+teamcity-messages==1.21

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.04.23.1
+git+https://github.com/dcos/dcos-e2e.git@2019.04.25.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -1,12 +1,24 @@
 """
 Surrogate conftest.py contents loaded by the conftest.py file.
 """
+import logging
 import os
 from pathlib import Path
 
 import pytest
 
 from dcos_e2e.backends import Docker
+
+
+@pytest.fixture(scope='session', autouse=True)
+def configure_logging() -> None:
+    """
+    Surpress DEBUG log messages from libraries that log excessive amount of
+    debug output that isn't useful for debugging e2e tests.
+    """
+    # Disble debug output from `docker` and `urllib3` libraries
+    logging.getLogger('urllib3.connectionpool').setLevel(logging.WARN)
+    logging.getLogger('docker').setLevel(logging.WARN)
 
 
 @pytest.fixture(scope='session')

--- a/test-e2e/test_master_node_replacement.py
+++ b/test-e2e/test_master_node_replacement.py
@@ -13,7 +13,7 @@ from _pytest.fixtures import SubRequest
 from cluster_helpers import wait_for_dcos_oss
 from dcos_e2e.backends import Docker
 from dcos_e2e.cluster import Cluster
-from dcos_e2e.node import Role
+from dcos_e2e.node import Output, Role
 from docker.models.networks import Network
 
 
@@ -101,6 +101,7 @@ def test_replace_all_static(
                 '|', 'grep', '-B1', str(master.public_ip_address),
                 '|', 'grep', '-o', '"^\w*"',
             ],
+            output=Output.LOG_AND_CAPTURE,
             shell=True,
         )
         interface = result.stdout.strip().decode()


### PR DESCRIPTION
This is a backport of #5224.

Original description of that PR Is below:

```
## High-level description

This updates DC/OS E2E to bring in better log control and fixes.

Disables debug log output for `urllib3` and `docker` modules in `e2e` tests.

`Output.LOG_AND_CAPTURE` is now used for various `run` commands because the default, `Output.CAPTURE`, no longer logs anything at all - it used to log errors.

This adds `teamcity-messages` as a test requirement.
When this is merged and backported we will remove `-s` in the `PARAMETERS` arguments for the TeamCity jobs.
This will allow us to separate log output for different tests.

In the case of a cluster not starting, we now store journal logs and so we do not need to see extensive logs while waiting for DC/OS to start.

This cuts down the build log to approximately 1/3 of the size and it will make finding the real problems much easier.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5088](https://jira.mesosphere.com/browse/DCOS_OSS-5088) DC/OS E2E - Don't print the same output twice in teamcity logs

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: an internal mesosphere only change visible in our CI
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: changing the testing library
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
```