### PR TITLE
Bump to latest Marathon snapshot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### What's new
 
-* Marathon 1.9 brings support for multirole, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
+* Upgraded Marathon to 1.9.29. Marathon 1.9 brings support for multirole, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
 
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### What's new
 
-* Upgraded Marathon to 1.9.29. Marathon 1.9 brings support for multirole, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
+* Upgraded Marathon to 1.9.30. Marathon 1.9 brings support for multirole, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
 
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/builds/1.9.29-527f757af/marathon-1.9.29-527f757af.tgz",
-    "sha1": "115f9afec4f6a6c46d04bf567daad4fc06bb4fbd"
+    "url": "https://downloads.mesosphere.io/marathon/builds/1.9.30-77eb26534/marathon-1.9.30-77eb26534.tgz",
+    "sha1": "7c9ca65c2636df2f44552b9c52888ab04e8f6451"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.29-a41f75640/marathon-1.9.29-a41f75640.tgz",
-    "sha1": "a87eb6257e45739211dff902e1e169ddb492033f"
+    "url": "https://downloads.mesosphere.io/marathon/builds/1.9.29-527f757af/marathon-1.9.29-527f757af.tgz",
+    "sha1": "115f9afec4f6a6c46d04bf567daad4fc06bb4fbd"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -2,8 +2,8 @@
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url" : "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.20-d56fe7703/marathon-1.9.20-d56fe7703.tgz",
-    "sha1" : "a983c2d6c7148ad4858c2172a22854bdd0b9b8ed"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.29-a41f75640/marathon-1.9.29-a41f75640.tgz",
+    "sha1": "a87eb6257e45739211dff902e1e169ddb492033f"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.9 latest, with the primary feature being multi-role support. See the related tickets for new features introduced in this bump.


## Corresponding DC/OS tickets (required)

  - [DCOS-56722](https://jira.mesosphere.com/browse/DCOS-56722) Include Marathon 1.9 snapshot it DC/OS latest


## Related tickets (optional)

* [MARATHON-8642](https://jira.mesosphere.com/browse/MARATHON-8642), [MARATHON-8666](https://jira.mesosphere.com/browse/MARATHON-8666) - Task role metadata
* [MARATHON-8650](https://jira.mesosphere.com/browse/MARATHON-8650) - Default group role behavior
* [MARATHON-8651](https://jira.mesosphere.com/browse/MARATHON-8651) - Patch group enforce role
* [MARATHON-8662](https://jira.mesosphere.com/browse/MARATHON-8662) - Support reservations for multirole
* [MARATHON-8653](https://jira.mesosphere.com/browse/MARATHON-8653) - Add deprecated feature flag to opt out of acceptedResourceRoles validation

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [d56fe7703...77eb26534](https://github.com/mesosphere/marathon/compare/d56fe7703...77eb26534)
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/1336/
  