### PR TITLE
Update Telegraf prometheus plugin for container mode

### DIFF
--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "808537d69a4e5426705a5cdb87f46cdc769c8ba0",
+    "ref": "91981822dadd136817770d92022e9b7f8b2cbe28",
     "ref_origin": "prom-network-scope"
   },
   "environment": {

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "25a378fbbec6acbe081dd53a4c2631ff9f1f3413",
-    "ref_origin": "1.9.4-dcos"
+    "ref": "808537d69a4e5426705a5cdb87f46cdc769c8ba0",
+    "ref_origin": "prom-network-scope"
   },
   "environment": {
     "STATSD_UDP_HOST": "localhost",

--- a/packages/telegraf/buildinfo.json
+++ b/packages/telegraf/buildinfo.json
@@ -3,8 +3,8 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/telegraf.git",
-    "ref": "91981822dadd136817770d92022e9b7f8b2cbe28",
-    "ref_origin": "prom-network-scope"
+    "ref": "4dba7d98691a4f9970b9421159c6a4cb1f49725e",
+    "ref_origin": "1.9.4-dcos"
   },
   "environment": {
     "STATSD_UDP_HOST": "localhost",


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This PR updates the Telegraf Prometheus plugin to use the IP address specified in a task's container status field, rather than relying on the private node IP. This fixes an issue where prometheus metrics could not be collected from tasks using container networking mode.

## Corresponding DC/OS tickets (required)

  - [DCOS-56018](https://jira.mesosphere.com/browse/DCOS-56018) Telegraf Prometheus plugin sources metrics from node IP, not task IP


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/4af92b507da53dd1d06a6637544b97b04724e5f0...808537d69a4e5426705a5cdb87f46cdc769c8ba0)
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [link to CI job test results for component](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/268/)
  - [x] Code Coverage (if available): [link to code coverage report](https://jenkins.mesosphere.com/service/jenkins/job/public-dcos-cluster-ops/job/telegraf/job/telegraf-dcos-pulls/268/)
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
