### PR TITLE
Include task metadata with task logs sent to Fluent Bit

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "2633cb7135c978f640d08819f2408c541d6dedb2",
-    "ref_origin": "1.13"
+    "ref": "2b74cd36d99d6540959b715dad0a942509570a4b",
+    "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

This bumps mesos-modules to include https://github.com/dcos/dcos-mesos-modules/pull/109.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53834](https://jira.mesosphere.com/browse/DCOS-53834) Integrate Mesos task log module fix with DC/OS

## Related tickets (optional)

Other tickets related to this change:

N/A

## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This fix will be backported to 1.13, so no changelog entry necessary.
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: Fluent Bit doesn't output logs by default, so we can't cover this with an integration test. Instead I tested manually that task logs are emitted to an Elasticsearch cluster with the correct metadata.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): https://github.com/dcos/dcos-mesos-modules/compare/2633cb7135c978f640d08819f2408c541d6dedb2...2b74cd36d99d6540959b715dad0a942509570a4b
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/modules/job/DCOS_Mesos_Modules-nightly/906/)
  - [x] Code Coverage (if available): N/A