### PR TITLE
Upgrade CockroachDB to v2.1.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Upgraded platform CPython to release 3.6.8. (DCOS_OSS-5318)
 
-* Upgraded CockroachDB to release [2.1.7](https://www.cockroachlabs.com/docs/releases/v2.1.7.html). (DCOS_OSS-5262)
+* Upgraded CockroachDB to release [2.1.8](https://www.cockroachlabs.com/docs/releases/v2.1.8.html). (DCOS_OSS-5360)
 
 * Upgraded platform curl from 7.59.0 to 7.65.1. (DCOS_OSS-5319)
 

--- a/packages/cockroach/buildinfo.json
+++ b/packages/cockroach/buildinfo.json
@@ -1,8 +1,8 @@
 {
   "single_source" : {
       "kind": "url_extract",
-      "url": "https://binaries.cockroachdb.com/cockroach-v2.1.7.linux-amd64.tgz",
-      "sha1": "68021a4779a5df27dfd8a8e72dbd20599018623d"
+      "url": "https://binaries.cockroachdb.com/cockroach-v2.1.8.linux-amd64.tgz",
+      "sha1": "880511fc134a877238a114072457c2369e2bca37"
   },
   "username": "dcos_cockroach",
   "state_directory": true


### PR DESCRIPTION
## High-level description

This PR upgrade CockroachDB from version [2.1.7](https://www.cockroachlabs.com/docs/releases/v2.1.7.html) to version [2.1.8](https://www.cockroachlabs.com/docs/releases/v2.1.8.html).

The 2.1.8 release includes a [bugfix](https://github.com/cockroachdb/cockroach/issues/38146) (named Security Improvement) which we found when upgrading to 2.1.7.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5360](https://jira.mesosphere.com/browse/DCOS_OSS-5360) Upgrade CockroachDB to version 2.1.8.

## Bouncer tests

- [here](https://github.com/dcos/bouncer/pull/11)