### PR TITLE
Mh/autoformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,3 +292,12 @@ A non-required status check is completely informational, and the success or the 
 
 The required status checks are encoded in the repo's megebot-config (For .e.g: https://github.com/dcos/dcos/blob/master/mergebot-config.json#L38)
 and are enforced by mergebot.
+
+### Formatting checks
+
+YAPF is used to check Python formatting for some files in the `teamcity/dcos/build/tox` builder.
+To fix errors reported by YAPF, install YAPF locally with `pip install yapf` and run the following command:
+
+```
+yapf --in-place --recursive packages/dcos-integration-test/extra/
+```

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -25,15 +25,16 @@ def dcos_api_session(dcos_api_session_factory):
         exhibitor_admin_password = expanded_config['exhibitor_admin_password']
 
     api = dcos_api_session_factory(
-        exhibitor_admin_password=exhibitor_admin_password,
-        **args)
+        exhibitor_admin_password=exhibitor_admin_password, **args
+    )
     api.wait_for_dcos()
     return api
 
 
 def pytest_addoption(parser):
-    parser.addoption("--windows-only", action="store_true",
-                     help="run only Windows tests")
+    parser.addoption(
+        "--windows-only", action="store_true", help="run only Windows tests"
+    )
 
 
 def pytest_runtest_setup(item):
@@ -45,8 +46,12 @@ def pytest_runtest_setup(item):
 
 
 def pytest_configure(config):
-    config.addinivalue_line('markers', 'first: run test before all not marked first')
-    config.addinivalue_line('markers', 'last: run test after all not marked last')
+    config.addinivalue_line(
+        'markers', 'first: run test before all not marked first'
+    )
+    config.addinivalue_line(
+        'markers', 'last: run test after all not marked last'
+    )
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -82,7 +87,9 @@ def clean_marathon_state(dcos_api_session):
         try:
             dcos_api_session.marathon.purge()
         except Exception as exc:
-            log.exception('Ignoring exception during marathon.purge(): %s', exc)
+            log.exception(
+                'Ignoring exception during marathon.purge(): %s', exc
+            )
             if isinstance(exc, requests.exceptions.HTTPError):
                 log.error('exc.response.text: %s', exc.response.text)
 
@@ -111,13 +118,12 @@ def _dump_diagnostics(request, dcos_api_session):
     """
     yield
 
-    make_diagnostics_report = os.environ.get('DIAGNOSTICS_DIRECTORY') is not None
+    make_diagnostics_report = os.environ.get(
+        'DIAGNOSTICS_DIRECTORY'
+    ) is not None
     if make_diagnostics_report:
         creation_start = datetime.datetime.now()
-        last_datapoint = {
-            'time': None,
-            'value': 0
-        }
+        last_datapoint = {'time': None, 'value': 0}
 
         health_url = dcos_api_session.default_url.copy(
             query='cache=0',

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -3,13 +3,11 @@ import re
 
 import pytest
 
-
 log = logging.getLogger(__name__)
 
 
 @pytest.mark.security
 class TestRedirectSecurity:
-
     @pytest.mark.parametrize(
         'path,expected', (
             ('/exhibitor', 301),
@@ -36,9 +34,7 @@ class TestRedirectSecurity:
         Redirection does not propagate a bad Host header
         """
         r = dcos_api_session.get(
-            path,
-            headers={'Host': 'bad.host'},
-            allow_redirects=False
+            path, headers={'Host': 'bad.host'}, allow_redirects=False
         )
 
         r.raise_for_status()
@@ -63,7 +59,9 @@ class TestEncodingGzip:
         assert len(filenames) > 0
         for filename in set(filenames):
             log.info('Load %r', filename)
-            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'gzip'})
+            r = dcos_api_session.head(
+                filename, headers={'Accept-Encoding': 'gzip'}
+            )
             r.raise_for_status()
             log.info('Response headers: %s', repr(r.headers))
             assert r.headers.get('content-encoding') == 'gzip'
@@ -81,7 +79,9 @@ class TestEncodingGzip:
             log.info('Load %r', filename)
             # Set a benign `Accept-Encoding` header to prevent underlying
             # libraries setting their own header based on their capabilities.
-            r = dcos_api_session.head(filename, headers={'Accept-Encoding': 'identity'})
+            r = dcos_api_session.head(
+                filename, headers={'Accept-Encoding': 'identity'}
+            )
             r.raise_for_status()
             log.info('Response headers: %s', repr(r.headers))
             assert 'content-encoding' not in r.headers

--- a/packages/dcos-integration-test/extra/test_auth.py
+++ b/packages/dcos-integration-test/extra/test_auth.py
@@ -11,11 +11,15 @@ def auth_enabled():
         '/bin/bash', '-c',
         'source /opt/mesosphere/etc/adminrouter.env && echo $ADMINROUTER_ACTIVATE_AUTH_MODULE']).\
         decode().strip('\n')
-    assert out in ['true', 'false'], 'Unknown ADMINROUTER_ACTIVATE_AUTH_MODULE state: {}'.format(out)
+    assert out in [
+        'true', 'false'
+    ], 'Unknown ADMINROUTER_ACTIVATE_AUTH_MODULE state: {}'.format(out)
     return out == 'true'
 
 
-def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_session):
+def test_adminrouter_access_control_enforcement(
+    dcos_api_session, noauth_api_session
+):
     reason = 'Can only test adminrouter enforcement if auth is enabled'
     if not auth_enabled():
         pytest.skip(reason)
@@ -37,10 +41,9 @@ def test_adminrouter_access_control_enforcement(dcos_api_session, noauth_api_ses
 
     # Test authentication with auth cookie instead of Authorization header.
     authcookie = {
-        'dcos-acs-auth-cookie': dcos_api_session.auth_user.auth_cookie}
-    r = noauth_api_session.get(
-        '/service/marathon/',
-        cookies=authcookie)
+        'dcos-acs-auth-cookie': dcos_api_session.auth_user.auth_cookie
+    }
+    r = noauth_api_session.get('/service/marathon/', cookies=authcookie)
     assert r.status_code == 200
 
 

--- a/packages/dcos-integration-test/extra/test_checks.py
+++ b/packages/dcos-integration-test/extra/test_checks.py
@@ -2,7 +2,6 @@ import logging
 import random
 import uuid
 
-
 __maintainer__ = 'branden'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
@@ -16,44 +15,56 @@ def test_checks_cli(dcos_api_session):
     test_uuid = uuid.uuid4().hex
 
     # Poststart node checks should pass.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-node-poststart-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(base_cmd + ['node-poststart']),
-        },
-    })
+    dcos_api_session.metronome_one_off(
+        {
+            'id': 'test-checks-node-poststart-' + test_uuid,
+            'run': {
+                'cpus': .1,
+                'mem': 128,
+                'disk': 0,
+                'cmd': ' '.join(base_cmd + ['node-poststart']),
+            },
+        }
+    )
 
     # Cluster checks should pass.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-cluster-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join(base_cmd + ['cluster']),
-        },
-    })
+    dcos_api_session.metronome_one_off(
+        {
+            'id': 'test-checks-cluster-' + test_uuid,
+            'run': {
+                'cpus': .1,
+                'mem': 128,
+                'disk': 0,
+                'cmd': ' '.join(base_cmd + ['cluster']),
+            },
+        }
+    )
 
     # Check runner should only use the PATH and LD_LIBRARY_PATH from check config.
-    dcos_api_session.metronome_one_off({
-        'id': 'test-checks-env-' + test_uuid,
-        'run': {
-            'cpus': .1,
-            'mem': 128,
-            'disk': 0,
-            'cmd': ' '.join([
-                'env',
-                'PATH=badvalue',
-                'LD_LIBRARY_PATH=badvalue',
-                '/opt/mesosphere/bin/dcos-check-runner',
-                'check',
-                'node-poststart',
-            ]),
-        },
-    })
+    dcos_api_session.metronome_one_off(
+        {
+            'id': 'test-checks-env-' + test_uuid,
+            'run': {
+                'cpus':
+                .1,
+                'mem':
+                128,
+                'disk':
+                0,
+                'cmd':
+                ' '.join(
+                    [
+                        'env',
+                        'PATH=badvalue',
+                        'LD_LIBRARY_PATH=badvalue',
+                        '/opt/mesosphere/bin/dcos-check-runner',
+                        'check',
+                        'node-poststart',
+                    ]
+                ),
+            },
+        }
+    )
 
 
 def test_checks_api(dcos_api_session):
@@ -66,10 +77,15 @@ def test_checks_api(dcos_api_session):
     checks_uri = '/system/checks/v1/'
     # Test that we can list and run node and cluster checks on a master, agent, and public agent.
     check_nodes = []
-    for nodes in [dcos_api_session.masters, dcos_api_session.slaves, dcos_api_session.public_slaves]:
+    for nodes in [
+        dcos_api_session.masters, dcos_api_session.slaves,
+        dcos_api_session.public_slaves
+    ]:
         if nodes:
             check_nodes.append(random.choice(nodes))
-    logging.info('Testing %s on these nodes: %s', checks_uri, ', '.join(check_nodes))
+    logging.info(
+        'Testing %s on these nodes: %s', checks_uri, ', '.join(check_nodes)
+    )
 
     for node in check_nodes:
         for check_type in ['node', 'cluster']:
@@ -90,7 +106,10 @@ def test_checks_api(dcos_api_session):
 
             # check that the returned statuses of each check is 0
             expected_status = {c: 0 for c in checks.keys()}
-            response_status = {c: v['status'] for c, v in results['checks'].items()}
+            response_status = {
+                c: v['status']
+                for c, v in results['checks'].items()
+            }
 
             # print out the response for debugging
             logging.info('Response: {}'.format(results))

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -21,10 +21,11 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 def test_dcos_cluster_is_up(dcos_api_session):
     def _docker_info(component):
         # sudo is required for non-coreOS installs
-        return (subprocess.check_output(['sudo', 'docker', 'version', '-f', component], timeout=60)
-                .decode('utf-8')
-                .rstrip()
-                )
+        return (
+            subprocess.check_output(
+                ['sudo', 'docker', 'version', '-f', component], timeout=60
+            ).decode('utf-8').rstrip()
+        )
 
     try:
         docker_client = _docker_info('{{.Client.Version}}')
@@ -87,7 +88,11 @@ def test_if_all_exhibitors_are_in_sync(dcos_api_session):
     for master_node_ip in dcos_api_session.masters:
         # This relies on the fact that Admin Router always proxies the local
         # Exhibitor.
-        resp = requests.get('http://{}/exhibitor/exhibitor/v1/cluster/status'.format(master_node_ip), verify=False)
+        resp = requests.get(
+            'http://{}/exhibitor/exhibitor/v1/cluster/status'.
+            format(master_node_ip),
+            verify=False
+        )
         assert resp.status_code == 200
 
         tested_data = sorted(resp.json(), key=lambda k: k['hostname'])
@@ -147,39 +152,29 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
         'dcos-ui-update-service.socket',
     ]
     all_node_units = [
-        'dcos-checks-api.service',
-        'dcos-checks-api.socket',
-        'dcos-diagnostics.service',
-        'dcos-diagnostics.socket',
-        'dcos-gen-resolvconf.service',
-        'dcos-gen-resolvconf.timer',
-        'dcos-net.service',
-        'dcos-net-watchdog.service',
-        'dcos-pkgpanda-api.service',
-        'dcos-signal.timer',
-        'dcos-checks-poststart.service',
-        'dcos-checks-poststart.timer',
-        'dcos-telegraf.service',
-        'dcos-telegraf.socket',
-        'dcos-fluent-bit.service']
-    slave_units = [
-        'dcos-mesos-slave.service']
-    public_slave_units = [
-        'dcos-mesos-slave-public.service']
+        'dcos-checks-api.service', 'dcos-checks-api.socket',
+        'dcos-diagnostics.service', 'dcos-diagnostics.socket',
+        'dcos-gen-resolvconf.service', 'dcos-gen-resolvconf.timer',
+        'dcos-net.service', 'dcos-net-watchdog.service',
+        'dcos-pkgpanda-api.service', 'dcos-signal.timer',
+        'dcos-checks-poststart.service', 'dcos-checks-poststart.timer',
+        'dcos-telegraf.service', 'dcos-telegraf.socket',
+        'dcos-fluent-bit.service'
+    ]
+    slave_units = ['dcos-mesos-slave.service']
+    public_slave_units = ['dcos-mesos-slave-public.service']
     all_slave_units = [
-        'dcos-docker-gc.service',
-        'dcos-docker-gc.timer',
-        'dcos-adminrouter-agent.service',
-        'dcos-log-agent.service',
-        'dcos-log-agent.socket',
-        'dcos-logrotate-agent.service',
-        'dcos-logrotate-agent.timer',
-        'dcos-rexray.service']
+        'dcos-docker-gc.service', 'dcos-docker-gc.timer',
+        'dcos-adminrouter-agent.service', 'dcos-log-agent.service',
+        'dcos-log-agent.socket', 'dcos-logrotate-agent.service',
+        'dcos-logrotate-agent.timer', 'dcos-rexray.service'
+    ]
 
     expected_units = {
         "master": set(all_node_units + master_units),
         "agent": set(all_node_units + all_slave_units + slave_units),
-        "agent_public": set(all_node_units + all_slave_units + public_slave_units),
+        "agent_public":
+        set(all_node_units + all_slave_units + public_slave_units),
     }
 
     # Collect the dcos-diagnostics output that `dcos-signal` uses to determine
@@ -226,8 +221,11 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
     for node, node_health in health_report["Nodes"].items():
         # Assert that this node is healthy.
         if node_health["Health"] != 0:
-            logging.info("Node {} was unhealthy: {}".format(
-                node, json.dumps(node_health, indent=4, sort_keys=True)))
+            logging.info(
+                "Node {} was unhealthy: {}".format(
+                    node, json.dumps(node_health, indent=4, sort_keys=True)
+                )
+            )
             unhealthy_nodes += 1
     assert unhealthy_nodes == 0
 
@@ -251,13 +249,17 @@ def test_signal_service(dcos_api_session):
         cluster_id = f.read().strip()
 
     if enabled == 'false':
-        pytest.skip('Telemetry disabled in /opt/mesosphere/etc/dcos-signal-config.json... skipping test')
+        pytest.skip(
+            'Telemetry disabled in /opt/mesosphere/etc/dcos-signal-config.json... skipping test'
+        )
 
     logging.info("Version: " + dcos_version)
     logging.info("Customer Key: " + customer_key)
     logging.info("Cluster ID: " + cluster_id)
 
-    signal_results = subprocess.check_output(["/opt/mesosphere/bin/dcos-signal", "-test"], universal_newlines=True)
+    signal_results = subprocess.check_output(
+        ["/opt/mesosphere/bin/dcos-signal", "-test"], universal_newlines=True
+    )
     r_data = json.loads(signal_results)
 
     resp = dcos_api_session.get('/system/health/v1/report?cache=0')
@@ -281,10 +283,12 @@ def test_signal_service(dcos_api_session):
                     # This unit is unhealthy on this node.
                     unhealthy += 1
         prefix = "health-unit-{}".format(unit.replace('.', '-'))
