### PR TITLE
[Backport 1.13] Remove dcos-oauth from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The tests can be run via Pytest while SSH'd as root into a master node of the cl
 1. Add the test user
 
     ```
-    dcos-shell python /opt/mesosphere/active/dcos-oauth/bin/dcos_add_user.py albert@bekstil.net
+    dcos-shell python /opt/mesosphere/bin/dcos_add_user.py albert@bekstil.net
     ```
 
     Running the above mentioned command will result in an output

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -340,12 +340,12 @@ def test_validate_check_config():
     validate_error(
         {'check_config': json.dumps({'cluster_checks': {}})},
         'check_config',
-        "Key 'cluster_checks' error: Missing keys: Check name must be a nonzero length string with no whitespace",
+        "Key 'cluster_checks' error: Missing key: Check name must be a nonzero length string with no whitespace",
     )
     validate_error(
         {'check_config': json.dumps({'node_checks': {}})},
         'check_config',
-        "Key 'node_checks' error: Missing keys: 'checks'",
+        "Key 'node_checks' error: Missing key: 'checks'",
     )
     validate_error(
         {
@@ -357,7 +357,7 @@ def test_validate_check_config():
         },
         'check_config',
         (
-            "Key 'node_checks' error: Key 'checks' error: Missing keys: Check name must be a nonzero length string "
+            "Key 'node_checks' error: Key 'checks' error: Missing key: Check name must be a nonzero length string "
             "with no whitespace"
         ),
     )
@@ -376,7 +376,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'cluster_checks' error: Missing keys: Check name must be a nonzero length string with no whitespace",
+        "Key 'cluster_checks' error: Missing key: Check name must be a nonzero length string with no whitespace",
     )
     validate_error(
         {
@@ -395,7 +395,7 @@ def test_validate_check_config():
         },
         'check_config',
         (
-            "Key 'node_checks' error: Key 'checks' error: Missing keys: Check name must be a nonzero length string "
+            "Key 'node_checks' error: Key 'checks' error: Missing key: Check name must be a nonzero length string "
             "with no whitespace"
         ),
     )
@@ -484,7 +484,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'cluster_checks' error: Key 'cluster-check-1' error: Missing keys: 'description'",
+        "Key 'cluster_checks' error: Key 'cluster-check-1' error: Missing key: 'description'",
     )
     validate_error(
         {
@@ -501,7 +501,7 @@ def test_validate_check_config():
             })
         },
         'check_config',
-        "Key 'node_checks' error: Key 'checks' error: Key 'node-check-1' error: Missing keys: 'description'",
+        "Key 'node_checks' error: Key 'checks' error: Key 'node-check-1' error: Missing key: 'description'",
     )
 
     # Check cmd is wrong type.


### PR DESCRIPTION
## High-level description

This PR removes the dcos-oauth reference from the README.md as this component no longer exists in DC/OS 1.13+.