### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x 1490400

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0)
 
+* Updated to Mesos [1.5.x](https://github.com/apache/mesos/blob/14904009a193636bb715115419bfa2f235beb33f/CHANGELOG)
+
 ### Notable changes
 
 * Updated to [Metronome 0.6.33](https://github.com/dcos/metronome/tree/b8a73dd)

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "6a8b61b59498dcea64d9380a233d517ce65dc2ef",
+    "ref": "14904009a193636bb715115419bfa2f235beb33f",
     "ref_origin": "1.5.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,7 +1,7 @@
-From 2f3d5a8aa20b435b67949a3c3d9577fc730ecc77 Mon Sep 17 00:00:00 2001
+From 1812092ab23c249502c4a246394ebc8285ef1f86 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH 01/24] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++
@@ -24,5 +24,5 @@ index ef4ef265b..18c8270cc 100644
    foreach (const Volume& volume, containerInfo.volumes()) {
      // The 'container_path' can be either an absolute path or a
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0002-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,8 +1,8 @@
-From 6b93b666f26d6b7939b0029b44fbb1bc19f78ce4 Mon Sep 17 00:00:00 2001
+From 77eb3ac2361211e94d85c54a71cf8679deab94c4 Mon Sep 17 00:00:00 2001
 From: Gaston Kleiman <gaston.kleiman@gmail.com>
 Date: Mon, 9 Oct 2017 15:19:08 -0700
-Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
- adminrouter.
+Subject: [PATCH 02/24] Mesos UI: updated the URL generation to make it work
+ with adminrouter.
 
 - Use /mesos/agent/{agent_id}/{process_name} as the agent URL prefix.
 - Redirect from Mesos webui location (host:5050) to adminrouter
@@ -47,5 +47,5 @@ index 59665869d..6e0a40f93 100644
              'Mesos Master (' + $scope.$location.host() + ':' + $scope.$location.port() + ')');
        }
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
+++ b/packages/mesos/extra/patches/0003-Revert-Fixed-the-broken-metrics-information-of-maste.patch
@@ -1,15 +1,15 @@
-From 3816fd7547f8be4fc7cc3ad03f7d6db34d5885cd Mon Sep 17 00:00:00 2001
+From 5b346926e9aa49e2d87a07ccbc32ab7e3893119b Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Thu, 10 Nov 2016 11:29:19 -0800
-Subject: [PATCH] Revert "Fixed the broken metrics information of master in
- WebUI."
+Subject: [PATCH 03/24] Revert "Fixed the broken metrics information of master
+ in WebUI."
 
 This reverts commit b2fc58883e2cd0ca144fd1b0e10cad4235a50223.
 
 In DC/OS, redirection to the leading master is handled by the
 Adminrouter component.
 ---
- src/webui/master/static/js/controllers.js | 24 +++++++-----------------
+ src/webui/master/static/js/controllers.js | 24 +++++++----------------
  1 file changed, 7 insertions(+), 17 deletions(-)
 
 diff --git a/src/webui/master/static/js/controllers.js b/src/webui/master/static/js/controllers.js
@@ -69,5 +69,5 @@ index 6e0a40f93..8d9b5f49d 100644
              $timeout(pollMetrics, $scope.delay);
            }
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0004-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From 6676da9be0ad56064a089a5c91f47a3560f1f38b Mon Sep 17 00:00:00 2001
+From 0d51c40f835b1be0c97e3a63e986f6ff84ef6354 Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
- failure.
+Subject: [PATCH 04/24] Updated mesos containerizer to ignore GPU isolator
+ creation failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -19,10 +19,10 @@ This is a decent compromise.
  1 file changed, 5 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 47f86211b..53899397c 100644
