### PR TITLE
DCOS-55100 Bump telegraf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Upgraded OTP version to 22.0.3 (DCOS_OSS-5276)
 
+* Telegraf now supports specyfying port names for task-label based Prometheus
+  endpoints discovery (DCOS-55100)
+
 ### Breaking changes
 
 Admin Router now requires a CPU with SSE4.2 support.

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "74daee435d70903c9f2181509a7600fa4857dc87",
+    "ref": "4af92b507da53dd1d06a6637544b97b04724e5f0",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

Telegraph bump to include changes from DCOS-55100.

## Corresponding DC/OS tickets (required)

  - [DCOS-25655](https://jira.mesosphere.com/browse/DCOS-55100) `Add support for using the port name in metrics endpoint discovery done by our Telegraf fork`


