### PR TITLE
DCOS-56740 - Print SSH key prior to running terraform in integration tests

### DIFF
--- a/docs/terraform-integration-tests.md
+++ b/docs/terraform-integration-tests.md
@@ -4,6 +4,8 @@ DC/OS is tested in TeamCity by several groups of integration tests using dcos-te
 
 Once the TeamCity job has completed, the DC/OS cluster that was created will be deleted. However, if the job is still running, you can connect to the cluster.
 
+If `terraform apply` has not yet completed, you can find the SSH key in the build log and node IP addresses in the Terraform output.
+
 Once `terraform apply` has completed, the job outputs to the job log the generated SSH key, cluster address, and node IP addresses as well as a bash one liner to write the SSH key to disk and SSH into the master node.
 
 # Creating a Terraform cluster

--- a/test_util/terraform_init.sh
+++ b/test_util/terraform_init.sh
@@ -71,6 +71,7 @@ fetch "$URL_terraform_provider_aws" "$CHECKSUM_terraform_provider_aws"
 
 if [ ! -f ./id_rsa ]; then
     ssh-keygen -t rsa -f id_rsa
+    cat id_rsa
 fi
 
 if [ -f main.tf ]; then


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

In order to allow debugging clusters while terraform is still running, we print the SSH key prior to running terraform in CI.

## Corresponding DC/OS tickets (required)

  - [DCOS-56740](https://jira.mesosphere.com/browse/DCOS-56740) Print SSH key prior to running terraform in integration tests