### PR TITLE
dcos_install.sh - xfs_info - use mount point instead of a device

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -397,12 +397,12 @@ function d_type_enabled_if_xfs()
     while [[ ! -d "$DIRNAME" ]]; do
         DIRNAME="$(dirname "$DIRNAME")"
     done
-    read -r filesystem_device filesystem_type <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2}')"
+    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
     # -b $filesystem_device check is there prevent this from failing in certain special dcos-docker configs
     # see https://jira.mesosphere.com/browse/DCOS_OSS-3549
     if [[ "$filesystem_type" == "xfs" && -b "$filesystem_device" ]]; then
         echo -n -e "Checking if $DIRNAME is mounted with \"ftype=1\": "
-        ftype_value="$(xfs_info $filesystem_device | grep -oE ftype=[0-9])"
+        ftype_value="$(xfs_info $filesystem_mount | grep -oE ftype=[0-9])"
         if [[ "$ftype_value" != "ftype=1" ]]; then
             RC=1
         fi

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -397,7 +397,8 @@ function d_type_enabled_if_xfs()
     while [[ ! -d "$DIRNAME" ]]; do
         DIRNAME="$(dirname "$DIRNAME")"
     done
-    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
+    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability \
+        --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
     # -b $filesystem_device check is there prevent this from failing in certain special dcos-docker configs
     # see https://jira.mesosphere.com/browse/DCOS_OSS-3549
     if [[ "$filesystem_type" == "xfs" && -b "$filesystem_device" ]]; then


### PR DESCRIPTION
## High-level description

According to the documentation `xfs_info` is supposed to be supplied with a mount point: 
`xfs_info [ -t mtab ] mount-point`

> The mount-point argument is the pathname of the **directory** where the filesystem is mounted.

At the moment, `dcos_install.sh` performs the `xfs_info` operation on a **device**:
`ftype_value="$(xfs_info $filesystem_device | grep -oE ftype=[0-9])"`

On some systems, such as Oracle Linux 7, this leads to a failure while trying to install DCOS on an agent node:

```
$ cd /tmp/dcos
$ sudo bash dcos_install.sh slave_public
Starting DC/OS Install Process
Running preflight checks
Checking if DC/OS is already installed: PASS (Not installed)
...
Checking if /var/lib/mesos is mounted with ftype=1: xfs_info: /dev/xvdz1 is not a mounted XFS filesystem
FAIL ()
...
Preflight checks failed. Exiting installation. Please consult product documentation
```

Looking closer at the context in which `xfs_info` is used:
```
$ df -h | grep mesos
/dev/xvdz1                   745G   33M  745G   1% /var/lib/mesos

$ xfs_info /dev/xvdz1
xfs_info: /dev/xvdz1 is not a mounted XFS filesystem

$ xfs_info /var/lib/mesos
meta-data=/dev/xvdz1             isize=256    agcount=4, agsize=48828288 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=0        finobt=0 spinodes=0 rmapbt=0
         =                       reflink=0
data     =                       bsize=4096   blocks=195313152, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
log      =internal               bsize=4096   blocks=95367, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
```

## Solution offered

Instead of a device, let's use a mount point as an input to the `xfs_info` program. In this way, we are in-line with the official `xfs_info` manual page and, more pragmatically, let DCOS work (again) on Oracle Linux, and most probably Red Hat / CentOS.

## Corresponding DC/OS tickets

None


