### PR TITLE
(1.12) Telegraf: Use decoded framework name in metric tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* Fixed undecoded framework names in metric tags. (DCOS_OSS-5039)
+
 * Fixed a bug as of which DC/OS checks may accidentally fail, pre-maturely reporting `network is unreachable`. (DCOS-47608)
 
 * Improved Cosmos to handle more transient errors behind the scenes, enhancing its fault tolerance. (DCOS-51139)

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "42d1e113f141a57be0cc8b5ebaed53b88a5c3850",
+    "ref": "79bf957a51895d8f3fc2c370bc5799b3dfc7f24e",
     "ref_origin": "1.7.2-dcos"
   },
   "username": "dcos_telegraf"


### PR DESCRIPTION
## High-level description

This is a 1.12 backport of #5354.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5039](https://jira.mesosphere.com/browse/DCOS_OSS-5039) Mesos telegraf plugin doesn't "percent-decode" per-framework metrics tags


## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This is a bugfix that will be backported to earlier releases.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Testing this requires running an arbitrarily-named framework, which isn't simple to do. Instead we rely on upstream tests in dcos/telegraf, which cover this scenario.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/telegraf/compare/42d1e113f141a57be0cc8b5ebaed53b88a5c3850...79bf957a51895d8f3fc2c370bc5799b3dfc7f24e
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/252/
  - [x] Code Coverage (if available): N/A