### PR TITLE
DCOS-55100 Bump telegraf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Telegraf reports procstat metrics only for DC/OS systemd services, instead of all processes. (DCOS-53589)
 
+* Telegraf now supports specyfying port names for task-label based Prometheus
+  endpoints discovery (DCOS-55100)
+
 ### Security updates
 
 

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "74daee435d70903c9f2181509a7600fa4857dc87",
+    "ref": "4af92b507da53dd1d06a6637544b97b04724e5f0",
     "ref_origin": "1.9.4-dcos"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

Telegraph bump to include changes from DCOS-55100.

This is a backport of https://github.com/dcos/dcos/pull/5731

## Corresponding DC/OS tickets (required)

  - [DCOS-25655](https://jira.mesosphere.com/browse/DCOS-55100) `Add support for using the port name in metrics endpoint discovery done by our Telegraf fork`