-        units_health.update({
-            "{}-total".format(prefix): len(unit_health["Nodes"]),
-            "{}-unhealthy".format(prefix): unhealthy,
-        })
+        units_health.update(
+            {
+                "{}-total".format(prefix): len(unit_health["Nodes"]),
+                "{}-unhealthy".format(prefix): unhealthy,
+            }
+        )
 
     exp_data = {
         'diagnostics': {
@@ -327,12 +331,17 @@ def test_signal_service(dcos_api_session):
         # The optional second argument to `assert` is an error message that
         # appears to get truncated in the output. As such, we log the output
         # instead.
-        logging.error("Cluster is unhealthy: {}".format(
-            json.dumps(health_report, indent=4, sort_keys=True)))
+        logging.error(
+            "Cluster is unhealthy: {}".format(
+                json.dumps(health_report, indent=4, sort_keys=True)
+            )
+        )
         assert r_data['diagnostics'] == exp_data['diagnostics']
 
     # Check a subset of things regarding Mesos that we can logically check for
-    framework_names = [x['name'] for x in r_data['mesos']['properties']['frameworks']]
+    framework_names = [
+        x['name'] for x in r_data['mesos']['properties']['frameworks']
+    ]
     assert 'marathon' in framework_names
     assert 'metronome' in framework_names
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -11,7 +11,6 @@ import test_helpers
 from dcos_test_utils.diagnostics import Diagnostics
 from dcos_test_utils.helpers import check_json
 
-
 __maintainer__ = 'mnaboka'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
 
@@ -26,22 +25,33 @@ def test_dcos_diagnostics_health(dcos_api_session):
     """
     test health endpoint /system/health/v1
     """
-    required_fields = ['units', 'hostname', 'ip', 'dcos_version', 'node_role', 'mesos_id', 'dcos_diagnostics_version']
-    required_fields_unit = ['id', 'health', 'output', 'description', 'help', 'name']
+    required_fields = [
+        'units', 'hostname', 'ip', 'dcos_version', 'node_role', 'mesos_id',
+        'dcos_diagnostics_version'
+    ]
+    required_fields_unit = [
+        'id', 'health', 'output', 'description', 'help', 'name'
+    ]
 
     # Check all masters dcos-diagnostics instances on base port since this is extra-cluster request (outside localhost)
     for host in dcos_api_session.masters:
         response = check_json(dcos_api_session.health.get('/', node=host))
-        assert len(response) == len(required_fields), 'response must have the following fields: {}'.format(
+        assert len(response) == len(
+            required_fields
+        ), 'response must have the following fields: {}'.format(
             ', '.join(required_fields)
         )
 
         # validate units
         assert 'units' in response, 'units field not found'
-        assert isinstance(response['units'], list), 'units field must be a list'
+        assert isinstance(
+            response['units'], list
+        ), 'units field must be a list'
         assert len(response['units']) > 0, 'units field cannot be empty'
         for unit in response['units']:
-            assert len(unit) == len(required_fields_unit), 'unit must have the following fields: {}'.format(
+            assert len(unit) == len(
+                required_fields_unit
+            ), 'unit must have the following fields: {}'.format(
                 ', '.join(required_fields_unit)
             )
             for required_field_unit in required_fields_unit:
@@ -54,22 +64,32 @@ def test_dcos_diagnostics_health(dcos_api_session):
 
         # check all required fields but units
         for required_field in required_fields[1:]:
-            assert required_field in response, '{} field not found'.format(required_field)
-            assert response[required_field], '{} cannot be empty'.format(required_field)
+            assert required_field in response, '{} field not found'.format(
+                required_field
+            )
+            assert response[required_field], '{} cannot be empty'.format(
+                required_field
+            )
 
     # Check all agents running dcos-diagnostics behind agent-adminrouter on 61001
     for host in dcos_api_session.slaves:
         response = check_json(dcos_api_session.health.get('/', node=host))
-        assert len(response) == len(required_fields), 'response must have the following fields: {}'.format(
+        assert len(response) == len(
+            required_fields
+        ), 'response must have the following fields: {}'.format(
             ', '.join(required_fields)
         )
 
         # validate units
         assert 'units' in response, 'units field not found'
-        assert isinstance(response['units'], list), 'units field must be a list'
+        assert isinstance(
+            response['units'], list
+        ), 'units field must be a list'
         assert len(response['units']) > 0, 'units field cannot be empty'
         for unit in response['units']:
-            assert len(unit) == len(required_fields_unit), 'unit must have the following fields: {}'.format(
+            assert len(unit) == len(
+                required_fields_unit
+            ), 'unit must have the following fields: {}'.format(
                 ', '.join(required_fields_unit)
             )
             for required_field_unit in required_fields_unit:
@@ -82,8 +102,12 @@ def test_dcos_diagnostics_health(dcos_api_session):
 
         # check all required fields but units
         for required_field in required_fields[1:]:
-            assert required_field in response, '{} field not found'.format(required_field)
-            assert response[required_field], '{} cannot be empty'.format(required_field)
+            assert required_field in response, '{} field not found'.format(
+                required_field
+            )
+            assert response[required_field], '{} cannot be empty'.format(
+                required_field
+            )
 
 
 @pytest.mark.supportedwindows
@@ -93,8 +117,12 @@ def test_dcos_diagnostics_nodes(dcos_api_session):
     test a list of nodes with statuses endpoint /system/health/v1/nodes
     """
     for master in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('/nodes', node=master))
-        assert len(response) == 1, 'nodes response must have only one field: nodes'
+        response = check_json(
+            dcos_api_session.health.get('/nodes', node=master)
+        )
+        assert len(
+            response
+        ) == 1, 'nodes response must have only one field: nodes'
         assert 'nodes' in response
         assert isinstance(response['nodes'], list)
         assert len(response['nodes']) == len(dcos_api_session.masters + dcos_api_session.all_slaves), \
@@ -112,11 +140,17 @@ def test_dcos_diagnostics_nodes_node(dcos_api_session):
     """
     for master in dcos_api_session.masters:
         # get a list of nodes
-        response = check_json(dcos_api_session.health.get('/nodes', node=master))
+        response = check_json(
+            dcos_api_session.health.get('/nodes', node=master)
+        )
         nodes = list(map(lambda node: node['host_ip'], response['nodes']))
 
         for node in nodes:
-            node_response = check_json(dcos_api_session.health.get('/nodes/{}'.format(node), node=master))
+            node_response = check_json(
+                dcos_api_session.health.get(
+                    '/nodes/{}'.format(node), node=master
+                )
+            )
             validate_node([node_response])
 
 
@@ -127,13 +161,21 @@ def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
     """
     for master in dcos_api_session.masters:
         # get a list of nodes
-        response = check_json(dcos_api_session.health.get('/nodes', node=master))
+        response = check_json(
+            dcos_api_session.health.get('/nodes', node=master)
+        )
         nodes = list(map(lambda node: node['host_ip'], response['nodes']))
 
         for node in nodes:
-            units_response = check_json(dcos_api_session.health.get('/nodes/{}/units'.format(node), node=master))
+            units_response = check_json(
+                dcos_api_session.health.get(
+                    '/nodes/{}/units'.format(node), node=master
+                )
+            )
 
-            assert len(units_response) == 1, 'unit response should have only 1 field `units`'
+            assert len(
+                units_response
+            ) == 1, 'unit response should have only 1 field `units`'
             assert 'units' in units_response
             validate_units(units_response['units'])
 
@@ -144,15 +186,29 @@ def test_dcos_diagnostics_nodes_node_units_unit(dcos_api_session):
     test a specific unit for a specific node, endpoint /system/health/v1/nodes/<node>/units/<unit>
     """
     for master in dcos_api_session.masters:
-        response = check_json(dcos_api_session.health.get('/nodes', node=master))
+        response = check_json(
+            dcos_api_session.health.get('/nodes', node=master)
+        )
         nodes = list(map(lambda node: node['host_ip'], response['nodes']))
         for node in nodes:
-            units_response = check_json(dcos_api_session.health.get('/nodes/{}/units'.format(node), node=master))
-            unit_ids = list(map(lambda unit: unit['id'], units_response['units']))
+            units_response = check_json(
+                dcos_api_session.health.get(
+                    '/nodes/{}/units'.format(node), node=master
+                )
+            )
+            unit_ids = list(
+                map(lambda unit: unit['id'], units_response['units'])
+            )
 
             for unit_id in unit_ids:
                 validate_unit(
-                    check_json(dcos_api_session.health.get('/nodes/{}/units/{}'.format(node, unit_id), node=master)))
+                    check_json(
+                        dcos_api_session.health.get(
+                            '/nodes/{}/units/{}'.format(node, unit_id),
+                            node=master
+                        )
+                    )
+                )
 
 
 @pytest.mark.supportedwindows
@@ -175,14 +231,20 @@ def test_dcos_diagnostics_units(dcos_api_session):
 
     # test against masters
     for master in dcos_api_session.masters:
-        units_response = check_json(dcos_api_session.health.get('/units', node=master))
+        units_response = check_json(
+            dcos_api_session.health.get('/units', node=master)
+        )
         validate_units(units_response['units'])
 
-        pulled_units = list(map(lambda unit: unit['id'], units_response['units']))
+        pulled_units = list(
+            map(lambda unit: unit['id'], units_response['units'])
+        )
         logging.info('collected units: {}'.format(pulled_units))
         diff = set(pulled_units).symmetric_difference(all_units)
-        assert set(pulled_units) == all_units, ('not all units have been collected by dcos-diagnostics '
-                                                'puller, missing: {}'.format(diff))
+        assert set(pulled_units) == all_units, (
+            'not all units have been collected by dcos-diagnostics '
+            'puller, missing: {}'.format(diff)
+        )
 
 
 @pytest.mark.supportedwindows
@@ -194,24 +256,49 @@ def test_systemd_units_health(dcos_api_session):
     """
     unhealthy_output = []
     assert dcos_api_session.masters, "Must have at least 1 master node"
-    report_response = check_json(dcos_api_session.health.get('/report', node=dcos_api_session.masters[0]))
+    report_response = check_json(
+        dcos_api_session.health.get(
+            '/report', node=dcos_api_session.masters[0]
+        )
+    )
     assert 'Units' in report_response, "Missing `Units` field in response"
     for unit_name, unit_props in report_response['Units'].items():
-        assert 'Health' in unit_props, "Unit {} missing `Health` field".format(unit_name)
+        assert 'Health' in unit_props, "Unit {} missing `Health` field".format(
+            unit_name
+        )
         if unit_props['Health'] != 0:
-            assert 'Nodes' in unit_props, "Unit {} missing `Nodes` field".format(unit_name)
-            assert isinstance(unit_props['Nodes'], list), 'Field `Node` must be a list'
+            assert 'Nodes' in unit_props, "Unit {} missing `Nodes` field".format(
+                unit_name
+            )
+            assert isinstance(
+                unit_props['Nodes'], list
+            ), 'Field `Node` must be a list'
             for node in unit_props['Nodes']:
-                assert 'Health' in node, 'Field `Health` is expected to be in nodes properties, got {}'.format(node)
+                assert 'Health' in node, 'Field `Health` is expected to be in nodes properties, got {}'.format(
+                    node
+                )
                 if node['Health'] != 0:
-                    assert 'Output' in node, 'Field `Output` is expected to be in nodes properties, got {}'.format(node)
-                    assert isinstance(node['Output'], dict), 'Field `Output` must be a dict'
-                    assert unit_name in node['Output'], 'unit {} must be in node Output, got {}'.format(unit_name,
-                                                                                                        node['Output'])
-                    assert 'IP' in node, 'Field `IP` is expected to be in nodes properties, got {}'.format(node)
+                    assert 'Output' in node, 'Field `Output` is expected to be in nodes properties, got {}'.format(
+                        node
+                    )
+                    assert isinstance(
+                        node['Output'], dict
+                    ), 'Field `Output` must be a dict'
+                    assert unit_name in node[
+                        'Output'
+                    ], 'unit {} must be in node Output, got {}'.format(
+                        unit_name, node['Output']
+                    )
+                    assert 'IP' in node, 'Field `IP` is expected to be in nodes properties, got {}'.format(
+                        node
+                    )
                     unhealthy_output.append(
-                        'Unhealthy unit {} has been found on node {}, health status {}. journalctl output {}'.format(
-                            unit_name, node['IP'], unit_props['Health'], node['Output'][unit_name]))
+                        'Unhealthy unit {} has been found on node {}, health status {}. journalctl output {}'
+                        .format(
+                            unit_name, node['IP'], unit_props['Health'],
+                            node['Output'][unit_name]
+                        )
+                    )
 
     if unhealthy_output:
         raise AssertionError('\n'.join(unhealthy_output))
@@ -223,10 +310,18 @@ def test_dcos_diagnostics_units_unit(dcos_api_session):
     test a unit response in a right format, endpoint: /system/health/v1/units/<unit>
     """
     for master in dcos_api_session.masters:
-        units_response = check_json(dcos_api_session.health.get('/units', node=master))
-        pulled_units = list(map(lambda unit: unit['id'], units_response['units']))
+        units_response = check_json(
+            dcos_api_session.health.get('/units', node=master)
+        )
+        pulled_units = list(
+            map(lambda unit: unit['id'], units_response['units'])
+        )
         for unit in pulled_units:
-            unit_response = check_json(dcos_api_session.health.get('/units/{}'.format(unit), node=master))
+            unit_response = check_json(
+                dcos_api_session.health.get(
+                    '/units/{}'.format(unit), node=master
+                )
+            )
             validate_units([unit_response])
 
 
@@ -237,41 +332,68 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
     """
 
     def get_nodes_from_response(response):
-        assert 'nodes' in response, 'response must have field `nodes`. Got {}'.format(response)
+        assert 'nodes' in response, 'response must have field `nodes`. Got {}'.format(
+            response
+        )
         nodes_ip_map = make_nodes_ip_map(dcos_api_session)
         nodes = []
         for node in response['nodes']:
-            assert 'host_ip' in node, 'node response must have `host_ip` field. Got {}'.format(node)
-            assert node['host_ip'] in nodes_ip_map, 'nodes_ip_map must have node {}.Got {}'.format(node['host_ip'],
-                                                                                                   nodes_ip_map)
+            assert 'host_ip' in node, 'node response must have `host_ip` field. Got {}'.format(
+                node
+            )
+            assert node[
+                'host_ip'
+            ] in nodes_ip_map, 'nodes_ip_map must have node {}.Got {}'.format(
+                node['host_ip'], nodes_ip_map
+            )
             nodes.append(nodes_ip_map.get(node['host_ip']))
         return nodes
 
     for master in dcos_api_session.masters:
-        units_response = check_json(dcos_api_session.health.get('/units', node=master))
-        pulled_units = list(map(lambda unit: unit['id'], units_response['units']))
+        units_response = check_json(
+            dcos_api_session.health.get('/units', node=master)
+        )
+        pulled_units = list(
+            map(lambda unit: unit['id'], units_response['units'])
+        )
         for unit in pulled_units:
-            nodes_response = check_json(dcos_api_session.health.get('/units/{}/nodes'.format(unit), node=master))
+            nodes_response = check_json(
+                dcos_api_session.health.get(
+                    '/units/{}/nodes'.format(unit), node=master
+                )
+            )
             validate_node(nodes_response['nodes'])
 
         # make sure dcos-mesos-master.service has master nodes and dcos-mesos-slave.service has agent nodes
         master_nodes_response = check_json(
-            dcos_api_session.health.get('/units/dcos-mesos-master.service/nodes', node=master))
+            dcos_api_session.health.get(
+                '/units/dcos-mesos-master.service/nodes', node=master
+            )
+        )
 
         master_nodes = get_nodes_from_response(master_nodes_response)
 
         assert len(master_nodes) == len(dcos_api_session.masters), \
             '{} != {}'.format(master_nodes, dcos_api_session.masters)
-        assert set(master_nodes) == set(dcos_api_session.masters), 'a list of difference: {}'.format(
-            set(master_nodes).symmetric_difference(set(dcos_api_session.masters))
+        assert set(master_nodes) == set(
+            dcos_api_session.masters
+        ), 'a list of difference: {}'.format(
+            set(master_nodes).symmetric_difference(
+                set(dcos_api_session.masters)
+            )
         )
 
         agent_nodes_response = check_json(
-            dcos_api_session.health.get('/units/dcos-mesos-slave.service/nodes', node=master))
+            dcos_api_session.health.get(
+                '/units/dcos-mesos-slave.service/nodes', node=master
+            )
+        )
 
         agent_nodes = get_nodes_from_response(agent_nodes_response)
 
-        assert len(agent_nodes) == len(dcos_api_session.slaves), '{} != {}'.format(agent_nodes, dcos_api_session.slaves)
+        assert len(agent_nodes) == len(
+            dcos_api_session.slaves
+        ), '{} != {}'.format(agent_nodes, dcos_api_session.slaves)
 
 
 @pytest.mark.supportedwindows
@@ -282,25 +404,45 @@ def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
     required_node_fields = ['host_ip', 'health', 'role', 'output', 'help']
 
     for master in dcos_api_session.masters:
-        units_response = check_json(dcos_api_session.health.get('/units', node=master))
-        pulled_units = list(map(lambda unit: unit['id'], units_response['units']))
+        units_response = check_json(
+            dcos_api_session.health.get('/units', node=master)
+        )
+        pulled_units = list(
+            map(lambda unit: unit['id'], units_response['units'])
+        )
         for unit in pulled_units:
-            nodes_response = check_json(dcos_api_session.health.get('/units/{}/nodes'.format(unit), node=master))
-            pulled_nodes = list(map(lambda node: node['host_ip'], nodes_response['nodes']))
+            nodes_response = check_json(
+                dcos_api_session.health.get(
+                    '/units/{}/nodes'.format(unit), node=master
+                )
+            )
+            pulled_nodes = list(
+                map(lambda node: node['host_ip'], nodes_response['nodes'])
+            )
             logging.info('pulled nodes: {}'.format(pulled_nodes))
             for node in pulled_nodes:
                 node_response = check_json(
-                    dcos_api_session.health.get('/units/{}/nodes/{}'.format(unit, node), node=master))
-                assert len(node_response) == len(required_node_fields), 'required fields: {}'.format(
+                    dcos_api_session.health.get(
+                        '/units/{}/nodes/{}'.format(unit, node), node=master
+                    )
+                )
+                assert len(node_response) == len(
+                    required_node_fields
+                ), 'required fields: {}'.format(
                     ', '.format(required_node_fields)
                 )
 
                 for required_node_field in required_node_fields:
-                    assert required_node_field in node_response, 'field {} must be set'.format(required_node_field)
+                    assert required_node_field in node_response, 'field {} must be set'.format(
+                        required_node_field
+                    )
 
                 # host_ip, health, role, help cannot be empty
-                assert node_response['host_ip'], 'host_ip field cannot be empty'
-                assert node_response['health'] in [0, 1], 'health must be 0 or 1'
+                assert node_response['host_ip'
+                                     ], 'host_ip field cannot be empty'
+                assert node_response['health'] in [
+                    0, 1
+                ], 'health must be 0 or 1'
                 assert node_response['role'], 'role field cannot be empty'
                 assert node_response['help'], 'help field cannot be empty'
 
@@ -311,7 +453,9 @@ def test_dcos_diagnostics_report(dcos_api_session):
     test dcos-diagnostics report endpoint /system/health/v1/report
     """
     for master in dcos_api_session.masters:
-        report_response = check_json(dcos_api_session.health.get('/report', node=master))
+        report_response = check_json(
+            dcos_api_session.health.get('/report', node=master)
+        )
         assert 'Units' in report_response
         assert len(report_response['Units']) > 0
 
@@ -328,32 +472,40 @@ def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
         bundle = _create_bundle(dcos_api_session)
         _check_diagnostics_bundle_status(dcos_api_session)
         _download_and_extract_bundle(dcos_api_session, bundle)
-        _download_and_extract_bundle_from_another_master(dcos_api_session, bundle)
+        _download_and_extract_bundle_from_another_master(
+            dcos_api_session, bundle
+        )
         _delete_bundle(dcos_api_session, bundle)
 
 
 def _check_diagnostics_bundle_status(dcos_api_session):
     # validate diagnostics job status response
-    diagnostics_bundle_status = check_json(dcos_api_session.health.get('/report/diagnostics/status/all'))
-    required_status_fields = ['is_running', 'status', 'errors', 'last_bundle_dir', 'job_started', 'job_ended',
-                              'job_duration', 'diagnostics_bundle_dir', 'diagnostics_job_timeout_min',
-                              'journald_logs_since_hours', 'diagnostics_job_get_since_url_timeout_min',
-                              'command_exec_timeout_sec', 'diagnostics_partition_disk_usage_percent',
-                              'job_progress_percentage']
+    diagnostics_bundle_status = check_json(
+        dcos_api_session.health.get('/report/diagnostics/status/all')
+    )
+    required_status_fields = [
+        'is_running', 'status', 'errors', 'last_bundle_dir', 'job_started',
+        'job_ended', 'job_duration', 'diagnostics_bundle_dir',
+        'diagnostics_job_timeout_min', 'journald_logs_since_hours',
+        'diagnostics_job_get_since_url_timeout_min',
+        'command_exec_timeout_sec', 'diagnostics_partition_disk_usage_percent',
+        'job_progress_percentage'
+    ]
 
     for _, properties in diagnostics_bundle_status.items():
-        assert len(properties) == len(required_status_fields), 'response must have the following fields: {}'.format(
+        assert len(properties) == len(
+            required_status_fields
+        ), 'response must have the following fields: {}'.format(
             required_status_fields
         )
         for required_status_field in required_status_fields:
-            assert required_status_field in properties, 'property {} not found'.format(required_status_field)
+            assert required_status_field in properties, 'property {} not found'.format(
+                required_status_field
+            )
 
 
 def _create_bundle(dcos_api_session):
-    last_datapoint = {
-        'time': None,
-        'value': 0
-    }
+    last_datapoint = {'time': None, 'value': 0}
 
     health_url = dcos_api_session.default_url.copy(
         query='cache=0',
@@ -392,7 +544,9 @@ def _delete_bundle(dcos_api_session, bundle):
     bundles = diagnostics.get_diagnostics_reports()
     assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
 
-    dcos_api_session.health.post(os.path.join('/report/diagnostics/delete', bundle))
+    dcos_api_session.health.post(
+        os.path.join('/report/diagnostics/delete', bundle)
+    )
 
     bundles = diagnostics.get_diagnostics_reports()
     assert bundle not in bundles, 'found {} in {}'.format(bundle, bundles)
@@ -416,8 +570,10 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
     :param master_index: master index from dcos_api_session.masters array
     :param bundle: bundle name to download from master
     """
-    assert len(dcos_api_session.masters) >= master_index + 1, '{} masters required. Got {}'.format(
-        master_index + 1, len(dcos_api_session.masters))
+    assert len(dcos_api_session.masters
+               ) >= master_index + 1, '{} masters required. Got {}'.format(
+                   master_index + 1, len(dcos_api_session.masters)
+               )
 
     health_url = dcos_api_session.default_url.copy(
         query='cache=0',
@@ -434,36 +590,37 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
     bundles = diagnostics.get_diagnostics_reports()
     assert bundle in bundles, 'not found {} in {}'.format(bundle, bundles)
 
-    expected_common_files = ['dmesg_-T.output.gz',
-                             'ip_addr.output.gz',
-                             'ip_route.output.gz',
-                             'ps_aux_ww_Z.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1vips.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1records.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsdefault.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsdns.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsmesos_listener.output.gz',
-                             'optmesospherebincurl_-s_-S_http:localhost:62080v1metricslashup.output.gz',
-                             'timedatectl.output.gz',
-                             'binsh_-c_cat etc*-release.output.gz',
-                             'systemctl_list-units_dcos*.output.gz',
-                             'sestatus.output.gz',
-                             'iptables-save.output.gz',
-                             'ip6tables-save.output.gz',
-                             'ipset_list.output.gz',
-                             'opt/mesosphere/active.buildinfo.full.json.gz',
-                             'opt/mesosphere/etc/dcos-version.json.gz',
-                             'opt/mesosphere/etc/expanded.config.json.gz',
-                             'opt/mesosphere/etc/user.config.yaml.gz',
-                             'dcos-diagnostics-health.json',
-                             'var/lib/dcos/cluster-id.gz',
-                             'proc/cmdline.gz',
-                             'proc/cpuinfo.gz',
-                             'proc/meminfo.gz',
-                             'proc/self/mountinfo.gz',
-                             'optmesospherebindetect_ip.output.gz',
-                             'sysctl_-a.output.gz',
-                             ]
+    expected_common_files = [
+        'dmesg_-T.output.gz',
+        'ip_addr.output.gz',
+        'ip_route.output.gz',
+        'ps_aux_ww_Z.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1vips.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1records.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsdefault.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsdns.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1metricsmesos_listener.output.gz',
+        'optmesospherebincurl_-s_-S_http:localhost:62080v1metricslashup.output.gz',
+        'timedatectl.output.gz',
+        'binsh_-c_cat etc*-release.output.gz',
+        'systemctl_list-units_dcos*.output.gz',
+        'sestatus.output.gz',
+        'iptables-save.output.gz',
+        'ip6tables-save.output.gz',
+        'ipset_list.output.gz',
+        'opt/mesosphere/active.buildinfo.full.json.gz',
+        'opt/mesosphere/etc/dcos-version.json.gz',
+        'opt/mesosphere/etc/expanded.config.json.gz',
+        'opt/mesosphere/etc/user.config.yaml.gz',
+        'dcos-diagnostics-health.json',
+        'var/lib/dcos/cluster-id.gz',
+        'proc/cmdline.gz',
+        'proc/cpuinfo.gz',
+        'proc/meminfo.gz',
+        'proc/self/mountinfo.gz',
+        'optmesospherebindetect_ip.output.gz',
+        'sysctl_-a.output.gz',
+    ]
 
     # these files are expected to be in archive for a master host
     expected_master_files = [
@@ -538,8 +695,11 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
     with tempfile.TemporaryDirectory() as tmp_dir:
         bundle_full_location = os.path.join(tmp_dir, bundle)
         with open(bundle_full_location, 'wb') as f:
-            r = dcos_api_session.health.get(os.path.join('/report/diagnostics/serve', bundle), stream=True,
-                                            node=dcos_api_session.masters[master_index])
+            r = dcos_api_session.health.get(
+                os.path.join('/report/diagnostics/serve', bundle),
+                stream=True,
+                node=dcos_api_session.masters[master_index]
+            )
 
             for chunk in r.iter_content(1024):
                 f.write(chunk)
@@ -553,8 +713,13 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
 
         # validate error log is empty
         if 'summaryErrorsReport.txt' in archived_items:
-            log_data = _read_from_zip(z, 'summaryErrorsReport.txt', to_json=False)
-            raise AssertionError('summaryErrorsReport.txt must be empty. Got {}'.format(log_data))
+            log_data = _read_from_zip(
+                z, 'summaryErrorsReport.txt', to_json=False
+            )
+            raise AssertionError(
+                'summaryErrorsReport.txt must be empty. Got {}'.
+                format(log_data)
+            )
 
         # validate all files in zip archive are not empty
         for item in archived_items:
@@ -565,17 +730,25 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
             master_folder = master_ip + '_master/'
 
             # try to load dcos-diagnostics health report and validate the report is for this host
-            health_report = _get_dcos_diagnostics_health(z, master_folder + 'dcos-diagnostics-health.json')
+            health_report = _get_dcos_diagnostics_health(
+                z, master_folder + 'dcos-diagnostics-health.json'
+            )
             assert 'ip' in health_report
             assert health_report['ip'] == master_ip
 
             # make sure systemd unit output is correct and does not contain error message
-            gzipped_unit_output = z.open(master_folder + 'dcos-mesos-master.service.gz')
+            gzipped_unit_output = z.open(
+                master_folder + 'dcos-mesos-master.service.gz'
+            )
             verify_unit_response(gzipped_unit_output, 100)
 
-            verify_archived_items(master_folder, archived_items, expected_master_files)
+            verify_archived_items(
+                master_folder, archived_items, expected_master_files
+            )
 
-            gzipped_state_output = z.open(master_folder + '5050-master_state.json.gz')
+            gzipped_state_output = z.open(
+                master_folder + '5050-master_state.json.gz'
+            )
             validate_state(gzipped_state_output)
 
         # make sure all required log files for agent node are in place.
@@ -583,30 +756,43 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle):
             agent_folder = slave_ip + '_agent/'
 
             # try to load dcos-diagnostics health report and validate the report is for this host
-            health_report = _get_dcos_diagnostics_health(z, agent_folder + 'dcos-diagnostics-health.json')
+            health_report = _get_dcos_diagnostics_health(
+                z, agent_folder + 'dcos-diagnostics-health.json'
+            )
             assert 'ip' in health_report
             assert health_report['ip'] == slave_ip
 
             # make sure systemd unit output is correct and does not contain error message
-            gzipped_unit_output = z.open(agent_folder + 'dcos-mesos-slave.service.gz')
+            gzipped_unit_output = z.open(
+                agent_folder + 'dcos-mesos-slave.service.gz'
+            )
             verify_unit_response(gzipped_unit_output, 100)
 
-            verify_archived_items(agent_folder, archived_items, expected_agent_files)
+            verify_archived_items(
+                agent_folder, archived_items, expected_agent_files
+            )
 
         # make sure all required log files for public agent node are in place.
         for public_slave_ip in dcos_api_session.public_slaves:
             agent_public_folder = public_slave_ip + '_agent_public/'
 
             # try to load dcos-diagnostics health report and validate the report is for this host
-            health_report = _get_dcos_diagnostics_health(z, agent_public_folder + 'dcos-diagnostics-health.json')
+            health_report = _get_dcos_diagnostics_health(
+                z, agent_public_folder + 'dcos-diagnostics-health.json'
+            )
             assert 'ip' in health_report
             assert health_report['ip'] == public_slave_ip
 
             # make sure systemd unit output is correct and does not contain error message
-            gzipped_unit_output = z.open(agent_public_folder + 'dcos-mesos-slave-public.service.gz')
+            gzipped_unit_output = z.open(
+                agent_public_folder + 'dcos-mesos-slave-public.service.gz'
+            )
             verify_unit_response(gzipped_unit_output, 100)
 
-            verify_archived_items(agent_public_folder, archived_items, expected_public_agent_files)
+            verify_archived_items(
+                agent_public_folder, archived_items,
+                expected_public_agent_files
+            )
 
 
 def make_nodes_ip_map(dcos_api_session):
@@ -615,11 +801,13 @@ def make_nodes_ip_map(dcos_api_session):
     """
     node_private_public_ip_map = {}
     for node in dcos_api_session.masters:
-        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
+        detected_ip = check_json(dcos_api_session.health.get('/',
+                                                             node=node))['ip']
         node_private_public_ip_map[detected_ip] = node
 
     for node in dcos_api_session.all_slaves:
-        detected_ip = check_json(dcos_api_session.health.get('/', node=node))['ip']
+        detected_ip = check_json(dcos_api_session.health.get('/',
+                                                             node=node))['ip']
         node_private_public_ip_map[detected_ip] = node
 
     return node_private_public_ip_map
@@ -631,10 +819,15 @@ def validate_node(nodes):
     required_fields = ['host_ip', 'health', 'role']
 
     for node in nodes:
-        assert len(node) == len(required_fields), 'node should have the following fields: {}. Actual: {}'.format(
-            ', '.join(required_fields), node)
+        assert len(node) == len(
+            required_fields
+        ), 'node should have the following fields: {}. Actual: {}'.format(
+            ', '.join(required_fields), node
+        )
         for required_field in required_fields:
-            assert required_field in node, '{} must be in node. Actual: {}'.format(required_field, node)
+            assert required_field in node, '{} must be in node. Actual: {}'.format(
+                required_field, node
+            )
 
         # host_ip, health, role fields cannot be empty
         assert node['health'] in [0, 1], 'health must be 0 or 1'
@@ -648,10 +841,15 @@ def validate_units(units):
     required_fields = ['id', 'name', 'health', 'description']
 
     for unit in units:
-        assert len(unit) == len(required_fields), 'a unit must have the following fields: {}. Actual: {}'.format(
-            ', '.join(required_fields), unit)
+        assert len(unit) == len(
+            required_fields
+        ), 'a unit must have the following fields: {}. Actual: {}'.format(
+            ', '.join(required_fields), unit
+        )
         for required_field in required_fields:
-            assert required_field in unit, 'unit response must have field: {}. Actual: {}'.format(required_field, unit)
+            assert required_field in unit, 'unit response must have field: {}. Actual: {}'.format(
+                required_field, unit
+            )
 
         # a unit must have all 3 fields not empty
         assert unit['id'], 'id field cannot be empty'
@@ -664,10 +862,15 @@ def validate_unit(unit):
     assert isinstance(unit, dict), 'input argument must be a dict'
 
     required_fields = ['id', 'health', 'output', 'description', 'help', 'name']
-    assert len(unit) == len(required_fields), 'unit must have the following fields: {}. Actual: {}'.format(
-        ', '.join(required_fields), unit)
+    assert len(unit) == len(
+        required_fields
+    ), 'unit must have the following fields: {}. Actual: {}'.format(
+        ', '.join(required_fields), unit
+    )
     for required_field in required_fields:
-        assert required_field in unit, '{} must be in a unit. Actual: {}'.format(required_field, unit)
+        assert required_field in unit, '{} must be in a unit. Actual: {}'.format(
+            required_field, unit
+        )
 
     # id, name, health, description, help should not be empty
     assert unit['id'], 'id field cannot be empty'
@@ -681,8 +884,11 @@ def validate_state(zip_state):
     assert isinstance(zip_state, zipfile.ZipExtFile)
     state_output = gzip.decompress(zip_state.read())
     state = json.loads(state_output)
-    assert len(state["frameworks"]) > 1, "bundle must contain information about frameworks"
-    task_count = len(state["frameworks"][1]["tasks"]) + len(state["frameworks"][0]["tasks"])
+    assert len(
+        state["frameworks"]
+    ) > 1, "bundle must contain information about frameworks"
+    task_count = len(state["frameworks"][1]["tasks"]
+                     ) + len(state["frameworks"][0]["tasks"])
     assert task_count == 1, "bundle must contains information about tasks"
 
 
@@ -699,18 +905,27 @@ def verify_archived_items(folder, archived_items, expected_files):
         # file type in case it wasn't explicitly specified in the assertion.
         # For more context, see: https://jira.mesosphere.com/browse/DCOS_OSS-4531
         if expected_file.endswith('.gz'):
-            assert expected_file in archived_items, ('expecting {} in {}'.format(expected_file, archived_items))
+            assert expected_file in archived_items, (
+                'expecting {} in {}'.format(expected_file, archived_items)
+            )
         else:
             expected_gzipped_file = (expected_file + '.gz')
             unzipped_exists = expected_file in archived_items
             gzipped_exists = expected_gzipped_file in archived_items
 
-            message = ('expecting {} or {} in {}'.format(expected_file, expected_gzipped_file, archived_items))
+            message = (
+                'expecting {} or {} in {}'.format(
+                    expected_file, expected_gzipped_file, archived_items
+                )
+            )
             assert (unzipped_exists or gzipped_exists), message
 
 
 def verify_unit_response(zip_ext_file, min_lines):
     assert isinstance(zip_ext_file, zipfile.ZipExtFile)
     unit_output = gzip.decompress(zip_ext_file.read())
-    assert len(unit_output.decode().split('\n')) >= min_lines, 'Expect at least {} lines. Full unit output {}'.format(
-        min_lines, unit_output)
+    assert len(
+        unit_output.decode().split('\n')
+    ) >= min_lines, 'Expect at least {} lines. Full unit output {}'.format(
+        min_lines, unit_output
+    )

--- a/packages/dcos-integration-test/extra/test_dcos_log.py
+++ b/packages/dcos-integration-test/extra/test_dcos_log.py
@@ -7,10 +7,8 @@ import pytest
 import requests
 import retrying
 
-
 __maintainer__ = 'mnaboka'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
-
 
 NEW_ENTRY_PATTERN = "\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: "
 
@@ -20,7 +18,8 @@ log = logging.getLogger(__name__)
 def skip_test_if_dcos_journald_log_disabled(dcos_api_session):
     response = dcos_api_session.get('/dcos-metadata/ui-config.json').json()
     try:
-        strategy = response['uiConfiguration']['plugins']['mesos']['logging-strategy']
+        strategy = response['uiConfiguration']['plugins']['mesos'
+                                                          ]['logging-strategy']
     except Exception:
         log.exception('Unable to find logging strategy')
         raise
@@ -29,12 +28,18 @@ def skip_test_if_dcos_journald_log_disabled(dcos_api_session):
 
 
 def validate_json_entry(entry: dict):
-    required_fields = {'fields', 'cursor', 'monotonic_timestamp', 'realtime_timestamp'}
+    required_fields = {
+        'fields', 'cursor', 'monotonic_timestamp', 'realtime_timestamp'
+    }
 
     assert set(entry.keys()) <= required_fields, (
-        "Entry didn't have all required fields. Entry fields: {}, required fields:{}".format(entry, required_fields))
+        "Entry didn't have all required fields. Entry fields: {}, required fields:{}"
+        .format(entry, required_fields)
+    )
 
-    assert entry['fields'], '`fields` cannot be empty dict. Got {}'.format(entry)
+    assert entry['fields'], '`fields` cannot be empty dict. Got {}'.format(
+        entry
+    )
 
 
 def validate_sse_entry(entry):
@@ -44,10 +49,15 @@ def validate_sse_entry(entry):
 
 
 def check_response_ok(response: requests.models.Response, headers: dict):
-    assert response.ok, 'Request {} returned response code {}'.format(response.url, response.status_code)
+    assert response.ok, 'Request {} returned response code {}'.format(
+        response.url, response.status_code
+    )
     for name, value in headers.items():
         assert response.headers.get(name) == value, (
-            'Request {} header {} must be {}. All headers {}'.format(response.url, name, value, response.headers))
+            'Request {} header {} must be {}. All headers {}'.format(
+                response.url, name, value, response.headers
+            )
+        )
 
 
 def test_log_text(dcos_api_session):
@@ -58,28 +68,52 @@ def test_log_text(dcos_api_session):
         # expect 10 entries
         logs = response.content.decode()
         entries_count = len(re.findall(NEW_ENTRY_PATTERN, logs))
-        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(entries_count, logs)
+        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(
+            entries_count, logs
+        )
 
 
 def test_log_json(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'application/json'})
+        response = dcos_api_session.logs.get(
+            '/v1/range/?limit=1',
+            node=node,
+            headers={'Accept': 'application/json'}
+        )
         check_response_ok(response, {'Content-Type': 'application/json'})
         validate_json_entry(response.json())
 
 
 def test_log_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('/v1/range/?limit=1', node=node, headers={'Accept': 'text/event-stream'})
-        check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
+        response = dcos_api_session.logs.get(
+            '/v1/range/?limit=1',
+            node=node,
+            headers={'Accept': 'text/event-stream'}
+        )
+        check_response_ok(
+            response, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+            }
+        )
         validate_sse_entry(response.text)
 
 
 def test_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('/v1/stream/?skip_prev=1', node=node, stream=True,
-                                             headers={'Accept': 'text/event-stream'})
-        check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
+        response = dcos_api_session.logs.get(
+            '/v1/stream/?skip_prev=1',
+            node=node,
+            stream=True,
+            headers={'Accept': 'text/event-stream'}
+        )
+        check_response_ok(
+            response, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+            }
+        )
         lines = response.iter_lines()
         sse_id = next(lines)
         assert sse_id, 'First line must be id. Got {}'.format(sse_id)
@@ -92,13 +126,23 @@ def test_log_proxy(dcos_api_session):
     check_response_ok(r, {})
 
     data = r.json()
-    slaves_ids = sorted(x['id'] for x in data['slaves'] if x['hostname'] in dcos_api_session.all_slaves)
+    slaves_ids = sorted(
+        x['id'] for x in data['slaves']
+        if x['hostname'] in dcos_api_session.all_slaves
+    )
 
     for slave_id in slaves_ids:
-        response = dcos_api_session.get('/system/v1/agent/{}/logs/v1/range/?skip_prev=10&limit=10'.format(slave_id))
+        response = dcos_api_session.get(
+            '/system/v1/agent/{}/logs/v1/range/?skip_prev=10&limit=10'.
+            format(slave_id)
+        )
         check_response_ok(response, {'Content-Type': 'text/plain'})
         lines = list(filter(lambda x: x != '', response.text.split('\n')))
-        assert len(lines) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(len(lines), lines)
+        assert len(
+            lines
+        ) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(
+            len(lines), lines
+        )
 
 
 def test_task_logs(dcos_api_session):
@@ -115,14 +159,27 @@ def test_task_logs(dcos_api_session):
         "cmd": "echo STDOUT_LOG; echo STDERR_LOG >&2;sleep 999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=False):
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        task_definition, check_health=False
+    ):
         url = get_task_url(dcos_api_session, task_id)
-        check_log_entry('STDOUT_LOG', url + '?filter=STREAM:STDOUT', dcos_api_session)
-        check_log_entry('STDERR_LOG', url + '?filter=STREAM:STDERR', dcos_api_session)
+        check_log_entry(
+            'STDOUT_LOG', url + '?filter=STREAM:STDOUT', dcos_api_session
+        )
+        check_log_entry(
+            'STDERR_LOG', url + '?filter=STREAM:STDERR', dcos_api_session
+        )
 
         stream_url = get_task_url(dcos_api_session, task_id, stream=True)
-        response = dcos_api_session.get(stream_url, stream=True, headers={'Accept': 'text/event-stream'})
-        check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
+        response = dcos_api_session.get(
+            stream_url, stream=True, headers={'Accept': 'text/event-stream'}
+        )
+        check_response_ok(
+            response, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+            }
+        )
         lines = response.iter_lines()
         sse_id = next(lines)
         assert sse_id, 'First line must be id. Got {}'.format(sse_id)
