### PR TITLE
Mute test_dcos_cni_l4lb until the universal installer 0.2.0 is made stable

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -597,6 +597,12 @@ def test_l4lb(dcos_api_session):
             app.purge(dcos_api_session)
 
 
+@pytest.mark.xfailflake(
+    jira='DCOS-53659',
+    reason='Update universal installer default range'
+           'DCOS-49805 - test_dcos_cni_l4lb fails on universal installer provisioned cluster',
+    since='2019-07-24'
+)
 def test_dcos_cni_l4lb(dcos_api_session):
     '''
     This tests the `dcos - l4lb` CNI plugins:


### PR DESCRIPTION
We discovered a number of stablity issues with Universal Installer 0.2.0

* DCOS-56983 - Universal Installer fails with KeyError: 'modules-init'
* DCOS-56126 - terraform/aws/onprem/static/strict/group failed with error executing "/tmp/terraform_157505586.sh": Process exited with status 1

We had to revert back to Universal Installer 0.1.0 which had problems with test_dcos_cni_l4lb (https://jira.mesosphere.com/browse/DCOS-49805)  Until a stable version of provision is identified, this test shall remain briefly muted.