### PR TITLE
DCOS-53581 - Update dvdcli reference to fix dvdcli package build.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,6 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### What's new
 
 * The DC/OS configuration variable `mesos_seccomp_enabled` now defaults to `true`, with `mesos_seccomp_profile_name` set to `default.json`. This is not expected to break tasks. If you experience problems, though, please note that seccomp can be disabled for individual tasks through the DC/OS SDK and Marathon. (DCOS-50038)
-
+* Updated ref of dvdcli to fix dvdcli package build (DCOS-53581)
 
 ### Breaking changes

--- a/packages/dvdcli/buildinfo.json
+++ b/packages/dvdcli/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/codedellemc/dvdcli.git",
-    "ref": "64827035b941029d01173822ca1fd1e80551cba4",
+    "ref": "7dede1486c87bef903bae9049e506af2049d734b",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This fixes the dvdcli package build.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53581](https://jira.mesosphere.com/browse/DCOS-53581) Update dvdcli reference to fix dvdcli package build.

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)