### PR TITLE
Metronome 0.6.33 Bump on 1.11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,15 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Notable changes
 
+* Updated to [Metronome 0.6.33](https://github.com/dcos/metronome/tree/b8a73dd)
 
 ### Fixed and improved
 
+* [Metronome] Querying run detail with embed=history, successfulFinishedRuns and failedFinishedRuns contains new field tasks which is an array of taskIds of that finished run. This will allow people to query task ids even for finished job runs.
+
+* [Metronome] Fixes metronome where it did not use the revive operation.
+
+* [Metronome] Updates to fix daylight saving issues.
 
 ### Security updates
 

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -2,8 +2,8 @@
   "requires": ["java", "exhibitor"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.27-b8a73dd/metronome-0.6.27-b8a73dd.tgz",
-    "sha1": "dc9f390d849bd7847a1ab6affead16c0f5b0940b"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.33-b28106a/metronome-0.6.33-b28106a.tgz",
+    "sha1": "9359a5a5e0ff0e123f4e460beb5c5f7c9e30f806"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5337](https://jira.mesosphere.com/browse/DCOS_OSS-5337) Bump Metronome 0.6.33.


## Related tickets (optional)

  - [DCOS_OSS-5166](https://jira.mesosphere.com/browse/DCOS_OSS-5166)  Fixed metronome not using revive operation


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/metronome/compare/b8a73dd...b28106a)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [CI](https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/job/master/26/)
  - [x] Code Coverage (if available): N/A
  