### PR TITLE
[Backport 1.13] ZooKeeper backup and restore scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Notable changes
 
+* ZooKeeper instances on master nodes can now be backed up and restored via a dedicated command line script `dcos-zk` that is shipped with DC/OS. (DCOS_OSS-5186)
+
 * Bumped DC/OS UI to [1.13+v2.82.3](https://github.com/dcos/dcos-ui/releases/tag/1.13+v2.82.3)
 
 ### Fixed and improved

--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -12,6 +12,9 @@ ln -s "$PKG_PATH/usr/zookeeper/bin/zkCli.sh" "$PKG_PATH/bin/zkCli.sh"
 # zkCli.sh expects zkEnv.sh to be in the same directory.
 ln -s "$PKG_PATH/usr/zookeeper/bin/zkEnv.sh" "$PKG_PATH/bin/zkEnv.sh"
 
+cp -p "/pkg/extra/dcos_zk_backup.py" "$PKG_PATH/bin/dcos-zk"
+chmod +x "$PKG_PATH/bin/dcos-zk"
+
 # Explicitly set JAVA_HOME to our java package
 export JAVA_HOME="$(find /opt/mesosphere/packages -type d -name java--*)/usr/java"
 

--- a/packages/exhibitor/extra/dcos_zk_backup.py
+++ b/packages/exhibitor/extra/dcos_zk_backup.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Command line tool for automated DC/OS ZooKeeper instance backup and restore.
+
+This script is made available as `dcos-zk` executable in DC/OS.
+
+"""
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+from argparse import ArgumentParser, ArgumentTypeError
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+
+EXHIBITOR_DIR = Path('/var/lib/dcos/exhibitor')
+
+
+def run_command(cmd: str, verbose: bool) -> None:
+    """
+    Run a command in a subprocess.
+
+    Args:
+        verbose: Show the output.
+
+    Raises:
+        subprocess.CalledProcessError: The given cmd exits with a non-0 exit code.
+    """
+    stdout = None if verbose else subprocess.PIPE
+    stderr = None if verbose else subprocess.STDOUT
+    subprocess.run(
+        args=shlex.split(cmd),
+        stdout=stdout,
+        stderr=stderr,
+        check=True,
+    )
+
+
+def _is_zookeeper_running(verbose: bool) -> bool:
+    """
+    Exhibitor and therefore ZooKeeper is in active state (running).
+    """
+    try:
+        run_command('systemctl is-active --quiet dcos-exhibitor', verbose)
+    except subprocess.CalledProcessError:
+        # Non-zero exit code indicates Exhibitor + ZooKeeper are dead.
+        return False
+    return True
+
+
+def _copy_dir_and_preserve_ownership(src: Path, dst: Path, verbose: bool) -> None:
+    """
+    Copy a directory from ``src`` to ``dst`` and preserve ownership.
+
+    We need to preserve ownership for a successful restore.
+    We use a subprocess (with `cp -p`) for this rather than Python's
+    `shutil.copytree` as `copytree` does not preserve ownership.
+    """
+    run_command('cp -prv {src} {dst}'.format(src=src, dst=dst), verbose)
+
+
+def backup_zookeeper(
+    backup: Path,
+    tmp_dir: Path,
+    verbose: bool,
+) -> None:
+    """
+    DC/OS ZooKeeper instance backup procedure.
+
+    ZooKeeper changes files while it is running.  In order to have a consistent
+    backup stop ZooKeeper, run the backup procedure, then start ZooKeeper.
+
+    See https://jira.mesosphere.com/browse/DCOS_OSS-5185
+    for changing this procedure to allow a backup without downtime.
+
+    If backing up ZooKeeper via a custom temporary directory, a failing backup
+    procedure does not clean up files created in the temporary directory in the
+    process.
+    """
+    zookeeper_dir = EXHIBITOR_DIR / 'zookeeper'
+    tmp_zookeeper_dir = tmp_dir / 'zookeeper'
+
+    print('Backing up ZooKeeper into {backup} via {tmp_zookeeper_dir}'.format(
+        backup=backup,
+        tmp_zookeeper_dir=tmp_zookeeper_dir,
+    ))
+
+    print('Validate that ZooKeeper is not running')
+    if _is_zookeeper_running(verbose):
+        sys.stderr.write('ZooKeeper must not be running. Aborting.\n')
+        sys.exit(1)
+
+    print('Copying ZooKeeper files to {tmp_zookeeper_dir}'.format(
+        tmp_zookeeper_dir=tmp_zookeeper_dir,
+    ))
+
+    _copy_dir_and_preserve_ownership(
+        src=zookeeper_dir,
+        dst=tmp_zookeeper_dir,
+        verbose=verbose,
+    )
+
+    print('Creating ZooKeeper backup tar archive at {backup}'.format(backup=backup))
+
+    def _tar_filter(tar_info: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+        # The myid file is not backed up because it identifies the local
+        # ZooKeeper instance and is automatically recreated on start up.
+        if 'myid' in tar_info.name:
+            return None
+        # The `zookeeper.out` contains ZooKeeper logs written to `stdout`.
+        # These take up space and are irrelevant to the backup procedure.
+        if 'zookeeper.out' in tar_info.name:
+            return None
+        return tar_info
+
+    with tarfile.open(name=str(backup), mode='x:gz') as tar:
+        tar.add(
+            name=str(tmp_zookeeper_dir),
+            arcname='./zookeeper',
+            filter=_tar_filter,
+        )
+        if verbose:
+            tar.list()
+
+    print('Deleting temporary files in {tmp_zookeeper_dir}'.format(
+        tmp_zookeeper_dir=tmp_zookeeper_dir,
+    ))
+    shutil.rmtree(path=str(tmp_zookeeper_dir), ignore_errors=True)
+
+    print('ZooKeeper backup taken successfully')
+
+
+def restore_zookeeper(backup: Path, tmp_dir: Path, verbose: bool) -> None:
+    """
+    DC/OS ZooKeeper restore from backup procedure.
+
+    ZooKeeper changes files while it is running.
+    In order to have a consistent restore, one must stop ZooKeeper on all
+    master nodes, execute this procedure on all master nodes, and then start
+    ZooKeeper again on all master nodes.
+
+    Stopping ZooKeeper on all master nodes inevitably causes the DC/OS cluster
+    to experience downtime.  The restore procedure is intended for recovering
+    from an unusable DC/OS cluster as a last resort measure.
+
+    Running this script requires at least as much free space as the ZooKeeper backup takes.
+    """
+    zookeeper_dir = EXHIBITOR_DIR / 'zookeeper'
+    tmp_zookeeper_dir = tmp_dir / 'zookeeper'
+
+    print('Restoring local ZooKeeper instance from {backup}'.format(backup=backup))
+
+    print('Validate that ZooKeeper is not running')
+    if _is_zookeeper_running(verbose):
+        sys.stderr.write('ZooKeeper must not be running. Aborting.\n')
+        sys.exit(1)
+
+    print('Moving ZooKeeper files temporarily to {tmp_zookeeper_dir}'.format(
+        tmp_zookeeper_dir=tmp_zookeeper_dir,
+    ))
+    # We copy files rather than move them so that if this script is interrupted
+    # while running, no data is lost inplace.
+    # However, this has a downside that we may use a lot of disk space -
+    # we have seen ZooKeeper files up to 20 GB in size.
+    _copy_dir_and_preserve_ownership(
+        src=zookeeper_dir,
+        dst=tmp_zookeeper_dir,
+        verbose=verbose,
+    )
+    shutil.rmtree(path=str(zookeeper_dir))
+
+    print('Restoring {zookeeper_dir} from backup {backup}'.format(
+        zookeeper_dir=zookeeper_dir,
+        backup=backup,
+    ))
+    with tarfile.open(name=str(backup), mode='r:gz') as tar:
+        tar.extractall(path=str(EXHIBITOR_DIR))
+        if verbose:
+            tar.list()
+
+    print('Deleting temporary files in {tmp_zookeeper_dir}'.format(
+        tmp_zookeeper_dir=tmp_zookeeper_dir,
+    ))
+    shutil.rmtree(path=str(tmp_zookeeper_dir), ignore_errors=True)
+
+    print('Local ZooKeeper instance restored successfully')
+
+
+def _non_existing_file_path_existing_parent_dir(value: str) -> Path:
+    """
+    Validate that the value is a path to a file which does not exist
+    but the parent directory tree exists.
+    """
+    path = Path(value)
+    if path.exists():
+        raise ArgumentTypeError('{} already exists'.format(path))
+    if not Path(path.parent).exists():
+        raise ArgumentTypeError(
+            '{} parent directory does not exist'.format(path),
+        )
+    return path.absolute()
+
+
+def _existing_file_path(value: str) -> Path:
+    """
+    Validate that the value is a file which does exist on the file system.
+    """
+    path = Path(value)
+    if not path.exists():
+        raise ArgumentTypeError('{} does not exist'.format(path))
+    if not path.is_file():
+        raise ArgumentTypeError('{} is not a file'.format(path))
+    return path.absolute()
+
+
+def _existing_dir_path(value: str) -> Path:
+    """
+    Validate that the value is a directory which does exist on the file system.
+    """
+    path = Path(value)
+    if not path.exists():
+        raise ArgumentTypeError('{} does not exist'.format(path))
+    if not path.is_dir():
+        raise ArgumentTypeError('{} is not a directory'.format(path))
+    return path.absolute()
+
+
+class DCOSZooKeeperCli:
+    """
+    Minimal CLI to backup/restore the local DC/OS ZooKeeper instance.
+    """
+
+    def __init__(self) -> None:
+        """
+        Present CLI command choices.
+        """
+        parser = ArgumentParser(
+            description=(
+                'Command line utility to more safely interact with the local '
+                'ZooKeeper instance on DC/OS master nodes'
+            )
+        )
+        parser.add_argument(
+            'command',
+            type=str,
+            choices=[
+                'backup',
+                'restore',
+            ],
+            help='CLI commands available',
+        )
+        args = parser.parse_args(sys.argv[1:2])
+        getattr(self, args.command)()
+
+    def backup(self) -> None:
+        """
+        Procedure invoked on `backup` command.
+        """
+        parser = ArgumentParser(
+            description=(
+                'Create a backup of the ZooKeeper instance running on this '
+                'DC/OS master node'
+            )
+        )
+        parser.add_argument(
+            'backup_path',
+            type=_non_existing_file_path_existing_parent_dir,
+            help=(
+                'File path that the gzipped ZooKeeper backup tar archive will '
+                'be written to'
+            ),
+        )
+        parser.add_argument(
+            '-t', '--tmp-dir',
+            type=_existing_dir_path,
+            help=(
+                'Location of an existing directory to be used as temporary '
+                'directory in the process'
+            ),
+        )
+        parser.add_argument(
+            '-v', '--verbose',
+            action='store_true',
+            help='Display the output of every command',
+        )
+        args = parser.parse_args(sys.argv[2:])
+        if args.tmp_dir is None:
+            with TemporaryDirectory(suffix='-zk-backup') as tmp_dir:
+                backup_zookeeper(
+                    backup=args.backup_path,
+                    tmp_dir=Path(tmp_dir),
+                    verbose=args.verbose,
+                )
+        else:
+            backup_zookeeper(
+                backup=args.backup_path,
+                tmp_dir=args.tmp_dir,
+                verbose=args.verbose,
+            )
+
+    def restore(self) -> None:
+        """
+        Procedure invoked on `restore` command.
+        """
+        parser = ArgumentParser(
+            description=(
+                'Restore the ZooKeeper instance running on this DC/OS master '
+                'node from the given backup'
+            ),
+        )
+        parser.add_argument(
+            'backup_path',
+            type=_existing_file_path,
+            help=(
+                'File path to the gzipped ZooKeeper backup tar archive to '
+                'restore from'
+            ),
+        )
+        parser.add_argument(
+            '-t', '--tmp-dir',
+            type=_existing_dir_path,
+            help=(
+                'Location of an existing directory to be used as temporary '
+                'directory in the process'
+            ),
+        )
+        parser.add_argument(
+            '-v', '--verbose',
+            action='store_true',
+            help='Display the output of every command',
+        )
+        args = parser.parse_args(sys.argv[2:])
+        if args.tmp_dir is None:
+            with TemporaryDirectory(suffix='-zk-restore') as tmp_dir:
+                restore_zookeeper(
+                    backup=args.backup_path,
+                    tmp_dir=Path(tmp_dir),
+                    verbose=args.verbose,
+                )
+        else:
+            restore_zookeeper(
+                backup=args.backup_path,
+                tmp_dir=args.tmp_dir,
+                verbose=args.verbose,
+            )
+
+
+if __name__ == '__main__':
+    try:
+        DCOSZooKeeperCli()
+    except subprocess.CalledProcessError as exc:
+        if exc.output:
+            sys.stdout.buffer.write(exc.output)
+        sys.exit(exc.returncode)

--- a/packages/exhibitor/extra/dcos_zk_backup.py
+++ b/packages/exhibitor/extra/dcos_zk_backup.py
@@ -90,7 +90,7 @@ def backup_zookeeper(
 
     print('Validate that ZooKeeper is not running')
     if _is_zookeeper_running(verbose):
-        sys.stderr.write('ZooKeeper must not be running. Aborting.\n')
+        sys.stderr.write('dcos-exhibitor must not be running. Aborting.\n')
         sys.exit(1)
 
     print('Copying ZooKeeper files to {tmp_zookeeper_dir}'.format(
@@ -155,7 +155,7 @@ def restore_zookeeper(backup: Path, tmp_dir: Path, verbose: bool) -> None:
 
     print('Validate that ZooKeeper is not running')
     if _is_zookeeper_running(verbose):
-        sys.stderr.write('ZooKeeper must not be running. Aborting.\n')
+        sys.stderr.write('dcos-exhibitor must not be running. Aborting.\n')
         sys.exit(1)
 
     print('Moving ZooKeeper files temporarily to {tmp_zookeeper_dir}'.format(
@@ -239,8 +239,8 @@ class DCOSZooKeeperCli:
         """
         parser = ArgumentParser(
             description=(
-                'Command line utility to more safely interact with the local '
-                'ZooKeeper instance on DC/OS master nodes'
+                'Command line utility to backup and restore the local '
+                'ZooKeeper instance on DC/OS master nodes.'
             )
         )
         parser.add_argument(
@@ -260,17 +260,20 @@ class DCOSZooKeeperCli:
         Procedure invoked on `backup` command.
         """
         parser = ArgumentParser(
+            usage=(
+                '{executable} backup [-h] [-t TMP_DIR] [-v] backup_path'
+            ).format(executable=sys.argv[0]),
             description=(
                 'Create a backup of the ZooKeeper instance running on this '
-                'DC/OS master node'
-            )
+                'DC/OS master node.'
+            ),
         )
         parser.add_argument(
             'backup_path',
             type=_non_existing_file_path_existing_parent_dir,
             help=(
                 'File path that the gzipped ZooKeeper backup tar archive will '
-                'be written to'
+                'be written to.'
             ),
         )
         parser.add_argument(
@@ -278,13 +281,14 @@ class DCOSZooKeeperCli:
             type=_existing_dir_path,
             help=(
                 'Location of an existing directory to be used as temporary '
-                'directory in the process'
+                'directory. A temporary directory will be created if not '
+                'specified.'
             ),
         )
         parser.add_argument(
             '-v', '--verbose',
             action='store_true',
-            help='Display the output of every command',
+            help='Display the output of every command.',
         )
         args = parser.parse_args(sys.argv[2:])
         if args.tmp_dir is None:
@@ -306,9 +310,12 @@ class DCOSZooKeeperCli:
         Procedure invoked on `restore` command.
         """
         parser = ArgumentParser(
+            usage=(
+                '{executable} restore [-h] [-t TMP_DIR] [-v] backup_path'
+            ).format(executable=sys.argv[0]),
             description=(
                 'Restore the ZooKeeper instance running on this DC/OS master '
-                'node from the given backup'
+                'node from the given backup.'
             ),
         )
         parser.add_argument(
@@ -316,7 +323,7 @@ class DCOSZooKeeperCli:
             type=_existing_file_path,
             help=(
                 'File path to the gzipped ZooKeeper backup tar archive to '
-                'restore from'
+                'restore from.'
             ),
         )
         parser.add_argument(
@@ -324,7 +331,8 @@ class DCOSZooKeeperCli:
             type=_existing_dir_path,
             help=(
                 'Location of an existing directory to be used as temporary '
-                'directory in the process'
+                'directory. A temporary directory will be created if not '
+                'specified.'
             ),
         )
         parser.add_argument(

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.05.23.0
+git+https://github.com/dcos/dcos-e2e.git@2019.06.03.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,7 +1,8 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.04.25.0
+git+https://github.com/dcos/dcos-e2e.git@2019.05.23.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4
+kazoo==2.6.1
 pytest==4.1.1
 requests==2.21.0
 wheel==0.33.1

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -54,3 +54,4 @@ groups:
     group_1:
         - test_service_account.py
         - test_master_node_replacement.py
+        - test_zookeeper_backup.py

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -1,0 +1,287 @@
+"""
+Tests for the ZooKeeper backup/restore via `dcos-zk`.
+"""
+
+import logging
+import uuid
+from pathlib import Path
+from typing import Set
+
+import pytest
+from _pytest.fixtures import SubRequest
+
+from cluster_helpers import wait_for_dcos_oss
+from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Node, Output
+from kazoo.client import KazooClient
+from kazoo.exceptions import NoNodeError
+from kazoo.retry import KazooRetry
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Arbitrary value written to ZooKeeper.
+FLAG = b'flag'
+
+
+@pytest.fixture
+def three_master_cluster(
+    artifact_path: Path,
+    docker_backend: Docker,
+    request: SubRequest,
+    log_dir: Path,
+) -> Cluster:
+    """
+    Spin up a highly-available DC/OS cluster with three master nodes.
+    """
+    with Cluster(
+        cluster_backend=docker_backend,
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=cluster.base_config,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        yield cluster
+
+
+@pytest.fixture
+def zk_client(three_master_cluster: Cluster) -> KazooClient:
+    """
+    ZooKeeper client connected to a given DC/OS cluster.
+    """
+    zk_hostports = ','.join(['{}:2181'.format(m.public_ip_address)
+                             for m in three_master_cluster.masters])
+    retry_policy = KazooRetry(
+        max_tries=-1,
+        delay=1,
+        backoff=1,
+        max_delay=600,
+        ignore_expire=True,
+    )
+    zk_client = KazooClient(
+        hosts=zk_hostports,
+        # Avoid failure due to client session timeout.
+        timeout=40,
+        # Work around https://github.com/python-zk/kazoo/issues/374
+        connection_retry=retry_policy,
+        command_retry=retry_policy,
+    )
+    zk_client.start()
+    try:
+        yield zk_client
+    finally:
+        zk_client.stop()
+        zk_client.close()
+
+
+def _zk_set_flag(zk: KazooClient, ephemeral: bool = False) -> str:
+    """
+    Store the `FLAG` value in ZooKeeper in a random Znode.
+    """
+    znode = '/{}'.format(uuid.uuid4())
+    zk.retry(zk.create, znode, makepath=True, ephemeral=ephemeral)
+    zk.retry(zk.set, znode, FLAG)
+    return znode
+
+
+def _zk_flag_exists(zk: KazooClient, znode: str) -> bool:
+    """
+    The `FLAG` value exists in ZooKeeper at `znode` path.
+    """
+    try:
+        value = zk.retry(zk.get, znode)
+    except NoNodeError:
+        return False
+    return bool(value[0] == FLAG)
+
+
+class TestZooKeeperBackup:
+    """
+    Within the context of DC/OS ZooKeeper can be backed up on a running
+    cluster and a previous state can be restored.
+    """
+
+    def test_transaction_log_backup_and_restore(
+        self,
+        three_master_cluster: Cluster,
+        zk_client: KazooClient,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        In a 3-master cluster, backing up the transaction log of ZooKeeper on
+        one node and restoring from the backup on all master results in a
+        functioning DC/OS cluster with previously backed up Znodes restored.
+        """
+        # Write to ZooKeeper before backup
+        persistent_flag = _zk_set_flag(zk_client)
+        ephemeral_flag = _zk_set_flag(zk_client, ephemeral=True)
+
+        random = uuid.uuid4().hex
+        backup_name = 'zk-backup-{random}.tar.gz'.format(random=random)
+        backup_local_path = tmp_path / backup_name
+
+        # Take ZooKeeper backup from one master node.
+        _do_backup(next(iter(three_master_cluster.masters)), backup_local_path)
+
+        # Store a datapoint which we expect to get lost.
+        not_backed_up_flag = _zk_set_flag(zk_client)
+
+        # Restore ZooKeeper from backup on all master nodes.
+        _do_restore(three_master_cluster.masters, backup_local_path)
+
+        # Read from ZooKeeper after restore
+        assert _zk_flag_exists(zk_client, persistent_flag)
+        assert _zk_flag_exists(zk_client, ephemeral_flag)
+        assert not _zk_flag_exists(zk_client, not_backed_up_flag)
+
+        # Assert that DC/OS is intact.
+        wait_for_dcos_oss(
+            cluster=three_master_cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+
+    def test_snapshot_backup_and_restore(
+        self,
+        three_master_cluster: Cluster,
+        zk_client: KazooClient,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        In a 3-master cluster, backing up a snapshot of ZooKeeper on
+        one node and restoring from the backup on all master results in a
+        functioning DC/OS cluster with previously backed up Znodes restored.
+        """
+        # Modify Exhibitor conf, generating ZooKeeper conf (set
+        # `snapCount=1`). This config change instructs ZooKeeper to Adding
+        # the `snapCount` here only works as long as DC/OS does not set it.
+        args = [
+            'sed',
+            '-i', "'s/zoo-cfg-extra=/zoo-cfg-extra=snapCount\\\\=1\\&/'",
+            '/opt/mesosphere/active/exhibitor/usr/exhibitor/start_exhibitor.py',
+        ]
+        for master in three_master_cluster.masters:
+            master.run(
+                args=args,
+                shell=True,
+                output=Output.LOG_AND_CAPTURE,
+            )
+        for master in three_master_cluster.masters:
+            master.run(['systemctl', 'restart', 'dcos-exhibitor'])
+
+        wait_for_dcos_oss(
+            cluster=three_master_cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+
+        # Write to ZooKeeper multiple times before backup
+        persistent_flag = _zk_set_flag(zk_client)
+        ephemeral_flag = _zk_set_flag(zk_client, ephemeral=True)
+
+        # Extra ZooKeeper write, triggering snapshot creation due to
+        # `snapCount=1`. After this we can be sure the previous writes are
+        # contained in at least one of the generated snapshots.
+        _zk_set_flag(zk_client)
+
+        random = uuid.uuid4().hex
+        backup_name = 'zk-backup-{random}.tar.gz'.format(random=random)
+        backup_local_path = tmp_path / backup_name
+
+        # Take ZooKeeper backup from one master node.
+        _do_backup(next(iter(three_master_cluster.masters)), backup_local_path)
+
+        # Store a datapoint which we expect to be lost.
+        not_backed_up_flag = _zk_set_flag(zk_client)
+
+        # Restore ZooKeeper from backup on all master nodes.
+        _do_restore(three_master_cluster.masters, backup_local_path)
+
+        # Read from ZooKeeper after restore
+        assert _zk_flag_exists(zk_client, persistent_flag)
+        assert _zk_flag_exists(zk_client, ephemeral_flag)
+        assert not _zk_flag_exists(zk_client, not_backed_up_flag)
+
+        # Assert DC/OS is intact.
+        wait_for_dcos_oss(
+            cluster=three_master_cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+
+
+def _do_backup(master: Node, backup_local_path: Path) -> None:
+    """
+    Automated ZooKeeper backup procedure.
+    Intended to be consistent with the documentation.
+    https://jira.mesosphere.com/browse/DCOS-51647
+    """
+    master.run(args=['systemctl', 'stop', 'dcos-exhibitor'])
+
+    backup_name = backup_local_path.name
+    # This must be an existing directory on the remote server.
+    backup_remote_path = Path('/etc/') / backup_name
+    master.run(
+        args=[
+            '/opt/mesosphere/bin/dcos-shell',
+            'dcos-zk',
+            'backup',
+            str(backup_remote_path),
+            '-v',
+        ],
+        output=Output.LOG_AND_CAPTURE,
+    )
+
+    master.run(args=['systemctl', 'start', 'dcos-exhibitor'])
+
+    master.download_file(
+        remote_path=backup_remote_path,
+        local_path=backup_local_path,
+    )
+
+    master.run(args=['rm', str(backup_remote_path)])
+
+
+def _do_restore(all_masters: Set[Node], backup_local_path: Path) -> None:
+    """
+    Automated ZooKeeper restore from backup procedure.
+    Intended to be consistent with the documentation.
+    https://jira.mesosphere.com/browse/DCOS-51647
+    """
+    backup_name = backup_local_path.name
+    backup_remote_path = Path('/etc/') / backup_name
+
+    for master in all_masters:
+        master.send_file(
+            local_path=backup_local_path,
+            remote_path=backup_remote_path,
+        )
+
+    for master in all_masters:
+        master.run(args=['systemctl', 'stop', 'dcos-exhibitor'])
+
+    for master in all_masters:
+        master.run(
+            args=[
+                '/opt/mesosphere/bin/dcos-shell',
+                'dcos-zk', 'restore', str(backup_remote_path), '-v',
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+    for master in all_masters:
+        master.run(args=['systemctl', 'start', 'dcos-exhibitor'])

--- a/tox.ini
+++ b/tox.ini
@@ -166,6 +166,7 @@ deps=
   mypy-mypyc==0.660
 commands=
   mypy ./test-e2e
+  mypy ./packages/exhibitor/extra/dcos_zk_backup.py
 
 [testenv:collect-integration-tests]
 platform=linux|darwin


### PR DESCRIPTION
## High-level description

Backport of #5575 
Only `CHANGES.md` differs.

The backup strategy was shifted to a backup/restore script shipped with DC/OS that will do a node local backup/restore on the particular master node that it is executed on.

The backup/restore script is now ported to Python3 and comprises a single file + CLI interface with commands backup and restore.

This PR adds two E2E tests for our ZooKeeper backup/restore procedures.
The actual backup/restore test is split into two because we want to test are two different scenarios:
* Restore from a ZooKeeper transaction log
* Restore from a ZooKeeper snapshot
Normally one would like to test `1.` with a snapshot+transaction log but success is difficult to assert in this case. Splitting it into to different test cases gives us confidence that a transaction log is replayed from our backup (`1.`) and that we could restore from snapshot directly, which limits the fallback of a backup to the `snapCount`. It's not a perfect test but it's reasonably close.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5186](https://jira.mesosphere.com/browse/DCOS_OSS-5186) Automate ZooKeeper backup and restoration testing with an E2E test.