### PR TITLE
Bump Metronome to 0.6.23

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated to [Mesos 1.7.3-dev](https://github.com/apache/mesos/blob/0f4e34b4dfe98178a7d94f5242041b5958eb7a24/CHANGELOG).
 
-* Updated to [Metronome 0.6.18](https://github.com/dcos/metronome/blob/e06e8285c089ed7e03590053395f9436a4ac34f4/changelog.md#0618).
+* Updated to [Metronome 0.6.23](https://github.com/dcos/metronome/tree/be50099).
 
 * Updated to [Marathon 1.7.216](https://github.com/mesosphere/marathon/tree/9e2a9b579).
 
@@ -65,6 +65,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Support large uploads for Admin Router service endpoint. (DCOS-52768)
 
 * Added Round-Robin DNS support. (DCOS_OSS-5118)
+
+* [Metronome] Missing request metrics in Metronome. (DCOS_OSS-5020)
+
+* [Metronome] Improve secrets validation to only point out unprovided secrets. (DCOS_OSS-5019)
 
 ### Security updates
 

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.18-b4016b0/metronome-0.6.18-b4016b0.tgz",
-    "sha1": "31e63a5796a0af7840f2f5c882dfbe3fc6dc251b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.23-be50099/metronome-0.6.23-be50099.tgz",
+    "sha1": "4cba78376137f31e420fa1a91de161b10564f533"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.23


## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5020](https://jira.mesosphere.com/browse/DCOS_OSS-5020) Missing request metrics in Metronome
  - [DCOS_OSS-5019](https://jira.mesosphere.com/browse/DCOS_OSS-5019) Improve secrets validation to only point out unprovided secrets


## Related tickets (optional)


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated: [b4016b0...be50099](https://github.com/dcos/metronome/compare/b4016b0...be50099)
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [Jenkins job](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/14/)
  - [ ] Code Coverage (if available): [link to code coverage report]
  