### PR TITLE
DCOS-53467 - test_mom_installation fails on Permissive Mode Cluster

### DIFF
--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -161,17 +161,16 @@ def test_packaging_api(dcos_api_session):
     assert len(packages) == 0
 
 
-@pytest.mark.xfailflake(
-    jira="DCOS-53467",
-    reason="test_mom_installation fails on Permissive Mode Cluster.",
-    since="2019-05-06"
-)
 def test_mom_installation(dcos_api_session):
     """Test the Cosmos installation of marathon on marathon (MoM)
     """
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
         pytest.skip('MoM disabled for strict mode')
+
+    if expanded_config.get('security') == 'permissive':
+        pytest.skip('DCOS-53467 - test_mom_installation fails '
+                    'on permissive mode cluster')
 
     install_response = dcos_api_session.cosmos.install_package('marathon')
     data = install_response.json()

--- a/packages/dcos-integration-test/extra/test_packaging.py
+++ b/packages/dcos-integration-test/extra/test_packaging.py
@@ -161,6 +161,11 @@ def test_packaging_api(dcos_api_session):
     assert len(packages) == 0
 
 
+@pytest.mark.xfailflake(
+    jira="DCOS-53467",
+    reason="test_mom_installation fails on Permissive Mode Cluster.",
+    since="2019-05-06"
+)
 def test_mom_installation(dcos_api_session):
     """Test the Cosmos installation of marathon on marathon (MoM)
     """


### PR DESCRIPTION
## High-level description

* DCOS-53467 - test_mom_installation fails on Permissive Mode Cluster 

Skip the test_mom_installation as the test hangs on the permissive mode cluster.