### PR TITLE
Support large uploads and processing times for services via AR

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/master.conf
+++ b/packages/adminrouter/extra/src/includes/server/master.conf
@@ -243,6 +243,12 @@ location ~ ^/service/(?<service_path>.+) {
     set $service_tag '';
     set $original_uri $uri;
 
+    # Give services a lot of leeway. A particular extreme is for uploading
+    # packages to a package registry. The Jupyter package is one of our
+    # largest at just under 10GB. Use 16GB as the limit to allow for this to
+    # expand.
+    client_max_body_size 16384m;
+
     rewrite_by_lua_block {
         local service_name
 
@@ -280,14 +286,19 @@ location ~ ^/service/(?<service_path>.+) {
             return ngx.exec("@service_requnbuffered");
         end
 
-            -- Do an internal redirect; proceed handling this request in the
-            -- @service_default location block below.
+        -- Do an internal redirect; proceed handling this request in the
+        -- @service_default location block below.
         return ngx.exec("@service_default");
     }
 }
 
 location @service_requnbuffered {
     proxy_request_buffering off;
+
+    # It takes 3-4 minutes for the DC/OS package registry to validate a 10GB
+    # package and respond. We relax the read timeout for all unbuffered
+    # services to handle this.
+    proxy_read_timeout 300s;
 
     include includes/metrics-service-location-level.conf;
     include includes/service-location.common.conf;


### PR DESCRIPTION
## High-level description

Support large uploads and long processing times for services accessed through Admin Router's `/service` endpoint. This supports package upload, required for package registries launched using Marathon.

This has been tested manually using the 10GB `beta-mesosphere-jupyter-service-1.3.0-0.35.4-beta.dcos` package.

There is a separate issue [DCOS-51222](https://jira.mesosphere.com/browse/DCOS-51222) for creation of an integration test. I consider this separation to be appropriate in this case, as there are non-trivial problems to be overcome for the test (time and bandwidth usage).

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-52768](https://jira.mesosphere.com/browse/DCOS-52768) COPS-4651 repo 413 Entity too large / 504 timeout


## Related tickets (optional)

Other tickets related to this change:

  - [COPS-4651](https://jira.mesosphere.com/browse/COPS-4651) 413 Entity Too Large error when trying to add any packages where the .dcos bundled file is over 1 GB


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Manually tested. Testing requires a large (10GB) download/upload, which takes significant time and bandwidth.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
