### PR TITLE
CHANGES.md: add note for mesos_seccomp_enabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,5 +6,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### What's new
 
+* The DC/OS configuration variable `mesos_seccomp_enabled` now defaults to `true`, with `mesos_seccomp_profile_name` set to `default.json`. This is not expected to break tasks. If you experience problems, though, please note that seccomp can be disabled for individual tasks through the DC/OS SDK and Marathon. (DCOS-50038)
+
 
 ### Breaking changes


### PR DESCRIPTION
This adds a CHANGES.md entry which we missed to add for https://github.com/dcos/dcos/pull/5366.