### PR TITLE
DCOS-54806 - Add script and documentation for setting up Terraform for running integration tests.

### DIFF
--- a/docs/terraform-integration-tests.md
+++ b/docs/terraform-integration-tests.md
@@ -1,0 +1,62 @@
+DC/OS is tested in TeamCity by several groups of integration tests using dcos-terraform and AWS spot instances.
+
+# Connecting to a test cluster
+
+Once the TeamCity job has completed, the DC/OS cluster that was created will be deleted. However, if the job is still running, you can connect to the cluster.
+
+Once `terraform apply` has completed, the job outputs to the job log the generated SSH key, cluster address, and node IP addresses as well as a bash one liner to write the SSH key to disk and SSH into the master node.
+
+# Creating a Terraform cluster
+
+To create a cluster with Terraform, see the [official Universal Installer documentation](https://docs.mesosphere.com/1.12/installing/evaluation/aws/).
+
+# Get the helper scripts
+
+The DC/OS repository has a couple of helper scripts to help setup the Terraform module to use spot instances, collect logs from a cluster, and run integration tests against a cluster.
+
+The scripts live in the master branch of the `dcos/dcos` repository. Clone it, if you haven't:
+
+```
+git clone https://github.com/dcos/dcos.git /tmp/dcos
+```
+
+# Reproducing issues locally
+
+Every TeamCity integration test job includes the `main.tf` file used to create the cluster in its build log (at runtime) and in the artifacts (after the build has completed).
+
+To recreate a cluster from a TeamCity job:
+
+1. Clone the DC/OS repository: `git clone https://github.com/dcos/dcos.git /tmp/dcos`.
+2. Create a new directory.
+3. Download the `main.tf` file to the new directory.
+4. Login to AWS: `eval $(maws login "account name")`.
+5. Start your SSH agent: `eval $(ssh-agent)`.
+6. Run `/tmp/dcos/test_util/terraform_init.sh`.
+7. Optionally, run the tests: `/tmp/dcos/test_util/terraform_test.sh $test_group_number`.
+8. Optionally, download the logs: `/tmp/dcos/test_util/terraform_logs.sh` or `/tmp/dcos/test_util/terraform_logs.sh enterprise` for an enterprise cluster.
+
+# Running tests
+
+The `./test_util/terraform_test.sh` script runs the DC/OS integration tests against the created DC/OS cluster.
+
+The tests are run in four groups, specify the group to run as the first argument:
+
+```
+/tmp/dcos/test_util/terraform_tesh.sh 1
+```
+
+# Collecting logs
+
+The `./test_util/terraform_logs.sh` script collects logs and diagnostics from the cluster into a local `logs/` directory.
+
+If the cluster is an OSS cluster:
+
+```
+/tmp/dcos/test_util/terraform_logs.sh open
+```
+
+If it is enterprise:
+
+```
+/tmp/dcos/test_util/terraform_logs.sh enterprise
+```

--- a/test_util/terraform_init.sh
+++ b/test_util/terraform_init.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+# COPS-4642: using fork of terraform-aws-instance as spot instances are unsupported in dcos-terraform.
+dcos_terraform_instance_aws="git::https://github.com/dcos/terraform-aws-spot-instance.git?ref=${DCOS_TERRAFORM_VERSION:-0.2.0}"
+
+# Forked terraform:
+
+# Terraformfile support to allow overriding module sources: https://github.com/hashicorp/terraform/pull/20229
+URL_terraform="https://downloads.mesosphere.com/dcos-terraform/terraform/v0.11.13-mesosphere/${OS}_amd64/terraform"
+
+# Forked terraform-provider-aws:
+
+# Workaround IAM role creation race with spot instances: https://github.com/terraform-providers/terraform-provider-aws/pull/8556
+# Retry InvalidTarget errors for AWS LB target group attachment: https://github.com/terraform-providers/terraform-provider-aws/pull/8538
+# Make the ready timeout configurable for ELB and spot instance requests: https://github.com/terraform-providers/terraform-provider-aws/pull/8180
+URL_terraform_provider_aws="https://downloads.mesosphere.com/dcos-terraform/terraform/v0.11.13-mesosphere/${OS}_amd64/terraform-provider-aws"
+
+if [ "$OS" == "linux" ]; then
+    CHECKSUM_terraform="19b19b9c979a75b523ce8ad044bade7a0987ce38f866cfe5479068531839f70c"
+    CHECKSUM_terraform_provider_aws="245ba160a0389c2177091e2dbc72d79d034f1b0a93a5fee01d0d4b69f22be4e1"
+elif [ "$OS" == "darwin" ]; then
+    CHECKSUM_terraform="9bf9567bb0d396f83dd8ee2cedde5f188bdbba3316528648798e1d3f6814a1f7"
+    CHECKSUM_terraform_provider_aws="bdb07595b393c2fba7e0a679e1d9355e9b30edeec138f48fd1ff9deb2065a8f9"
+else
+    # How did you even get here?
+    echo "terraform_init.sh is not supported on Windows."
+    exit 1
+fi
+
+# Check if a file matches an expected SHA256 checksum.
+#   usage: checksum <filename> <sha256 hash>
+function checksum {
+    echo "$2  $1" |sha256sum --check /proc/self/fd/0 --quiet
+}
+
+# Download a binary over HTTPS if it does not exist or has an invalid checksum. The file will be marked executable
+# after downloading.
+# The download will be retried up to ten times if it fails.
+#   usage: fetch <url> <sha256sum>
+function fetch {
+    filename=$(basename "$1")
+
+    if ! checksum "$filename" "$2"; then
+        for _ in $(seq 1 10); do
+            wget "$1" -O "$filename" && break
+            echo "$filename download failed. Retrying.."
+            sleep 2
+        done
+
+        chmod +x "$filename"
+        checksum "$filename" "$2"
+    fi
+}
+
+if [ "$USE_SPOTBLOCK" != "0" ]; then
+    cat << EOF > Terraformfile
+{
+ "dcos-terraform/instance/aws": {
+   "source": "$dcos_terraform_instance_aws"
+ }
+}
+EOF
+else
+    rm -f Terraformfile
+fi
+
+fetch "$URL_terraform" "$CHECKSUM_terraform"
+fetch "$URL_terraform_provider_aws" "$CHECKSUM_terraform_provider_aws"
+
+if [ ! -f ./id_rsa ]; then
+    ssh-keygen -t rsa -f id_rsa
+fi
+
+if [ -f main.tf ]; then
+    ./terraform init
+else
+    echo -e "Download your main.tf file either from your build's artifacts or follow the DC/OS documentation to create one: https://docs.mesosphere.com/1.13/installing/evaluation/aws/#creating-a-dcos-cluster\n"
+    echo -e "Once you have done that, run:\n\n  ./terraform init\n"
+fi
+
+if [ "$AWS_PROFILE" == "" ]; then
+    echo -e "Login to AWS with maws:\n\n  eval \$(maws login \"account\")\n"
+fi
+
+if [ "$SSH_AUTH_SOCK" == "" ]; then
+    echo -e "Load the SSH key into your SSH agent:\n\n  eval \$(ssh-agent)\n  ssh-add ./id_rsa\n"
+else
+    ssh-add ./id_rsa
+fi
+
+echo -e "Start the cluster:\n\n  ./terraform apply"

--- a/test_util/terraform_logs.sh
+++ b/test_util/terraform_logs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -x
+set +e
+
+master_ip=$(./terraform output --json masters-ips |jq -r '.value[0]')
+master_fqdn=$(./terraform output --json cluster-address |jq -r '.value')
+ssh_user=$(./terraform output --json -module dcos.dcos-infrastructure masters.os_user |jq -r '.value')
+
+ssh -i id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${ssh_user}@$master_ip -- "ls pytest_output || exit 0; cat pytest_output | tail -n 10 | grep -q xfailed"
+if [[ ( $? != 0 ) && ( -f all_tests_passed ) ]]; then
+  exit 0
+fi
+
+rm -rf logs/
+mkdir logs/
+cd logs/
+
+wget https://raw.githubusercontent.com/dcos/dcos/master/fetch_cluster_logs.bash
+
+if [ "$1" == "enterprise" ]; then
+    bash fetch_cluster_logs.bash enterprise "$ssh_user" "$master_fqdn" --username=testadmin --password=testpassword --identity-file=../id_rsa --max-artifact-size=${MAX_ARTIFACT_SIZE_MB:-1000} --debug
+else
+    extra_args=""
+    if [ "$DCOS_OPEN_LOGIN_TOKEN" != "" ]; then
+        extra_args="--login-token=$DCOS_OPEN_LOGIN_TOKEN"
+    fi
+
+    bash fetch_cluster_logs.bash open "$ssh_user" "$master_fqdn" --identity-file=../id_rsa --max-artifact-size=${MAX_ARTIFACT_SIZE_MB:-1000} --debug $extra_args
+fi

--- a/test_util/terraform_test.sh
+++ b/test_util/terraform_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <test group>"
+    echo "This script runs the DC/OS integration tests against an existing cluster, by SSHing into the master node and running the tests."
+    exit 1
+fi
+
+set +e
+set -x
+set -o pipefail
+
+MASTER_IP=$(./terraform output --json masters-ips |jq -r '.value[0]')
+ssh_user=$(./terraform output --json -module dcos.dcos-infrastructure masters.os_user |jq -r '.value')
+ssh_user=${ssh_user:-$(./terraform output --json -module dcos.dcos-infrastructure masters.admin_username |jq -r '.value')}
+
+SSH="ssh  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./id_rsa ${ssh_user}@$MASTER_IP"
+LOAD_DCOS_ENVIRONMENT='source /opt/mesosphere/environment.export && cd `find /opt/mesosphere/active/ -name dcos-integration-test* | sort | tail -n 1` && '
+
+function run_pytest {
+     $SSH -- $LOAD_DCOS_ENVIRONMENT $@
+}
+
+PUBLIC_MASTER_HOSTS=$(./terraform output --json -module dcos.dcos-infrastructure masters.private_ips |jq -r '.value[0]')
+
+TEST_GROUPS_PATH=/opt/mesosphere/active/dcos-integration-test/get_test_group.py
+if [ "$2" == "enterprise" ]; then
+    TEST_GROUPS_PATH=/opt/mesosphere/active/dcos-integration-test/open_source_tests/get_test_group.py
+fi
+
+PYTEST_LOCALE=${PYTEST_LOCALE:-en_US.utf8}
+
+TEST_NAMES=$(run_pytest LC_ALL=$PYTEST_LOCALE LANG=$PYTEST_LOCALE python "$TEST_GROUPS_PATH" group_$1)
+run_pytest PUBLIC_SLAVE_HOSTS="$(./terraform output --json -module dcos.dcos-infrastructure public_agents.private_ips |jq -r '.value |join(",")')" \
+           SLAVE_HOSTS="$(./terraform output --json -module dcos.dcos-infrastructure private_agents.private_ips |jq -r '.value |join(",")')" \
+           DCOS_PROVIDER=onprem \
+           DNS_SEARCH=false \
+           DCOS_CLI_URL="https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos" \
+           PUBLIC_MASTER_HOSTS="$PUBLIC_MASTER_HOSTS" \
+           MASTER_HOSTS="$PUBLIC_MASTER_HOSTS" \
+           DCOS_DNS_ADDRESS="http://$PUBLIC_MASTER_HOSTS" \
+           DCOS_LOGIN_UNAME=testadmin \
+           DCOS_LOGIN_PW=testpassword \
+           py.test ${EXTRA_PYTEST_ARGS} ${TEST_NAMES}
+
+# if the last return code is zero, we create a file to indicate all tests passed. The existence of this
+# file will be checked in the next build step to determine if log collection can be skipped.
+return_code=$?
+if [[ $return_code = 0 ]]; then
+  touch all_tests_passed
+fi
+exit $return_code


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This adds a script `terraform_init.sh` that sets up Terraform modules and providers in order to run the integration tests or reproduce a CI test run.

This is a part of the user documentation for running dcos-terraform jobs.

## Corresponding DC/OS tickets (required)

  - [DCOS-54806](https://jira.mesosphere.com/browse/DCOS-54806) - Write documentation for Terraform integration tests.