### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 6a8b61b

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -381,11 +381,6 @@ def test_dcos_diagnostics_runner_cluster(dcos_api_session):
     dcos_api_session.metronome_one_off(job)
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-52191',
-    reason='test_dcos_diagnostics_bundle_create_download_delete is flaky.',
-    since='2019-04-26'
-)
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
     """
     test bundle create, read, delete workflow

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "f38b69c2299152b28a2d263d5e6c5af79c78ca49",
+    "ref": "6a8b61b59498dcea64d9380a233d517ce65dc2ef",
     "ref_origin": "1.5.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/f38b69c2299152b28a2d263d5e6c5af79c78ca49...6a8b61b59498dcea64d9380a233d517ce65dc2ef
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