@@ -137,37 +194,70 @@ def test_pod_logs(dcos_api_session):
     pod_id = 'integration-test-pod-logs-{}'.format(test_uuid)
 
     pod_definition = {
-        'id': '/{}'.format(pod_id),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/{}'.format(pod_id),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'sleep1',
-                'exec': {'command': {'shell': 'echo $PING > foo;echo STDOUT_LOG;echo STDERR_LOG >&2;sleep 10000'}},
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo;echo STDOUT_LOG;echo STDERR_LOG >&2;sleep 10000'
+                    }
+                },
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
 
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         url = get_task_url(dcos_api_session, pod_id)
         container_id = url.split('/')[-1]
 
-        check_log_entry('STDOUT_LOG', url + '?filter=STREAM:STDOUT', dcos_api_session)
-        check_log_entry('STDERR_LOG', url + '?filter=STREAM:STDERR', dcos_api_session)
+        check_log_entry(
+            'STDOUT_LOG', url + '?filter=STREAM:STDOUT', dcos_api_session
+        )
+        check_log_entry(
+            'STDERR_LOG', url + '?filter=STREAM:STDERR', dcos_api_session
+        )
 
-        response = dcos_api_session.get(url + '/download', query='limit=10&postfix=stdout')
+        response = dcos_api_session.get(
+            url + '/download', query='limit=10&postfix=stdout'
+        )
         log_file_name = 'task-{}-stdout.log.gz'.format(container_id)
-        check_response_ok(response, {'Content-Disposition': 'attachment; filename={}'.format(log_file_name)})
+        check_response_ok(
+            response, {
+                'Content-Disposition':
+                'attachment; filename={}'.format(log_file_name)
+            }
+        )
 
 
 @retrying.retry(wait_fixed=1000, stop_max_delay=3000)
 def check_log_entry(log_line, url, dcos_api_session):
     response = dcos_api_session.get(url)
     check_response_ok(response, {})
-    assert log_line in response.text, 'Missing {} in output {}'.format(log_line, response.text)
+    assert log_line in response.text, 'Missing {} in output {}'.format(
+        log_line, response.text
+    )
 
 
 def get_task_url(dcos_api_session, task_name, stream=False):
@@ -187,27 +277,46 @@ def get_task_url(dcos_api_session, task_name, stream=False):
     container_id = None
 
     state_response_json = state_response.json()
-    assert 'frameworks' in state_response_json, 'Missing field `framework` in {}'.format(state_response_json)
-    assert isinstance(state_response_json['frameworks'], list), '`framework` must be list. Got {}'.format(
-        state_response_json)
+    assert 'frameworks' in state_response_json, 'Missing field `framework` in {}'.format(
+        state_response_json
+    )
+    assert isinstance(
+        state_response_json['frameworks'], list
+    ), '`framework` must be list. Got {}'.format(state_response_json)
 
     for framework in state_response_json['frameworks']:
-        assert 'name' in framework, 'Missing field `name` in `frameworks`. Got {}'.format(state_response_json)
+        assert 'name' in framework, 'Missing field `name` in `frameworks`. Got {}'.format(
+            state_response_json
+        )
         # search for marathon framework
         if framework['name'] != 'marathon':
             continue
 
-        assert 'tasks' in framework, 'Missing field `tasks`. Got {}'.format(state_response_json)
-        assert isinstance(framework['tasks'], list), '`tasks` must be list. Got {}'.format(state_response_json)
+        assert 'tasks' in framework, 'Missing field `tasks`. Got {}'.format(
+            state_response_json
+        )
+        assert isinstance(
+            framework['tasks'], list
+        ), '`tasks` must be list. Got {}'.format(state_response_json)
         for task in framework['tasks']:
-            assert 'id' in task, 'Missing field `id` in task. Got {}'.format(state_response_json)
+            assert 'id' in task, 'Missing field `id` in task. Got {}'.format(
+                state_response_json
+            )
             if not task['id'].startswith(task_name):
                 continue
 
-            assert 'framework_id' in task, 'Missing `framework_id` in task. Got {}'.format(state_response_json)
-            assert 'executor_id' in task, 'Missing `executor_id` in task. Got {}'.format(state_response_json)
-            assert 'id' in task, 'Missing `id` in task. Got {}'.format(state_response_json)
-            assert 'slave_id' in task, 'Missing `slave_id` in task. Got {}'.format(state_response_json)
+            assert 'framework_id' in task, 'Missing `framework_id` in task. Got {}'.format(
+                state_response_json
+            )
+            assert 'executor_id' in task, 'Missing `executor_id` in task. Got {}'.format(
+                state_response_json
+            )
+            assert 'id' in task, 'Missing `id` in task. Got {}'.format(
+                state_response_json
+            )
+            assert 'slave_id' in task, 'Missing `slave_id` in task. Got {}'.format(
+                state_response_json
+            )
 
             framework_id = task['framework_id']
             # if task['executor_id'] is empty, we should use task['id']
@@ -216,14 +325,28 @@ def get_task_url(dcos_api_session, task_name, stream=False):
                 executor_id = task['id']
             slave_id = task['slave_id']
 
-            assert task['statuses'], 'Invalid field `statuses`. Got {}'.format(state_response_json)
+            assert task['statuses'], 'Invalid field `statuses`. Got {}'.format(
+                state_response_json
+            )
             statuses = task['statuses']
-            assert isinstance(statuses, list), 'Invalid field `statuses`. Got {}'.format(state_response_json)
-            assert len(statuses) == 1, 'Must have only one status TASK_RUNNING. Got {}'.format(state_response_json)
+            assert isinstance(
+                statuses, list
+            ), 'Invalid field `statuses`. Got {}'.format(state_response_json)
+            assert len(
+                statuses
+            ) == 1, 'Must have only one status TASK_RUNNING. Got {}'.format(
+                state_response_json
+            )
             status = statuses[0]
-            assert status['container_status'], 'Invalid field `container_status`. Got {}'.format(state_response_json)
+            assert status['container_status'
+                          ], 'Invalid field `container_status`. Got {}'.format(
+                              state_response_json
+                          )
             container_status = status['container_status']
-            assert container_status['container_id'], 'Invalid field `container_id`. Got {}'.format(state_response_json)
+            assert container_status[
+                'container_id'], 'Invalid field `container_id`. Got {}'.format(
+                    state_response_json
+                )
             container_id_field = container_status['container_id']
 
             # traverse nested container_id fields
@@ -242,9 +365,9 @@ def get_task_url(dcos_api_session, task_name, stream=False):
     assert container_id, 'Missing container_id'
 
     endpoint_type = 'stream' if stream else 'range'
-    return '/system/v1/agent/{}/logs/v1/{}/framework/{}/executor/{}/container/{}'.format(slave_id, endpoint_type,
-                                                                                         framework_id, executor_id,
-                                                                                         container_id)
+    return '/system/v1/agent/{}/logs/v1/{}/framework/{}/executor/{}/container/{}'.format(
+        slave_id, endpoint_type, framework_id, executor_id, container_id
+    )
 
 
 def validate_journald_cursor(c: str, cursor_regexp=None):
@@ -253,25 +376,40 @@ def validate_journald_cursor(c: str, cursor_regexp=None):
         cursor_regexp += b'm=[a-f0-9]+;t=[a-f0-9]+;x=[a-f0-9]+$'
 
     p = re.compile(cursor_regexp)
-    assert p.match(c), "Cursor {} does not match regexp {}".format(c, cursor_regexp)
+    assert p.match(c), "Cursor {} does not match regexp {}".format(
+        c, cursor_regexp
+    )
 
 
 def test_log_v2_text(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('/v2/component?limit=10', node=node)
+        response = dcos_api_session.logs.get(
+            '/v2/component?limit=10', node=node
+        )
         check_response_ok(response, {'Content-Type': 'text/plain'})
 
         # expect 10 entries
         logs = response.content.decode()
         entries_count = len(re.findall(NEW_ENTRY_PATTERN, logs))
-        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(entries_count, logs)
+        assert entries_count == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(
+            entries_count, logs
+        )
 
 
 def test_log_v2_server_sent_events(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
         response = dcos_api_session.logs.get(
-            '/v2/component?limit=1', node=node, headers={'Accept': 'text/event-stream'}, stream=True)
-        check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
+            '/v2/component?limit=1',
+            node=node,
+            headers={'Accept': 'text/event-stream'},
+            stream=True
+        )
+        check_response_ok(
+            response, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+            }
+        )
         lines = response.iter_lines()
         sse_id = next(lines)
         validate_journald_cursor(sse_id)
@@ -281,9 +419,18 @@ def test_log_v2_server_sent_events(dcos_api_session):
 
 def test_log_v2_stream(dcos_api_session):
     for node in dcos_api_session.masters + dcos_api_session.all_slaves:
-        response = dcos_api_session.logs.get('/v2/component?skip=-1', node=node, stream=True,
-                                             headers={'Accept': 'text/event-stream'})
-        check_response_ok(response, {'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache'})
+        response = dcos_api_session.logs.get(
+            '/v2/component?skip=-1',
+            node=node,
+            stream=True,
+            headers={'Accept': 'text/event-stream'}
+        )
+        check_response_ok(
+            response, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache'
+            }
+        )
         lines = response.iter_lines()
         sse_id = next(lines)
         validate_journald_cursor(sse_id)
@@ -296,13 +443,23 @@ def test_log_v2_proxy(dcos_api_session):
     check_response_ok(r, {})
 
     data = r.json()
-    slaves_ids = sorted(x['id'] for x in data['slaves'] if x['hostname'] in dcos_api_session.all_slaves)
+    slaves_ids = sorted(
+        x['id'] for x in data['slaves']
+        if x['hostname'] in dcos_api_session.all_slaves
+    )
 
     for slave_id in slaves_ids:
-        response = dcos_api_session.get('/system/v1/agent/{}/logs/v2/component?skip=-10&limit=10'.format(slave_id))
+        response = dcos_api_session.get(
+            '/system/v1/agent/{}/logs/v2/component?skip=-10&limit=10'.
+            format(slave_id)
+        )
         check_response_ok(response, {'Content-Type': 'text/plain'})
         lines = list(filter(lambda x: x != '', response.text.split('\n')))
-        assert len(lines) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(len(lines), lines)
+        assert len(
+            lines
+        ) == 10, 'Expect 10 log entries. Got {}. All lines {}'.format(
+            len(lines), lines
+        )
 
 
 def test_log_v2_task_logs(dcos_api_session):
@@ -311,32 +468,52 @@ def test_log_v2_task_logs(dcos_api_session):
     task_id = "integration-test-task-logs-{}".format(test_uuid)
 
     task_definition = {
-        "id": "/{}".format(task_id),
-        "cpus": 0.1,
-        "instances": 1,
-        "mem": 128,
+        "id":
+        "/{}".format(task_id),
+        "cpus":
+        0.1,
+        "instances":
+        1,
+        "mem":
+        128,
         "healthChecks": [
             {
                 "protocol": "COMMAND",
                 "command": {
-                    "value": "grep -q STDOUT_LOG stdout;grep -q STDERR_LOG stderr"
+                    "value":
+                    "grep -q STDOUT_LOG stdout;grep -q STDERR_LOG stderr"
                 }
             }
         ],
-        "cmd": "echo STDOUT_LOG; echo STDERR_LOG >&2;sleep 999"
+        "cmd":
+        "echo STDOUT_LOG; echo STDERR_LOG >&2;sleep 999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
-        response = dcos_api_session.logs.get('/v2/task/{}/file/stdout'.format(task_id))
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        task_definition, check_health=True
+    ):
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/stdout'.format(task_id)
+        )
         check_response_ok(response, {})
-        assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
+        assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(
+            response.text
+        )
 
-        response = dcos_api_session.logs.get('/v2/task/{}/file/stderr'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/stderr'.format(task_id)
+        )
         check_response_ok(response, {})
-        assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
+        assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(
+            response.text
+        )
 
-        _assert_files_in_browse_response(dcos_api_session, task_id, ['stdout', 'stderr'])
-        _assert_can_download_files(dcos_api_session, task_id, ['stdout', 'stderr'])
+        _assert_files_in_browse_response(
+            dcos_api_session, task_id, ['stdout', 'stderr']
+        )
+        _assert_can_download_files(
+            dcos_api_session, task_id, ['stdout', 'stderr']
+        )
 
 
 def test_log_v2_pod_logs(dcos_api_session):
@@ -345,31 +522,59 @@ def test_log_v2_pod_logs(dcos_api_session):
     pod_id = 'integration-test-pod-logs-{}'.format(test_uuid)
 
     pod_definition = {
-        'id': '/{}'.format(pod_id),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/{}'.format(pod_id),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'sleep1',
-                'exec': {'command': {'shell': 'echo $PING > foo;echo STDOUT_LOG;echo STDERR_LOG >&2;sleep 10000'}},
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo;echo STDOUT_LOG;echo STDERR_LOG >&2;sleep 10000'
+                    }
+                },
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
 
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         response = dcos_api_session.logs.get('/v2/task/sleep1')
         check_response_ok(response, {})
-        assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(response.text)
+        assert 'STDOUT_LOG' in response.text, "Expect STDOUT_LOG in stdout file. Got {}".format(
+            response.text
+        )
 
         response = dcos_api_session.logs.get('/v2/task/sleep1/file/stderr')
         check_response_ok(response, {})
