### PR TITLE
Upgrade CockroachDB to version 2.1.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### What's new
 
+* Upgraded CockroachDB to version [2.1.7](https://www.cockroachlabs.com/docs/releases/v2.1.7.html). (DCOS_OSS-5262)
+
 * The DC/OS configuration variable `mesos_seccomp_enabled` now defaults to `true`, with `mesos_seccomp_profile_name` set to `default.json`. This is not expected to break tasks. If you experience problems, though, please note that seccomp can be disabled for individual tasks through the DC/OS SDK and Marathon. (DCOS-50038)
 
 * Updated ref of dvdcli to fix dvdcli package build (DCOS-53581)

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -2,56 +2,11 @@
 
 set -ex
 
-# Support https sources in apt
-apt-get -y update
-apt-get -y install apt-transport-https software-properties-common
-
-# CockroachDB requires node and yarn to build UI
-# https://github.com/cockroachdb/cockroach/blob/v2.0.7/build/bootstrap/bootstrap-debian.sh#L8-L12
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-echo "deb https://deb.nodesource.com/node_6.x xenial main" | tee /etc/apt/sources.list.d/nodesource.list
-
-curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-add-apt-repository ppa:ubuntu-toolchain-r/test
-
-# cockroachdb requires gcc 6.0+
-apt-get -y update
-apt-get install -y gcc-6 g++-6 cpp-6 \
-    nodejs yarn
-
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 40
-update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-6 40
-update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 40
-
-GOLANG_VERSION=1.11.5
-GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25
-
-rm -rf /usr/local/go
-curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz
-echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c -
-tar -C /usr/local -xzf golang.tar.gz
-rm golang.tar.gz
-
 cd /pkg/src/cockroach
-
-# go-libedit requries `ncurses` library. We need to replace `cgo` flags so that
-# go compiler passes path to DCOS included ncurses library.
-sed -i 's/LDFLAGS: -lncurses/LDFLAGS: -L\/opt\/mesosphere\/active\/ncurses\/lib -ltinfo -lncurses/g' src/github.com/cockroachdb/cockroach/vendor/github.com/knz/go-libedit/unix/editline_unix.go
-sed -i 's/CFLAGS: -Wno-unused-result/CFLAGS: -Wno-unused-result -I\/opt\/mesosphere\/active\/ncurses\/include -I\/opt\/mesosphere\/active\/ncurses\/include\/ncurses/g' src/github.com/cockroachdb/cockroach/vendor/github.com/knz/go-libedit/unix/editline_unix.go
-
-# Build the cockroach binary.
-# We need to set CC_PATH and CXX_PATH because the build in the teamcity is not
-# recognizing paths correctly
-export CC=/usr/bin/gcc
-export CXX=/usr/bin/g++
-make build TYPE=release-linux-gnu CC_PATH=/usr/bin/gcc  CXX_PATH=/usr/bin/g++
 
 # Copy the cockroach binary to the the package bin directory.
 mkdir -p $PKG_PATH/bin
-install -m 755 /pkg/src/cockroach/src/github.com/cockroachdb/cockroach/cockroach-linux-2.6.32-gnu-amd64 $PKG_PATH/bin/cockroach
+install -m 755 /pkg/src/cockroach/cockroach $PKG_PATH/bin/cockroach
 
 # Copy the registration script to the package bin directory.
 install -m 755 /pkg/extra/register.py $PKG_PATH/bin/register.py

--- a/packages/cockroach/buildinfo.json
+++ b/packages/cockroach/buildinfo.json
@@ -1,9 +1,8 @@
 {
-  "requires": ["ncurses"],
   "single_source" : {
       "kind": "url_extract",
-      "url": "https://binaries.cockroachdb.com/cockroach-v2.0.7.src.tgz",
-      "sha1": "8b3940ef9ab46646b4178bc93c9904b57d9f3c50"
+      "url": "https://binaries.cockroachdb.com/cockroach-v2.1.7.linux-amd64.tgz",
+      "sha1": "68021a4779a5df27dfd8a8e72dbd20599018623d"
   },
   "username": "dcos_cockroach",
   "state_directory": true

--- a/packages/cockroach/extra/cockroachdb-change-config.py
+++ b/packages/cockroach/extra/cockroachdb-change-config.py
@@ -20,63 +20,69 @@ log = logging.getLogger(__name__)
 logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
 
 
-def set_cluster_version(my_internal_ip: str, version: str) -> None:
-    """
-    Use `cockroach sql` to set the cluster-wide configuration setting
-    version to `version`. This requires that all nodes are running the
-    given version of CockroachDB and are operating successfully.
-
-    Relevant JIRA ticket: https://jira.mesosphere.com/browse/DCOS-19427
-
-    Args:
-        my_internal_ip: The internal IP of the current host.
-        version: The current 'major.minor' version of CockroachDB.
-    """
-    command = [
-        '/opt/mesosphere/active/cockroach/bin/cockroach',
-        'sql',
-        '--insecure',
-        '--host={}'.format(my_internal_ip),
-        '-e',
-        "SET CLUSTER SETTING version = '{}';".format(version),
-        ]
-    config_text = 'version: {}'.format(version)
-    log.info('Set `%s` via command `%s`', config_text, ' '.join(command))
-    subprocess.run(command, input=config_text.encode('ascii'))
-    log.info('Command returned')
-
-
 def set_num_replicas(my_internal_ip: str, num_replicas: int) -> None:
     """
-    Use `cockroach zone set` to set the cluster-wide configuration setting
-    num_replicas to `num_replicas`. This does not matter on a 3-master
-    DC/OS cluster because the CockroachDB default for num_replicas is 3.
-    This however ensures that num_replicas is set to 5 on a 5-master DC/OS
-    cluster. Feed the configuration key/value pair to the `cockroach` program
-    via stdin.
+    CockroachDB version 2.1.7 sets the internal system range replication
+    factor to `5` by default:
+    https://www.cockroachlabs.com/docs/stable/configure-replication-zones.html#view-all-replication-zones
 
+    In order to adjust this to the maximum replication factor possible for a
+    given DC/OS cluster and to provide maximum fault-tolerance we set the
+    cluster-wide configuration setting `num_replicas` for any database entity
+    to the given `num_replicas` count which equals the number of DC/OS master
+    nodes.
     Relevant JIRA ticket: https://jira.mesosphere.com/browse/DCOS-20352
     """
+    zone_config = 'num_replicas = {}'.format(num_replicas)
 
-    def _set_replicas_for_zone(zone: str) -> None:
-        command = [
-            '/opt/mesosphere/active/cockroach/bin/cockroach',
-            'zone',
-            'set',
-            zone,
-            '--insecure',
-            '--host={}'.format(my_internal_ip),
-            '-f',
-            '-'
-            ]
-        config_text = 'num_replicas: %s' % (num_replicas, )
-        log.info('Set `%s` via command `%s`', config_text, ' '.join(command))
-        subprocess.run(command, input=config_text.encode('ascii'))
+    # If more entities that must have their `num_replicas` setting adjusted are
+    # added to CockroachDB, a DC/OS check will fail on all clusters (DC/OS OSS
+    # 1.13+, DC/OS Enterprise 1.12+).
+    # describing that there are "underreplicated ranges".
+    # The DC/OS check is named "cockroachdb_replication".
+    #
+    # To resolve this, add more items to the following list.
+    # To display CockroachDB entities that must have their `num_replicas` setting
+    # adjusted, issue the following SQL command: `SHOW ALL ZONE CONFIGURATIONS;`
+    #
+    # One option is to parse the output of the above SQL command.
+    # However, there is a plan for CockroachDB that all replication will be
+    # derived from ``.default``.
+    # See https://forum.cockroachlabs.com/t/change-replication-factor/2052/3.
+    # Should this happen, we can replace the following loop initialisation with:
+    # zone = '.default'
+    # db_entity = 'RANGE default'
+    for zone, db_entity in [
+        ('.default', 'RANGE default'),
+        ('system', 'DATABASE system'),
+        ('system.jobs', 'TABLE system.public.jobs'),
+        ('.meta', 'RANGE meta'),
+        ('.system', 'RANGE system'),
+        ('.liveness', 'RANGE liveness'),
+    ]:
+        sql_command = (
+            'ALTER {db_entity} CONFIGURE ZONE USING {zone_config};'
+        ).format(
+            db_entity=db_entity,
+            zone_config=zone_config,
+        )
+        command = (
+            '/opt/mesosphere/active/cockroach/bin/cockroach '
+            'sql -e "{sql_command}" --insecure --host={host}'
+        ).format(
+            sql_command=sql_command,
+            host=my_internal_ip,
+        )
+        message = (
+            'Set {zone_config} for {zone} via command {command}'
+        ).format(
+            zone_config=zone_config,
+            zone=zone,
+            command=command,
+        )
+        log.info(message)
+        subprocess.run(command, shell=True)
         log.info('Command returned')
-
-    zones = ['.default', '.liveness', '.meta']
-    for zone in zones:
-        _set_replicas_for_zone(zone=zone)
 
 
 def get_expected_master_node_count() -> int:
@@ -106,9 +112,6 @@ def main() -> None:
     log.info('Expected number of DC/OS master nodes: %s', master_node_count)
 
     set_num_replicas(my_internal_ip, master_node_count)
-
-    # We are running CockroachDB v2.0.x so pass '2.0'.
-    set_cluster_version(my_internal_ip, '2.0')
 
 
 if __name__ == '__main__':

--- a/packages/cockroach/extra/cockroachdb-change-config.py
+++ b/packages/cockroach/extra/cockroachdb-change-config.py
@@ -74,11 +74,11 @@ def set_num_replicas(my_internal_ip: str, num_replicas: int) -> None:
             host=my_internal_ip,
         )
         message = (
-            'Set {zone_config} for {zone} via command {command}'
+            'Set `{zone_config}` for `{zone}` via command `{command}`'
         ).format(
-            zone_config=zone_config,
-            zone=zone,
-            command=command,
+            zone_config=repr(zone_config),
+            zone=repr(zone),
+            command=repr(command),
         )
         log.info(message)
         subprocess.run(command, shell=True)


### PR DESCRIPTION
## High-level description

This PR upgrades CockroachDB to version [2.1.7](
https://www.cockroachlabs.com/docs/releases/v2.1.7.html) in DC/OS.

The PR removes `set_cluster_version` which was previously used to `finalize` an upgrade of CockroachDB. With version 2.1.x CockroachDB [auto-finalizes](https://www.cockroachlabs.com/docs/v2.1/upgrade-cockroach-version.html#step-3-decide-how-the-upgrade-will-be-finalized) upgraded nodes by default.

The PR fixes a race-condition in our CockroachDB init procedure where we first start one CockroachDB instance that initializes a new cluster before it get killed to then restart and `join` the cluster it previously created. The problem there appeared to be that the instance got terminated to quickly which led to the cluster not being properly initialized in rare cases.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5262](https://jira.mesosphere.com/browse/DCOS_OSS-5262) [CRDB update] Upgrade to the latest CockroachDB 2.1.x in dcos/dcos.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review):
    - [2.1.7](https://www.cockroachlabs.com/docs/releases/v2.1.7.html) (Now)
    - [2.1.0](https://www.cockroachlabs.com/docs/releases/v2.1.0.html)
    - [2.0.7](https://www.cockroachlabs.com/docs/releases/v2.0.7.html) (Previous)