### PR TITLE
platform CPython: bump from 3.6.6 to 3.6.8

### DIFF
--- a/packages/python/buildinfo.json
+++ b/packages/python/buildinfo.json
@@ -7,8 +7,8 @@
   "sources": {
     "python": {
       "kind": "url_extract",
-      "url": "https://www.python.org/ftp/python/3.6.6/Python-3.6.6.tar.xz",
-      "sha1": "5731cf379838023fc8c55491b4068c4404d0e34f"
+      "url": "https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tgz",
+      "sha1": "09fcc4edaef0915b4dedbfb462f1cd15f82d3a6f"
     },
     "cython": {
       "kind": "url_extract",


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This changes system CPython from release 3.6.6 to the latest maintenance release 3.6.8.

## Corresponding DC/OS tickets (required)

https://jira.mesosphere.com/browse/DCOS_OSS-5318