-        assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(response.text)
+        assert 'STDERR_LOG' in response.text, "Expect STDERR_LOG in stdout file. Got {}".format(
+            response.text
+        )
 
-        _assert_files_in_browse_response(dcos_api_session, pod_id, ['stdout', 'stderr', 'foo'])
-        _assert_can_download_files(dcos_api_session, pod_id, ['stdout', 'stderr', 'foo'])
+        _assert_files_in_browse_response(
+            dcos_api_session, pod_id, ['stdout', 'stderr', 'foo']
+        )
+        _assert_can_download_files(
+            dcos_api_session, pod_id, ['stdout', 'stderr', 'foo']
+        )
 
 
 def test_log_v2_api(dcos_api_session):
@@ -378,57 +583,77 @@ def test_log_v2_api(dcos_api_session):
     task_id = "integration-test-task-logs-{}".format(test_uuid)
 
     task_definition = {
-        "id": "/{}".format(task_id),
-        "cpus": 0.1,
-        "instances": 1,
-        "mem": 128,
-        "healthChecks": [
-            {
-                "protocol": "COMMAND",
-                "command": {
-                    "value": "test -f test"
-                }
+        "id":
+        "/{}".format(task_id),
+        "cpus":
+        0.1,
+        "instances":
+        1,
+        "mem":
+        128,
+        "healthChecks":
+        [{
+            "protocol": "COMMAND",
+            "command": {
+                "value": "test -f test"
             }
-        ],
-        "cmd": "echo \"one\ntwo\nthree\nfour\nfive\n\">test;sleep 9999"
+        }],
+        "cmd":
+        "echo \"one\ntwo\nthree\nfour\nfive\n\">test;sleep 9999"
     }
 
-    with dcos_api_session.marathon.deploy_and_cleanup(task_definition, check_health=True):
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        task_definition, check_health=True
+    ):
         # skip 2 entries from the beggining
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=2'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?skip=2'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "three\nfour\nfive\n"
 
         # move to the end of file and read 2 last LINE_SIZE
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?cursor=END&skip=-2'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # move three lines from the top and limit to one entry
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?skip=3&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?skip=3&limit=1'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "four\n"
 
         # set cursor to 7 (bytes) which the second word and skip 1 lines
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=1'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?cursor=7&skip=1'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "four\nfive\n"
 
         # set cursor to 7 (bytes) which the second word and skip -1 lines and limit 1
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?cursor=7&skip=-1&limit=1'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "two\n"
 
         # validate the bug is fixed https://jira.mesosphere.com/browse/DCOS_OSS-1995
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id))
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?cursor=END&skip=-5'.format(task_id)
+        )
         check_response_ok(response, {})
         assert response.text == "one\ntwo\nthree\nfour\nfive\n"
 
         # make sure if 'Last-Event-ID' header is passed, other get parameters are ignored
         # https://jira.mesosphere.com/browse/DCOS_OSS-2292
         # number 7 used in 'Last-Event-ID' header points to a second word.
-        response = dcos_api_session.logs.get('/v2/task/{}/file/test?cursor=END&skip=-1'.format(task_id),
-                                             headers={'Last-Event-ID': '7'})
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/test?cursor=END&skip=-1'.format(task_id),
+            headers={'Last-Event-ID': '7'}
+        )
         check_response_ok(response, {})
         assert response.text == "three\nfour\nfive\n"
 
@@ -442,18 +667,29 @@ def _assert_files_in_browse_response(dcos_api_session, task, expected_files):
     files = []
     for item in data:
         for field in expected_fields:
-            assert field in item, 'Field {} must be in response. Item {}'.format(field, item)
+            assert field in item, 'Field {} must be in response. Item {}'.format(
+                field, item
+            )
         _file = item['path'].split('/')[-1]
         files += [_file]
 
     for expected_file in expected_files:
-        assert expected_file in files, 'Expecting file {} in {}'.format(expected_file, files)
+        assert expected_file in files, 'Expecting file {} in {}'.format(
+            expected_file, files
+        )
 
 
 def _assert_can_download_files(dcos_api_session, task, expected_files):
     for expected_file in expected_files:
-        response = dcos_api_session.logs.get('/v2/task/{}/file/{}/download'.format(task, expected_file))
-        check_response_ok(response, {
-            'Content-Type': 'application/octet-stream',
-            'Content-Disposition': 'attachment; filename={}'.format(expected_file)})
+        response = dcos_api_session.logs.get(
+            '/v2/task/{}/file/{}/download'.format(task, expected_file)
+        )
+        check_response_ok(
+            response, {
+                'Content-Type':
+                'application/octet-stream',
+                'Content-Disposition':
+                'attachment; filename={}'.format(expected_file)
+            }
+        )
         assert response.text

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -148,7 +148,9 @@ def test_if_pkgpanda_metadata_is_available(dcos_api_session):
 
     data = r.json()
     assert 'mesos' in data
-    assert len(data) > 5  # (prozlach) We can try to put minimal number of pacakages required
+    assert len(
+        data
+    ) > 5  # (prozlach) We can try to put minimal number of pacakages required
 
 
 def test_if_dcos_history_service_is_getting_data(dcos_api_session):
@@ -172,7 +174,8 @@ def test_if_we_have_capabilities(dcos_api_session):
     r = dcos_api_session.get(
         '/capabilities',
         headers={
-            'Accept': 'application/vnd.dcos.capabilities+json;charset=utf-8;version=v1'
+            'Accept':
+            'application/vnd.dcos.capabilities+json;charset=utf-8;version=v1'
         }
     )
     assert r.status_code == 200
@@ -181,24 +184,31 @@ def test_if_we_have_capabilities(dcos_api_session):
 
 def test_if_overlay_master_is_up(dcos_api_session):
     r = dcos_api_session.get('/mesos/overlay-master/state')
-    assert r.ok, "status_code: {}, content: {}".format(r.status_code, r.content)
+    assert r.ok, "status_code: {}, content: {}".format(
+        r.status_code, r.content
+    )
 
     # Make sure the `dcos` and `dcos6` overlays have been configured.
     json = r.json()
 
     dcos_overlay_network = {
-        'vtep_subnet': '44.128.0.0/20',
-        'vtep_subnet6': 'fd01:a::/64',
-        'vtep_mac_oui': '70:B3:D5:00:00:00',
-        'overlays': [{
-            'name': 'dcos',
-            'subnet': '9.0.0.0/8',
-            'prefix': 24
-        }, {
-            'name': 'dcos6',
-            'subnet6': 'fd01:b::/64',
-            'prefix6': 80
-        }]
+        'vtep_subnet':
+        '44.128.0.0/20',
+        'vtep_subnet6':
+        'fd01:a::/64',
+        'vtep_mac_oui':
+        '70:B3:D5:00:00:00',
+        'overlays': [
+            {
+                'name': 'dcos',
+                'subnet': '9.0.0.0/8',
+                'prefix': 24
+            }, {
+                'name': 'dcos6',
+                'subnet6': 'fd01:b::/64',
+                'prefix6': 80
+            }
+        ]
     }
 
     assert nested_match(dcos_overlay_network, json['network'])
@@ -234,9 +244,13 @@ def test_if_overlay_master_agent_is_up(dcos_api_session):
     for agent_overlay in agent_overlay_json['overlays']:
         overlay_name = agent_overlay['info']['name']
         if master_agent_overlays[0]['info']['name'] == overlay_name:
-            _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlays[0])
+            _validate_dcos_overlay(
+                overlay_name, agent_overlay, master_agent_overlays[0]
+            )
         else:
-            _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlays[1])
+            _validate_dcos_overlay(
+                overlay_name, agent_overlay, master_agent_overlays[1]
+            )
 
 
 def _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlay):
@@ -254,7 +268,9 @@ def _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlay):
         try:
             agent_overlay.pop('mesos_bridge')
         except KeyError as ex:
-            raise AssertionError("Could not find expected 'mesos_bridge' in agent:" + str(ex)) from ex
+            raise AssertionError(
+                "Could not find expected 'mesos_bridge' in agent:" + str(ex)
+            ) from ex
     else:
         # Master didn't configure a `mesos-bridge` so shouldn't be
         # seeing it in the agent as well.
@@ -264,7 +280,9 @@ def _validate_dcos_overlay(overlay_name, agent_overlay, master_agent_overlay):
         try:
             agent_overlay.pop('docker_bridge')
         except KeyError as ex:
-            raise AssertionError("Could not find expected 'docker_bridge' in agent:" + str(ex)) from ex
+            raise AssertionError(
+                "Could not find expected 'docker_bridge' in agent:" + str(ex)
+            ) from ex
     else:
         # Master didn't configure a `docker-bridge` so shouldn't be
         # seeing it in the agent as well.
@@ -308,8 +326,10 @@ def _validate_overlay_subnet(agent_subnet, overlay_subnet, prefixlen):
         assert allocated_subnet.overlaps(ipaddress.ip_network(overlay_subnet)),\
             "Allocated subnet: {}".format(allocated_subnet)
     except ValueError as ex:
-        raise AssertionError("Could not convert subnet(" + agent_subnet + ")\
-            network address: " + str(ex)) from ex
+        raise AssertionError(
+            "Could not convert subnet(" + agent_subnet + ")\
+            network address: " + str(ex)
+        ) from ex
 
 
 def _validate_overlay_backend(overlay_name, backend):
@@ -345,9 +365,13 @@ def test_if_cosmos_is_only_available_locally(dcos_api_session):
     # over non-lo interfaces
     msg = "Cosmos reachable from non-lo interface"
     with pytest.raises(ConnectionError, message=msg):
-        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=7070, scheme='http')
+        dcos_api_session.get(
+            '/', host=dcos_api_session.masters[0], port=7070, scheme='http'
+        )
     with pytest.raises(ConnectionError, message=msg):
-        dcos_api_session.get('/', host=dcos_api_session.masters[0], port=9990, scheme='http')
+        dcos_api_session.get(
+            '/', host=dcos_api_session.masters[0], port=9990, scheme='http'
+        )
 
     # One should be able to connect to the cosmos HTTP and admin ports at
     # 127.0.0.1:7070 and 127.0.0.1:9990.

--- a/packages/dcos-integration-test/extra/test_exhibitor.py
+++ b/packages/dcos-integration-test/extra/test_exhibitor.py
@@ -4,7 +4,6 @@ import pytest
 
 
 class TestExhibitor:
-
     def test_permissions(self):
         """
         ZooKeeper data files are not accessible

--- a/packages/dcos-integration-test/extra/test_iam_migration.py
+++ b/packages/dcos-integration-test/extra/test_iam_migration.py
@@ -12,10 +12,8 @@ from dcos_test_utils.dcos_api import DcosApiSession
 from kazoo.client import KazooClient
 from kazoo.retry import KazooRetry
 
-
 __maintainer__ = 'mhrabovcin'
 __contact__ = 'security-team@mesosphere.io'
-
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +22,8 @@ log = logging.getLogger(__name__)
 def zk() -> KazooClient:
     conn_retry_policy = KazooRetry(max_tries=-1, delay=0.1, max_delay=0.1)
     cmd_retry_policy = KazooRetry(
-        max_tries=3, delay=0.3, backoff=1, max_delay=1, ignore_expire=False)
+        max_tries=3, delay=0.3, backoff=1, max_delay=1, ignore_expire=False
+    )
     zk = KazooClient(
         hosts='zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181',
         connection_retry=conn_retry_policy,
@@ -37,7 +36,6 @@ def zk() -> KazooClient:
 
 @pytest.fixture()
 def create_dcos_oauth_users(zk: KazooClient) -> None:
-
     def _create_dcos_oauth_user(uid):
         log.info('Creating user `%s`', uid)
         zk.create('/dcos/users/{uid}'.format(uid=uid), makepath=True)
@@ -59,17 +57,22 @@ def create_dcos_oauth_users(zk: KazooClient) -> None:
 
 @pytest.mark.usefixtures('create_dcos_oauth_users')
 def test_iam_migration(dcos_api_session: DcosApiSession) -> None:
-    check_call(['sudo', 'systemctl', 'stop', 'dcos-bouncer-migrate-users.service'])
+    check_call(
+        ['sudo', 'systemctl', 'stop', 'dcos-bouncer-migrate-users.service']
+    )
 
     def _filter_test_uids(r):
         return [
-            u['uid'] for u in r.json()['array'] if '@example.com' in u['uid']]
+            u['uid'] for u in r.json()['array'] if '@example.com' in u['uid']
+        ]
 
     r = dcos_api_session.get('/acs/api/v1/users')
     test_uids = _filter_test_uids(r)
     assert len(test_uids) == 0
 
-    check_call(['sudo', 'systemctl', 'start', 'dcos-bouncer-migrate-users.service'])
+    check_call(
+        ['sudo', 'systemctl', 'start', 'dcos-bouncer-migrate-users.service']
+    )
     # Sleep for 5 seconds and let the migration script run
     time.sleep(5)
 

--- a/packages/dcos-integration-test/extra/test_legacy_user_management.py
+++ b/packages/dcos-integration-test/extra/test_legacy_user_management.py
@@ -26,10 +26,8 @@ from dcos_test_utils import dcos_cli
 
 from test_helpers import get_expanded_config
 
-
 __maintainer__ = 'jgehrcke'
 __contact__ = 'security-team@mesosphere.io'
-
 
 log = logging.getLogger(__name__)
 
@@ -147,7 +145,10 @@ def test_user_put_with_legacy_body(dcos_api_session):
     # the 1.13 development cycle.
     r = dcos_api_session.put(
         '/acs/api/v1/users/user2@domain.foo',
-        json={'creator_uid': 'any@thing.bla', 'cluster_url': 'foobar'}
+        json={
+            'creator_uid': 'any@thing.bla',
+            'cluster_url': 'foobar'
+        }
     )
     assert r.status_code == 201, r.text
 

--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -18,19 +18,28 @@ __contact__ = 'core-team@mesosphere.io'
 # Creates and yields the initial ATTACH_CONTAINER_INPUT message, then a data message,
 # then an empty data chunk to indicate end-of-stream.
 def input_streamer(nested_container_id):
-    encoder = recordio.Encoder(lambda s: bytes(json.dumps(s, ensure_ascii=False), "UTF-8"))
+    encoder = recordio.Encoder(
+        lambda s: bytes(json.dumps(s, ensure_ascii=False), "UTF-8")
+    )
     message = {
         'type': 'ATTACH_CONTAINER_INPUT',
         'attach_container_input': {
             'type': 'CONTAINER_ID',
-            'container_id': nested_container_id}}
+            'container_id': nested_container_id
+        }
+    }
     yield encoder.encode(message)
 
     message['attach_container_input'] = {
         'type': 'PROCESS_IO',
         'process_io': {
             'type': 'DATA',
-            'data': {'type': 'STDIN', 'data': 'meow'}}}
+            'data': {
+                'type': 'STDIN',
+                'data': 'meow'
+            }
+        }
+    }
     yield encoder.encode(message)
 
     # Place an empty string to indicate EOF to the server and push
@@ -57,18 +66,28 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
         for framework in state['frameworks']:
             for task in framework['tasks']:
                 if app_id in task['id']:
-                    container_id = task['statuses'][0]['container_status']['container_id']['value']
+                    container_id = task['statuses'][0]['container_status'][
+                        'container_id']['value']
                     agent_id = task['slave_id']
-        assert container_id is not None, 'Container ID not found for instance of app_id {}'.format(app_id)
-        assert agent_id is not None, 'Agent ID not found for instance of app_id {}'.format(app_id)
+        assert container_id is not None, 'Container ID not found for instance of app_id {}'.format(
+            app_id
+        )
+        assert agent_id is not None, 'Agent ID not found for instance of app_id {}'.format(
+            app_id
+        )
 
         # Find hostname and URL from agent_id
         agent_hostname = None
         for agent in state['slaves']:
             if agent['id'] == agent_id:
                 agent_hostname = agent['hostname']
-        assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(agent_id)
-        logging.debug('Located %s with containerID %s on agent %s', app_id, container_id, agent_hostname)
+        assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(
+            agent_id
+        )
+        logging.debug(
+            'Located %s with containerID %s on agent %s', app_id, container_id,
+            agent_hostname
+        )
 
         def _post_agent(url, headers, json=None, data=None, stream=False):
             r = dcos_api_session.post(
@@ -78,14 +97,18 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
                 headers=headers,
                 json=json,
                 data=data,
-                stream=stream)
+                stream=stream
+            )
             assert r.status_code == 200
             return r
 
         # Prepare nested container id data
         nested_container_id = {
             'value': 'debug-%s' % str(uuid.uuid4()),
-            'parent': {'value': '%s' % container_id}}
+            'parent': {
+                'value': '%s' % container_id
+            }
+        }
 
         # Launch debug session and attach to output stream of debug container
         output_headers = {
@@ -96,15 +119,26 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
         lncs_data = {
             'type': 'LAUNCH_NESTED_CONTAINER_SESSION',
             'launch_nested_container_session': {
-                'command': {'value': 'cat'},
-                'container_id': nested_container_id}}
-        launch_output = _post_agent('/api/v1', output_headers, json=lncs_data, stream=True)
+                'command': {
+                    'value': 'cat'
+                },
+                'container_id': nested_container_id
+            }
+        }
+        launch_output = _post_agent(
+            '/api/v1', output_headers, json=lncs_data, stream=True
+        )
 
         # Attach to output stream of nested container
         attach_out_data = {
             'type': 'ATTACH_CONTAINER_OUTPUT',
-            'attach_container_output': {'container_id': nested_container_id}}
-        attached_output = _post_agent('/api/v1', output_headers, json=attach_out_data, stream=True)
+            'attach_container_output': {
+                'container_id': nested_container_id
+            }
+        }
+        attached_output = _post_agent(
+            '/api/v1', output_headers, json=attach_out_data, stream=True
+        )
 
         # Attach to input stream of debug container and stream a message
         input_headers = {
@@ -113,7 +147,9 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
             'Accept': 'application/json',
             'Transfer-Encoding': 'chunked'
         }
-        _post_agent('/api/v1', input_headers, data=input_streamer(nested_container_id))
+        _post_agent(
+            '/api/v1', input_headers, data=input_streamer(nested_container_id)
+        )
 
         # Verify the streamed output from the launch session
         meowed = False
@@ -122,7 +158,8 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
             for r in decoder.decode(chunk):
                 if r['type'] == 'DATA':
                     logging.debug('Extracted data chunk: %s', r['data'])
-                    assert r['data']['data'] == 'meow', 'Output did not match expected'
+                    assert r['data'][
+                        'data'] == 'meow', 'Output did not match expected'
                     meowed = True
         assert meowed, 'Read launch output without seeing meow.'
 
@@ -132,7 +169,8 @@ def test_if_marathon_app_can_be_debugged(dcos_api_session):
             for r in decoder.decode(chunk):
                 if r['type'] == 'DATA':
                     logging.debug('Extracted data chunk: %s', r['data'])
-                    assert r['data']['data'] == 'meow', 'Output did not match expected'
+                    assert r['data'][
+                        'data'] == 'meow', 'Output did not match expected'
                     meowed = True
         assert meowed, 'Read output stream without seeing meow.'
 
@@ -148,14 +186,21 @@ def test_files_api(dcos_api_session):
     app['cmd'] = 'echo $DCOS_TEST_UUID && ' + app['cmd']
 
     with dcos_api_session.marathon.deploy_and_cleanup(app):
-        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']
-        app_task = dcos_api_session.marathon.get('/v2/apps/{}/tasks'.format(app['id'])).json()['tasks'][0]
+        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json(
+        )['frameworkId']
+        app_task = dcos_api_session.marathon.get(
+            '/v2/apps/{}/tasks'.format(app['id'])
+        ).json()['tasks'][0]
 
         for required_sandbox_file in ('stdout', 'stderr'):
             content = dcos_api_session.mesos_sandbox_file(
-                app_task['slaveId'], marathon_framework_id, app_task['id'], required_sandbox_file)
+                app_task['slaveId'], marathon_framework_id, app_task['id'],
+                required_sandbox_file
+            )
 
-            assert content, 'File {} should not be empty'.format(required_sandbox_file)
+            assert content, 'File {} should not be empty'.format(
+                required_sandbox_file
+            )
 
 
 def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
@@ -163,14 +208,19 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
     # doesn't support running docker images with the UCR. We need this
     # functionality in order to test that the pid namespace isolator
     # is functioning correctly.
-    app, test_uuid = test_helpers.marathon_test_app(container_type=marathon.Container.MESOS)
+    app, test_uuid = test_helpers.marathon_test_app(
+        container_type=marathon.Container.MESOS
+    )
 
     ps_output_file = 'ps_output'
     app['cmd'] = 'ps ax -o pid= > {}; sleep 1000'.format(ps_output_file)
 
     with dcos_api_session.marathon.deploy_and_cleanup(app, check_health=False):
-        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']
-        app_task = dcos_api_session.marathon.get('/v2/apps/{}/tasks'.format(app['id'])).json()['tasks'][0]
+        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json(
+        )['frameworkId']
+        app_task = dcos_api_session.marathon.get(
+            '/v2/apps/{}/tasks'.format(app['id'])
+        ).json()['tasks'][0]
 
         # There is a short delay between the `app_task` starting and it writing
         # its output to the `pd_output_file`. Because of this, we wait up to 10
@@ -178,35 +228,45 @@ def test_if_ucr_app_runs_in_new_pid_namespace(dcos_api_session):
         @retrying.retry(wait_fixed=1000, stop_max_delay=10000)
         def get_ps_output():
             return dcos_api_session.mesos_sandbox_file(
-                app_task['slaveId'], marathon_framework_id, app_task['id'], ps_output_file)
+                app_task['slaveId'], marathon_framework_id, app_task['id'],
+                ps_output_file
+            )
 
-        assert len(get_ps_output().split()) <= 4, 'UCR app has more than 4 processes running in its pid namespace'
+        assert len(
+            get_ps_output().split()
+        ) <= 4, 'UCR app has more than 4 processes running in its pid namespace'
 
 
 def test_memory_profiling(dcos_api_session):
     # Test that we can fetch raw memory profiles
     master_ip = dcos_api_session.masters[0]
     r0 = dcos_api_session.get(
-        '/memory-profiler/start', host=master_ip, port=5050)
+        '/memory-profiler/start', host=master_ip, port=5050
+    )
     assert r0.status_code == 200, r0.text
 
     r1 = dcos_api_session.get(
-        '/memory-profiler/stop', host=master_ip, port=5050)
+        '/memory-profiler/stop', host=master_ip, port=5050
+    )
     assert r1.status_code == 200, r1.text
 
     r2 = dcos_api_session.get(
-        '/memory-profiler/download/raw', host=master_ip, port=5050)
+        '/memory-profiler/download/raw', host=master_ip, port=5050
+    )
     assert r2.status_code == 200, r2.text
 
 
 def test_blkio_stats(dcos_api_session):
     expanded_config = test_helpers.get_expanded_config()
-    if expanded_config['provider'] == 'azure' or expanded_config['platform'] == 'azure':
+    if expanded_config['provider'] == 'azure' or expanded_config['platform'
+                                                                 ] == 'azure':
         pytest.skip('See: https://jira.mesosphere.com/browse/DCOS-49023')
 
     # Launch a Marathon application to do some disk writes, and then verify that
     # the cgroups blkio statistics of the application can be correctly retrieved.
-    app, test_uuid = test_helpers.marathon_test_app(container_type=marathon.Container.MESOS)
+    app, test_uuid = test_helpers.marathon_test_app(
+        container_type=marathon.Container.MESOS
+    )
     app_id = 'integration-test-{}'.format(test_uuid)
 
     # The application will generate a 10k file with 10 disk writes.
@@ -219,20 +279,27 @@ def test_blkio_stats(dcos_api_session):
     # throttling statistics. When we drop the CentOS 6 and Ubuntu 14
     # support in future, we should remove the first `dd` command.
     marker_file = 'marker'
-    app['cmd'] = ('dd if=/dev/zero of=file bs=1024 count=1 oflag=dsync && '
-                  'dd if=/dev/zero of=file bs=1024 count=10 oflag=dsync && '
-                  'echo -n done > {} && sleep 1000').format(marker_file)
+    app['cmd'] = (
+        'dd if=/dev/zero of=file bs=1024 count=1 oflag=dsync && '
+        'dd if=/dev/zero of=file bs=1024 count=10 oflag=dsync && '
+        'echo -n done > {} && sleep 1000'
+    ).format(marker_file)
 
     with dcos_api_session.marathon.deploy_and_cleanup(app, check_health=False):
-        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json()['frameworkId']
-        app_task = dcos_api_session.marathon.get('/v2/apps/{}/tasks'.format(app['id'])).json()['tasks'][0]
+        marathon_framework_id = dcos_api_session.marathon.get('/v2/info').json(
+        )['frameworkId']
+        app_task = dcos_api_session.marathon.get(
+            '/v2/apps/{}/tasks'.format(app['id'])
+        ).json()['tasks'][0]
 
         # Wait up to 10 seconds for the marker file to appear which
         # indicates the disk writes via `dd` command are done.
         @retrying.retry(wait_fixed=1000, stop_max_delay=10000)
         def get_marker_file_content():
             return dcos_api_session.mesos_sandbox_file(
-                app_task['slaveId'], marathon_framework_id, app_task['id'], marker_file)
+                app_task['slaveId'], marathon_framework_id, app_task['id'],
+                marker_file
+            )
 
         assert get_marker_file_content() == 'done'
 
@@ -248,18 +315,24 @@ def test_blkio_stats(dcos_api_session):
             for task in framework['tasks']:
                 if app_id in task['id']:
                     agent_id = task['slave_id']
-        assert agent_id is not None, 'Agent ID not found for instance of app_id {}'.format(app_id)
+        assert agent_id is not None, 'Agent ID not found for instance of app_id {}'.format(
+            app_id
+        )
 
         # Find hostname from agent_id
         agent_hostname = None
         for agent in state['slaves']:
             if agent['id'] == agent_id:
                 agent_hostname = agent['hostname']
-        assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(agent_id)
+        assert agent_hostname is not None, 'Agent hostname not found for agent_id {}'.format(
+            agent_id
+        )
         logging.debug('Located %s on agent %s', app_id, agent_hostname)
 
         # Fetch the Mesos agent statistics
-        r = dcos_api_session.get('/monitor/statistics', host=agent_hostname, port=5051)
+        r = dcos_api_session.get(
+            '/monitor/statistics', host=agent_hostname, port=5051
+        )
         assert r.status_code == 200
         stats = r.json()
 
@@ -275,41 +348,59 @@ def test_blkio_stats(dcos_api_session):
                 # We only care about the blkio throttle statistics but not the blkio cfq statistics,
                 # because in the environment where the disk IO scheduler is not `cfq`, all the cfq
                 # statistics may be 0.
-                throttle_stats = stat['statistics']['blkio_statistics']['throttling']
+                throttle_stats = stat['statistics']['blkio_statistics'
+                                                    ]['throttling']
                 for throttle_stat in throttle_stats:
                     if 'device' not in throttle_stat:
-                        total_io_serviced = throttle_stat['io_serviced'][0]['value']
-                        total_io_service_bytes = throttle_stat['io_service_bytes'][0]['value']
+                        total_io_serviced = throttle_stat['io_serviced'
+                                                          ][0]['value']
+                        total_io_service_bytes = throttle_stat[
+                            'io_service_bytes'][0]['value']
 
-        assert total_io_serviced is not None, ('Total blkio throttling IO serviced not found '
-                                               'for app_id {}'.format(app_id))
-        assert total_io_service_bytes is not None, ('Total blkio throttling IO service bytes '
-                                                    'not found for app_id {}'.format(app_id))
+        assert total_io_serviced is not None, (
+            'Total blkio throttling IO serviced not found '
+            'for app_id {}'.format(app_id)
+        )
+        assert total_io_service_bytes is not None, (
+            'Total blkio throttling IO service bytes '
+            'not found for app_id {}'.format(app_id)
+        )
         # We expect the statistics retrieved from Mesos agent are equal or greater than what we
         # did with the `dd` command (i.e., 10 and 10240), because:
         #   1. Besides the disk writes done by the `dd` command, the statistics may also include
         #      some disk reads, e.g., to load the necessary executable binary and libraries.
         #   2. In the environment where RAID is enabled, there may be multiple disk writes to
         #      different disks for a single `dd` write.
-        assert int(total_io_serviced) >= 10, ('Total blkio throttling IO serviced for app_id {} '
-                                              'are less than 10'.format(app_id))
-        assert int(total_io_service_bytes) >= 10240, ('Total blkio throttling IO service bytes for '
-                                                      'app_id {} are less than 10240'.format(app_id))
+        assert int(total_io_serviced) >= 10, (
+            'Total blkio throttling IO serviced for app_id {} '
+            'are less than 10'.format(app_id)
+        )
+        assert int(total_io_service_bytes) >= 10240, (
+            'Total blkio throttling IO service bytes for '
+            'app_id {} are less than 10240'.format(app_id)
+        )
 
 
 def get_region_zone(domain):
     assert isinstance(domain, dict), 'input must be dict'
 
-    assert 'fault_domain' in domain, 'fault_domain is missing. {}'.format(domain)
+    assert 'fault_domain' in domain, 'fault_domain is missing. {}'.format(
+        domain
+    )
 
     # check region set correctly
-    assert 'region' in domain['fault_domain'], 'missing region. {}'.format(domain)
-    assert 'name' in domain['fault_domain']['region'], 'missing region. {}'.format(domain)
+    assert 'region' in domain['fault_domain'], 'missing region. {}'.format(
+        domain
+    )
+    assert 'name' in domain['fault_domain'
+                            ]['region'], 'missing region. {}'.format(domain)
     region = domain['fault_domain']['region']['name']
 
     # check zone set correctly
     assert 'zone' in domain['fault_domain'], 'missing zone. {}'.format(domain)
-    assert 'name' in domain['fault_domain']['zone'], 'missing zone. {}'.format(domain)
+    assert 'name' in domain['fault_domain']['zone'], 'missing zone. {}'.format(
+        domain
+    )
     zone = domain['fault_domain']['zone']['name']
 
     return region, zone
@@ -334,16 +425,26 @@ def test_fault_domain(dcos_api_session):
     # check master top level keys
     assert 'leader_info' in state, 'leader_info is missing in state json'
     assert 'domain' in state['leader_info'], 'domain is missing in state json'
-    leader_region, leader_zone = get_region_zone(state['leader_info']['domain'])
+    leader_region, leader_zone = get_region_zone(
+        state['leader_info']['domain']
+    )
 
-    assert leader_region == expected_region, 'expect region {}. Got {}'.format(expected_region, leader_region)
-    assert leader_zone == expected_zone, 'expect zone {}. Got {}'.format(expected_zone, leader_zone)
+    assert leader_region == expected_region, 'expect region {}. Got {}'.format(
+        expected_region, leader_region
+    )
+    assert leader_zone == expected_zone, 'expect zone {}. Got {}'.format(
+        expected_zone, leader_zone
+    )
 
     for agent in state['slaves']:
-        assert 'domain' in agent, 'missing domain field for agent. {}'.format(agent)
+        assert 'domain' in agent, 'missing domain field for agent. {}'.format(
+            agent
+        )
         agent_region, agent_zone = get_region_zone(agent['domain'])
 
-        assert agent_region == expected_region, 'expect region {}. Got {}'.format(expected_region, agent_region)
+        assert agent_region == expected_region, 'expect region {}. Got {}'.format(
+            expected_region, agent_region
+        )
 
         # agent_zone might be different on agents, so we just make sure it's a sane value
         assert agent_zone, 'agent_zone cannot be empty'
@@ -358,6 +459,7 @@ def reserved_disk(dcos_api_session):
     remaining resources to another role. With that a framework in the first
     role will only be offered `disk` resources.
     """
