### PR TITLE
[1.13] Backport tweidner/improve-iam-database-restore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* Change `iam-database-restore` to work when no database exists. (DCOS_OSS-5317)
+
 ### Security updates
 
 

--- a/packages/cockroach/build
+++ b/packages/cockroach/build
@@ -63,8 +63,8 @@ install -m 755 /pkg/extra/cockroach.sh $PKG_PATH/bin/cockroach.sh
 install -m 755 /pkg/extra/cockroachdb-change-config.py $PKG_PATH/bin/cockroachdb-change-config.py
 
 # Copy the IAM database backup/restore scripts to the package bin directory.
-install -m 755 /pkg/extra/iam-database-backup $PKG_PATH/bin/iam-database-backup
-install -m 755 /pkg/extra/iam-database-restore $PKG_PATH/bin/iam-database-restore
+install -m 755 /pkg/extra/iam-database-backup.py $PKG_PATH/bin/iam-database-backup
+install -m 755 /pkg/extra/iam-database-restore.py $PKG_PATH/bin/iam-database-restore
 
 # Auto-start the dcos-cockroach service on the masters.
 mkdir -p "$PKG_PATH/dcos.target.wants_master"

--- a/packages/cockroach/extra/iam-database-backup.py
+++ b/packages/cockroach/extra/iam-database-backup.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import subprocess
 import sys
-from typing import IO
+from typing import IO, Union
 
 from dcos_internal_utils import utils
 
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 logging.basicConfig(format='[%(levelname)s] %(message)s', level='INFO')
 
 
-def dump_database(my_internal_ip: str, out: IO[bytes]) -> None:
+def dump_database(my_internal_ip: str, out: Union[IO[bytes], IO[str]]) -> None:
     """
     Use `cockroach dump` to dump the IAM database to stdout.
 
@@ -40,7 +40,7 @@ def dump_database(my_internal_ip: str, out: IO[bytes]) -> None:
         ]
     log.info('Dump iam database via command `%s`', ' '.join(command))
     try:
-        result = subprocess.run(command, check=True, stdout=out)
+        subprocess.run(command, check=True, stdout=out)
         log.info('Database successfully dumped.')
     except subprocess.CalledProcessError:
         # The stderr output of the underlying cockroach command will be printed

--- a/tox.ini
+++ b/tox.ini
@@ -166,6 +166,7 @@ deps=
   mypy-mypyc==0.660
 commands=
   mypy ./test-e2e
+  mypy ./packages/cockroach/extra
   mypy ./packages/exhibitor/extra/dcos_zk_backup.py
 
 [testenv:collect-integration-tests]


### PR DESCRIPTION
Backport of @timaa2k 's PR at #5747. There are no intended changes.
The description from that PR:

```
## High-level description

This PR improves the IAM database restore script to handle the case gracefully where CockroachDB state has been wiped out completely. I also reduces the amount of errors shown in the logs when a failure occurs. In addition, it also enables `tox` linting in the `packages/cockroach/extra` folder.

## Corresponding DC/OS tickets (required)

  - [DCOS-46121](https://jira.mesosphere.com/browse/DCOS-46121) packages/cockroachdb: improve exception handling in `iam-database-restore` script.


## Related tickets (optional)

  - [COPS-4976](https://jira.mesosphere.com/browse/COPS-4976) Cockroachdb failing with message: "failed node liveness heartbeat: context deadline exceeded" - recovery failed.
```