### PR TITLE
[1.13] DCOS_OSS-5152 - remove ssh_key_path validation

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -163,7 +163,6 @@ def test_do_validate_config(tmpdir, monkeypatch):
     expected_output = {
         'ip_detect_contents': 'ip-detect script `genconf/ip-detect` must exist',
         'master_list': 'Must set master_list, no way to calculate value.',
-        'ssh_key_path': 'could not find ssh private key: genconf/ssh_key'
     }
     with tmpdir.as_cwd():
         assert Config(config_path='genconf/config.yaml').do_validate(include_ssh=True) == expected_output

--- a/ssh/test_unit.py
+++ b/ssh/test_unit.py
@@ -26,16 +26,18 @@ def test_validate_config(default_config):
 
 
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows does not support ssh native")
+def test_validate_config_without_ssh_key_path(default_config):
+    assert ssh.validate.validate_config(default_config) == {}
+
+
+@pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows does not support ssh native")
 def test_validate_config_not_encrypted(default_config):
     with tempfile.NamedTemporaryFile() as tmp:
         default_config['ssh_key_path'] = tmp.name
         with open(tmp.name, 'w') as fh:
             fh.write('ENCRYPTED')
 
-        assert ssh.validate.validate_config(default_config) == {
-            'ssh_key_path': ('Encrypted SSH keys (which contain passphrases) are not allowed. Use a key without a '
-                             'passphrase.')
-        }
+        assert ssh.validate.validate_config(default_config) == {}
 
 
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows does not support ssh native")
@@ -43,10 +45,7 @@ def test_config_permissions(default_config):
     with tempfile.NamedTemporaryFile() as tmp:
         default_config['ssh_key_path'] = tmp.name
         os.chmod(tmp.name, 777)
-        assert ssh.validate.validate_config(default_config) == {
-            'ssh_key_path': ('ssh_key_path must be only read / write / executable by the owner. It may not be read / '
-                             'write / executable by group, or other.')
-        }
+        assert ssh.validate.validate_config(default_config) == {}
 
 
 @pytest.mark.skipif(pkgpanda.util.is_windows, reason="Windows does not support ssh native")

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -5,17 +5,6 @@ import gen
 from gen.internals import Source, Target
 
 
-def validate_ssh_key_path(ssh_key_path):
-    assert os.path.isfile(ssh_key_path), 'could not find ssh private key: {}'.format(ssh_key_path)
-    assert stat.S_IMODE(
-        os.stat(ssh_key_path).st_mode) & (stat.S_IRWXG + stat.S_IRWXO) == 0, (
-            'ssh_key_path must be only read / write / executable by the owner. It may not be read / write / executable '
-            'by group, or other.')
-    with open(ssh_key_path) as fh:
-        assert 'ENCRYPTED' not in fh.read(), ('Encrypted SSH keys (which contain passphrases) '
-                                              'are not allowed. Use a key without a passphrase.')
-
-
 def compare_lists(first_json: str, second_json: str):
     first_list = gen.calc.validate_json_list(first_json)
     second_list = gen.calc.validate_json_list(second_json)
@@ -37,7 +26,6 @@ source = Source({
         lambda master_list, public_agent_list: compare_lists(master_list, public_agent_list),
         # the agent lists shouldn't contain any common items
         lambda agent_list, public_agent_list: compare_lists(agent_list, public_agent_list),
-        validate_ssh_key_path,
         lambda ssh_port: gen.calc.validate_int_in_range(ssh_port, 1, 32000),
         lambda ssh_parallelism: gen.calc.validate_int_in_range(ssh_parallelism, 1, 100)
     ],

--- a/ssh/validate.py
+++ b/ssh/validate.py
@@ -1,6 +1,3 @@
-import os
-import stat
-
 import gen
 from gen.internals import Source, Target
 


### PR DESCRIPTION
Backport of #5522 

The `ssh_key_path` is only used by the deprecated/undocumented CLI
installer. No one should be using this, anymore. Since there's no easy
way to make the validation warning go away for `ssh_key_path` I simply
removed the validation of it completely for two reasons:

1. No one should be using it, anymore.
2. People that are using it most probably have a working configuration
   in place.

As Thorsten stated in eaff454200578f1bcea243f556af926da75c57fb we
should really get rid of this installation method and all of its
accompanying code.

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5152](https://jira.mesosphere.com/browse/DCOS_OSS-5152)  Modify dcos-installer not to warn on missing optional ssh_* keys in dcos-config.yml


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

  - [x] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change: This changes an undocumented/deprecated feature
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
