### PR TITLE
DCOS-54568 - Disable test_dcos_diagnostics for ifconfig comand not found in PATH

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -319,6 +319,11 @@ def test_dcos_diagnostics_report(dcos_api_session):
         assert len(report_response['Nodes']) > 0
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-54568',
+    reason='test_dcos_diagnostics_bundle fails with ifconfig - executable file not found in $PATH"',
+    since='2019-05-30'
+)
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session):
     """
     test bundle create, read, delete workflow


### PR DESCRIPTION
## High-level description

* DCOS-54568 - Disable test_dcos_diagnostics for ifconfig comand not found in $PATH
