### PR TITLE
Collect procstat metrics only for components

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2275,16 +2275,29 @@ package:
       [[inputs.net]]
       # Get the number of processes and group them by status
       [[inputs.processes]]
-      # Gather resource usage of processes
-      [[inputs.procstat]]
-        pattern = "."
-        pid_finder = "pgrep"
       # Read metrics about system load & uptime
       [[inputs.system]]
       # Collect statistics about itself
       [[inputs.internal]]
         ## If true, collect telegraf memory stats.
         collect_memstats = true
+      # The following procstat inputs collect process resource metrics for components that run on all cluster nodes.
+      [[inputs.procstat]]
+        systemd_unit = "dcos-checks-api.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-checks-poststart.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-diagnostics.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-fluent-bit.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-net-watchdog.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-net.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-pkgpanda-api.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-telegraf.service"
       # Configuration for the Prometheus client to spawn
       [[outputs.prometheus_client]]
         ## Address to listen on
@@ -2347,6 +2360,37 @@ package:
   - path: /etc_master/telegraf/telegraf.d/master.conf
     content: |
       # Additional Telegraf config for masters
+      # The following procstat inputs collect process resource metrics for components that run on masters.
+      [[inputs.procstat]]
+        systemd_unit = "dcos-adminrouter.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-bouncer.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-cockroach.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-cockroachdb-config-change.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-cosmos.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-exhibitor.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-history.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-log-master.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-logrotate-master.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-marathon.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-mesos-dns.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-mesos-master.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-metronome.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-signal.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-ui-update-service.service"
 {% switch enable_mesos_input_plugin %}
 {% case "true" %}
       # Telegraf plugin for gathering metrics from mesos
@@ -2503,6 +2547,23 @@ package:
   - path: /etc_slave/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
+      # The following procstat inputs collect process resource metrics for components that run on agents.
+      [[inputs.procstat]]
+        systemd_unit = "dcos-adminrouter-agent.service"
+{% switch enable_docker_gc %}
+{% case "true" %}
+      [[inputs.procstat]]
+        systemd_unit = "dcos-docker-gc.service"
+{% case "false" %}
+{% endswitch %}
+      [[inputs.procstat]]
+        systemd_unit = "dcos-log-agent.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-logrotate-agent.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-mesos-slave.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-rexray.service"
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
         ## The interval at which to collect metrics
@@ -2637,6 +2698,23 @@ package:
   - path: /etc_slave_public/telegraf/telegraf.d/agent.conf
     content: |
       # Additional Telegraf config for agents
+      # The following procstat inputs collect process resource metrics for components that run on agents.
+      [[inputs.procstat]]
+        systemd_unit = "dcos-adminrouter-agent.service"
+{% switch enable_docker_gc %}
+{% case "true" %}
+      [[inputs.procstat]]
+        systemd_unit = "dcos-docker-gc.service"
+{% case "false" %}
+{% endswitch %}
+      [[inputs.procstat]]
+        systemd_unit = "dcos-log-agent.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-logrotate-agent.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-mesos-slave.service"
+      [[inputs.procstat]]
+        systemd_unit = "dcos-rexray.service"
       # Plugin for monitoring mesos container resource consumption
       [[inputs.dcos_containers]]
         ## The interval at which to collect metrics


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This PR removes config that directs Telegraf to monitor resource consumption for all processes running on all cluster nodes. This is wasteful on agents with many Mesos tasks, because task metrics are already collected by other inputs. Instead we provide a whitelist of component systemd units to monitor. This causes Telegraf to monitor the main PID for each component.

I tested this manually by installing dcos-monitoring and querying Prometheus to confirm that procstat metrics are present for all components.

This will be backported to 1.13, so no changelog entry is necessary.

## Corresponding DC/OS tickets (required)

  - [DCOS-53589](https://jira.mesosphere.com/browse/DCOS-53589) Whitelist the processes to monitor when using the procstat input plugin


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

N/A

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