+
     # Setup.
 
     def principal():
@@ -382,7 +484,8 @@ def reserved_disk(dcos_api_session):
         response = json.loads(r.text)
         slaves = [
             slave['id'] for slave in response['slaves']
-            if 'public_ip' not in slave['attributes']]
+            if 'public_ip' not in slave['attributes']
+        ]
         assert slaves, 'Could not find any private agents'
         slave_id = slaves[0]
 
@@ -391,11 +494,15 @@ def reserved_disk(dcos_api_session):
         dcos_api_session.role = 'disk-' + uuid.uuid4().hex
 
         resources1 = {
-            'agent_id': {'value': slave_id},
+            'agent_id': {
+                'value': slave_id
+            },
             'resources': [
                 {
-                    'type': 'SCALAR',
-                    'name': 'disk',
+                    'type':
+                    'SCALAR',
+                    'name':
+                    'disk',
                     'reservations': [
                         {
                             'type': 'DYNAMIC',
@@ -403,12 +510,17 @@ def reserved_disk(dcos_api_session):
                             'principal': dcos_api_session.principal,
                         }
                     ],
-                    'scalar': {'value': 32}
+                    'scalar': {
+                        'value': 32
+                    }
                 }
             ]
         }
 
-        request = {'type': 'RESERVE_RESOURCES', 'reserve_resources': resources1}
+        request = {
+            'type': 'RESERVE_RESOURCES',
+            'reserve_resources': resources1
+        }
         r = dcos_api_session.post('/mesos/api/v1', json=request)
         assert r.status_code == 202, r.text
 
@@ -423,7 +535,8 @@ def reserved_disk(dcos_api_session):
 
         unreserved = [
             slave['unreserved_resources_full'] for slave in response['slaves']
-            if slave['id'] == slave_id]
+            if slave['id'] == slave_id
+        ]
         assert len(unreserved) == 1
         unreserved = unreserved[0]
         another_role = uuid.uuid4().hex
@@ -439,7 +552,10 @@ def reserved_disk(dcos_api_session):
 
         resources2 = copy.deepcopy(resources1)
         resources2['resources'] = unreserved
-        request = {'type': 'RESERVE_RESOURCES', 'reserve_resources': resources2}
+        request = {
+            'type': 'RESERVE_RESOURCES',
+            'reserve_resources': resources2
+        }
         r = dcos_api_session.post('/mesos/api/v1', json=request)
         assert r.status_code == 202, r.text
 
@@ -454,6 +570,7 @@ def reserved_disk(dcos_api_session):
         for resources in reversed(reserved_resources):
             request = {
                 'type': 'UNRESERVE_RESOURCES',
-                'unreserve_resources': resources}
+                'unreserve_resources': resources
+            }
             r = dcos_api_session.post('/mesos/api/v1', json=request)
             assert r.status_code == 202, r.text

--- a/packages/dcos-integration-test/extra/test_meta.py
+++ b/packages/dcos-integration-test/extra/test_meta.py
@@ -35,7 +35,12 @@ def _tests_from_pattern(ci_pattern: str) -> Set[str]:
     result = subprocess.run(
         args=args,
         stdout=subprocess.PIPE,
-        env={**os.environ, **{'PYTHONIOENCODING': 'UTF-8'}},
+        env={
+            **os.environ,
+            **{
+                'PYTHONIOENCODING': 'UTF-8'
+            }
+        },
     )
     output = result.stdout
     for line in output.splitlines():
@@ -60,8 +65,8 @@ def _tests_from_pattern(ci_pattern: str) -> Set[str]:
             # Some tests are skipped on collection.
             b'skipped in' not in line and
             # Some tests are deselected by the ``pytest.ini`` configuration.
-            b' deselected' not in line and
-            not line.startswith(b'no tests ran in')
+            b' deselected' not in line
+            and not line.startswith(b'no tests ran in')
         ):
             tests.add(line.decode())
 
@@ -105,7 +110,9 @@ def test_test_groups() -> None:
     if errs:
         for message in errs:
             log.error(message)
-        raise Exception("Some tests are not collected exactly once, see errors.")
+        raise Exception(
+            "Some tests are not collected exactly once, see errors."
+        )
 
     all_tests = _tests_from_pattern(ci_pattern='')
     assert tests_to_patterns.keys() - all_tests == set()

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -10,10 +10,8 @@ from prometheus_client.parser import text_string_to_metric_families
 
 from test_helpers import get_expanded_config
 
-
 __maintainer__ = 'philipnrmn'
 __contact__ = 'dcos-cluster-ops@mesosphere.io'
-
 
 METRICS_WAITTIME = 5 * 60 * 1000
 METRICS_INTERVAL = 2 * 1000
@@ -24,13 +22,18 @@ STD_INTERVAL = 5 * 1000
 FAULT_DOMAIN_TAGS = {'fault_domain_zone', 'fault_domain_region'}
 
 
-def check_tags(tags: dict, required_tag_names: set, optional_tag_names: set = set()):
+def check_tags(
+    tags: dict, required_tag_names: set, optional_tag_names: set = set()
+):
     """Assert that tags contains only expected keys with nonempty values."""
     keys = set(tags.keys())
     assert keys & required_tag_names == required_tag_names, 'Not all required tags were set'
-    assert keys - required_tag_names - optional_tag_names == set(), 'Encountered unexpected tags'
+    assert keys - required_tag_names - optional_tag_names == set(
+    ), 'Encountered unexpected tags'
     for tag_name, tag_val in tags.items():
-        assert tag_val != '', 'Value for tag "%s" must not be empty'.format(tag_name)
+        assert tag_val != '', 'Value for tag "%s" must not be empty'.format(
+            tag_name
+        )
 
 
 @pytest.mark.supportedwindows
@@ -41,8 +44,12 @@ def test_metrics_ping(dcos_api_session):
 
     for node in nodes:
         response = dcos_api_session.metrics.get('/ping', node=node)
-        assert response.status_code == 200, 'Status code: {}, Content {}'.format(response.status_code, response.content)
-        assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
+        assert response.status_code == 200, 'Status code: {}, Content {}'.format(
+            response.status_code, response.content
+        )
+        assert response.json()['ok'], 'Status code: {}, Content {}'.format(
+            response.status_code, response.content
+        )
 
 
 def test_metrics_agents_prom(dcos_api_session):
@@ -50,8 +57,12 @@ def test_metrics_agents_prom(dcos_api_session):
     nodes = get_master_and_agents(dcos_api_session)
 
     for node in nodes:
