### PR TITLE
[1.13.0] Reverted the container sandbox permission from 0750 back to 0755.

### DIFF
--- a/packages/mesos/extra/patches/0007-Reverted-the-container-sandbox-permission-from-0750-.patch
+++ b/packages/mesos/extra/patches/0007-Reverted-the-container-sandbox-permission-from-0750-.patch
@@ -1,0 +1,45 @@
+From d764ddabe51f1dddd9846046df883e9aefbf9aca Mon Sep 17 00:00:00 2001
+From: Qian Zhang <zhq527725@gmail.com>
+Date: Tue, 30 Apr 2019 22:28:25 +0800
+Subject: [PATCH] Reverted the container sandbox permission from 0750 back to
+ 0755.
+
+This patch is used to revert the sandbox permission semantic change
+in Mesos 1.6.0 (caused by this commit 04dd7f32). 04dd7f32 caused
+nestd container could not traverse its parent container's sandbox
+if the nested container user is an arbitrary non-root user and
+different from its parent's user.
+
+Without this revert, there will be two issues:
+1. Some modules may not be able to create files under the sandbox
+   as a non-root user.
+2. Task launched as non-root users may not be able to open files
+   under the sandbox if the task is launched as a non-root user.
+
+This patch could be removed once DCOS-47501 and MESOS-9536 are
+landed.
+---
+ src/slave/paths.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/src/slave/paths.cpp b/src/slave/paths.cpp
+index 1163c88ee..52422d431 100644
+--- a/src/slave/paths.cpp
++++ b/src/slave/paths.cpp
+@@ -845,13 +845,6 @@ Try<Nothing> createSandboxDirectory(
+   }
+ 
+ #ifndef __WINDOWS__
+-  // Since this is a sandbox directory containing private task data,
+-  // we want to ensure that it is not accessible to "others".
+-  Try<Nothing> chmod = os::chmod(directory, 0750);
+-  if (chmod.isError()) {
+-    return Error("Failed to chmod directory: " + chmod.error());
+-  }
+-
+   if (user.isSome()) {
+     Try<Nothing> chown = os::chown(user.get(), directory);
+     if (chown.isError()) {
+-- 
+2.17.0
+


### PR DESCRIPTION
This patch is used to revert the sandbox permission semantic change
in Mesos 1.6.0 (caused by this commit 04dd7f32). 04dd7f32 caused
nested container could not traverse its parent container's sandbox
if the nested container user is an arbitrary non-root user and
different from its parent's user.

Without this revert, there will be two issues:
1. Some modules may not be able to create files under the sandbox
   as a non-root user.
2. Task launched as non-root users may not be able to open files
   under the sandbox if the task is launched as a non-root user.

This patch could be removed once DCOS-47501 and MESOS-9536 are
landed.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53196](https://jira.mesosphere.com/browse/DCOS-53196) Revert the 1.13 sandbox permission change back to 0755.

## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [ ] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
