### PR TITLE
Added libseccomp package for dynamic linking with Mesos due to license.

### DIFF
--- a/packages/libseccomp/build
+++ b/packages/libseccomp/build
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+mkdir -p build
+pushd build
+
+export CFLAGS=-I/opt/mesosphere/include
+export LDFLAGS="-L/opt/mesosphere/lib -Wl,-rpath=/opt/mesosphere/lib"
+export CPPFLAGS=-I/opt/mesosphere/include
+
+cd /pkg/src/libseccomp
+./configure --prefix="$PKG_PATH"
+make
+make install

--- a/packages/libseccomp/buildinfo.json
+++ b/packages/libseccomp/buildinfo.json
@@ -1,0 +1,7 @@
+{
+  "single_source": {
+    "kind": "url_extract",
+    "url": "https://github.com/seccomp/libseccomp/releases/download/v2.3.3/libseccomp-2.3.3.tar.gz",
+    "sha1": "89b1f35447b1891a3051de979dc92ad9f7258b60"
+  }
+}

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -28,6 +28,7 @@ LDFLAGS="-Wl,-rpath,/opt/mesosphere/lib" "/pkg/src/mesos/configure" \
   --with-libevent=/opt/mesosphere/active/libevent \
   --with-curl=/opt/mesosphere/active/curl \
   --with-boost=/opt/mesosphere/active/boost-libs \
+  --with-libseccomp=/opt/mesosphere/active/libseccomp \
   --disable-werror \
   --sbindir="$PKG_PATH/bin"
 make -j$NUM_CORES

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -3,7 +3,8 @@
     "openssl",
     "libevent",
     "curl",
-    "boost-libs"
+    "boost-libs",
+    "libseccomp"
   ],
   "single_source": {
     "kind": "git",


### PR DESCRIPTION
## High-level description

This patch adds `libseccomp` package which is used by the Mesos agent.
Previously, we linked `libseccomp` library statically which violated
the license agreement. This patch enables dynamic linking with
`libseccomp` library by default in order to meet license requirements.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53450](https://jira.mesosphere.com/browse/DCOS-53450) De-couple libseccomp static bundle from dc/os because of LGPL2 license.


## Checklist for all PRs

  - [ ] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A - not a functional change.
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)