### PR TITLE
[1.13][DCOS-53077] Create TMPDIRs in known locations for various services to avoid probl…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Security updates
 
+* Made it possible to install and run DC/OS with `/tmp` mounted with `noexec`. (DCOS-53077)
 
 ## DC/OS 1.13.0
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -199,7 +199,7 @@ bootstrappers = {
     'dcos-cockroach': noop,
     'dcos-cockroach-config-change': dcos_cockroach_config_change,
     'dcos-metronome': noop,
-    'dcos-history': noop,
+    'dcos-history': dcos_history,
     'dcos-mesos-dns': noop,
     'dcos-net': dcos_net,
     'dcos-telegraf-master': dcos_telegraf_master,

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -108,6 +108,51 @@ def dcos_net_agent(b, opts):
 def dcos_bouncer(b, opts):
     os.makedirs('/run/dcos/dcos-bouncer', exist_ok=True)
     shutil.chown('/run/dcos/dcos-bouncer', user='dcos_bouncer')
+    # Permissions are restricted to the dcos_bouncer user as this directory
+    # contains sensitive data.  See
+    # https://jira.mesosphere.com/browse/DCOS-18350
+
+    # The ``bouncer_tmpdir`` directory path corresponds to the
+    # TMPDIR environment variable configured in the dcos-bouncer.service file.
+    user = 'dcos_bouncer'
+    bouncer_tmpdir = known_exec_directory() / user
+    bouncer_tmpdir.mkdir(mode=0o700, exist_ok=True)
+    shutil.chown(str(bouncer_tmpdir), user=user)
+
+
+@check_root
+def dcos_history(b, opts):
+    # Permissions are restricted to the dcos_history user in case this
+    # directory contains sensitive data - we also want to avoid the security
+    # risk of other users writing to this directory.
+    # See https://jira.mesosphere.com/browse/DCOS-18350 for a related change to
+    # dcos-bouncer.
+
+    # The ``dcos_history_tmpdir`` directory path corresponds to the
+    # TMPDIR environment variable configured in the dcos-history.service file.
+    user = 'dcos_history'
+    dcos_history_tmpdir = known_exec_directory() / user
+    dcos_history_tmpdir.mkdir(mode=0o700, exist_ok=True)
+    shutil.chown(str(dcos_history_tmpdir), user=user)
+
+
+@check_root
+def dcos_cockroach_config_change(b, opts):
+    # Permissions are restricted to the dcos_cockroach user in case this
+    # directory contains sensitive data - we also want to avoid the security
+    # risk of other users writing to this directory.
+    # See https://jira.mesosphere.com/browse/DCOS-18350 for a related change to
+    # dcos-bouncer.
+    #
+    # The ``dcos_cockroach`` user is the ``User`` used in the
+    # ``dcos-cockroachdb-config-change.service``
+
+    # The ``cockroach_tmpdir`` directory path corresponds to the
+    # dcos-cockroachdb-config-change.service.
+    user = 'dcos_cockroach'
+    cockroach_tmpdir = known_exec_directory() / user
+    cockroach_tmpdir.mkdir(mode=0o700, exist_ok=True)
+    shutil.chown(str(cockroach_tmpdir), user=user)
 
 
 def noop(b, opts):
@@ -130,6 +175,7 @@ bootstrappers = {
     'dcos-mesos-slave-public': noop,
     'dcos-cosmos': noop,
     'dcos-cockroach': noop,
+    'dcos-cockroach-config-change': dcos_cockroach_config_change,
     'dcos-metronome': noop,
     'dcos-history': noop,
     'dcos-mesos-dns': noop,

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -22,6 +22,31 @@ from pkgpanda.actions import apply_service_configuration
 log = logging.getLogger(__name__)
 
 
+def _known_exec_directory():
+    """
+    Returns a directory which we have told users to mark as ``exec``.
+    """
+    # This directory must be outside /tmp to support
+    # environments where /tmp is mounted noexec.
+    known_directory = Path('/var/lib/dcos/exec')
+    known_directory.mkdir(parents=True, exist_ok=True)
+    return known_directory
+
+
+def _create_private_directory(path, owner):
+    """
+    Create a directory which ``owner`` can create, modify and delete files in
+    but other non-root users cannot.
+
+    Args:
+        path (pathlib.Path): The path to the directory to create.
+        owner (str): The owner of the directory.
+    """
+    path.mkdir(exist_ok=True)
+    path.chmod(0o700)
+    shutil.chown(str(path), user=owner)
+
+
 def check_root(fun):
     def wrapper(b, opts):
         if os.getuid() != 0:
@@ -115,9 +140,8 @@ def dcos_bouncer(b, opts):
     # The ``bouncer_tmpdir`` directory path corresponds to the
     # TMPDIR environment variable configured in the dcos-bouncer.service file.
     user = 'dcos_bouncer'
-    bouncer_tmpdir = known_exec_directory() / user
-    bouncer_tmpdir.mkdir(mode=0o700, exist_ok=True)
-    shutil.chown(str(bouncer_tmpdir), user=user)
+    bouncer_tmpdir = _known_exec_directory() / user
+    _create_private_directory(path=bouncer_tmpdir, owner=user)
 
 
 @check_root
@@ -131,9 +155,8 @@ def dcos_history(b, opts):
     # The ``dcos_history_tmpdir`` directory path corresponds to the
     # TMPDIR environment variable configured in the dcos-history.service file.
     user = 'dcos_history'
-    dcos_history_tmpdir = known_exec_directory() / user
-    dcos_history_tmpdir.mkdir(mode=0o700, exist_ok=True)
-    shutil.chown(str(dcos_history_tmpdir), user=user)
+    dcos_history_tmpdir = _known_exec_directory() / user
+    _create_private_directory(path=dcos_history_tmpdir, owner=user)
 
 
 @check_root
@@ -150,9 +173,8 @@ def dcos_cockroach_config_change(b, opts):
     # The ``cockroach_tmpdir`` directory path corresponds to the
     # dcos-cockroachdb-config-change.service.
     user = 'dcos_cockroach'
-    cockroach_tmpdir = known_exec_directory() / user
-    cockroach_tmpdir.mkdir(mode=0o700, exist_ok=True)
-    shutil.chown(str(cockroach_tmpdir), user=user)
+    cockroach_tmpdir = _known_exec_directory() / user
+    _create_private_directory(path=cockroach_tmpdir, owner=user)
 
 
 def noop(b, opts):

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 import sys
 import tempfile
+from pathlib import Path
 
 import cryptography.hazmat.backends
 import requests

--- a/packages/bouncer/extra/dcos-bouncer.service
+++ b/packages/bouncer/extra/dcos-bouncer.service
@@ -17,7 +17,7 @@ Environment=BOUNCER_PACKAGE_PATH=${PKG_PATH}
 Environment=BOUNCER_CONFIG_FILE_PATH=/opt/mesosphere/etc/bouncer-config.json
 Environment=SECRET_KEY_FILE_PATH=/run/dcos/dcos-bouncer/bouncer_private.key
 Environment=BOUNCER_CONFIG_CLASS=DCOSConfig
-Environment=TMPDIR=/var/lib/dcos/bouncer/tmp
+Environment=TMPDIR=/var/lib/dcos/exec/dcos_bouncer
 WorkingDirectory=${PKG_PATH}
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-bouncer
 ExecStart=${PKG_PATH}/bouncer/bin/bouncer.sh

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -9,6 +9,9 @@ StartLimitInterval=0
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=16384
+# The TMPDIR is created by the bootstrapper.
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach-config-change
+Environment=TMPDIR=/var/lib/dcos/exec/dcos_cockroach
 EnvironmentFile=/opt/mesosphere/environment
 ExecStart=/opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
 

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -5,6 +5,7 @@ Documentation=https://docs.mesosphere.com
 [Service]
 Type=simple
 User=dcos_cockroach
+PermissionsStartOnly=True
 StartLimitInterval=0
 Restart=on-failure
 RestartSec=5

--- a/packages/dcos-history/extra/dcos-history.service
+++ b/packages/dcos-history/extra/dcos-history.service
@@ -11,6 +11,7 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/dcos-history.env
 EnvironmentFile=-/opt/mesosphere/etc/dcos-history-extras.env
 Environment=HISTORY_BUFFER_DIR=/var/lib/dcos/dcos-history
+Environment=TMPDIR=/var/lib/dcos/exec/dcos_history
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-history
 ExecStart=/opt/mesosphere/bin/gunicorn --bind 127.0.0.1:15055 \


### PR DESCRIPTION
This is a backport of #5367.

It is exactly the same except CHANGES have been added.
The original PR description was:

```
## High-level description

Along with DC/OS Enterprise changes, this allows DC/OS Enteprise to start when temporary directories are marked `noexec` on master nodes.
This was done with @jongiddy and @timaa2k and with input from @mhrabovcin .

See the Enterprise PR for the manual testing done there.

Once this is approved, I will backport this and make the following follow up issues:

* Create a preflight check that `/var/lib/dcos/exec` is marked `exec`.
* Document that `/var/lib/dcos/exec` must be marked `exec`.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53077](https://jira.mesosphere.com/browse/DCOS-53077) DC/OS cannot be installed if temporary directories are marked noexec.

## Checklist for all PRs

  - [X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: As per https://github.com/dcos/dcos/wiki/CHANGES.md-guidelines#major-releases, and our intention to port this to 1.13 (and below) my understanding is that there is no CHANGES entry required here.
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: [DCOS-18799](https://jira.mesosphere.com/browse/DCOS-18799) will count as a test for this.
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)
```