### PR TITLE
Bump platform curl from 7.59.0 to 7.65.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Telegraf now supports specyfying port names for task-label based Prometheus
   endpoints discovery (DCOS-55100)
 
+* Upgraded platform curl from 7.59.0 to 7.65.1. (DCOS_OSS-5319)
+
 ### Breaking changes
 
 Admin Router now requires a CPU with SSE4.2 support.

--- a/packages/curl/buildinfo.json
+++ b/packages/curl/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["openssl", "python-requests"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://curl.haxx.se/download/curl-7.59.0.tar.gz",
-    "sha1": "1a9bd7e201e645207b23a4b4dc38a32cc494a638"
+    "url": "https://curl.haxx.se/download/curl-7.65.1.tar.gz",
+    "sha1": "9564c29955966976e63475e02c888b9e23d1df55"
   }
 }


### PR DESCRIPTION
## High-level description

This bumps platform curl from 7.59.0 to 7.65.1.

Various components use curl/libcurl for some of the heavy lifting HTTP machinery within DC/OS, such as the Mesos fetcher.


## Corresponding DC/OS tickets (required)

https://jira.mesosphere.com/browse/DCOS_OSS-5319
