### PR TITLE
DCOS-56234 - Do not collect logs from successful jobs.

### DIFF
--- a/test_util/terraform_logs.sh
+++ b/test_util/terraform_logs.sh
@@ -7,8 +7,8 @@ master_ip=$(./terraform output --json masters-ips |jq -r '.value[0]')
 master_fqdn=$(./terraform output --json cluster-address |jq -r '.value')
 ssh_user=$(./terraform output --json -module dcos.dcos-infrastructure masters.os_user |jq -r '.value')
 
-ssh -i id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${ssh_user}@$master_ip -- "ls pytest_output || exit 0; cat pytest_output | tail -n 10 | grep -q xfailed"
-if [[ ( $? != 0 ) && ( -f all_tests_passed ) ]]; then
+# Exit early if all tests passed.
+if [[ -f all_tests_passed ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## High-level description

Do not collect logs from successful jobs.

We clean up these lines by just checking for the `all_tests_passed` marker file. I am not sure what the purpose of the removed lines was, but they made the logic more complicated and brittle.

## Corresponding DC/OS tickets (required)

  - [DCOS-56234](https://jira.mesosphere.com/browse/DCOS-56234) Do not collect logs from successful jobs.