### PR TITLE
Module scoped, autouse `clean_marathon_state`

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -64,33 +64,54 @@ def pytest_collection_modifyitems(session, config, items):
     items[:] = new_items + last_items
 
 
-# Note(JP): Attempt to reset Marathon state before and after every test run in
-# this test suite. This is a brute force approach but we found that the problem
-# of side effects as of too careless test isolation and resource cleanup became
-# too large. If this test suite ever introduces a session- or module-scoped
-# fixture providing a Marathon app then the `autouse=True` approach will need to
-# be relaxed.
-@pytest.fixture(autouse=True)
+def _purge_marathon_nofail(session):
+    """
+    Try to clean Marathon.
+    Do not error if there is a problem.
+    """
+    try:
+        session.marathon.purge()
+    except Exception as exc:
+        log.exception('Ignoring exception during marathon.purge(): %s', exc)
+        if isinstance(exc, requests.exceptions.HTTPError):
+            log.error('exc.response.text: %s', exc.response.text)
+
+
+# Note(JP): Attempt to reset Marathon state before and after every test module
+# run in this test suite. This is a brute force approach but we found that the
+# problem of side effects as of too careless test isolation and resource
+# cleanup became too large.
+#
+# Note: This is module-scoped so that we can have module- and class-scoped
+# fixtures which create Marathon resources.
+# The trade-off here is that tests, in particular failing tests, can leak
+# resources within a module.
+@pytest.fixture(autouse=True, scope='module')
 def clean_marathon_state(dcos_api_session):
     """
-    Attempt to clean up Marathon state before entering the test and when leaving
-    the test. Especially attempt to clean up when the test code failed. When the
-    cleanup fails do not fail the test but log relevant information.
+    Attempt to clean up Marathon state before entering the test module and when
+    leaving the test module. Especially attempt to clean up when the test code
+    failed. When the cleanup fails do not fail the test but log relevant
+    information.
     """
-
-    def _purge_nofail():
-        try:
-            dcos_api_session.marathon.purge()
-        except Exception as exc:
-            log.exception('Ignoring exception during marathon.purge(): %s', exc)
-            if isinstance(exc, requests.exceptions.HTTPError):
-                log.error('exc.response.text: %s', exc.response.text)
-
-    _purge_nofail()
+    _purge_marathon_nofail(session=dcos_api_session)
     try:
         yield
     finally:
-        _purge_nofail()
+        _purge_marathon_nofail(session=dcos_api_session)
+
+
+@pytest.fixture(autouse=False, scope='function')
+def clean_marathon_state_function_scoped(dcos_api_session):
+    """
+    See ``clean_marathon_state`` - this is function scoped as some test modules
+    require cleanup after every test.
+    """
+    _purge_marathon_nofail(session=dcos_api_session)
+    try:
+        yield
+    finally:
+        _purge_marathon_nofail(session=dcos_api_session)
 
 
 @pytest.fixture(scope='session')

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -27,6 +27,10 @@ log = logging.getLogger(__name__)
 GLOBAL_PORT_POOL = iter(range(10000, 32000))
 GLOBAL_OCTET_POOL = itertools.cycle(range(254, 10, -1))
 
+# Apply fixture(s) in this list to all tests in this module. From
+# pytest docs: "Note that the assigned variable must be called pytestmark"
+pytestmark = [pytest.mark.usefixtures("clean_marathon_state_function_scoped")]
+
 
 class Container(enum.Enum):
     POD = 'POD'


### PR DESCRIPTION
## High-level description

This changes `clean_marathon_state` to `module` scoped - so that it can exist in EE and OSS, and coexist with module scoped fixtures which create Marathon resources. See the JIRA issue for alternatives discussed.

## Corresponding DC/OS tickets (required)

  - [DCOS-45746](https://jira.mesosphere.com/browse/DCOS-45746) tests: autouse=True Marathon fixture breaks module-scoped Marathon app fixtures.