### PR TITLE
Bump Metronome to 0.6.23

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated DC/OS UI to [master+v2.108.0](https://github.com/dcos/dcos-ui/releases/tag/master+v2.108.0)
 
+* Updated to [Metronome 0.6.23](https://github.com/dcos/metronome/tree/be50099).
+
 ### Breaking changes
 
 Admin Router now requires a CPU with SSE4.2 support.
@@ -26,3 +28,7 @@ The following parameters have been removed from the DC/OS installer:
 * --install-prereqs
 * --deploy
 * --postflight
+
+### Fixed and improved
+
+* [Metronome] Improve secrets validation to only point out unprovided secrets. (DCOS_OSS-5019)

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.21-9055768/metronome-0.6.21-9055768.tgz",
-    "sha1": "4d43d7dfbc8251e7e98e050d5f735995d7102106"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.23-be50099/metronome-0.6.23-be50099.tgz",
+    "sha1": "4cba78376137f31e420fa1a91de161b10564f533"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.23


## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5019](https://jira.mesosphere.com/browse/DCOS_OSS-5019) Improve secrets validation to only point out unprovided secrets.


## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] [Change log 9055768...be50099](https://github.com/dcos/metronome/compare/9055768...be50099)
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [Jenkins CI](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/14/)
  - [ ] Code Coverage (if available): [link to code coverage report]