### PR TITLE
DCOS-52080 - Fix AWS Onprem w/ Static Backend and Security Permissive CI

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -732,9 +732,11 @@ def validate_state(zip_state):
     assert isinstance(zip_state, zipfile.ZipExtFile)
     state_output = gzip.decompress(zip_state.read())
     state = json.loads(state_output)
-    assert len(state["frameworks"]) == 2, "bundle must contain information about frameworks"
-    task_count = len(state["frameworks"][1]["tasks"]) + len(state["frameworks"][0]["tasks"])
-    assert task_count == 1, "bundle must contain information about tasks"
+
+    assert len(state["frameworks"]) > 1, "bundle must contain information about frameworks"
+
+    task_count = sum([len(f["tasks"]) for f in state["frameworks"]])
+    assert task_count > 0, "bundle must contains information about tasks"
 
 
 def verify_archived_items(folder, archived_items, expected_files):


### PR DESCRIPTION
Backport of  https://github.com/dcos/dcos/pull/5634/

Fixes: DCOS-54487 - test_dcos_diagnostics_bundle_create_download_delete fails on Permissive mode cluster
