### PR TITLE
Use extra requirements for tox to catch more mypy errors

### DIFF
--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -5,7 +5,7 @@ Tests for the ZooKeeper backup/restore via `dcos-zk`.
 import logging
 import uuid
 from pathlib import Path
-from typing import Set
+from typing import Iterator, Set
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -31,7 +31,7 @@ def three_master_cluster(
     docker_backend: Docker,
     request: SubRequest,
     log_dir: Path,
-) -> Cluster:
+) -> Iterator[Cluster]:
     """
     Spin up a highly-available DC/OS cluster with three master nodes.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -163,6 +163,7 @@ commands=
 [testenv:mypy]
 deps=
   mypy-mypyc==0.660
+  -r test-e2e/requirements.txt
 commands=
   mypy ./test-e2e
   mypy ./packages/exhibitor/extra/dcos_zk_backup.py

--- a/tox.ini
+++ b/tox.ini
@@ -163,7 +163,7 @@ commands=
 [testenv:mypy]
 deps=
   mypy-mypyc==0.660
-  -r test-e2e/requirements.txt
+  -r ./test-e2e/requirements.txt
 commands=
   mypy ./test-e2e
   mypy ./packages/exhibitor/extra/dcos_zk_backup.py


### PR DESCRIPTION
## High-level description

I spotted while bumping DC/OS E2E in another branch that `tox -e mypy` did not catch as much as it should - in particular an API change in DC/OS E2E (a typed library) itself.
This is because `tox` was not using the requirements of the `test-e2e` tests.
This change makes `tox` more strict by installing those requirements, and it fixes the issues which came up.

## Corresponding DC/OS tickets (required)

  - [DCOS-55311](https://jira.mesosphere.com/browse/DCOS-55311) DC/OS tests - E2E test logs are rotated so we are missing logs