-        response = dcos_api_session.session.request('GET', 'http://' + node + ':61091/metrics')
-        assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
+        response = dcos_api_session.session.request(
+            'GET', 'http://' + node + ':61091/metrics'
+        )
+        assert response.status_code == 200, 'Status code: {}'.format(
+            response.status_code
+        )
 
 
 @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -62,8 +73,11 @@ def get_metrics_prom(dcos_api_session, node):
 
     """
     response = dcos_api_session.session.request(
-        'GET', 'http://{}:61091/metrics'.format(node))
-    assert response.status_code == 200, 'Status code: {}'.format(response.status_code)
+        'GET', 'http://{}:61091/metrics'.format(node)
+    )
+    assert response.status_code == 200, 'Status code: {}'.format(
+        response.status_code
+    )
     return response
 
 
@@ -72,14 +86,20 @@ def test_metrics_procstat(dcos_api_session):
     nodes = get_master_and_agents(dcos_api_session)
 
     for node in nodes:
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_procstat_metrics():
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
                     if sample[0] == 'procstat_lookup_pid_count':
                         return
-            raise Exception('Expected Procstat procstat_lookup_pid_count metric not found')
+            raise Exception(
+                'Expected Procstat procstat_lookup_pid_count metric not found'
+            )
+
         check_procstat_metrics()
 
 
@@ -88,82 +108,117 @@ def test_metrics_agents_mesos(dcos_api_session):
     nodes = get_agents(dcos_api_session)
 
     for node in nodes:
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_mesos_metrics():
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
                     if sample[0] == 'mesos_slave_uptime_secs':
                         return
-            raise Exception('Expected Mesos mesos_slave_uptime_secs metric not found')
+            raise Exception(
+                'Expected Mesos mesos_slave_uptime_secs metric not found'
+            )
+
         check_mesos_metrics()
 
 
 def test_metrics_master_mesos(dcos_api_session):
     """Assert that mesos metrics on master are present."""
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_mesos_metrics():
-        response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
+        response = get_metrics_prom(
+            dcos_api_session, dcos_api_session.masters[0]
+        )
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
                 if sample[0] == 'mesos_master_uptime_secs':
                     return
-        raise Exception('Expected Mesos mesos_master_uptime_secs metric not found')
+        raise Exception(
+            'Expected Mesos mesos_master_uptime_secs metric not found'
+        )
+
     check_mesos_metrics()
 
 
 def test_metrics_master_zookeeper(dcos_api_session):
     """Assert that ZooKeeper metrics on master are present."""
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_zookeeper_metrics():
-        response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
+        response = get_metrics_prom(
+            dcos_api_session, dcos_api_session.masters[0]
+        )
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
                 if sample[0] == 'zookeeper_avg_latency':
                     assert sample[1]['dcos_component_name'] == 'ZooKeeper'
                     return
-        raise Exception('Expected ZooKeeper zookeeper_avg_latency metric not found')
+        raise Exception(
+            'Expected ZooKeeper zookeeper_avg_latency metric not found'
+        )
+
     check_zookeeper_metrics()
 
 
 def test_metrics_master_cockroachdb(dcos_api_session):
     """Assert that CockroachDB metrics on master are present."""
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_cockroachdb_metrics():
-        response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
+        response = get_metrics_prom(
+            dcos_api_session, dcos_api_session.masters[0]
+        )
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
                 if sample[0] == 'ranges_underreplicated':
                     assert sample[1]['dcos_component_name'] == 'CockroachDB'
                     return
-        raise Exception('Expected CockroachDB ranges_underreplicated metric not found')
+        raise Exception(
+            'Expected CockroachDB ranges_underreplicated metric not found'
+        )
+
     check_cockroachdb_metrics()
 
 
 def test_metrics_master_adminrouter_nginx_vts(dcos_api_session):
     """Assert that Admin Router Nginx VTS metrics on master are present."""
+
     @retrying.retry(
         wait_fixed=STD_INTERVAL,
         stop_max_delay=METRICS_WAITTIME,
         retry_on_exception=lambda e: isinstance(e, AssertionError)
     )
     def check_adminrouter_metrics():
-        response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
+        response = get_metrics_prom(
+            dcos_api_session, dcos_api_session.masters[0]
+        )
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
                 if sample[0].startswith('nginx_vts_'):
                     assert sample[1]['dcos_component_name'] == 'Admin Router'
                     return
-        raise AssertionError('Expected Admin Router nginx_vts_* metrics not found')
+        raise AssertionError(
+            'Expected Admin Router nginx_vts_* metrics not found'
+        )
+
     check_adminrouter_metrics()
 
 
 def test_metrics_master_exhibitor_status(dcos_api_session):
     """Assert that Exhibitor status metrics on master are present."""
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def check_exhibitor_metrics():
-        response = get_metrics_prom(dcos_api_session, dcos_api_session.masters[0])
-        expected_metrics = {'exhibitor_status_code', 'exhibitor_status_isleader'}
+        response = get_metrics_prom(
+            dcos_api_session, dcos_api_session.masters[0]
+        )
+        expected_metrics = {
+            'exhibitor_status_code', 'exhibitor_status_isleader'
+        }
         samples = []
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
@@ -173,13 +228,15 @@ def test_metrics_master_exhibitor_status(dcos_api_session):
         assert reported_metrics == expected_metrics, (
             'Expected Exhibitor status metrics not found. '
             'Expected: {} Reported: {}'.format(
-                expected_metrics, reported_metrics,
+                expected_metrics,
+                reported_metrics,
             )
         )
         for sample in samples:
             assert sample[1]['dcos_component_name'] == 'Exhibitor'
             assert 'url' not in sample[1]
             assert 'exhibitor_address' in sample[1]
+
     check_exhibitor_metrics()
 
 
@@ -193,7 +250,9 @@ def _nginx_vts_measurement_basename(name: str) -> str:
     return '_'.join(name.split('_')[:3])
 
 
-def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session):
+def test_metrics_master_adminrouter_nginx_drop_requests_seconds(
+    dcos_api_session
+):
     """
     nginx_vts_*_request_seconds* metrics are not present.
     """
@@ -212,7 +271,9 @@ def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session
         response = get_metrics_prom(dcos_api_session, node)
         for family in text_string_to_metric_families(response.text):
             for sample in family.samples:
-                match = re.match(r'^nginx_vts_.+_request_seconds.*$', sample[0])
+                match = re.match(
+                    r'^nginx_vts_.+_request_seconds.*$', sample[0]
+                )
                 assert match is None
                 # We assert the validity of the test here by confirming that
                 # VTS reported metrics have been scraped by telegraf.
@@ -223,21 +284,28 @@ def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session
     check_adminrouter_metrics()
 
 
-def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(dcos_api_session):
+def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(
+    dcos_api_session
+):
     """
     nginx_vts_*_request_seconds* metrics are not present.
     """
     # Make request to Admin Router on every agent to ensure metrics.
-    state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+    state_response = dcos_api_session.get(
+        '/state', host=dcos_api_session.masters[0], port=5050
+    )
     assert state_response.status_code == 200
     state = state_response.json()
     for agent in state['slaves']:
-        agent_url = '/system/v1/agent/{}/dcos-metadata/dcos-version.json'.format(agent['id'])
+        agent_url = '/system/v1/agent/{}/dcos-metadata/dcos-version.json'.format(
+            agent['id']
+        )
         response = dcos_api_session.get(agent_url)
         assert response.status_code == 200
 
     nodes = get_agents(dcos_api_session)
     for node in nodes:
+
         @retrying.retry(
             wait_fixed=STD_INTERVAL,
             stop_max_delay=METRICS_WAITTIME,
@@ -248,7 +316,9 @@ def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(dcos_api_session)
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
-                    match = re.match(r'^nginx_vts_.+_request_seconds.*$', sample[0])
+                    match = re.match(
+                        r'^nginx_vts_.+_request_seconds.*$', sample[0]
+                    )
                     assert match is None
                     # We assert the validity of the test here by confirming that
                     # VTS reported metrics have been scraped by telegraf.
@@ -279,11 +349,13 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     )
     def check_adminrouter_metrics():
         measurements = set()
-        expect_dropped = set([
-            'nginx_vts_filter',
-            'nginx_vts_upstream',
-            'nginx_vts_server',
-        ])
+        expect_dropped = set(
+            [
+                'nginx_vts_filter',
+                'nginx_vts_upstream',
+                'nginx_vts_server',
+            ]
+        )
         unexpected_samples = []
 
         response = get_metrics_prom(dcos_api_session, node)
@@ -298,19 +370,22 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
 
         assert unexpected_samples == []
 
-        expected = set([
-            'nginx_server_status',
-            'nginx_upstream_status',
-            'nginx_upstream_backend',
-            'nginx_service_backend',
-            'nginx_service_status',
-        ])
+        expected = set(
+            [
+                'nginx_server_status',
+                'nginx_upstream_status',
+                'nginx_upstream_backend',
+                'nginx_service_backend',
+                'nginx_service_status',
+            ]
+        )
 
         difference = expected - measurements
         assert not difference
 
         remainders = expect_dropped & measurements
         assert not remainders
+
     check_adminrouter_metrics()
 
 
@@ -319,6 +394,7 @@ def test_metrics_agents_adminrouter_nginx_vts(dcos_api_session):
     nodes = get_agents(dcos_api_session)
 
     for node in nodes:
+
         @retrying.retry(
             wait_fixed=STD_INTERVAL,
             stop_max_delay=METRICS_WAITTIME,
@@ -329,25 +405,34 @@ def test_metrics_agents_adminrouter_nginx_vts(dcos_api_session):
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
                     if sample[0].startswith('nginx_vts_'):
-                        assert sample[1]['dcos_component_name'] == 'Admin Router Agent'
+                        assert sample[1]['dcos_component_name'
+                                         ] == 'Admin Router Agent'
                         return
-            raise AssertionError('Expected Admin Router nginx_vts_* metrics not found')
+            raise AssertionError(
+                'Expected Admin Router nginx_vts_* metrics not found'
+            )
+
         check_adminrouter_metrics()
 
 
 def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
     """Assert that processed Admin Router metrics on agent are present."""
     # Make request to Admin Router on every agent to ensure metrics.
-    state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+    state_response = dcos_api_session.get(
+        '/state', host=dcos_api_session.masters[0], port=5050
+    )
     assert state_response.status_code == 200
     state = state_response.json()
     for agent in state['slaves']:
-        agent_url = '/system/v1/agent/{}/dcos-metadata/dcos-version.json'.format(agent['id'])
+        agent_url = '/system/v1/agent/{}/dcos-metadata/dcos-version.json'.format(
+            agent['id']
+        )
         response = dcos_api_session.get(agent_url)
         assert response.status_code == 200
 
     nodes = get_agents(dcos_api_session)
     for node in nodes:
+
         @retrying.retry(
             wait_fixed=STD_INTERVAL,
             stop_max_delay=METRICS_WAITTIME,
@@ -355,18 +440,21 @@ def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
         )
         def check_adminrouter_metrics():
             measurements = set()
-            expect_dropped = set([
-                'nginx_vts_filter',
-                'nginx_vts_upstream',
-                'nginx_vts_server',
-            ])
+            expect_dropped = set(
+                [
+                    'nginx_vts_filter',
+                    'nginx_vts_upstream',
+                    'nginx_vts_server',
+                ]
+            )
             unexpected_samples = []
 
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
                     if sample[0].startswith('nginx_'):
-                        assert sample[1]['dcos_component_name'] == 'Admin Router Agent'
+                        assert sample[1]['dcos_component_name'
+                                         ] == 'Admin Router Agent'
                         basename = _nginx_vts_measurement_basename(sample[0])
                         measurements.add(basename)
                         if basename in expect_dropped:
@@ -382,6 +470,7 @@ def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
 
             remainders = expect_dropped & measurements
             assert not remainders
+
         check_adminrouter_metrics()
 
 
@@ -390,24 +479,39 @@ def test_metrics_diagnostics(dcos_api_session):
     nodes = get_master_and_agents(dcos_api_session)
 
     for node in nodes:
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_diagnostics_metrics():
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
                     if sample[0].startswith('bundle_creation_time_seconds'):
-                        assert sample[1]['dcos_component_name'] == 'DC/OS Diagnostics'
+                        assert sample[1]['dcos_component_name'
+                                         ] == 'DC/OS Diagnostics'
                         return
             raise Exception('Expected DC/OS Diagnostics metrics not found')
+
         check_diagnostics_metrics()
 
 
-def check_statsd_app_metrics(dcos_api_session, marathon_app, node, expected_metrics):
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+def check_statsd_app_metrics(
+    dcos_api_session, marathon_app, node, expected_metrics
+):
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_app, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_app['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
 
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_statsd_metrics():
             expected_copy = copy.deepcopy(expected_metrics)
             response = get_metrics_prom(dcos_api_session, node)
@@ -419,6 +523,7 @@ def check_statsd_app_metrics(dcos_api_session, marathon_app, node, expected_metr
                         if len(expected_copy) == 0:
                             return
             raise Exception('Expected statsd metrics not found')
+
         check_statsd_metrics()
 
 
@@ -427,67 +532,92 @@ def test_metrics_agent_statsd(dcos_api_session):
     task_name = 'test-metrics-statsd-app'
     metric_name_pfx = 'test_metrics_statsd_app'
     marathon_app = {
-        'id': '/' + task_name,
-        'instances': 1,
-        'cpus': 0.1,
-        'mem': 128,
+        'id':
+        '/' + task_name,
+        'instances':
+        1,
+        'cpus':
+        0.1,
+        'mem':
+        128,
         'env': {
             'STATIC_STATSD_UDP_PORT': '61825',
             'STATIC_STATSD_UDP_HOST': 'localhost'
         },
-        'cmd': '\n'.join([
-            'echo "Sending metrics to $STATIC_STATSD_UDP_HOST:$STATIC_STATSD_UDP_PORT"',
-            'echo "Sending gauge"',
-            'echo "{}.gauge:100|g" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'.format(
-                metric_name_pfx),
-
-            'echo "Sending counts"',
-            'echo "{}.count:1|c" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'.format(
-                metric_name_pfx),
-
-            'echo "Sending timings"',
-            'echo "{}.timing:1|ms" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'.format(
-                metric_name_pfx),
-
-            'echo "Sending histograms"',
-            'echo "{}.histogram:1|h" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'.format(
-                metric_name_pfx),
-
-            'echo "Done. Sleeping forever."',
-            'while true; do',
-            '  sleep 1000',
-            'done',
-        ]),
+        'cmd':
+        '\n'.join(
+            [
+                'echo "Sending metrics to $STATIC_STATSD_UDP_HOST:$STATIC_STATSD_UDP_PORT"',
+                'echo "Sending gauge"',
+                'echo "{}.gauge:100|g" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending counts"',
+                'echo "{}.count:1|c" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending timings"',
+                'echo "{}.timing:1|ms" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending histograms"',
+                'echo "{}.histogram:1|h" | nc -w 1 -u $STATIC_STATSD_UDP_HOST $STATIC_STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Done. Sleeping forever."',
+                'while true; do',
+                '  sleep 1000',
+                'done',
+            ]
+        ),
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'library/alpine'}
+            'docker': {
+                'image': 'library/alpine'
+            }
         },
-        'networks': [{'mode': 'host'}],
+        'networks': [{
+            'mode': 'host'
+        }],
     }
     expected_metrics = {
-        metric_name_pfx + '_gauge': 100.0,
+        metric_name_pfx + '_gauge':
+        100.0,
         # NOTE: prometheus_client appends _total to counter-type metrics if they don't already have the suffix
         # ref: https://github.com/prometheus/client_python/blob/master/prometheus_client/parser.py#L169
         # (the raw prometheus output here omits _total)
-        metric_name_pfx + '_count_total': 1.0,
-        metric_name_pfx + '_timing_count': 1.0,
-        metric_name_pfx + '_histogram_count': 1.0,
+        metric_name_pfx + '_count_total':
+        1.0,
+        metric_name_pfx + '_timing_count':
+        1.0,
+        metric_name_pfx + '_histogram_count':
+        1.0,
     }
 
     if dcos_api_session.slaves:
-        marathon_app['constraints'] = [['hostname', 'LIKE', dcos_api_session.slaves[0]]]
-        check_statsd_app_metrics(dcos_api_session, marathon_app, dcos_api_session.slaves[0], expected_metrics)
+        marathon_app['constraints'] = [
+            ['hostname', 'LIKE', dcos_api_session.slaves[0]]
+        ]
+        check_statsd_app_metrics(
+            dcos_api_session, marathon_app, dcos_api_session.slaves[0],
+            expected_metrics
+        )
 
     if dcos_api_session.public_slaves:
         marathon_app['acceptedResourceRoles'] = ["slave_public"]
-        marathon_app['constraints'] = [['hostname', 'LIKE', dcos_api_session.public_slaves[0]]]
-        check_statsd_app_metrics(dcos_api_session, marathon_app, dcos_api_session.public_slaves[0], expected_metrics)
+        marathon_app['constraints'] = [
+            ['hostname', 'LIKE', dcos_api_session.public_slaves[0]]
+        ]
+        check_statsd_app_metrics(
+            dcos_api_session, marathon_app, dcos_api_session.public_slaves[0],
+            expected_metrics
+        )
 
 
 @contextlib.contextmanager
-def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_version, framework_name):
+def deploy_and_cleanup_dcos_package(
+    dcos_api_session, package_name, package_version, framework_name
+):
     """Deploys dcos package and waits for package teardown once the context is left"""
-    app_id = dcos_api_session.cosmos.install_package(package_name, package_version=package_version).json()['appId']
+    app_id = dcos_api_session.cosmos.install_package(
+        package_name, package_version=package_version
+    ).json()['appId']
     dcos_api_session.marathon.wait_for_deployments_complete()
 
     try:
@@ -498,7 +628,9 @@ def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_vers
         # Retry for 15 minutes for teardown completion
         @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=STD_WAITTIME)
         def wait_for_package_teardown():
-            state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+            state_response = dcos_api_session.get(
+                '/state', host=dcos_api_session.masters[0], port=5050
+            )
             assert state_response.status_code == 200
             state = state_response.json()
 
@@ -508,7 +640,9 @@ def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_vers
             # check if there are any running tasks.
             frameworks = {f['name']: f for f in state['frameworks']}
             assert framework_name not in frameworks or len(
-                frameworks[framework_name]['tasks']) == 0, 'Framework {} still running'.format(framework_name)
+                frameworks[framework_name]['tasks']
+            ) == 0, 'Framework {} still running'.format(framework_name)
+
         wait_for_package_teardown()
 
 
@@ -516,7 +650,9 @@ def deploy_and_cleanup_dcos_package(dcos_api_session, package_name, package_vers
 def get_task_hostname(dcos_api_session, framework_name, task_name):
     # helper func that gets a framework's task's hostname
     mesos_id = node = ''
-    state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+    state_response = dcos_api_session.get(
+        '/state', host=dcos_api_session.masters[0], port=5050
+    )
     assert state_response.status_code == 200
     state = state_response.json()
 
@@ -543,10 +679,14 @@ def test_task_metrics_metadata(dcos_api_session):
     expanded_config = get_expanded_config()
     if expanded_config.get('security') == 'strict':
         pytest.skip('MoM disabled for strict mode')
-    with deploy_and_cleanup_dcos_package(dcos_api_session, 'marathon', '1.6.535', 'marathon-user'):
+    with deploy_and_cleanup_dcos_package(
+        dcos_api_session, 'marathon', '1.6.535', 'marathon-user'
+    ):
         node = get_task_hostname(dcos_api_session, 'marathon', 'marathon-user')
 
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
@@ -554,9 +694,11 @@ def test_task_metrics_metadata(dcos_api_session):
                     if sample[1].get('task_name') == 'marathon-user':
                         assert sample[1]['service_name'] == 'marathon'
                         # check for whitelisted label
-                        assert sample[1]['DCOS_SERVICE_NAME'] == 'marathon-user'
+                        assert sample[1]['DCOS_SERVICE_NAME'
+                                         ] == 'marathon-user'
                         return
             raise Exception('Expected marathon task metrics not found')
+
         check_metrics_metadata()
 
 
@@ -566,20 +708,29 @@ def test_executor_metrics_metadata(dcos_api_session):
     if expanded_config.get('security') == 'strict':
         pytest.skip('Framework disabled for strict mode')
 
-    with deploy_and_cleanup_dcos_package(dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'):
+    with deploy_and_cleanup_dcos_package(
+        dcos_api_session, 'hello-world', '2.2.0-0.42.2', 'hello-world'
+    ):
         node = get_task_hostname(dcos_api_session, 'marathon', 'hello-world')
 
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def check_executor_metrics_metadata():
             response = get_metrics_prom(dcos_api_session, node)
             for family in text_string_to_metric_families(response.text):
                 for sample in family.samples:
-                    if sample[0] == 'cpus_nr_periods' and sample[1].get('service_name') == 'hello-world':
+                    if sample[0] == 'cpus_nr_periods' and sample[
+                        1].get('service_name') == 'hello-world':
                         assert sample[1]['task_name'] == ''
                         # hello-world executors can be named "hello" or "world"
-                        assert (sample[1]['executor_name'] == 'hello' or sample[1]['executor_name'] == 'world')
+                        assert (
+                            sample[1]['executor_name'] == 'hello'
+                            or sample[1]['executor_name'] == 'world'
+                        )
                         return
             raise Exception('Expected hello-world executor metrics not found')
+
         check_executor_metrics_metadata()
 
 
@@ -588,6 +739,7 @@ def test_metrics_node(dcos_api_session):
     """Test that the '/system/v1/metrics/v0/node' endpoint returns the expected
     metrics and metric metadata.
     """
+
     def expected_datapoint_response(response):
         """Enure that the "node" endpoint returns a "datapoints" dict.
         """
@@ -595,15 +747,21 @@ def test_metrics_node(dcos_api_session):
         'in response, got {}'.format(response)
 
         for dp in response['datapoints']:
-            assert 'name' in dp, '"name" parameter should not be empty, got {}'.format(dp)
+            assert 'name' in dp, '"name" parameter should not be empty, got {}'.format(
+                dp
+            )
             if 'filesystem' in dp['name']:
                 assert 'tags' in dp, '"tags" key not found, got {}'.format(dp)
 
-                assert 'path' in dp['tags'], ('"path" tag not found for filesystem metric, '
-                                              'got {}'.format(dp))
+                assert 'path' in dp['tags'], (
+                    '"path" tag not found for filesystem metric, '
+                    'got {}'.format(dp)
+                )
 
-                assert len(dp['tags']['path']) > 0, ('"path" tag should not be empty for '
-                                                     'filesystem metrics, got {}'.format(dp))
+                assert len(dp['tags']['path']) > 0, (
+                    '"path" tag should not be empty for '
+                    'filesystem metrics, got {}'.format(dp)
+                )
 
         return True
 
@@ -617,9 +775,12 @@ def test_metrics_node(dcos_api_session):
         assert 'cluster_id' in response['dimensions'], '"cluster_id" key not'
         'found in dimensions, got {}'.format(response)
 
-        assert response['dimensions']['cluster_id'] != "", 'expected cluster to contain a value'
+        assert response['dimensions'][
+            'cluster_id'] != "", 'expected cluster to contain a value'
 
-        assert response['dimensions']['mesos_id'] == '', 'expected dimensions to include empty "mesos_id"'
+        assert response['dimensions'][
+            'mesos_id'
+        ] == '', 'expected dimensions to include empty "mesos_id"'
 
         return True
 
@@ -636,7 +797,8 @@ def test_metrics_node(dcos_api_session):
         response = wait_for_node_response(node)
 
         assert response.status_code == 200, 'Status code: {}, Content {}'.format(
-            response.status_code, response.content)
+            response.status_code, response.content
+        )
         assert expected_datapoint_response(response.json())
         assert expected_dimension_response(response.json())
 
@@ -658,10 +820,13 @@ def get_agents(dcos_api_session):
 
 def test_metrics_containers(dcos_api_session):
     """Assert that a Marathon app's container and app metrics can be retrieved."""
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
     def test_containers(app_endpoints):
         for agent in app_endpoints:
-            container_metrics, app_metrics = get_metrics_for_task(dcos_api_session, agent.host, 'statsd-emitter')
+            container_metrics, app_metrics = get_metrics_for_task(
+                dcos_api_session, agent.host, 'statsd-emitter'
+            )
 
             # Check container metrics.
             # Check tags on each datapoint.
@@ -684,7 +849,9 @@ def test_metrics_containers(dcos_api_session):
                 # the same.
                 cid_registry.add(dp['tags']['container_id'])
 
-            assert len(cid_registry) == 1, 'Not all container IDs in the metrics response are equal'
+            assert len(
+                cid_registry
+            ) == 1, 'Not all container IDs in the metrics response are equal'
 
             # Check app metrics.
             # We expect three datapoints, could be in any order
@@ -702,10 +869,7 @@ def test_metrics_containers(dcos_api_session):
                 assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
             expected_tag_names = {
-                'dcos_cluster_id',
-                'test_tag_key',
-                'dcos_cluster_name',
-                'host'
+                'dcos_cluster_id', 'test_tag_key', 'dcos_cluster_name', 'host'
             }
 
             # If fault domain is enabled, ensure that fault domain tags are present
@@ -714,25 +878,40 @@ def test_metrics_containers(dcos_api_session):
                 expected_tag_names |= FAULT_DOMAIN_TAGS
 
             check_tags(uptime_dp['tags'], expected_tag_names)
-            assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+            assert uptime_dp['tags']['test_tag_key'
+                                     ] == 'test_tag_value', 'got {}'.format(
+                                         uptime_dp
+                                     )
             assert uptime_dp['value'] > 0
 
     marathon_config = {
-        "id": "/statsd-emitter",
-        "cmd": "./statsd-emitter -debug",
+        "id":
+        "/statsd-emitter",
+        "cmd":
+        "./statsd-emitter -debug",
         "fetch": [
             {
-                "uri": "https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter",
+                "uri":
+                "https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter",
                 "executable": True
             }
         ],
-        "cpus": 0.5,
-        "mem": 128.0,
-        "instances": 1
+        "cpus":
+        0.5,
+        "mem":
+        128.0,
+        "instances":
+        1
     }
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_config, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_config['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_config, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_config['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
         test_containers(endpoints)
 
 
@@ -741,40 +920,57 @@ def test_statsd_metrics_containers_app(dcos_api_session):
     task_name = 'test-statsd-metrics-containers-app'
     metric_name_pfx = 'test_statsd_metrics_containers_app'
     marathon_app = {
-        'id': '/' + task_name,
-        'instances': 1,
-        'cpus': 0.1,
-        'mem': 128,
-        'cmd': '\n'.join([
-            'echo "Sending metrics to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
-            'echo "Sending gauge"',
-            'echo "{}.gauge:100|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-
-            'echo "Sending counts"',
-            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-
-            'echo "Sending timings"',
-            'echo "{}.timing:1|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.timing:2|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.timing:3|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-
-            'echo "Sending histograms"',
-            'echo "{}.histogram:1|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:2|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:3|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-            'echo "{}.histogram:4|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name_pfx),
-
-            'echo "Done. Sleeping forever."',
-            'while true; do',
-            '  sleep 1000',
-            'done',
-        ]),
+        'id':
+        '/' + task_name,
+        'instances':
+        1,
+        'cpus':
+        0.1,
+        'mem':
+        128,
+        'cmd':
+        '\n'.join(
+            [
+                'echo "Sending metrics to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
+                'echo "Sending gauge"',
+                'echo "{}.gauge:100|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending counts"',
+                'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.count:1|c" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending timings"',
+                'echo "{}.timing:1|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.timing:2|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.timing:3|ms" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Sending histograms"',
+                'echo "{}.histogram:1|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.histogram:2|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.histogram:3|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "{}.histogram:4|h" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name_pfx),
+                'echo "Done. Sleeping forever."',
+                'while true; do',
+                '  sleep 1000',
+                'done',
+            ]
+        ),
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'library/alpine'}
+            'docker': {
+                'image': 'library/alpine'
+            }
         },
-        'networks': [{'mode': 'host'}],
+        'networks': [{
+            'mode': 'host'
+        }],
     }
     expected_metrics = [
         # metric_name, metric_value
@@ -784,12 +980,20 @@ def test_statsd_metrics_containers_app(dcos_api_session):
         ('.'.join([metric_name_pfx, 'histogram', 'count']), 4),
     ]
 
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_app, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_app['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
         node = endpoints[0].host
         for metric_name, metric_value in expected_metrics:
-            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+            assert_app_metric_value_for_task(
+                dcos_api_session, node, task_name, metric_name, metric_value
+            )
 
 
 def test_prom_metrics_containers_app_host(dcos_api_session):
@@ -797,37 +1001,51 @@ def test_prom_metrics_containers_app_host(dcos_api_session):
     task_name = 'test-prom-metrics-containers-app-host'
     metric_name_pfx = 'test_prom_metrics_containers_app_host'
     marathon_app = {
-        'id': '/' + task_name,
-        'instances': 1,
-        'cpus': 0.1,
-        'mem': 128,
-        'cmd': '\n'.join([
-            'echo "Creating metrics file..."',
-            'touch metrics',
-
-            'echo "# TYPE {}_gauge gauge" >> metrics'.format(metric_name_pfx),
-            'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
-
-            'echo "# TYPE {}_count counter" >> metrics'.format(metric_name_pfx),
-            'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
-
-            'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
-
-            'echo "Serving prometheus metrics on http://localhost:$PORT0"',
-            'python3 -m http.server $PORT0',
-        ]),
+        'id':
+        '/' + task_name,
+        'instances':
+        1,
+        'cpus':
+        0.1,
+        'mem':
+        128,
+        'cmd':
+        '\n'.join(
+            [
+                'echo "Creating metrics file..."',
+                'touch metrics',
+                'echo "# TYPE {}_gauge gauge" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
+                'echo "# TYPE {}_count counter" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
+                'echo "# TYPE {}_histogram histogram" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
+                'echo "{}_histogram_seconds_count 4" >> metrics'.
+                format(metric_name_pfx),
+                'echo "Serving prometheus metrics on http://localhost:$PORT0"',
+                'python3 -m http.server $PORT0',
+            ]
+        ),
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'library/python:3'}
+            'docker': {
+                'image': 'library/python:3'
+            }
         },
-        'portDefinitions': [{
-            'protocol': 'tcp',
-            'port': 0,
-            'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
-        }],
+        'portDefinitions': [
+            {
+                'protocol': 'tcp',
+                'port': 0,
+                'labels': {
+                    'DCOS_METRICS_FORMAT': 'prometheus'
+                },
+            }
+        ],
     }
 
     logging.debug('Starting marathon app with config: %s', marathon_app)
