### PR TITLE
DCOS-56054 - Retry on Terraform init errors.

### DIFF
--- a/test_util/terraform_init.sh
+++ b/test_util/terraform_init.sh
@@ -74,7 +74,11 @@ if [ ! -f ./id_rsa ]; then
 fi
 
 if [ -f main.tf ]; then
-    ./terraform init
+    for _ in $(seq 1 10); do
+        ./terraform init && break
+        echo "Terraform init failed Retrying.."
+        sleep 2
+    done
 else
     echo -e "Download your main.tf file either from your build's artifacts or follow the DC/OS documentation to create one: https://docs.mesosphere.com/1.13/installing/evaluation/aws/#creating-a-dcos-cluster\n"
     echo -e "Once you have done that, run:\n\n  ./terraform init\n"


### PR DESCRIPTION
## High-level description

Sometimes terraform init fails due to network issues. This makes us retry on Terraform init errors.

## Corresponding DC/OS tickets (required)

  - [DCOS-56054](https://jira.mesosphere.com/browse/DCOS-56054) Retry downloading Terraform modules if it fails.