### PR TITLE
Bump Marathon to 1.8.194-1590825ea.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,20 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Added Round-Robin DNS support. (DCOS_OSS-5118)
 
+* [Marathon] Fix restarting resident apps and pods. (DCOS_OSS-5212)
+
+* [Marathon] Only match disk with profile if that profile is needed. (DCOS_OSS-5211)
+
+* [Marathon] Better handle invalid state command exceptions in InstanceTrackerActor. (MARATHON-8623)
+
+* [Marathon] Add TASK_UNKNOWN to the valid mesos task status enums. (MARATHON-8624)
+
+* [Marathon] Prevent a rare but benign NPE when a deployment is canceled. (MARATHON-8616)
+
+* [Marathon] Prevent instance leak. (DCOS-51375)
+
+* [Marathon] Introduce new exit error code when the framework was removed from Mesos.
+
 ### Security updates
 
 * Updated urllib3 to version 1.24.2, for addressing [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324). (DCOS-52210)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.180-b00f71136/marathon-1.8.180-b00f71136.tgz",
-    "sha1": "c42d07aa14fc548f956fbcdbb2e4e3f9fc8861fc"
+    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.194-1590825ea/marathon-1.8.194-1590825ea.tgz",
+    "sha1": "ba2cffabb64a0e6b2c58c99d69ee50f983c13d71"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5212](https://jira.mesosphere.com/browse/DCOS_OSS-5212) Fix restarting resident apps and pods.
 - [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) Only match disk with profile if that profile is needed.
 - [MARATHON-8623](https://jira.mesosphere.com/browse/MARATHON-8623) Better handle invalid state command exceptions in InstanceTrackerActor.
 - [MARATHON-8624](https://jira.mesosphere.com/browse/MARATHON-8624) Add TASK_UNKNOWN to the valid mesos task status enums.
 - [MARATHON-8616](https://jira.mesosphere.com/browse/MARATHON-8616) Prevent a rare but benign NPE when a deployment is canceled.
 - [DCOS-51375](https://jira.mesosphere.com/browse/DCOS-51375) Prevent instance leak.
 - Introduce new exit error code when the framework was removed from Mesos.


## Related tickets (optional)
n/a


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [x] Test Results: [Marathon Jenkins](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/1287/testReport/)
  - [ ] Code Coverage (if available): [link to code coverage report]
  
