### PR TITLE
DCOS-54316 - Enable dcos-terraform tests for integration test group 3

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -49,10 +49,10 @@
                     "teamcity/dcos/build/tox",
                     "continuous-integration/jenkins/pr-head",
                     "teamcity/dcos/test/aws/cloudformation/simple",
-                    "teamcity/dcos/test/aws/onprem/static/group3",
                     "teamcity/dcos/test/test-e2e/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                    "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.13.2" : [
@@ -65,10 +65,10 @@
                     "teamcity/dcos/build/tox",
                     "continuous-integration/jenkins/pr-head",
                     "teamcity/dcos/test/aws/cloudformation/simple",
-                    "teamcity/dcos/test/aws/onprem/static/group3",
                     "teamcity/dcos/test/test-e2e/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                    "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.13" : [
@@ -81,10 +81,10 @@
                     "teamcity/dcos/build/tox",
                     "continuous-integration/jenkins/pr-head",
                     "teamcity/dcos/test/aws/cloudformation/simple",
-                    "teamcity/dcos/test/aws/onprem/static/group3",
                     "teamcity/dcos/test/test-e2e/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                    "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                     "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.12.5" : [
@@ -97,10 +97,10 @@
                   "teamcity/dcos/build/tox",
                   "continuous-integration/jenkins/pr-head",
                   "teamcity/dcos/test/aws/cloudformation/simple",
-                  "teamcity/dcos/test/aws/onprem/static/group3",
                   "teamcity/dcos/test/test-e2e/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                  "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.12" : [
@@ -113,10 +113,10 @@
                   "teamcity/dcos/build/tox",
                   "continuous-integration/jenkins/pr-head",
                   "teamcity/dcos/test/aws/cloudformation/simple",
-                  "teamcity/dcos/test/aws/onprem/static/group3",
                   "teamcity/dcos/test/test-e2e/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                  "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.11" : [
@@ -129,10 +129,10 @@
                   "teamcity/dcos/build/tox",
                   "continuous-integration/jenkins/pr-head",
                   "teamcity/dcos/test/aws/cloudformation/simple",
-                  "teamcity/dcos/test/aws/onprem/static/group3",
                   "teamcity/dcos/test/test-e2e/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                  "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ],
         "1.10" : [
@@ -145,10 +145,10 @@
                   "teamcity/dcos/build/tox",
                   "continuous-integration/jenkins/pr-head",
                   "teamcity/dcos/test/aws/cloudformation/simple",
-                  "teamcity/dcos/test/aws/onprem/static/group3",
                   "teamcity/dcos/test/test-e2e/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group1",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group2",
+                  "teamcity/dcos/test/terraform/aws/onprem/static/group3",
                   "teamcity/dcos/test/terraform/aws/onprem/static/group4"
         ]
     }


### PR DESCRIPTION
## High-level description

Make dcos-terraform integration test group 3 required, make dcos-launch test group 3 not required.

## Corresponding DC/OS tickets (required)

  - [DCOS-54316](https://jira.mesosphere.com/browse/DCOS-54316) Enable dcos-terraform tests for integration test group 3
  - [DCOS-55957](https://jira.mesosphere.com/browse/DCOS-55957) Disable dcos-launch tests