### PR TITLE
Increase default checks timeout to 5 seconds for "instant" checks

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -824,7 +824,7 @@ def calculate_check_config(check_time):
     # The 30s value was chosen arbitrarily. It may be increased in the future as required.
     # We chose not to use a value greater than 1min, as the checks are automatically executed
     # in parallel every minute.
-    instant_check_timeout = "1s"
+    instant_check_timeout = "5s"
     normal_check_timeout = "30s"
     check_config = {
         'node_checks': {


### PR DESCRIPTION
## High-level description

Attempts to reduce the relatively common occurrence of timeouts in checks that have no real way to time out by increasing the timeout to 5 seconds in case load is preventing a cluster from being able to run the check in the normal 1 second.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-53742](https://jira.mesosphere.com/browse/DCOS-53742)

## Checklist for all PRs

  - [ X] Added a comprehensible changelog entry to `CHANGES.md` or explain why this is not a user-facing change:
  - [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [X] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [X] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
