### PR TITLE
Set the 1.11 branch UI version to 1.11.11-dev.

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -83,7 +83,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.11-dev',
+        'version': '1.11.11-dev',
         'variant': 'some-variant'
     }
 

--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -83,7 +83,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.11.9',
+        'version': '1.11-dev',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1097,7 +1097,7 @@ entry = {
         'mesos_agent_log_file': '/var/log/mesos/mesos-agent.log',
         'mesos_master_log_file': '/var/lib/dcos/mesos/log/mesos-master.log',
         'marathon_port': '8080',
-        'dcos_version': '1.11.9',
+        'dcos_version': '1.11-dev',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1097,7 +1097,7 @@ entry = {
         'mesos_agent_log_file': '/var/log/mesos/mesos-agent.log',
         'mesos_master_log_file': '/var/lib/dcos/mesos/log/mesos-master.log',
         'marathon_port': '8080',
-        'dcos_version': '1.11-dev',
+        'dcos_version': '1.11.11-dev',
         'dcos_gen_resolvconf_search_str': calculate_gen_resolvconf_search,
         'curly_pound': '{#',
         'exhibitor_static_ensemble': calculate_exhibitor_static_ensemble,


### PR DESCRIPTION
## High-level description

* Set the 1.11 branch UI version to 1.11.11-dev

* DCOS-53938 - Set UI versions consistently across all in-development branches