@@ -838,12 +1056,20 @@ def test_prom_metrics_containers_app_host(dcos_api_session):
         ('_'.join([metric_name_pfx, 'histogram_seconds', 'count']), 4),
     ]
 
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_app, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_app['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
         node = endpoints[0].host
         for metric_name, metric_value in expected_metrics:
-            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+            assert_app_metric_value_for_task(
+                dcos_api_session, node, task_name, metric_name, metric_value
+            )
 
 
 def test_prom_metrics_containers_app_bridge(dcos_api_session):
@@ -851,38 +1077,53 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
     task_name = 'test-prom-metrics-containers-app-bridge'
     metric_name_pfx = 'test_prom_metrics_containers_app_bridge'
     marathon_app = {
-        'id': '/' + task_name,
-        'instances': 1,
-        'cpus': 0.1,
-        'mem': 128,
-        'cmd': '\n'.join([
-            'echo "Creating metrics file..."',
-            'touch metrics',
-
-            'echo "# TYPE {}_gauge gauge" >> metrics'.format(metric_name_pfx),
-            'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
-
-            'echo "# TYPE {}_count counter" >> metrics'.format(metric_name_pfx),
-            'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
-
-            'echo "# TYPE {}_histogram histogram" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
-            'echo "{}_histogram_seconds_count 4" >> metrics'.format(metric_name_pfx),
-
-            'echo "Serving prometheus metrics on http://localhost:8000"',
-            'python3 -m http.server 8000',
-        ]),
-        'networks': [{'mode': 'container/bridge'}],
+        'id':
+        '/' + task_name,
+        'instances':
+        1,
+        'cpus':
+        0.1,
+        'mem':
+        128,
+        'cmd':
+        '\n'.join(
+            [
+                'echo "Creating metrics file..."',
+                'touch metrics',
+                'echo "# TYPE {}_gauge gauge" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_gauge 100" >> metrics'.format(metric_name_pfx),
+                'echo "# TYPE {}_count counter" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_count 2" >> metrics'.format(metric_name_pfx),
+                'echo "# TYPE {}_histogram histogram" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_histogram_bucket{{le=\\"+Inf\\"}} 4" >> metrics'.
+                format(metric_name_pfx),
+                'echo "{}_histogram_sum 4" >> metrics'.format(metric_name_pfx),
+                'echo "{}_histogram_seconds_count 4" >> metrics'.
+                format(metric_name_pfx),
+                'echo "Serving prometheus metrics on http://localhost:8000"',
+                'python3 -m http.server 8000',
+            ]
+        ),
+        'networks': [{
+            'mode': 'container/bridge'
+        }],
         'container': {
-            'type': 'MESOS',
-            'docker': {'image': 'library/python:3'},
+            'type':
+            'MESOS',
+            'docker': {
+                'image': 'library/python:3'
+            },
             'portMappings': [
                 {
                     'containerPort': 8000,
                     'hostPort': 0,
                     'protocol': 'tcp',
-                    'labels': {'DCOS_METRICS_FORMAT': 'prometheus'},
+                    'labels': {
+                        'DCOS_METRICS_FORMAT': 'prometheus'
+                    },
                 }
             ]
         },
@@ -896,12 +1137,20 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
         ('_'.join([metric_name_pfx, 'histogram_seconds', 'count']), 4),
     ]
 
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_app, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_app['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
         node = endpoints[0].host
         for metric_name, metric_value in expected_metrics:
-            assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
+            assert_app_metric_value_for_task(
+                dcos_api_session, node, task_name, metric_name, metric_value
+            )
 
 
 def test_metrics_containers_nan(dcos_api_session):
@@ -909,47 +1158,75 @@ def test_metrics_containers_nan(dcos_api_session):
     task_name = 'test-metrics-containers-nan'
     metric_name = 'test_metrics_containers_nan'
     marathon_app = {
-        'id': '/' + task_name,
-        'instances': 1,
-        'cpus': 0.1,
-        'mem': 128,
-        'cmd': '\n'.join([
-            'echo "Sending gauge with NaN value to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
-            'echo "{}:NaN|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'.format(metric_name),
-            'echo "Done. Sleeping forever."',
-            'while true; do',
-            '  sleep 1000',
-            'done',
-        ]),
+        'id':
+        '/' + task_name,
+        'instances':
+        1,
+        'cpus':
+        0.1,
+        'mem':
+        128,
+        'cmd':
+        '\n'.join(
+            [
+                'echo "Sending gauge with NaN value to $STATSD_UDP_HOST:$STATSD_UDP_PORT"',
+                'echo "{}:NaN|g" | nc -w 1 -u $STATSD_UDP_HOST $STATSD_UDP_PORT'
+                .format(metric_name),
+                'echo "Done. Sleeping forever."',
+                'while true; do',
+                '  sleep 1000',
+                'done',
+            ]
+        ),
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'library/alpine'}
+            'docker': {
+                'image': 'library/alpine'
+            }
         },
-        'networks': [{'mode': 'host'}],
+        'networks': [{
+            'mode': 'host'
+        }],
     }
-    with dcos_api_session.marathon.deploy_and_cleanup(marathon_app, check_health=False):
-        endpoints = dcos_api_session.marathon.get_app_service_endpoints(marathon_app['id'])
-        assert len(endpoints) == 1, 'The marathon app should have been deployed exactly once.'
+    with dcos_api_session.marathon.deploy_and_cleanup(
+        marathon_app, check_health=False
+    ):
+        endpoints = dcos_api_session.marathon.get_app_service_endpoints(
+            marathon_app['id']
+        )
+        assert len(
+            endpoints
+        ) == 1, 'The marathon app should have been deployed exactly once.'
         node = endpoints[0].host
 
         # NaN should be converted to empty string.
-        metric_value = get_app_metric_for_task(dcos_api_session, node, task_name, metric_name)['value']
-        assert metric_value == '', 'unexpected metric value: {}'.format(metric_value)
+        metric_value = get_app_metric_for_task(
+            dcos_api_session, node, task_name, metric_name
+        )['value']
+        assert metric_value == '', 'unexpected metric value: {}'.format(
+            metric_value
+        )
 
 
 @retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
-def assert_app_metric_value_for_task(dcos_api_session, node: str, task_name: str, metric_name: str, metric_value):
+def assert_app_metric_value_for_task(
+    dcos_api_session, node: str, task_name: str, metric_name: str, metric_value
+):
     """Assert the value of app metric metric_name for container task_name is metric_value.
 
     Retries on error, non-200 status, missing container metrics, missing app
     metric, or unexpected app metric value for up to 5 minutes.
 
     """
-    assert get_app_metric_for_task(dcos_api_session, node, task_name, metric_name)['value'] == metric_value
+    assert get_app_metric_for_task(
+        dcos_api_session, node, task_name, metric_name
+    )['value'] == metric_value
 
 
 @retrying.retry(wait_fixed=METRICS_INTERVAL, stop_max_delay=METRICS_WAITTIME)
-def get_app_metric_for_task(dcos_api_session, node: str, task_name: str, metric_name: str):
+def get_app_metric_for_task(
+    dcos_api_session, node: str, task_name: str, metric_name: str
+):
     """Return the app metric metric_name for container task_name.
 
     Retries on error, non-200 status, or missing container metrics, or missing
@@ -957,9 +1234,13 @@ def get_app_metric_for_task(dcos_api_session, node: str, task_name: str, metric_
 
     """
     _, app_metrics = get_metrics_for_task(dcos_api_session, node, task_name)
-    assert app_metrics is not None, "missing metrics for task {}".format(task_name)
+    assert app_metrics is not None, "missing metrics for task {}".format(
+        task_name
+    )
     dps = [dp for dp in app_metrics['datapoints'] if dp['name'] == metric_name]
-    assert len(dps) == 1, 'expected 1 datapoint for metric {}, got {}'.format(metric_name, len(dps))
+    assert len(dps) == 1, 'expected 1 datapoint for metric {}, got {}'.format(
+        metric_name, len(dps)
+    )
     return dps[0]
 
 
@@ -989,7 +1270,9 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     to 5 minutes.
 
     """
-    response = dcos_api_session.metrics.get('/containers/' + container_id, node=node)
+    response = dcos_api_session.metrics.get(
+        '/containers/' + container_id, node=node
+    )
 
     if response.status_code == 204:
         return None
@@ -998,10 +1281,12 @@ def get_container_metrics(dcos_api_session, node: str, container_id: str):
     container_metrics = response.json()
 
     assert 'datapoints' in container_metrics, (
-        'container metrics must include datapoints. Got: {}'.format(container_metrics)
+        'container metrics must include datapoints. Got: {}'.
+        format(container_metrics)
     )
     assert 'dimensions' in container_metrics, (
-        'container metrics must include dimensions. Got: {}'.format(container_metrics)
+        'container metrics must include dimensions. Got: {}'.
+        format(container_metrics)
     )
 
     return container_metrics
@@ -1016,7 +1301,9 @@ def get_app_metrics(dcos_api_session, node: str, container_id: str):
     Retries on error or non-200 status for up to 5 minutes.
 
     """
-    resp = dcos_api_session.metrics.get('/containers/' + container_id + '/app', node=node)
+    resp = dcos_api_session.metrics.get(
+        '/containers/' + container_id + '/app', node=node
+    )
 
     if resp.status_code == 204:
         return None
@@ -1038,7 +1325,8 @@ def get_metrics_for_task(dcos_api_session, node: str, task_name: str):
     up to 5 minutes.
 
     """
-    task_names_seen = []  # Used for exception message if task_name can't be found.
+    task_names_seen = [
+    ]  # Used for exception message if task_name can't be found.
 
     for cid in get_container_ids(dcos_api_session, node):
         container_metrics = get_container_metrics(dcos_api_session, node, cid)
@@ -1048,14 +1336,18 @@ def get_metrics_for_task(dcos_api_session, node: str, task_name: str):
             continue
 
         if container_metrics['dimensions'].get('task_name') != task_name:
-            task_names_seen.append((cid, container_metrics['dimensions'].get('task_name')))
+            task_names_seen.append(
+                (cid, container_metrics['dimensions'].get('task_name'))
+            )
             continue
 
         app_metrics = get_app_metrics(dcos_api_session, node, cid)
         return container_metrics, app_metrics
 
     raise Exception(
-        'No metrics found for task {} on host {}. Task names seen: {}'.format(task_name, node, task_names_seen)
+        'No metrics found for task {} on host {}. Task names seen: {}'.format(
+            task_name, node, task_names_seen
+        )
     )
 
 
@@ -1098,7 +1390,8 @@ def test_standalone_container_metrics(dcos_api_session):
             headers=headers,
             json=json,
             data=None,
-            stream=False)
+            stream=False
+        )
         return r
 
     # Prepare container ID data
@@ -1110,27 +1403,36 @@ def test_standalone_container_metrics(dcos_api_session):
         'type': 'LAUNCH_CONTAINER',
         'launch_container': {
             'command': {
-                'value': './statsd-emitter',
-                'uris': [{
-                    'value': 'https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter',
-                    'executable': True
-                }]
+                'value':
+                './statsd-emitter',
+                'uris': [
+                    {
+                        'value':
+                        'https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter',
+                        'executable': True
+                    }
+                ]
             },
-            'container_id': container_id,
+            'container_id':
+            container_id,
             'resources': [
                 {
                     'name': 'cpus',
-                    'scalar': {'value': 0.2},
+                    'scalar': {
+                        'value': 0.2
+                    },
                     'type': 'SCALAR'
-                },
-                {
+                }, {
                     'name': 'mem',
-                    'scalar': {'value': 64.0},
+                    'scalar': {
+                        'value': 64.0
+                    },
                     'type': 'SCALAR'
-                },
-                {
+                }, {
                     'name': 'disk',
-                    'scalar': {'value': 1024.0},
+                    'scalar': {
+                        'value': 1024.0
+                    },
                     'type': 'SCALAR'
                 }
             ],
@@ -1146,21 +1448,28 @@ def test_standalone_container_metrics(dcos_api_session):
     def _should_retry_metrics_fetch(response):
         return response.status_code == 204
 
-    @retrying.retry(wait_fixed=METRICS_INTERVAL,
-                    stop_max_delay=METRICS_WAITTIME,
-                    retry_on_result=_should_retry_metrics_fetch,
-                    retry_on_exception=lambda x: False)
+    @retrying.retry(
+        wait_fixed=METRICS_INTERVAL,
+        stop_max_delay=METRICS_WAITTIME,
+        retry_on_result=_should_retry_metrics_fetch,
+        retry_on_exception=lambda x: False
+    )
     def _get_metrics():
         master_response = dcos_api_session.get(
-            '/system/v1/agent/%s/metrics/v0/containers/%s/app' % (agent_id, container_id['value']),
-            host=master_ip)
+            '/system/v1/agent/%s/metrics/v0/containers/%s/app' %
+            (agent_id, container_id['value']),
+            host=master_ip
+        )
         return master_response
 
     r = _post_agent(launch_data)
     assert r.status_code == 200, 'Received unexpected status code when launching standalone container'
 
     try:
-        logging.debug('Successfully created standalone container with container ID %s', container_id['value'])
+        logging.debug(
+            'Successfully created standalone container with container ID %s',
+            container_id['value']
+        )
 
         # Verify that the standalone container's metrics are being collected
         r = _get_metrics()
@@ -1168,7 +1477,9 @@ def test_standalone_container_metrics(dcos_api_session):
 
         metrics_response = r.json()
 
-        assert 'datapoints' in metrics_response, 'got {}'.format(metrics_response)
+        assert 'datapoints' in metrics_response, 'got {}'.format(
+            metrics_response
+        )
 
         uptime_dp = None
         for dp in metrics_response['datapoints']:
@@ -1184,17 +1495,18 @@ def test_standalone_container_metrics(dcos_api_session):
             assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
         expected_tag_names = {
-            'dcos_cluster_id',
-            'test_tag_key',
-            'dcos_cluster_name',
-            'host'
+            'dcos_cluster_id', 'test_tag_key', 'dcos_cluster_name', 'host'
         }
         check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
-        assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+        assert uptime_dp['tags'][
+            'test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
         assert uptime_dp['value'] > 0
 
-        assert 'dimensions' in metrics_response, 'got {}'.format(metrics_response)
-        assert metrics_response['dimensions']['container_id'] == container_id['value']
+        assert 'dimensions' in metrics_response, 'got {}'.format(
+            metrics_response
+        )
+        assert metrics_response['dimensions']['container_id'
+                                              ] == container_id['value']
     finally:
         # Clean up the standalone container
         kill_data = {
@@ -1213,13 +1525,20 @@ def test_pod_application_metrics(dcos_api_session):
     1) Container statistics metrics are provided for the executor container
     2) Application metrics are exposed for the task container
     """
+
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
-    def test_application_metrics(agent_ip, agent_id, task_name, num_containers):
+    def test_application_metrics(
+        agent_ip, agent_id, task_name, num_containers
+    ):
         # Get expected 2 container ids from mesos state endpoint
         # (one container + its parent container)
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def get_container_ids_from_state(dcos_api_session, num_containers):
-            state_response = dcos_api_session.get('/state', host=dcos_api_session.masters[0], port=5050)
+            state_response = dcos_api_session.get(
+                '/state', host=dcos_api_session.masters[0], port=5050
+            )
             assert state_response.status_code == 200
             state = state_response.json()
 
@@ -1228,26 +1547,40 @@ def test_pod_application_metrics(dcos_api_session):
                 if framework['name'] == 'marathon':
                     for task in framework['tasks']:
                         if task['name'] == 'statsd-emitter-task':
-                            container = task['statuses'][0]['container_status']['container_id']
+                            container = task['statuses'][0]['container_status'
+                                                            ]['container_id']
                             cids.add(container['value'])
                             if 'parent' in container:
                                 cids.add(container['parent']['value'])
                             break
                     break
 
-            assert len(cids) == num_containers, 'Test should create {} containers'.format(num_containers)
+            assert len(
+                cids
+            ) == num_containers, 'Test should create {} containers'.format(
+                num_containers
+            )
             return cids
 
-        container_ids = get_container_ids_from_state(dcos_api_session, num_containers)
+        container_ids = get_container_ids_from_state(
+            dcos_api_session, num_containers
+        )
 
         # Retry for two and a half minutes since the collector collects
         # state every 2 minutes to propagate containers to the API
-        @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
+        @retrying.retry(
+            wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME
+        )
         def wait_for_container_metrics_propagation(container_ids):
-            response = dcos_api_session.metrics.get('/containers', node=agent_ip)
+            response = dcos_api_session.metrics.get(
+                '/containers', node=agent_ip
+            )
             assert response.status_code == 200
             assert container_ids.issubset(
-                response.json()), "Containers {} should have been propagated".format(container_ids)
+                response.json()
+            ), "Containers {} should have been propagated".format(
+                container_ids
+            )
 
         wait_for_container_metrics_propagation(container_ids)
 
@@ -1259,11 +1592,18 @@ def test_pod_application_metrics(dcos_api_session):
             }
         }
 
-        r = dcos_api_session.post('/agent/{}/api/v1'.format(agent_id), json=get_containers)
+        r = dcos_api_session.post(
+            '/agent/{}/api/v1'.format(agent_id), json=get_containers
+        )
         r.raise_for_status()
         mesos_agent_containers = r.json()['get_containers']['containers']
-        mesos_agent_cids = [container['container_id']['value'] for container in mesos_agent_containers]
-        assert container_ids.issubset(mesos_agent_cids), "Missing expected containers {}".format(container_ids)
+        mesos_agent_cids = [
+            container['container_id']['value']
+            for container in mesos_agent_containers
+        ]
+        assert container_ids.issubset(
+            mesos_agent_cids
+        ), "Missing expected containers {}".format(container_ids)
 
         def is_nested_container(container):
             """Helper to check whether or not a container returned in the
@@ -1283,7 +1623,9 @@ def test_pod_application_metrics(dcos_api_session):
                 # expect the response code to be 204.
                 @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
-                    response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
+                    response = dcos_api_session.metrics.get(
+                        container_id_path, node=agent_ip
+                    )
                     assert response.status_code == 204
                     return response
 
@@ -1292,11 +1634,17 @@ def test_pod_application_metrics(dcos_api_session):
                 assert not wait_for_container_response().json()
 
                 # Test that expected application metrics are present.
-                app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(container_id), node=agent_ip)
-                assert app_response.status_code == 200, 'got {}'.format(app_response.status_code)
+                app_response = dcos_api_session.metrics.get(
+                    '/containers/{}/app'.format(container_id), node=agent_ip
+                )
+                assert app_response.status_code == 200, 'got {}'.format(
+                    app_response.status_code
+                )
 
                 # Ensure all /container/<id>/app data is correct
-                assert 'datapoints' in app_response.json(), 'got {}'.format(app_response.json())
+                assert 'datapoints' in app_response.json(), 'got {}'.format(
+                    app_response.json()
+                )
 
                 # We expect three datapoints, could be in any order
                 uptime_dp = None
@@ -1306,25 +1654,34 @@ def test_pod_application_metrics(dcos_api_session):
                         break
 
                 # If this metric is missing, statsd-emitter's metrics were not received
-                assert uptime_dp is not None, 'got {}'.format(app_response.json())
+                assert uptime_dp is not None, 'got {}'.format(
+                    app_response.json()
+                )
 
                 datapoint_keys = ['name', 'value', 'unit', 'timestamp', 'tags']
                 for k in datapoint_keys:
                     assert k in uptime_dp, 'got {}'.format(uptime_dp)
 
                 expected_tag_names = {
-                    'dcos_cluster_id',
-                    'test_tag_key',
-                    'dcos_cluster_name',
+                    'dcos_cluster_id', 'test_tag_key', 'dcos_cluster_name',
                     'host'
                 }
-                check_tags(uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
-                assert uptime_dp['tags']['test_tag_key'] == 'test_tag_value', 'got {}'.format(uptime_dp)
+                check_tags(
+                    uptime_dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS
+                )
+                assert uptime_dp['tags'][
+                    'test_tag_key'] == 'test_tag_value', 'got {}'.format(
+                        uptime_dp
+                    )
                 assert uptime_dp['value'] > 0
 
-                assert 'dimensions' in app_response.json(), 'got {}'.format(app_response.json())
-                assert 'task_name' in app_response.json()['dimensions'], 'got {}'.format(
-                    app_response.json()['dimensions'])
+                assert 'dimensions' in app_response.json(), 'got {}'.format(
+                    app_response.json()
+                )
+                assert 'task_name' in app_response.json(
+                )['dimensions'], 'got {}'.format(
+                    app_response.json()['dimensions']
+                )
 
                 # Look for the specified task name.
                 assert task_name.strip('/') == app_response.json()['dimensions']['task_name'],\
@@ -1334,12 +1691,15 @@ def test_pod_application_metrics(dcos_api_session):
                 # content.
                 @retrying.retry(stop_max_delay=METRICS_WAITTIME)
                 def wait_for_container_response():
-                    response = dcos_api_session.metrics.get(container_id_path, node=agent_ip)
+                    response = dcos_api_session.metrics.get(
+                        container_id_path, node=agent_ip
+                    )
                     assert response.status_code == 200
                     return response
 
                 container_response = wait_for_container_response()
-                assert 'datapoints' in container_response.json(), 'got {}'.format(container_response.json())
+                assert 'datapoints' in container_response.json(
+                ), 'got {}'.format(container_response.json())
 
                 cid_registry = set()
                 for dp in container_response.json()['datapoints']:
@@ -1351,58 +1711,79 @@ def test_pod_application_metrics(dcos_api_session):
                     if dp['name'].startswith('blkio.'):
                         # blkio stats have 'blkio_device' tags.
                         expected_tag_names.add('blkio_device')
-                    check_tags(dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS)
+                    check_tags(
+                        dp['tags'], expected_tag_names, FAULT_DOMAIN_TAGS
+                    )
 
                     # Ensure all container IDs in the response from the
                     # containers/<id> endpoint are the same.
                     cid_registry.add(dp['tags']['container_id'])
 
-                assert len(cid_registry) == 1, 'Not all container IDs in the metrics response are equal'
+                assert len(
+                    cid_registry
+                ) == 1, 'Not all container IDs in the metrics response are equal'
 
-                assert 'dimensions' in container_response.json(), 'got {}'.format(container_response.json())
+                assert 'dimensions' in container_response.json(
+                ), 'got {}'.format(container_response.json())
 
                 # The executor container shouldn't expose application metrics.
-                app_response = dcos_api_session.metrics.get('/containers/{}/app'.format(container_id), node=agent_ip)
-                assert app_response.status_code == 204, 'got {}'.format(app_response.status_code)
+                app_response = dcos_api_session.metrics.get(
+                    '/containers/{}/app'.format(container_id), node=agent_ip
+                )
+                assert app_response.status_code == 204, 'got {}'.format(
+                    app_response.status_code
+                )
 
                 return True
 
     marathon_pod_config = {
-        "id": "/statsd-emitter-task-group",
-        "containers": [{
-            "name": "statsd-emitter-task",
-            "resources": {
-                "cpus": 0.5,
-                "mem": 128.0,
-                "disk": 1024.0
-            },
-            "image": {
-                "kind": "DOCKER",
-                "id": "alpine"
-            },
-            "exec": {
-                "command": {
-                    "shell": "./statsd-emitter"
-                }
-            },
-            "artifacts": [{
-                "uri": "https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter",
-                "executable": True
-            }],
-        }],
+        "id":
+        "/statsd-emitter-task-group",
+        "containers": [
+            {
+                "name":
+                "statsd-emitter-task",
+                "resources": {
+                    "cpus": 0.5,
+                    "mem": 128.0,
+                    "disk": 1024.0
+                },
+                "image": {
+                    "kind": "DOCKER",
+                    "id": "alpine"
+                },
+                "exec": {
+                    "command": {
+                        "shell": "./statsd-emitter"
+                    }
+                },
+                "artifacts": [
+                    {
+                        "uri":
+                        "https://downloads.mesosphere.com/dcos-metrics/1.11.0/statsd-emitter",
+                        "executable": True
+                    }
+                ],
+            }
+        ],
         "scheduling": {
             "instances": 1
         }
     }
 
     with dcos_api_session.marathon.deploy_pod_and_cleanup(marathon_pod_config):
-        r = dcos_api_session.marathon.get('/v2/pods/{}::status'.format(marathon_pod_config['id']))
+        r = dcos_api_session.marathon.get(
+            '/v2/pods/{}::status'.format(marathon_pod_config['id'])
+        )
         r.raise_for_status()
         data = r.json()
 
-        assert len(data['instances']) == 1, 'The marathon pod should have been deployed exactly once.'
+        assert len(
+            data['instances']
+        ) == 1, 'The marathon pod should have been deployed exactly once.'
 
         test_application_metrics(
             data['instances'][0]['agentHostname'],
             data['instances'][0]['agentId'],
-            marathon_pod_config['containers'][0]['name'], 2)
+            marathon_pod_config['containers'][0]['name'], 2
+        )

--- a/packages/dcos-integration-test/extra/test_metronome.py
+++ b/packages/dcos-integration-test/extra/test_metronome.py
@@ -8,12 +8,16 @@ def test_metronome(dcos_api_session):
         'id': 'test.metronome',
         'run': {
             'cmd': 'ls',
-            'docker': {'image': 'busybox:latest'},
+            'docker': {
+                'image': 'busybox:latest'
+            },
             'cpus': 1,
             'mem': 512,
             'disk': 0,
             'user': 'nobody',
-            'restart': {'policy': 'ON_FAILURE'}
+            'restart': {
+                'policy': 'ON_FAILURE'
+            }
         }
     }
     dcos_api_session.metronome_one_off(job)

--- a/packages/dcos-integration-test/extra/test_rlimit.py
+++ b/packages/dcos-integration-test/extra/test_rlimit.py
@@ -18,16 +18,14 @@ def test_if_rlimits_can_be_used(dcos_api_session):
     argv = [
         '/opt/mesosphere/bin/mesos-execute',
         '--rlimits={"rlimits": [{"type":"RLMT_CORE"}]}',
-        '--master=leader.mesos:5050',
-        '--name={}'.format(name),
-        '--command=ulimit -c | grep -q unlimited',
-        '--shell=true',
-        '--env={"LC_ALL":"C"}']
+        '--master=leader.mesos:5050', '--name={}'.format(name),
+        '--command=ulimit -c | grep -q unlimited', '--shell=true',
+        '--env={"LC_ALL":"C"}'
+    ]
 
     output = subprocess.check_output(
-        argv,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True)
+        argv, stderr=subprocess.STDOUT, universal_newlines=True
+    )
 
     expected_output = \
         "Received status update TASK_FINISHED for task '{name}'".format(

--- a/packages/dcos-integration-test/extra/test_sysctl.py
+++ b/packages/dcos-integration-test/extra/test_sysctl.py
@@ -13,24 +13,26 @@ def test_if_default_systctls_are_set(dcos_api_session):
     The job then examines the default sysctls, and returns a failure if another
     value is found."""
 
