### PR TITLE
[1.13] Backport tweidner/assert-zk-not-running-during-backup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Changed `iam-database-restore` to work when no database exists. (DCOS_OSS-5317)
 
-* Changed `iam-database-backup` to exit early if ZooKeeper is not running. (DCOS_OSS-5353)
+* Changed `dcos-zk backup` and `dcos-zk restore` to exit early if ZooKeeper is running. (DCOS_OSS-5353)
 
 * [Marathon] Marathon will not get stuck anymore when trying to kill an unreachable instance. (MARATHON-8422)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Changed `iam-database-restore` to work when no database exists. (DCOS_OSS-5317)
 
+* Changed `iam-database-backup` to exit early if ZooKeeper is not running. (DCOS_OSS-5353)
+
 * [Marathon] Marathon will not get stuck anymore when trying to kill an unreachable instance. (MARATHON-8422)
 
 * [Marathon] Persistent volumes with profile now default to `DiskType.Mount`. (MARATHON-8631)

--- a/packages/exhibitor/extra/dcos_zk_backup.py
+++ b/packages/exhibitor/extra/dcos_zk_backup.py
@@ -47,6 +47,10 @@ def _is_zookeeper_running(verbose: bool) -> bool:
     zk_pid = int(zk_pid_file.read_text())
     try:
         # Check whether the ZooKeeper that Exhibitor controls is running.
+        #
+        # From the man page:
+        # If  signal  is  0, then no actual signal is sent, but error checking
+        # is still performed.
         run_command('kill -0 {zk_pid}'.format(zk_pid=zk_pid), verbose)
     except subprocess.CalledProcessError:
         # Exit code 1 indicates that ZooKeeper is dead.


### PR DESCRIPTION
Backport of @timaa2k 's #5810, with `CHANGES.md` change added and a comment added as suggested by @jgehrcke on the original PR at https://github.com/dcos/dcos/pull/5810/files#r300683262.

Original PR's description:

```
## High-level description

This PR changes the ZooKeeper backup/restore script so that it checks that the ZooKeeper process is not running. Before it only asserted that `dcos-exhibitor` was not running which we suspect to not coincide with the former 100% of the cases.

The change enables getting a better understanding of the failure mode next time the flaky test in the JIRA fails. This is not a fix but a mere improvement of the debug output.

## Corresponding DC/OS tickets (required)

  - [DCOS-55827](https://jira.mesosphere.com/browse/DCOS-55827) TestZooKeeperBackup.test_transaction_log_backup_and_restore if flaky.

**edit by @adamtheturtle : We now have an issue just for this, https://jira.mesosphere.com/browse/DCOS-56097 **
```
