### PR TITLE
[1.14 / master] Bump DC/OS E2E to 2019.06.19.0

### DIFF
--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.06.03.0
+git+https://github.com/dcos/dcos-e2e.git@2019.06.19.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -13,12 +13,12 @@ from dcos_e2e.backends import Docker
 @pytest.fixture(scope='session', autouse=True)
 def configure_logging() -> None:
     """
-    Surpress DEBUG log messages from libraries that log excessive amount of
-    debug output that isn't useful for debugging e2e tests.
+    Surpress INFO, DEBUG and NOTSET log messages from libraries that log
+    excessive amount of debug output that isn't useful for debugging e2e tests.
     """
-    # Disble debug output from `docker` and `urllib3` libraries
     logging.getLogger('urllib3.connectionpool').setLevel(logging.WARN)
     logging.getLogger('docker').setLevel(logging.WARN)
+    logging.getLogger('sarge').setLevel(logging.WARN)
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
## High-level description

This change bumps the version of DC/OS E2E used in tests.
The main goal of this is to keep more logs in the event of a `DCOSTimeoutError` - a long running test which times out after an hour of waiting for DC/OS previously kept only ~20 minutes of logs.

In particular, [DC/OS E2E PR #1857](https://github.com/dcos/dcos-e2e/pull/1857) provides a change we want to bring in.

This PR is submitted without evidence that more logs are kept by DC/OS.
One test we could do is add a loop to bootstrap which would mean that the cluster start up time is > 1h, and then we could check the amount of logs kept with or without this change.
We prefer not to do this and instead reason that this change will work, and then come back if we get evidence that it has not worked.
Reviewer feedback on that strategy is welcome!

## Corresponding DC/OS tickets (required)

  - [DCOS-55311](https://jira.mesosphere.com/browse/DCOS-55311) DC/OS tests - E2E test logs are rotated so we are missing logs.

## Related tickets (optional)

  - [DCOS-55257](https://jira.mesosphere.com/browse/DCOS-55257) test-e2e.test_master_node_replacement.test_dynamic_cluster - DCOSTimeoutError.