-    test_command = ('test "$(/sbin/sysctl vm.swappiness)" = '
-                    '"vm.swappiness = 1"'
-                    ' && test "$(/sbin/sysctl vm.max_map_count)" = '
-                    '"vm.max_map_count = 262144"')
+    test_command = (
+        'test "$(/sbin/sysctl vm.swappiness)" = '
+        '"vm.swappiness = 1"'
+        ' && test "$(/sbin/sysctl vm.max_map_count)" = '
+        '"vm.max_map_count = 262144"'
+    )
 
     argv = [
-        '/opt/mesosphere/bin/mesos-execute',
-        '--master=leader.mesos:5050',
-        '--command={}'.format(test_command),
-        '--shell=true',
-        '--env={"LC_ALL":"C"}']
+        '/opt/mesosphere/bin/mesos-execute', '--master=leader.mesos:5050',
+        '--command={}'.format(test_command), '--shell=true',
+        '--env={"LC_ALL":"C"}'
+    ]
 
     def run_and_check(argv):
         name = 'test-sysctl-{}'.format(uuid.uuid4().hex)
         output = subprocess.check_output(
             argv + ['--name={}'.format(name)],
             stderr=subprocess.STDOUT,
-            universal_newlines=True)
+            universal_newlines=True
+        )
 
         expected_output = \
             "Received status update TASK_FINISHED for task '{name}'".format(

--- a/packages/dcos-integration-test/extra/test_ucr.py
+++ b/packages/dcos-integration-test/extra/test_ucr.py
@@ -19,23 +19,35 @@ def test_if_ucr_app_can_be_deployed_with_image_whiteout(dcos_api_session):
     https://hub.docker.com/r/mesosphere/whiteout/
     """
     app = {
-        'id': '/test-ucr-' + str(uuid.uuid4().hex),
-        'cpus': 0.1,
-        'mem': 32,
-        'instances': 1,
-        'cmd': 'while true; do sleep 1; done',
+        'id':
+        '/test-ucr-' + str(uuid.uuid4().hex),
+        'cpus':
+        0.1,
+        'mem':
+        32,
+        'instances':
+        1,
+        'cmd':
+        'while true; do sleep 1; done',
         'container': {
             'type': 'MESOS',
-            'docker': {'image': 'mesosphere/whiteout:test'}
+            'docker': {
+                'image': 'mesosphere/whiteout:test'
+            }
         },
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {'value': 'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'},
-            'gracePeriodSeconds': 5,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 3
-        }]
+        'healthChecks': [
+            {
+                'protocol': 'COMMAND',
+                'command': {
+                    'value':
+                    'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'
+                },
+                'gracePeriodSeconds': 5,
+                'intervalSeconds': 10,
+                'timeoutSeconds': 10,
+                'maxConsecutiveFailures': 3
+            }
+        ]
     }
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Trivial app if it deploys, there is nothing else to check
@@ -49,25 +61,35 @@ def test_if_ucr_app_can_be_deployed_with_image_digest(dcos_api_session):
     by digest.
     """
     app = {
-        'id': '/test-ucr-' + str(uuid.uuid4().hex),
-        'cpus': 0.1,
-        'mem': 32,
-        'instances': 1,
-        'cmd': 'while true; do sleep 1; done',
+        'id':
+        '/test-ucr-' + str(uuid.uuid4().hex),
+        'cpus':
+        0.1,
+        'mem':
+        32,
+        'instances':
+        1,
+        'cmd':
+        'while true; do sleep 1; done',
         'container': {
             'type': 'MESOS',
             'docker': {
-                'image': 'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
+                'image':
+                'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
             }
         },
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {'value': 'test -d $MESOS_SANDBOX'},
-            'gracePeriodSeconds': 5,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 3
-        }]
+        'healthChecks': [
+            {
+                'protocol': 'COMMAND',
+                'command': {
+                    'value': 'test -d $MESOS_SANDBOX'
+                },
+                'gracePeriodSeconds': 5,
+                'intervalSeconds': 10,
+                'timeoutSeconds': 10,
+                'maxConsecutiveFailures': 3
+            }
+        ]
     }
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Trivial app if it deploys, there is nothing else to check
@@ -90,28 +112,36 @@ def test_if_ucr_app_can_be_deployed_with_auto_cgroups(dcos_api_session):
     0.2 * 1024 = 204 CPU shares) and 64MB memory (i.e., 67108864 bytes).
     """
     app = {
-        'id': '/test-ucr-' + str(uuid.uuid4().hex),
-        'cpus': 0.1,
-        'mem': 32,
-        'instances': 1,
-        'cmd': 'while true; do sleep 1; done',
+        'id':
+        '/test-ucr-' + str(uuid.uuid4().hex),
+        'cpus':
+        0.1,
+        'mem':
+        32,
+        'instances':
+        1,
+        'cmd':
+        'while true; do sleep 1; done',
         'container': {
             'type': 'MESOS',
             'docker': {
                 'image': 'library/alpine'
             }
         },
-        'healthChecks': [{
-            'protocol': 'COMMAND',
-            'command': {
-                'value': 'test `cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes` = 67108864 && '
-                         'test `cat /sys/fs/cgroup/cpu/cpu.shares` = 204'
-            },
-            'gracePeriodSeconds': 5,
-            'intervalSeconds': 10,
-            'timeoutSeconds': 10,
-            'maxConsecutiveFailures': 3
-        }]
+        'healthChecks': [
+            {
+                'protocol': 'COMMAND',
+                'command': {
+                    'value':
+                    'test `cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes` = 67108864 && '
+                    'test `cat /sys/fs/cgroup/cpu/cpu.shares` = 204'
+                },
+                'gracePeriodSeconds': 5,
+                'intervalSeconds': 10,
+                'timeoutSeconds': 10,
+                'maxConsecutiveFailures': 3
+            }
+        ]
     }
     with dcos_api_session.marathon.deploy_and_cleanup(app):
         # Trivial app if it deploys, there is nothing else to check
@@ -126,23 +156,48 @@ def test_if_ucr_pods_can_be_deployed_with_image_entrypoint(dcos_api_session):
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'mesosphere/inky'}
-            },
-            {
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'mesosphere/inky'
+                }
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
@@ -158,23 +213,48 @@ def test_if_ucr_pods_can_be_deployed_with_scratch_image(dcos_api_session):
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'hello-world'}
-            },
-            {
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'hello-world'
+                }
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
@@ -195,28 +275,54 @@ def test_if_ucr_pods_can_be_deployed_with_image_whiteout(dcos_api_session):
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'mesosphere/whiteout:test'},
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'mesosphere/whiteout:test'
+                },
                 'exec': {
                     'command': {
-                        'shell': 'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'
+                        'shell':
+                        'test ! -f /dir1/file1 && test ! -f /dir1/dir2/file2 && test -f /dir1/dir2/file3'
                     }
                 }
-            },
-            {
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
@@ -231,27 +337,55 @@ def test_if_ucr_pods_can_be_deployed_with_image_digest(dcos_api_session):
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {
-                    'kind': 'DOCKER',
-                    'id': 'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
                 },
-                'exec': {'command': {'shell': 'ls -al /'}}
-            },
-            {
+                'image': {
+                    'kind':
+                    'DOCKER',
+                    'id':
+                    'library/alpine@sha256:9f08005dff552038f0ad2f46b8e65ff3d25641747d3912e3ea8da6785046561a'
+                },
+                'exec': {
+                    'command': {
+                        'shell': 'ls -al /'
+                    }
+                }
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
@@ -275,29 +409,55 @@ def test_if_ucr_pods_can_be_deployed_with_auto_cgroups(dcos_api_session):
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'library/alpine'},
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'library/alpine'
+                },
                 'exec': {
                     'command': {
-                        'shell': 'test `cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes` = 100663296 && '
-                                 'test `cat /sys/fs/cgroup/cpu/cpu.shares` = 307'
+                        'shell':
+                        'test `cat /sys/fs/cgroup/memory/memory.soft_limit_in_bytes` = 100663296 && '
+                        'test `cat /sys/fs/cgroup/cpu/cpu.shares` = 307'
                     }
                 }
-            },
-            {
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}]
+        'networks': [{
+            'mode': 'host'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check
@@ -306,7 +466,9 @@ def test_if_ucr_pods_can_be_deployed_with_auto_cgroups(dcos_api_session):
 
 # TODO: Unmute this test once volume gid manager is enabled.
 @pytest.mark.skip(reason="cannot test this without volume gid manager enabled")
-def test_if_ucr_pods_can_be_deployed_with_non_root_user_ephemeral_volume(dcos_api_session):
+def test_if_ucr_pods_can_be_deployed_with_non_root_user_ephemeral_volume(
+    dcos_api_session
+):
     """Marathon pods inside ucr deployment integration test.
 
     This test launches a marathon ucr pod with a non-root user (nobody)
@@ -323,27 +485,61 @@ def test_if_ucr_pods_can_be_deployed_with_non_root_user_ephemeral_volume(dcos_ap
     """
     test_uuid = uuid.uuid4().hex
     pod_definition = {
-        'id': '/integration-test-pods-{}'.format(test_uuid),
-        'scaling': {'kind': 'fixed', 'instances': 1},
-        'environment': {'PING': 'PONG'},
+        'id':
+        '/integration-test-pods-{}'.format(test_uuid),
+        'scaling': {
+            'kind': 'fixed',
+            'instances': 1
+        },
+        'environment': {
+            'PING': 'PONG'
+        },
         'containers': [
             {
                 'name': 'container1',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'image': {'kind': 'DOCKER', 'id': 'library/alpine'},
-                'exec': {'command': {'shell': 'echo data > ./etc/file'}},
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'image': {
+                    'kind': 'DOCKER',
+                    'id': 'library/alpine'
+                },
+                'exec': {
+                    'command': {
+                        'shell': 'echo data > ./etc/file'
+                    }
+                },
                 'user': 'nobody',
-                "volumeMounts": [{"name": "volume1", "mountPath": "etc"}]
-            },
-            {
+                "volumeMounts": [{
+                    "name": "volume1",
+                    "mountPath": "etc"
+                }]
+            }, {
                 'name': 'container2',
-                'resources': {'cpus': 0.1, 'mem': 32},
-                'exec': {'command': {'shell': 'echo $PING > foo; while true; do sleep 1; done'}},
-                'healthcheck': {'command': {'shell': 'test $PING = `cat foo`'}}
+                'resources': {
+                    'cpus': 0.1,
+                    'mem': 32
+                },
+                'exec': {
+                    'command': {
+                        'shell':
+                        'echo $PING > foo; while true; do sleep 1; done'
+                    }
+                },
+                'healthcheck': {
+                    'command': {
+                        'shell': 'test $PING = `cat foo`'
+                    }
+                }
             }
         ],
-        'networks': [{'mode': 'host'}],
-        'volumes': [{'name': 'volume1'}]
+        'networks': [{
+            'mode': 'host'
+        }],
+        'volumes': [{
+            'name': 'volume1'
+        }]
     }
     with dcos_api_session.marathon.deploy_pod_and_cleanup(pod_definition):
         # Trivial app if it deploys, there is nothing else to check

--- a/packages/dcos-integration-test/extra/test_units.py
+++ b/packages/dcos-integration-test/extra/test_units.py
@@ -7,7 +7,6 @@ import subprocess
 
 import pytest
 
-
 __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
@@ -15,6 +14,7 @@ __contact__ = 'dcos-security@mesosphere.io'
 @pytest.mark.supportedwindows
 def test_verify_units():
     """Test that all systemd units are valid."""
+
     def _check_units(path):
         """Verify all the units given by `path'"""
         for file in glob.glob(path):
@@ -22,7 +22,8 @@ def test_verify_units():
                 ["/usr/bin/systemd-analyze", "verify", "--no-pager", file],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                universal_newlines=True)
+                universal_newlines=True
+            )
             # systemd-analyze returns 0 even if there were warnings, so we
             # assert that the command output was empty.
             if cmd.stdout:
@@ -82,12 +83,17 @@ def test_socket_units():
     """Test that socket units configure socket files in /run/dcos
     that are owned by 'dcos_adminrouter'.
     """
+
     def _check_unit(file):
         logging.info("Checking socket unit {}".format(file))
         out = subprocess.check_output(
-            ["/usr/bin/systemctl", "show", "--no-pager", os.path.basename(file)],
+            [
+                "/usr/bin/systemctl", "show", "--no-pager",
+                os.path.basename(file)
+            ],
             stderr=subprocess.STDOUT,
-            universal_newlines=True)
+            universal_newlines=True
+        )
         user = ""
         group = ""
         mode = ""
@@ -106,7 +112,9 @@ def test_socket_units():
                 # character in the value of the ListenStream directive.
                 if v.startswith("/"):
                     had_unix_socket = True
-                    assert v.startswith("/run/dcos/"), "DC/OS unix sockets must go in the /run/dcos directory"
+                    assert v.startswith(
+                        "/run/dcos/"
+                    ), "DC/OS unix sockets must go in the /run/dcos directory"
             if k == "SocketMode":
                 mode = v
         if not had_unix_socket:

--- a/packages/dcos-integration-test/extra/util/python_test_server.py
+++ b/packages/dcos-integration-test/extra/util/python_test_server.py
@@ -31,6 +31,7 @@ class RequestProcessingException(Exception):
         explanation: long explanation of the problem. Will be included in
                      response's body
     """
+
     def __init__(self, code, reason, explanation=''):
         """Inits RequestProcessingException with data used to build a reply to client"""
         self.code = code
@@ -80,7 +81,9 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
-        body_str = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
+        body_str = json.dumps(
+            data, sort_keys=True, indent=4, separators=(',', ': ')
+        )
         bytes_arr = bytes(body_str, "utf-8")
         self.wfile.write(bytes_arr)
 
@@ -113,15 +116,19 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
 
     def _handle_path_reflect(self):
         """Respond to request for client's IP with it's as seen by the server"""
-        data = {"test_uuid": os.environ[TEST_UUID_VARNAME],
-                "request_ip": self.address_string()}
+        data = {
+            "test_uuid": os.environ[TEST_UUID_VARNAME],
+            "request_ip": self.address_string()
+        }
         self._send_reply(data)
 
     def _handle_path_signal_test_cache(self, set_data):
         """Use the sever to cache results from application runs"""
         global TEST_DATA_CACHE
         if set_data:
-            TEST_DATA_CACHE = self.rfile.read(int(self.headers['Content-Length'])).decode()
+            TEST_DATA_CACHE = self.rfile.read(
+                int(self.headers['Content-Length'])
+            ).decode()
         self._send_reply(TEST_DATA_CACHE)
 
     def parse_POST_headers(self):  # noqa: ignore=N802
@@ -151,10 +158,12 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
                                         malformed. Request should be aborted.
         """
         if "reflector_ip" not in fields or "reflector_port" not in fields:
-            raise RequestProcessingException(400, 'Reflector data missing',
-                                             'Reflector IP and/or port has not '
-                                             'been provided, so the request cannot '
-                                             'be processed.')
+            raise RequestProcessingException(
+                400, 'Reflector data missing',
+                'Reflector IP and/or port has not '
+                'been provided, so the request cannot '
+                'be processed.'
+            )
 
         fields['reflector_ip'] = fields['reflector_ip'][0]
         fields['reflector_port'] = fields['reflector_port'][0]
@@ -163,13 +172,17 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
             fields['reflector_port'] = int(fields['reflector_port'])
         except ValueError:
             msg = 'Reflector port "{}" is not an integer'
-            raise RequestProcessingException(400, msg.format(fields['reflector_port']))
+            raise RequestProcessingException(
+                400, msg.format(fields['reflector_port'])
+            )
 
         try:
             socket.inet_aton(fields['reflector_ip'])
         except socket.error:
             msg = 'Reflector IP "{}" is invalid/not a proper ipv4'
-            raise RequestProcessingException(400, msg.format(fields['reflector_ip']))
+            raise RequestProcessingException(
+                400, msg.format(fields['reflector_ip'])
+            )
 
     def _query_reflector_for_ip(self, reflector_ip, reflector_port):
         """Ask the reflector to report server's IP address
@@ -195,28 +208,33 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         try:
             r = requests.get(uri, timeout=1.0)
         except requests.Timeout as e:
-            raise RequestProcessingException(500, 'Reflector timed out',
-                                             "Reflector was unable to respond "
-                                             "in timely manner: {}".format(e))
+            raise RequestProcessingException(
+                500, 'Reflector timed out', "Reflector was unable to respond "
+                "in timely manner: {}".format(e)
+            )
         except requests.RequestException as e:
-            raise RequestProcessingException(500, 'Reflector connection error',
-                                             "Unable to connect to reflector: "
-                                             "{}".format(e))
+            raise RequestProcessingException(
+                500, 'Reflector connection error',
+                "Unable to connect to reflector: "
+                "{}".format(e)
+            )
 
         if r.status_code != 200:
             msg_short = 'Data fetch from reflector failed.'
             msg_detailed = 'Reflector responded with code: {}, response body: {}'
             reply_body = r.text.replace('\n', ' ')
-            raise RequestProcessingException(500, msg_short,
-                                             msg_detailed.format(r.status_code,
-                                                                 reply_body))
+            raise RequestProcessingException(
+                500, msg_short, msg_detailed.format(r.status_code, reply_body)
+            )
 
         try:
             return r.json()
         except ValueError as e:
-            raise RequestProcessingException(500, 'Malformed reflector response',
-                                             "Reflectors response is not a "
-                                             "valid JSON: {}".format(e))
+            raise RequestProcessingException(
+                500, 'Malformed reflector response',
+                "Reflectors response is not a "
+                "valid JSON: {}".format(e)
+            )
 
     def _handle_path_your_ip(self):
         """Responds to requests for server's IP address as seen by other cluster members
@@ -228,12 +246,15 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
         """
         form_data = self.parse_POST_headers()
         self._verify_path_your_ip_args(form_data)
-        reflector_data = self._query_reflector_for_ip(form_data['reflector_ip'],
-                                                      form_data['reflector_port'])
+        reflector_data = self._query_reflector_for_ip(
+            form_data['reflector_ip'], form_data['reflector_port']
+        )
 
-        data = {"reflector_uuid": reflector_data['test_uuid'],
-                "test_uuid": os.environ[TEST_UUID_VARNAME],
-                "my_ip": reflector_data['request_ip']}
+        data = {
+            "reflector_uuid": reflector_data['test_uuid'],
+            "test_uuid": os.environ[TEST_UUID_VARNAME],
+            "my_ip": reflector_data['request_ip']
+        }
         self._send_reply(data)
 
     def _handle_path_run_cmd(self):
@@ -249,9 +270,7 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
 
     def _handle_operating_environment(self):
         """Gets basic operating environment info (such as running user)"""
-        self._send_reply({
-            'uid': os.getuid()
-        })
+        self._send_reply({'uid': os.getuid()})
 
     def do_GET(self):  # noqa: ignore=N802
         """Mini service router handling GET requests"""
@@ -276,9 +295,12 @@ class TestHTTPRequestHandler(BaseHTTPRequestHandler):
             try:
                 self._handle_path_your_ip()
             except RequestProcessingException as e:
-                logging.error("Request processing exception occured: "
-                              "code: {}, reason: '{}', explanation: '{}'".format(
-                                  e.code, e.reason, e.explanation))
+                logging.error(
+                    "Request processing exception occured: "
+                    "code: {}, reason: '{}', explanation: '{}'".format(
+                        e.code, e.reason, e.explanation
+                    )
+                )
                 self.send_error(e.code, e.reason, e.explanation)
         elif self.path == '/signal_test_cache':
             self._handle_path_signal_test_cache(True)
@@ -310,9 +332,15 @@ def start_http_server(listen_port):
     """
     _verify_environment()
 
-    logging.info("HTTP server is starting, port: "
-                 "{}, test-UUID: '{}'".format(listen_port, os.environ[TEST_UUID_VARNAME]))
-    test_server = ThreadingSimpleServer(('', listen_port), TestHTTPRequestHandler)
+    logging.info(
+        "HTTP server is starting, port: "
+        "{}, test-UUID: '{}'".format(
+            listen_port, os.environ[TEST_UUID_VARNAME]
+        )
+    )
+    test_server = ThreadingSimpleServer(
+        ('', listen_port), TestHTTPRequestHandler
+    )
 
     def sigterm_handler(_signo, _stack_frame):
         test_server.server_close()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[yapf]
+DEDENT_CLOSING_BRACKETS = true
+

--- a/tox.ini
+++ b/tox.ini
@@ -167,6 +167,12 @@ deps=
 commands=
   mypy ./test-e2e
 
+[testenv:format]
+deps=
+  yapf==0.27.0
+commands=
+  yapf --diff --recursive packages/dcos-integration-test/extra/
+
 [testenv:collect-integration-tests]
 platform=linux|darwin
 basepython=python3.5


### PR DESCRIPTION
## High-level description

Introduce automated formatting checking for python files in `packages/dcos-integration-test/extra`.
This can be considered a first step.
The incentive behind this is a recent number of stylistic discussions on PRs.
Where possible we would like to defer to a tool.
This looks like a big PR but it has the following trivial change sets:

* `tox.ini` to add the automated chec
* `setup.cfg` to configure `yapf`
* `README.md` to describe how to automatically format code
* Automatic formatting of code

If this works well we can consider adding more linters, or adding this check to other Python code in the repository.

## Corresponding DC/OS tickets (required)

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.