### PR TITLE
Collect adminrouter and task metrics with separate plugins

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2578,24 +2578,22 @@ package:
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
         percentile_limit = 1000
-      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      # Read metrics from Prometheus endpoints provided by Mesos tasks.
       [[inputs.prometheus]]
         ## The URL of the local mesos agent
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:{{ mesos_agent_port }}"
         ## The period after which requests to mesos agent should time out
         mesos_timeout = "10s"
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
         ## The user agent to send with requests
         user_agent = "Telegraf-prometheus"
+      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
         response_timeout = "10s"
-        ## Optional TLS Config
-        # tls_ca = /path/to/cafile
-        # tls_cert = /path/to/certfile
-        # tls_key = /path/to/keyfile
-        ## Use TLS but skip chain & host verification
-        # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
         namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*", "nginx_vts_*_request_seconds*"]
         [inputs.prometheus.tagdrop]
@@ -2603,6 +2601,7 @@ package:
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router Agent"
+        user_agent = "Telegraf-prometheus"
       # Read metrics from DC/OS Diagnostics Prometheus endpoint.
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
@@ -2711,25 +2710,22 @@ package:
         ## calculation of percentiles. Raising this limit increases the accuracy
         ## of percentiles but also increases the memory usage and cpu time.
         percentile_limit = 1000
-      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      # Read metrics from Prometheus endpoints provided by Mesos tasks.
       [[inputs.prometheus]]
         ## The URL of the local mesos agent
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:{{ mesos_agent_port }}"
         ## The period after which requests to mesos agent should time out
         mesos_timeout = "10s"
+        ## Specify timeout duration for slower prometheus clients (default is 3s)
+        response_timeout = "10s"
         ## The user agent to send with requests
         user_agent = "Telegraf-prometheus"
-
+      # Read metrics from Admin Router Nginx Prometheus endpoint.
+      [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
         urls = ["http://127.0.0.1:61001/nginx/metrics"]
         ## Specify timeout duration for slower prometheus clients (default is 3s)
         response_timeout = "10s"
-        ## Optional TLS Config
-        # tls_ca = /path/to/cafile
-        # tls_cert = /path/to/certfile
-        # tls_key = /path/to/keyfile
-        ## Use TLS but skip chain & host verification
-        # insecure_skip_verify = true
         ## Drop unused Admin Router metrics from the Nginx VTS module
         namedrop = ["nginx_vts_filter_cache_*", "nginx_vts_server_*", "nginx_vts_upstream_*", "nginx_vts_*_request_seconds*"]
         [inputs.prometheus.tagdrop]
@@ -2737,7 +2733,7 @@ package:
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "Admin Router Agent"
-      # Plugin for adding metadata to dcos-specific metrics
+        user_agent = "Telegraf-prometheus"
       # Read metrics from DC/OS Diagnostics Prometheus endpoint.
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
@@ -2745,6 +2741,7 @@ package:
         ## Apply DC/OS component name tag according to the documentation.
         [inputs.prometheus.tags]
           dcos-component-name = "DC/OS Diagnostics"
+      # Plugin for adding metadata to dcos-specific metrics
       [[processors.dcos_metadata]]
         ## The URL of the local mesos agent
         mesos_agent_url = "http://$DCOS_NODE_PRIVATE_IP:{{ mesos_agent_port }}"

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -918,6 +918,8 @@ def test_task_prom_metrics_not_filtered(dcos_api_session):
         'cpus': 0.1,
         'mem': 128,
         'cmd': '\n'.join([
+            # Serve metrics that would be dropped by Telegraf were they collected from the adminrouter. These are task
+            # metrics, so we expect Telegraf to gather and output them.
             'echo "Creating metrics file..."',
 
             # Adminrouter metrics with direction="[1-5]xx" tags get dropped.

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -151,8 +151,7 @@ def test_metrics_master_adminrouter_nginx_vts(dcos_api_session):
         response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
-                if sample[0].startswith('nginx_vts_'):
-                    assert sample[1]['dcos_component_name'] == 'Admin Router'
+                if sample[0].startswith('nginx_vts_') and sample[1].get('dcos_component_name') == 'Admin Router':
                     return
         raise AssertionError('Expected Admin Router nginx_vts_* metrics not found')
     check_adminrouter_metrics()
@@ -289,8 +288,7 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
         response = get_metrics_prom(dcos_api_session, node)
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
-                if sample[0].startswith('nginx_'):
-                    assert sample[1]['dcos_component_name'] == 'Admin Router'
+                if sample[0].startswith('nginx_') and sample[1].get('dcos_component_name') == 'Admin Router':
                     basename = _nginx_vts_measurement_basename(sample[0])
                     measurements.add(basename)
                     if basename in expect_dropped:
@@ -328,8 +326,10 @@ def test_metrics_agents_adminrouter_nginx_vts(dcos_api_session):
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
-                    if sample[0].startswith('nginx_vts_'):
-                        assert sample[1]['dcos_component_name'] == 'Admin Router Agent'
+                    if (
+                        sample[0].startswith('nginx_vts_') and
+                        sample[1].get('dcos_component_name') == 'Admin Router Agent'
+                    ):
                         return
             raise AssertionError('Expected Admin Router nginx_vts_* metrics not found')
         check_adminrouter_metrics()
@@ -365,8 +365,7 @@ def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
-                    if sample[0].startswith('nginx_'):
-                        assert sample[1]['dcos_component_name'] == 'Admin Router Agent'
+                    if sample[0].startswith('nginx_') and sample[1].get('dcos_component_name') == 'Admin Router Agent':
                         basename = _nginx_vts_measurement_basename(sample[0])
                         measurements.add(basename)
                         if basename in expect_dropped:


### PR DESCRIPTION
## High-level description

This splits up the instance of the Prometheus input plugin that was collecting both adminrouter and task metrics. It creates one input for collecting adminrouter metrics, and another for collecting task metrics. This prevents task metrics from being inadvertently dropped if they meet the filter criteria for adminrouter metrics.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5032](https://jira.mesosphere.com/browse/DCOS_OSS-5032) Don't apply Telegraf config for adminrouter metrics to Mesos task metrics

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This will be backported to 1.13, so no changelog entry required.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]