+index fa1473edd..79c5090cd 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
-@@ -424,8 +424,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -430,8 +430,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
      {"gpu/nvidia",
        [&nvidia] (const Flags& flags) -> Try<Isolator*> {
          if (!nvml::isAvailable()) {
@@ -35,7 +35,7 @@ index 47f86211b..53899397c 100644
          }
  
          CHECK_SOME(nvidia)
-@@ -489,7 +491,7 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -495,7 +497,7 @@ Try<MesosContainerizer*> MesosContainerizer::create(
      // prepared filesystem (e.g., any volume mounts are performed).
      if (strings::contains(isolation, "filesystem/")) {
        isolators.insert(isolators.begin(), Owned<Isolator>(isolator.get()));
@@ -45,5 +45,5 @@ index 47f86211b..53899397c 100644
      }
    }
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
+++ b/packages/mesos/extra/patches/0005-Displayed-resource-provider-resources-in-GET_RESOURC.patch
@@ -1,7 +1,7 @@
-From da2881641fa4ddb143416cfca38d7366599ef1bd Mon Sep 17 00:00:00 2001
+From ca6e87bea52678bc5249b7ddf405cc1f4d955787 Mon Sep 17 00:00:00 2001
 From: Benjamin Bannier <benjamin.bannier@mesosphere.io>
 Date: Tue, 20 Mar 2018 10:08:09 +0100
-Subject: [PATCH] Displayed resource provider resources in
+Subject: [PATCH 05/24] Displayed resource provider resources in
  GET_RESOURCE_PROVIDER response.
 
 Review: https://reviews.apache.org/r/65832/
@@ -87,5 +87,5 @@ index 01440330f..5985070f8 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
+++ b/packages/mesos/extra/patches/0006-Improved-logging-for-offers-and-inverse-offers.patch
@@ -1,7 +1,7 @@
-From 16950c2a545494a06be1212c65fd286788a94618 Mon Sep 17 00:00:00 2001
+From 048401921cef9c2c94793b2e4b800e23440e9516 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Gast=C3=B3n=20Kleiman?= <gaston@mesosphere.io>
 Date: Tue, 10 Jul 2018 08:06:32 -0700
-Subject: [PATCH] Improved logging for offers and inverse offers.
+Subject: [PATCH 06/24] Improved logging for offers and inverse offers.
 
 Log offer IDs and inverse offer IDs when sending out offers and
 inverse offers so it is easier to match them to their ACCEPT or DECLINE
@@ -19,10 +19,10 @@ Review: https://reviews.apache.org/r/67817/
  1 file changed, 18 insertions(+), 4 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 36b167fee..1e9775122 100644
+index 42f88b699..e49883e96 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -8713,6 +8713,9 @@ void Master::offer(
+@@ -8753,6 +8753,9 @@ void Master::offer(
    // and a single allocation role.
    ResourceOffersMessage message;
  
@@ -32,7 +32,7 @@ index 36b167fee..1e9775122 100644
    foreachkey (const string& role, resources) {
      foreachpair (const SlaveID& slaveId,
                   const Resources& offered,
-@@ -8857,6 +8860,13 @@ void Master::offer(
+@@ -8897,6 +8900,13 @@ void Master::offer(
        // Add the offer *AND* the corresponding slave's PID.
        message.add_offers()->MergeFrom(offer_);
        message.add_pids(slave->pid);
@@ -46,7 +46,7 @@ index 36b167fee..1e9775122 100644
      }
    }
  
-@@ -8864,8 +8874,7 @@ void Master::offer(
+@@ -8904,8 +8914,7 @@ void Master::offer(
      return;
    }
  
@@ -56,7 +56,7 @@ index 36b167fee..1e9775122 100644
  
    framework->send(message);
  }
-@@ -8953,8 +8962,13 @@ void Master::inverseOffer(
+@@ -8993,8 +9002,13 @@ void Master::inverseOffer(
      return;
    }
  
@@ -73,5 +73,5 @@ index 36b167fee..1e9775122 100644
    framework->send(message);
  }
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
+++ b/packages/mesos/extra/patches/0007-Introduced-a-push-based-gauge-metric.patch
@@ -1,7 +1,7 @@
-From 9a0a7cbaf34995ba72f631836b72fdb0d9a29b9f Mon Sep 17 00:00:00 2001
+From c5cf17c94de6fe0365adee2f970aa922f6a5d917 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:53 -0700
-Subject: [PATCH] Introduced a push-based gauge metric.
+Subject: [PATCH 07/24] Introduced a push-based gauge metric.
 
 A push-based gauge differs from a pull-based gauge in that the
 client is responsible for pushing the latest value into the gauge
@@ -20,8 +20,8 @@ the `Process` pushes new values in.
 
 Review: https://reviews.apache.org/r/66828/
 ---
- 3rdparty/libprocess/include/Makefile.am            |   1 +
- .../include/process/metrics/push_gauge.hpp         | 100 +++++++++++++++++++++
+ 3rdparty/libprocess/include/Makefile.am       |   1 +
+ .../include/process/metrics/push_gauge.hpp    | 100 ++++++++++++++++++
  2 files changed, 101 insertions(+)
  create mode 100644 3rdparty/libprocess/include/process/metrics/push_gauge.hpp
 
@@ -144,5 +144,5 @@ index 000000000..5c3984617
 +
 +#endif // __PROCESS_METRICS_PUSH_GAUGE_HPP__
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
+++ b/packages/mesos/extra/patches/0008-Added-a-test-for-PushGauge.patch
@@ -1,11 +1,11 @@
-From 22577ebbce1b65245caafdcf34018fb1eae48527 Mon Sep 17 00:00:00 2001
+From 4943cb2348715086e5ffa322b41012f2a191f628 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:06:58 -0700
-Subject: [PATCH] Added a test for PushGauge.
+Subject: [PATCH 08/24] Added a test for PushGauge.
 
 Review: https://reviews.apache.org/r/66830/
 ---
- 3rdparty/libprocess/src/tests/metrics_tests.cpp | 32 +++++++++++++++++++++++++
+ .../libprocess/src/tests/metrics_tests.cpp    | 32 +++++++++++++++++++
  1 file changed, 32 insertions(+)
 
 diff --git a/3rdparty/libprocess/src/tests/metrics_tests.cpp b/3rdparty/libprocess/src/tests/metrics_tests.cpp
@@ -66,5 +66,5 @@ index bb7c9e37e..d394a42bf 100644
  {
    Counter counter("test/counter", process::TIME_SERIES_WINDOW);
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
+++ b/packages/mesos/extra/patches/0009-Renamed-Gauge-to-PullGauge-and-documented-difference.patch
@@ -1,21 +1,21 @@
-From 95b4a13df1d37dc8903bc138d3f05f277ebe8239 Mon Sep 17 00:00:00 2001
+From 53268d77bf71e669b6fedcfb019d85adb078e726 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:01 -0700
-Subject: [PATCH] Renamed Gauge to PullGauge and documented differences to
- PushGauge.
+Subject: [PATCH 09/24] Renamed Gauge to PullGauge and documented differences
+ to PushGauge.
 
 Given `PushGauge`, it makes sense to explicitly distinguish the two
 gauge types and document the the caveats of `PullGauge`.
 
 Review: https://reviews.apache.org/r/66831/
 ---
- 3rdparty/libprocess/include/Makefile.am            |  2 +-
- .../libprocess/include/process/metrics/gauge.hpp   | 58 ----------------
- .../libprocess/include/process/metrics/metric.hpp  |  2 +-
- .../include/process/metrics/pull_gauge.hpp         | 77 ++++++++++++++++++++++
- 3rdparty/libprocess/include/process/system.hpp     | 14 ++--
- 3rdparty/libprocess/src/tests/metrics_tests.cpp    | 51 +++++++-------
- 3rdparty/libprocess/src/tests/system_tests.cpp     |  2 +-
+ 3rdparty/libprocess/include/Makefile.am       |  2 +-
+ .../include/process/metrics/gauge.hpp         | 58 --------------
+ .../include/process/metrics/metric.hpp        |  2 +-
+ .../include/process/metrics/pull_gauge.hpp    | 77 +++++++++++++++++++
+ .../libprocess/include/process/system.hpp     | 14 ++--
+ .../libprocess/src/tests/metrics_tests.cpp    | 51 ++++++------
+ .../libprocess/src/tests/system_tests.cpp     |  2 +-
  7 files changed, 116 insertions(+), 90 deletions(-)
  delete mode 100644 3rdparty/libprocess/include/process/metrics/gauge.hpp
  create mode 100644 3rdparty/libprocess/include/process/metrics/pull_gauge.hpp
@@ -353,5 +353,5 @@ index 6beb973e0..4a193d778 100644
  // endpoint. This has been observed specifically for the memory
  // metrics. If in the future we put the error message from the Failure
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
+++ b/packages/mesos/extra/patches/0010-Updated-mesos-source-for-Gauge-PullGauge-renaming.patch
@@ -1,31 +1,31 @@
-From 4f8f62199b35f97617a3095618b6fc8c0141f07b Mon Sep 17 00:00:00 2001
+From 93ea2ab8bb1e70d25fa0f0968d7993e863728942 Mon Sep 17 00:00:00 2001
 From: Benjamin Mahler <bmahler@apache.org>
 Date: Fri, 27 Apr 2018 16:07:05 -0700
-Subject: [PATCH] Updated mesos source for Gauge -> PullGauge renaming.
+Subject: [PATCH 10/24] Updated mesos source for Gauge -> PullGauge renaming.
 
 Review: https://reviews.apache.org/r/66832/
 ---
- src/examples/balloon_framework.cpp                 |  8 ++--
- src/examples/disk_full_framework.cpp               |  8 ++--
- src/examples/long_lived_framework.cpp              |  8 ++--
- src/log/log.hpp                                    |  2 +-
- src/log/metrics.hpp                                |  6 +--
- src/master/allocator/mesos/metrics.cpp             | 32 ++++++-------
- src/master/allocator/mesos/metrics.hpp             | 26 +++++------
- src/master/allocator/sorter/drf/metrics.cpp        |  6 +--
- src/master/allocator/sorter/drf/metrics.hpp        |  4 +-
- src/master/master.hpp                              |  2 +-
- src/master/metrics.cpp                             | 28 +++++------
- src/master/metrics.hpp                             | 54 +++++++++++-----------
- src/master/registrar.cpp                           | 10 ++--
- src/sched/sched.cpp                                |  6 +--
- src/scheduler/scheduler.cpp                        |  6 +--
- src/slave/containerizer/fetcher_process.hpp        |  6 +--
- .../mesos/isolators/filesystem/linux.hpp           |  4 +-
- src/slave/gc_process.hpp                           |  4 +-
- src/slave/metrics.cpp                              | 28 +++++------
- src/slave/metrics.hpp                              | 36 +++++++--------
- src/slave/slave.hpp                                |  2 +-
+ src/examples/balloon_framework.cpp            |  8 +--
+ src/examples/disk_full_framework.cpp          |  8 +--
+ src/examples/long_lived_framework.cpp         |  8 +--
+ src/log/log.hpp                               |  2 +-
+ src/log/metrics.hpp                           |  6 +--
+ src/master/allocator/mesos/metrics.cpp        | 32 +++++------
+ src/master/allocator/mesos/metrics.hpp        | 26 ++++-----
+ src/master/allocator/sorter/drf/metrics.cpp   |  6 +--
+ src/master/allocator/sorter/drf/metrics.hpp   |  4 +-
+ src/master/master.hpp                         |  2 +-
+ src/master/metrics.cpp                        | 28 +++++-----
+ src/master/metrics.hpp                        | 54 +++++++++----------
+ src/master/registrar.cpp                      | 10 ++--
+ src/sched/sched.cpp                           |  6 +--
+ src/scheduler/scheduler.cpp                   |  6 +--
+ src/slave/containerizer/fetcher_process.hpp   |  6 +--
+ .../mesos/isolators/filesystem/linux.hpp      |  4 +-
+ src/slave/gc_process.hpp                      |  4 +-
+ src/slave/metrics.cpp                         | 28 +++++-----
+ src/slave/metrics.hpp                         | 36 ++++++-------
+ src/slave/slave.hpp                           |  2 +-
  21 files changed, 143 insertions(+), 143 deletions(-)
 
 diff --git a/src/examples/balloon_framework.cpp b/src/examples/balloon_framework.cpp
@@ -673,7 +673,7 @@ index e5e82d5d7..bde1cf7bb 100644
  
    double _event_queue_messages()
 diff --git a/src/scheduler/scheduler.cpp b/src/scheduler/scheduler.cpp
-index 07d2b37e0..c04cfbc42 100644
+index 1342d9054..9fde5e4cd 100644
 --- a/src/scheduler/scheduler.cpp
 +++ b/src/scheduler/scheduler.cpp
 @@ -56,7 +56,7 @@
@@ -685,7 +685,7 @@ index 07d2b37e0..c04cfbc42 100644
  #include <process/metrics/metrics.hpp>
  
  #include <process/ssl/flags.hpp>
-@@ -814,8 +814,8 @@ private:
+@@ -816,8 +816,8 @@ private:
      }
  
      // Process metrics.
@@ -954,5 +954,5 @@ index d638b8806..8d42011be 100644
    {
      return static_cast<double>(frameworks.size());
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
+++ b/packages/mesos/extra/patches/0011-Enabled-per-framework-metrics-in-the-master.patch
@@ -1,7 +1,7 @@
-From d12b7703893796c8d19d1ae6e89cc9e8c90bd466 Mon Sep 17 00:00:00 2001
+From 7d5ca245409cbb1a47f6228217e1922f20812fa6 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:57:56 -0700
-Subject: [PATCH] Enabled per-framework metrics in the master.
+Subject: [PATCH 11/24] Enabled per-framework metrics in the master.
 
 The `FrameworkMetrics` struct will be used to track per-framework
 metrics in the master.
@@ -99,5 +99,5 @@ index 1ef74dedf..9f10aecba 100644
  } // namespace internal {
  } // namespace mesos {
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
+++ b/packages/mesos/extra/patches/0012-Added-per-framework-subscribed-metric-and-helpers.patch
@@ -1,7 +1,7 @@
-From 4cdfdb1b6a432298daaf1a34300c9e1f2d014ffe Mon Sep 17 00:00:00 2001
+From 6e5d3e7ee4ed7fc0626109efa78834a3bd489d71 Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Wed, 1 Aug 2018 07:58:06 -0700
-Subject: [PATCH] Added per-framework 'subscribed' metric and helpers.
+Subject: [PATCH 12/24] Added per-framework 'subscribed' metric and helpers.
 
 Review: https://reviews.apache.org/r/66820/
 ---
@@ -12,7 +12,7 @@ Review: https://reviews.apache.org/r/66820/
  4 files changed, 30 insertions(+), 8 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 1e9775122..075c6ad2d 100644
+index e49883e96..5c615cabf 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -455,6 +455,13 @@ void Framework::untrackUnderRole(const string& role)
@@ -29,7 +29,7 @@ index 1e9775122..075c6ad2d 100644
  void Master::initialize()
  {
    LOG(INFO) << "Master " << info_.id() << " (" << info_.hostname() << ")"
-@@ -3229,7 +3236,7 @@ void Master::_subscribe(
+@@ -3244,7 +3251,7 @@ void Master::_subscribe(
        // NOTE: We do this after recovering resources (above) so that
        // the allocator has the correct view of the framework's share.
        if (!framework->active()) {
@@ -38,7 +38,7 @@ index 1e9775122..075c6ad2d 100644
          allocator->activateFramework(framework->id());
        }
  
-@@ -3343,7 +3350,7 @@ void Master::disconnect(Framework* framework)
+@@ -3358,7 +3365,7 @@ void Master::disconnect(Framework* framework)
  
    LOG(INFO) << "Disconnecting framework " << *framework;
  
@@ -47,7 +47,7 @@ index 1e9775122..075c6ad2d 100644
  
    if (framework->pid.isSome()) {
      // Remove the framework from authenticated. This is safe because
-@@ -3366,7 +3373,7 @@ void Master::deactivate(Framework* framework, bool rescind)
+@@ -3381,7 +3388,7 @@ void Master::deactivate(Framework* framework, bool rescind)
  
    LOG(INFO) << "Deactivating framework " << *framework;
  
@@ -56,7 +56,7 @@ index 1e9775122..075c6ad2d 100644
  
    // Tell the allocator to stop allocating resources to this framework.
    allocator->deactivateFramework(framework->id());
-@@ -9396,7 +9403,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -9436,7 +9443,7 @@ Try<Nothing> Master::activateRecoveredFramework(
    }
  
    // Activate the framework.
@@ -65,7 +65,7 @@ index 1e9775122..075c6ad2d 100644
    allocator->activateFramework(framework->id());
  
    // Export framework metrics if a principal is specified in `FrameworkInfo`.
-@@ -9546,7 +9553,7 @@ void Master::_failoverFramework(Framework* framework)
+@@ -9586,7 +9593,7 @@ void Master::_failoverFramework(Framework* framework)
    // NOTE: We do this after recovering resources (above) so that
    // the allocator has the correct view of the framework's share.
    if (!framework->active()) {
@@ -159,5 +159,5 @@ index 9f10aecba..d3f093f9d 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
+++ b/packages/mesos/extra/patches/0013-Added-per-framework-metrics-for-scheduler-calls.patch
@@ -1,13 +1,13 @@
-From 796760ed0fc41693a790e326377834d9af2c82a5 Mon Sep 17 00:00:00 2001
+From fc45102e925ed56c24ea60d4e87fe827416a7ea5 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:14 -0700
-Subject: [PATCH] Added per-framework metrics for scheduler calls.
+Subject: [PATCH 13/24] Added per-framework metrics for scheduler calls.
 
 Review: https://reviews.apache.org/r/67776/
 ---
  src/master/http.cpp    |  2 ++
  src/master/master.cpp  |  6 ++++++
- src/master/metrics.cpp | 43 ++++++++++++++++++++++++++++++++++++++++++-
+ src/master/metrics.cpp | 43 +++++++++++++++++++++++++++++++++++++++++-
  src/master/metrics.hpp |  7 +++++++
  4 files changed, 57 insertions(+), 1 deletion(-)
 
@@ -25,10 +25,10 @@ index 1f9aac44f..f4cd2dc68 100644
    // into the authorizer. See MESOS-7399.
    if (principal.isSome() && principal != framework->info.principal()) {
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 075c6ad2d..ed827c1b2 100644
+index 5c615cabf..f19a0eeec 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -2482,6 +2482,8 @@ void Master::receive(
+@@ -2497,6 +2497,8 @@ void Master::receive(
      return;
    }
  
@@ -37,7 +37,7 @@ index 075c6ad2d..ed827c1b2 100644
    // This is possible when master --> framework link is broken (i.e., one
    // way network partition) and the framework is not aware of it. There
    // is no way for driver based frameworks to detect this in the absence
-@@ -2803,6 +2805,8 @@ void Master::_subscribe(
+@@ -2818,6 +2820,8 @@ void Master::_subscribe(
  
      addFramework(framework, suppressedRoles);
  
@@ -46,7 +46,7 @@ index 075c6ad2d..ed827c1b2 100644
      FrameworkRegisteredMessage message;
      message.mutable_framework_id()->MergeFrom(framework->id());
      message.mutable_master_info()->MergeFrom(info_);
-@@ -2836,6 +2840,8 @@ void Master::_subscribe(
+@@ -2851,6 +2855,8 @@ void Master::_subscribe(
  
    CHECK_NOTNULL(framework);
  
@@ -153,5 +153,5 @@ index d3f093f9d..7a7b3a316 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
+++ b/packages/mesos/extra/patches/0014-Added-per-framework-metrics-for-scheduler-events.patch
@@ -1,7 +1,7 @@
-From 257f968c5d3860baa1297b4eee76afbc37192a19 Mon Sep 17 00:00:00 2001
+From 5e145dee2b6acf9a9f5ca3427073282cb8ea7c58 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:22 -0700
-Subject: [PATCH] Added per-framework metrics for scheduler events.
+Subject: [PATCH 14/24] Added per-framework metrics for scheduler events.
 
 Review: https://reviews.apache.org/r/67809/
 ---
@@ -172,5 +172,5 @@ index 7a7b3a316..fac4440da 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
+++ b/packages/mesos/extra/patches/0015-Added-per-framework-offer-metrics.patch
@@ -1,7 +1,7 @@
-From af2c2800eba96a4a7fbfbb8fedf78301286ffd71 Mon Sep 17 00:00:00 2001
+From 1a407d39df5a186d25709b8522e030b4e5d40cf7 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:25 -0700
-Subject: [PATCH] Added per-framework offer metrics.
+Subject: [PATCH 15/24] Added per-framework offer metrics.
 
 Review: https://reviews.apache.org/r/67812/
 ---
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67812/
  3 files changed, 38 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index ed827c1b2..bb39b48e8 100644
+index f19a0eeec..1569e978d 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -3984,6 +3984,8 @@ void Master::accept(
+@@ -3999,6 +3999,8 @@ void Master::accept(
      // Validate the offers.
      error = validation::offer::validate(accept.offer_ids(), this, framework);
  
@@ -23,7 +23,7 @@ index ed827c1b2..bb39b48e8 100644
      // Compute offered resources and remove the offers. If the
      // validation failed, return resources to the allocator.
      foreach (const OfferID& offerId, accept.offer_ids()) {
-@@ -4001,6 +4003,8 @@ void Master::accept(
+@@ -4016,6 +4018,8 @@ void Master::accept(
            slaveId = offer->slave_id();
            allocationInfo = offer->allocation_info();
            offeredResources += offer->resources();
@@ -32,7 +32,7 @@ index ed827c1b2..bb39b48e8 100644
          }
  
          removeOffer(offer);
-@@ -4012,6 +4016,8 @@ void Master::accept(
+@@ -4027,6 +4031,8 @@ void Master::accept(
        LOG(WARNING) << "Ignoring accept of offer " << offerId
                     << " since it is no longer valid";
      }
@@ -41,7 +41,7 @@ index ed827c1b2..bb39b48e8 100644
    }
  
    // If invalid, send TASK_DROPPED for the launch attempts. If the
-@@ -5534,6 +5540,8 @@ void Master::decline(
+@@ -5574,6 +5580,8 @@ void Master::decline(
  
    ++metrics->messages_decline_offers;
  
@@ -50,7 +50,7 @@ index ed827c1b2..bb39b48e8 100644
    //  Return resources to the allocator.
    foreach (const OfferID& offerId, decline.offer_ids()) {
      Offer* offer = getOffer(offerId);
-@@ -5545,6 +5553,8 @@ void Master::decline(
+@@ -5585,6 +5593,8 @@ void Master::decline(
            decline.filters());
  
        removeOffer(offer);
@@ -59,7 +59,7 @@ index ed827c1b2..bb39b48e8 100644
        continue;
      }
  
-@@ -5553,6 +5563,8 @@ void Master::decline(
+@@ -5593,6 +5603,8 @@ void Master::decline(
      LOG(WARNING) << "Ignoring decline of offer " << offerId
                   << " since it is no longer valid";
    }
@@ -68,7 +68,7 @@ index ed827c1b2..bb39b48e8 100644
  }
  
  
-@@ -8889,6 +8901,7 @@ void Master::offer(
+@@ -8929,6 +8941,7 @@ void Master::offer(
  
    LOG(INFO) << "Sending offers " << offerIds << " to framework " << *framework;
  
@@ -76,7 +76,7 @@ index ed827c1b2..bb39b48e8 100644
    framework->send(message);
  }
  
-@@ -10817,6 +10830,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
+@@ -10857,6 +10870,7 @@ void Master::removeOffer(Offer* offer, bool rescind)
    if (rescind) {
      RescindResourceOfferMessage message;
      message.mutable_offer_id()->MergeFrom(offer->id());
@@ -142,5 +142,5 @@ index fac4440da..b6fe20fb5 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
+++ b/packages/mesos/extra/patches/0016-Added-per-framework-metrics-for-task-states.patch
@@ -1,21 +1,21 @@
-From 4d88c19345bc6f50f66c5c7114e592cc22460a94 Mon Sep 17 00:00:00 2001
+From 61567e86c97a2886372a0e12bcf3573d36289528 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:31 -0700
-Subject: [PATCH] Added per-framework metrics for task states.
+Subject: [PATCH 16/24] Added per-framework metrics for task states.
 
 Review: https://reviews.apache.org/r/67813/
 ---
- src/master/master.cpp  | 18 +++++++++++++++--
+ src/master/master.cpp  | 18 ++++++++++++--
  src/master/master.hpp  |  2 ++
- src/master/metrics.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++
- src/master/metrics.hpp |  7 +++++++
+ src/master/metrics.cpp | 54 ++++++++++++++++++++++++++++++++++++++++++
+ src/master/metrics.hpp |  7 ++++++
  4 files changed, 79 insertions(+), 2 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index bb39b48e8..c9d8d4a84 100644
+index 1569e978d..263839e7e 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -10257,6 +10257,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10297,6 +10297,8 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
    // task transitioned to a new state.
    bool sendSubscribersUpdate = false;
  
@@ -24,7 +24,7 @@ index bb39b48e8..c9d8d4a84 100644
    // Set 'removable' to true if this is the first time the task
    // transitioned to a removable state. Also set the latest state.
    bool removable;
-@@ -10270,6 +10272,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10310,6 +10312,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -38,7 +38,7 @@ index bb39b48e8..c9d8d4a84 100644
        task->set_state(latestState.get());
      }
    } else {
-@@ -10283,6 +10292,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10323,6 +10332,13 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
          sendSubscribersUpdate = true;
        }
  
@@ -52,7 +52,7 @@ index bb39b48e8..c9d8d4a84 100644
        task->set_state(status.state());
      }
    }
-@@ -10314,7 +10330,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10354,7 +10370,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
      // transitioned to `TASK_KILLED` by `removeFramework()`, thus
      // `sendSubscribersUpdate` shouldn't have been set to true.
      // TODO(chhsiao): This may be changed after MESOS-6608 is resolved.
@@ -60,7 +60,7 @@ index bb39b48e8..c9d8d4a84 100644
      CHECK_NOTNULL(framework);
  
      subscribers.send(
-@@ -10343,7 +10358,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
+@@ -10383,7 +10398,6 @@ void Master::updateTask(Task* task, const StatusUpdate& update)
  
      slave->recoverResources(task);
  
@@ -200,5 +200,5 @@ index b6fe20fb5..071246b71 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
+++ b/packages/mesos/extra/patches/0017-Added-per-framework-metrics-for-offer-operations.patch
@@ -1,7 +1,7 @@
-From 52c1c07b36c1721538fd97567fa9cfc12f5fa4de Mon Sep 17 00:00:00 2001
+From a19dbbe8c08ca0f8237bd1da4a9eb13408064f33 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:39 -0700
-Subject: [PATCH] Added per-framework metrics for offer operations.
+Subject: [PATCH 17/24] Added per-framework metrics for offer operations.
 
 Review: https://reviews.apache.org/r/67814/
 ---
@@ -11,10 +11,10 @@ Review: https://reviews.apache.org/r/67814/
  3 files changed, 59 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index c9d8d4a84..7f11211df 100644
+index 263839e7e..e26057449 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -5072,6 +5072,10 @@ void Master::_accept(
+@@ -5087,6 +5087,10 @@ void Master::_accept(
                        << (launchExecutor ?
                            " new executor" : " existing executor");
  
@@ -25,7 +25,7 @@ index c9d8d4a84..7f11211df 100644
              send(slave->pid, message);
            }
          }
-@@ -5278,6 +5282,10 @@ void Master::_accept(
+@@ -5293,6 +5297,10 @@ void Master::_accept(
                    << *slave << " on "
                    << (launchExecutor ? " new executor" : " existing executor");
  
@@ -36,7 +36,7 @@ index c9d8d4a84..7f11211df 100644
          send(slave->pid, message);
  
          break;
-@@ -10806,6 +10814,12 @@ void Master::_apply(
+@@ -10846,6 +10854,12 @@ void Master::_apply(
  
      send(slave->pid, message);
    }
@@ -146,5 +146,5 @@ index 071246b71..7ce3941b2 100644
  
  
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0018-Enabled-per-framework-metrics-in-the-allocator.patch
@@ -1,7 +1,7 @@
-From d1e5c97a1f2a4674e63e2d20332097fe1ad9aeab Mon Sep 17 00:00:00 2001
+From 45e3c7d70a04d9e14109963e67f68ba8c4aea213 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:45 -0700
-Subject: [PATCH] Enabled per-framework metrics in the allocator.
+Subject: [PATCH 18/24] Enabled per-framework metrics in the allocator.
 
 The `FrameworkMetrics` struct will hold per-framework metrics tracked
 by the allocator.
@@ -15,10 +15,10 @@ Review: https://reviews.apache.org/r/66843/
  4 files changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index 87e7d536e..96671033b 100644
+index dbfa08a01..bb36d406a 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -141,7 +141,8 @@ HierarchicalAllocatorProcess::Framework::Framework(
+@@ -175,7 +175,8 @@ HierarchicalAllocatorProcess::Framework::Framework(
    : roles(protobuf::framework::getRoles(frameworkInfo)),
      suppressedRoles(_suppressedRoles),
      capabilities(frameworkInfo.capabilities()),
@@ -29,11 +29,11 @@ index 87e7d536e..96671033b 100644
  
  void HierarchicalAllocatorProcess::initialize(
 diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
-index 4da109709..ec4d445f5 100644
+index 56d1d7d35..b4594199c 100644
 --- a/src/master/allocator/mesos/hierarchical.hpp
 +++ b/src/master/allocator/mesos/hierarchical.hpp
-@@ -332,6 +332,8 @@ protected:
-     hashmap<SlaveID, hashset<InverseOfferFilter*>> inverseOfferFilters;
+@@ -336,6 +336,8 @@ protected:
+       inverseOfferFilters;
  
      bool active;
 +
@@ -81,5 +81,5 @@ index 6d386225c..daac93f7e 100644
  } // namespace allocator {
  } // namespace master {
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
+++ b/packages/mesos/extra/patches/0019-Changed-the-capacity_-member-of-BoundedHashMap-to-no.patch
@@ -1,7 +1,7 @@
-From a5049d41009c8ca16de1fa2cf77968dfb56f7cc8 Mon Sep 17 00:00:00 2001
+From c99d42b4781ef7a125f3a8d1fe0d4d45a22a2b6d Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:48 -0700
-Subject: [PATCH] Changed the 'capacity_' member of 'BoundedHashMap' to
+Subject: [PATCH 19/24] Changed the 'capacity_' member of 'BoundedHashMap' to
  non-const.
 
 This prevents the assignment operator from being implicitly deleted.
@@ -25,5 +25,5 @@ index 09a9b96f0..f73ec6b66 100644
    map keys_; // Map from key to "pointer" to key's location in list.
  };
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
+++ b/packages/mesos/extra/patches/0020-Tracked-completed-framework-metrics-in-the-allocator.patch
@@ -1,7 +1,7 @@
-From 194f7fa2730abbfbdcadbe2bc55afc72fb93b0c8 Mon Sep 17 00:00:00 2001
+From d2d9bfdb5a625d5ff3cde4bc5128c15ff68c87e8 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:58:49 -0700
-Subject: [PATCH] Tracked completed framework metrics in the allocator.
+Subject: [PATCH 20/24] Tracked completed framework metrics in the allocator.
 
 This ensures that per-framework metrics which are tracked in the
 allocator will be retained as long as the per-framework metrics
@@ -9,16 +9,16 @@ which are tracked in the master.
 
 Review: https://reviews.apache.org/r/66856/
 ---
- include/mesos/allocator/allocator.hpp       |  4 +++-
- src/master/allocator/mesos/allocator.hpp    | 12 ++++++----
- src/master/allocator/mesos/hierarchical.cpp | 15 ++++++++++--
- src/master/allocator/mesos/hierarchical.hpp |  8 ++++++-
- src/master/master.cpp                       |  3 ++-
- src/tests/allocator.hpp                     | 11 +++++----
- src/tests/api_tests.cpp                     |  4 ++--
- src/tests/master_allocator_tests.cpp        | 36 ++++++++++++++---------------
- src/tests/master_quota_tests.cpp            | 20 ++++++++--------
- src/tests/reservation_tests.cpp             |  6 ++---
+ include/mesos/allocator/allocator.hpp       |  4 ++-
+ src/master/allocator/mesos/allocator.hpp    | 12 ++++---
+ src/master/allocator/mesos/hierarchical.cpp | 15 +++++++--
+ src/master/allocator/mesos/hierarchical.hpp |  8 ++++-
+ src/master/master.cpp                       |  3 +-
+ src/tests/allocator.hpp                     | 11 ++++---
+ src/tests/api_tests.cpp                     |  4 +--
+ src/tests/master_allocator_tests.cpp        | 36 ++++++++++-----------
+ src/tests/master_quota_tests.cpp            | 20 ++++++------
+ src/tests/reservation_tests.cpp             |  6 ++--
  src/tests/resource_offers_tests.cpp         |  2 +-
  src/tests/slave_recovery_tests.cpp          |  2 +-
  12 files changed, 74 insertions(+), 49 deletions(-)
@@ -83,10 +83,10 @@ index 32dd40cb0..bc35d2fff 100644
  
  
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index 96671033b..2af633c5c 100644
+index bb36d406a..91c27f619 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -159,7 +159,8 @@ void HierarchicalAllocatorProcess::initialize(
+@@ -193,7 +193,8 @@ void HierarchicalAllocatorProcess::initialize(
      bool _filterGpuResources,
      const Option<DomainInfo>& _domain,
      const Option<std::vector<mesos::internal::ResourceQuantities>>&
@@ -96,7 +96,7 @@ index 96671033b..2af633c5c 100644
  {
    allocationInterval = _allocationInterval;
    offerCallback = _offerCallback;
-@@ -171,6 +172,10 @@ void HierarchicalAllocatorProcess::initialize(
+@@ -205,6 +206,10 @@ void HierarchicalAllocatorProcess::initialize(
    initialized = true;
    paused = false;
  
@@ -107,7 +107,7 @@ index 96671033b..2af633c5c 100644
    // Resources for quota'ed roles are allocated separately and prior to
    // non-quota'ed roles, hence a dedicated sorter for quota'ed roles is
    // necessary.
-@@ -315,7 +320,7 @@ void HierarchicalAllocatorProcess::removeFramework(
+@@ -349,7 +354,7 @@ void HierarchicalAllocatorProcess::removeFramework(
    CHECK(initialized);
    CHECK(frameworks.contains(frameworkId)) << frameworkId;
  
@@ -116,7 +116,7 @@ index 96671033b..2af633c5c 100644
  
    foreach (const string& role, framework.roles) {
      // Might not be in 'frameworkSorters[role]' because it
-@@ -340,6 +345,12 @@ void HierarchicalAllocatorProcess::removeFramework(
+@@ -374,6 +379,12 @@ void HierarchicalAllocatorProcess::removeFramework(
      untrackFrameworkUnderRole(frameworkId, role);
    }
  
@@ -126,14 +126,14 @@ index 96671033b..2af633c5c 100644
 +      frameworkId,
 +      Owned<FrameworkMetrics>(framework.metrics.release()));
 +
-   // Do not delete the filters contained in this
-   // framework's `offerFilters` hashset yet, see comments in
-   // HierarchicalAllocatorProcess::reviveOffers and
+   frameworks.erase(frameworkId);
+ 
+   LOG(INFO) << "Removed framework " << frameworkId;
 diff --git a/src/master/allocator/mesos/hierarchical.hpp b/src/master/allocator/mesos/hierarchical.hpp
-index ec4d445f5..6baf15add 100644
+index b4594199c..be62158fb 100644
 --- a/src/master/allocator/mesos/hierarchical.hpp
 +++ b/src/master/allocator/mesos/hierarchical.hpp
-@@ -26,6 +26,7 @@
+@@ -27,6 +27,7 @@
  #include <process/id.hpp>
  #include <process/owned.hpp>
  
@@ -159,7 +159,7 @@ index ec4d445f5..6baf15add 100644
  
    void recover(
        const int _expectedAgentCount,
-@@ -356,6 +359,9 @@ protected:
+@@ -360,6 +363,9 @@ protected:
  
    hashmap<FrameworkID, Framework> frameworks;
  
@@ -170,7 +170,7 @@ index ec4d445f5..6baf15add 100644
    {
    public:
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 7f11211df..05b7111e5 100644
+index e26057449..69385a519 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -805,7 +805,8 @@ void Master::initialize()
@@ -416,10 +416,10 @@ index fec69b2f7..10ed36d69 100644
    master::Flags masterFlags = this->CreateMasterFlags();
    Try<Owned<cluster::Master>> master =
 diff --git a/src/tests/master_quota_tests.cpp b/src/tests/master_quota_tests.cpp
-index e49e5cccd..320f3db51 100644
+index 995edb0c5..cd57a43b4 100644
 --- a/src/tests/master_quota_tests.cpp
 +++ b/src/tests/master_quota_tests.cpp
-@@ -424,7 +424,7 @@ TEST_F(MasterQuotaTest, SetExistingQuota)
+@@ -426,7 +426,7 @@ TEST_F(MasterQuotaTest, SetExistingQuota)
  TEST_F(MasterQuotaTest, RemoveSingleQuota)
  {
    TestAllocator<> allocator;
@@ -428,7 +428,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -588,7 +588,7 @@ TEST_F(MasterQuotaTest, Status)
+@@ -649,7 +649,7 @@ TEST_F(MasterQuotaTest, Status)
  TEST_F(MasterQuotaTest, InsufficientResourcesSingleAgent)
  {
    TestAllocator<> allocator;
@@ -437,7 +437,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -648,7 +648,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesSingleAgent)
+@@ -709,7 +709,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesSingleAgent)
  TEST_F(MasterQuotaTest, InsufficientResourcesMultipleAgents)
  {
    TestAllocator<> allocator;
@@ -446,7 +446,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -723,7 +723,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesMultipleAgents)
+@@ -784,7 +784,7 @@ TEST_F(MasterQuotaTest, InsufficientResourcesMultipleAgents)
  TEST_F(MasterQuotaTest, AvailableResourcesSingleAgent)
  {
    TestAllocator<> allocator;
@@ -455,7 +455,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -773,7 +773,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesSingleAgent)
+@@ -834,7 +834,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesSingleAgent)
  TEST_F(MasterQuotaTest, AvailableResourcesMultipleAgents)
  {
    TestAllocator<> allocator;
@@ -464,7 +464,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -842,7 +842,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesMultipleAgents)
+@@ -903,7 +903,7 @@ TEST_F(MasterQuotaTest, AvailableResourcesMultipleAgents)
  TEST_F(MasterQuotaTest, AvailableResourcesAfterRescinding)
  {
    TestAllocator<> allocator;
@@ -473,7 +473,7 @@ index e49e5cccd..320f3db51 100644
  
    Try<Owned<cluster::Master>> master = StartMaster(&allocator);
    ASSERT_SOME(master);
-@@ -1077,7 +1077,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
+@@ -1138,7 +1138,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
    }
  
    TestAllocator<> allocator;
@@ -482,7 +482,7 @@ index e49e5cccd..320f3db51 100644
  
    // Restart the master; configured quota should be recovered from the registry.
    master->reset();
-@@ -1110,7 +1110,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
+@@ -1171,7 +1171,7 @@ TEST_F(MasterQuotaTest, RecoverQuotaEmptyCluster)
  TEST_F(MasterQuotaTest, NoAuthenticationNoAuthorization)
  {
    TestAllocator<> allocator;
@@ -491,7 +491,7 @@ index e49e5cccd..320f3db51 100644
  
    // Disable http_readwrite authentication and authorization.
    // TODO(alexr): Setting master `--acls` flag to `ACLs()` or `None()` seems
-@@ -1216,7 +1216,7 @@ TEST_F(MasterQuotaTest, UnauthenticatedQuotaRequest)
+@@ -1277,7 +1277,7 @@ TEST_F(MasterQuotaTest, UnauthenticatedQuotaRequest)
  TEST_F(MasterQuotaTest, AuthorizeGetUpdateQuotaRequests)
  {
    TestAllocator<> allocator;
@@ -500,7 +500,7 @@ index e49e5cccd..320f3db51 100644
  
    // Setup ACLs so that only the default principal can modify quotas
    // for `ROLE1` and read status.
-@@ -1764,7 +1764,7 @@ TEST_F(MasterQuotaTest, DISABLED_ChildRoleDeleteParentQuota)
+@@ -1825,7 +1825,7 @@ TEST_F(MasterQuotaTest, DISABLED_ChildRoleDeleteParentQuota)
  TEST_F(MasterQuotaTest, DISABLED_ClusterCapacityWithNestedRoles)
  {
    TestAllocator<> allocator;
@@ -567,5 +567,5 @@ index d012d396a..348ad492f 100644
    Try<Owned<cluster::Master>> master = this->StartMaster(&allocator);
    ASSERT_SOME(master);
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
+++ b/packages/mesos/extra/patches/0021-Added-per-framework-metrics-for-suppressed-roles.patch
@@ -1,20 +1,20 @@
-From 1304a0d3b5d18c9a5590b0cf0003e8e251982d9e Mon Sep 17 00:00:00 2001
+From aff32bda9922f88a6bed2ae201d2731ceecd5e65 Mon Sep 17 00:00:00 2001
 From: Greg Mann <greg@mesosphere.io>
 Date: Wed, 1 Aug 2018 07:59:04 -0700
-Subject: [PATCH] Added per-framework metrics for suppressed roles.
+Subject: [PATCH 21/24] Added per-framework metrics for suppressed roles.
 
 Review: https://reviews.apache.org/r/66870/
 ---
- src/master/allocator/mesos/hierarchical.cpp | 17 ++++++++
- src/master/allocator/mesos/metrics.cpp      | 66 ++++++++++++++++++++++++++++-
- src/master/allocator/mesos/metrics.hpp      | 12 ++++++
- 3 files changed, 93 insertions(+), 2 deletions(-)
+ src/master/allocator/mesos/hierarchical.cpp |  7 +++
+ src/master/allocator/mesos/metrics.cpp      | 66 ++++++++++++++++++++-
+ src/master/allocator/mesos/metrics.hpp      | 12 ++++
+ 3 files changed, 83 insertions(+), 2 deletions(-)
 
 diff --git a/src/master/allocator/mesos/hierarchical.cpp b/src/master/allocator/mesos/hierarchical.cpp
-index 2af633c5c..27fa561c8 100644
+index 91c27f619..982377c5b 100644
 --- a/src/master/allocator/mesos/hierarchical.cpp
 +++ b/src/master/allocator/mesos/hierarchical.cpp
-@@ -285,8 +285,10 @@ void HierarchicalAllocatorProcess::addFramework(
+@@ -319,8 +319,10 @@ void HierarchicalAllocatorProcess::addFramework(
  
      if (suppressedRoles.count(role)) {
        frameworkSorters.at(role)->deactivate(frameworkId.value());
@@ -25,64 +25,39 @@ index 2af633c5c..27fa561c8 100644
      }
    }
  
-@@ -454,6 +456,10 @@ void HierarchicalAllocatorProcess::updateFramework(
-     return result;
-   }();
+@@ -463,6 +465,8 @@ void HierarchicalAllocatorProcess::updateFramework(
+   const set<string> oldSuppressedRoles = framework.suppressedRoles;
  
-+  foreach (const string& role, newSuppressedRoles) {
-+    framework.metrics->suppressRole(role);
-+  }
-+
-   foreach (const string& role, removedRoles | newSuppressedRoles) {
-     CHECK(frameworkSorters.contains(role));
-     frameworkSorters.at(role)->deactivate(frameworkId.value());
-@@ -469,6 +475,8 @@ void HierarchicalAllocatorProcess::updateFramework(
-     if (framework.offerFilters.contains(role)) {
-       framework.offerFilters.erase(role);
-     }
-+
-+    framework.metrics->removeSubscribedRole(role);
-   }
- 
-   const set<string> addedRoles = [&]() {
-@@ -487,7 +495,13 @@ void HierarchicalAllocatorProcess::updateFramework(
-     return result;
-   }();
- 
-+  foreach (const string& role, newRevivedRoles) {
-+    framework.metrics->reviveRole(role);
-+  }
-+
-   foreach (const string& role, addedRoles) {
+   foreach (const string& role, newRoles - oldRoles) {
 +    framework.metrics->addSubscribedRole(role);
 +
      // NOTE: It's possible that we're already tracking this framework
      // under the role because a framework can unsubscribe from a role
      // while it still has resources allocated to the role.
-@@ -752,6 +766,7 @@ void HierarchicalAllocatorProcess::removeFilters(const SlaveID& slaveId)
-       if (erased) {
-         frameworkSorters.at(role)->activate(id.value());
-         framework.suppressedRoles.erase(role);
-+        framework.metrics->reviveRole(role);
-       }
+@@ -486,6 +490,7 @@ void HierarchicalAllocatorProcess::updateFramework(
+       framework.offerFilters.erase(role);
      }
+ 
++    framework.metrics->removeSubscribedRole(role);
+     framework.suppressedRoles.erase(role);
    }
-@@ -1316,6 +1331,7 @@ void HierarchicalAllocatorProcess::suppressOffers(
+ 
+@@ -1282,6 +1287,7 @@ void HierarchicalAllocatorProcess::suppressRoles(
  
      frameworkSorters.at(role)->deactivate(frameworkId.value());
      framework.suppressedRoles.insert(role);
 +    framework.metrics->suppressRole(role);
    }
  
-   LOG(INFO) << "Suppressed offers for roles " << stringify(roles)
-@@ -1344,6 +1360,7 @@ void HierarchicalAllocatorProcess::reviveOffers(
+   // TODO(bmahler): This logs roles that were already suppressed,
+@@ -1322,6 +1328,7 @@ void HierarchicalAllocatorProcess::unsuppressRoles(
  
      frameworkSorters.at(role)->activate(frameworkId.value());
      framework.suppressedRoles.erase(role);
 +    framework.metrics->reviveRole(role);
    }
  
-   // We delete each actual `OfferFilter` when
+   // TODO(bmahler): This logs roles that were already unsuppressed,
 diff --git a/src/master/allocator/mesos/metrics.cpp b/src/master/allocator/mesos/metrics.cpp
 index 7a4b153db..0b5534715 100644
 --- a/src/master/allocator/mesos/metrics.cpp
@@ -210,5 +185,5 @@ index daac93f7e..34cc16b3a 100644
  
  } // namespace internal {
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0022-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,7 +1,8 @@
-From f342d0d485c3cc48c187a2682264aa1828123284 Mon Sep 17 00:00:00 2001
+From bf7a4b4518f66c3a3806c9cc8715810bcf006123 Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Fri, 2 Nov 2018 16:13:01 -0700
-Subject: [PATCH] Added task health check definitions to master API responses.
+Subject: [PATCH 22/24] Added task health check definitions to master API
+ responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified. Associated helpers are
@@ -19,7 +20,7 @@ Review: https://reviews.apache.org/r/69110/
  4 files changed, 20 insertions(+), 4 deletions(-)
 
 diff --git a/include/mesos/mesos.proto b/include/mesos/mesos.proto
-index a147ce291..f9c6e8318 100644
+index 21533286f..070e14d5e 100644
 --- a/include/mesos/mesos.proto
 +++ b/include/mesos/mesos.proto
 @@ -2139,8 +2139,8 @@ message TaskGroupInfo {
@@ -45,7 +46,7 @@ index a147ce291..f9c6e8318 100644
    optional string user = 14;
  }
 diff --git a/include/mesos/v1/mesos.proto b/include/mesos/v1/mesos.proto
-index ce3b31ee3..f46aa343e 100644
+index 9863c3a31..a73c52a7e 100644
 --- a/include/mesos/v1/mesos.proto
 +++ b/include/mesos/v1/mesos.proto
 @@ -2131,8 +2131,8 @@ message TaskGroupInfo {
@@ -101,5 +102,5 @@ index fda130727..5f3c2ae61 100644
    if (task.has_command() && task.command().has_user()) {
      t.set_user(task.command().user());
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
+++ b/packages/mesos/extra/patches/0023-Put-TerminateEvent-at-the-end-of-the-queue-in-the-Me.patch
@@ -1,8 +1,8 @@
-From 4554a4fca4b1280bcb0d8c2ab858cd294aba69f1 Mon Sep 17 00:00:00 2001
+From 24e056553e4506176c18a3e5d8e7234ad81cce23 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 27 Sep 2018 15:20:01 +0200
-Subject: [PATCH] Put `TerminateEvent` at the end of the queue in the Mesos
- library.
+Subject: [PATCH 23/24] Put `TerminateEvent` at the end of the queue in the
+ Mesos library.
 
 This is to ensure all pending dispatches are processed. However
 multistage events, e.g., `Call`, might still be dropped, because
@@ -16,10 +16,10 @@ Review: https://reviews.apache.org/r/68865
  1 file changed, 6 insertions(+), 1 deletion(-)
 
 diff --git a/src/scheduler/scheduler.cpp b/src/scheduler/scheduler.cpp
-index c04cfbc42..7ca306702 100644
+index 9fde5e4cd..d889d762d 100644
 --- a/src/scheduler/scheduler.cpp
 +++ b/src/scheduler/scheduler.cpp
-@@ -927,7 +927,12 @@ void Mesos::reconnect()
+@@ -929,7 +929,12 @@ void Mesos::reconnect()
  void Mesos::stop()
  {
    if (process != nullptr) {
@@ -34,5 +34,5 @@ index c04cfbc42..7ca306702 100644
  
      delete process;
 -- 
-2.14.3
+2.21.0
 

--- a/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
+++ b/packages/mesos/extra/patches/0024-Waited-for-TEARDOWN-to-be-sent-in-v1-Java-scheduler-.patch
@@ -1,7 +1,8 @@
-From dd75a794b9cbcfcd675f5b01d5824b62ec09fa5b Mon Sep 17 00:00:00 2001
+From 2dd0f553a3490eb16d206e700687dbbd878982dc Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Tue, 9 Oct 2018 18:22:16 +0200
-Subject: [PATCH] Waited for TEARDOWN to be sent in v1 Java scheduler shim.
+Subject: [PATCH 24/24] Waited for TEARDOWN to be sent in v1 Java scheduler
+ shim.
 
 Destruction of the library is not always under our control. For
 example, the JVM can call JNI `finalize()` if the Java scheduler
@@ -9,7 +10,7 @@ nullifies its reference to the V1Mesos library immediately after
 sending `TEARDOWN`. We want to make sure that `TEARDOWN` is sent
 before the Mesos library is destructed.
 ---
- src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp | 17 +++++++++++++++++
+ .../org_apache_mesos_v1_scheduler_V1Mesos.cpp   | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp b/src/java/jni/org_apache_mesos_v1_scheduler_V1Mesos.cpp
@@ -48,5 +49,5 @@ index 2a5fbd79a..6ec771111 100644
  
  
 -- 
-2.14.3
+2.21.0
 


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/6a8b61b59498dcea64d9380a233d517ce65dc2ef...14904009a193636bb715115419bfa2f235beb33f
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
