### PR TITLE
[1.12] Backport change-scope-fixtures

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -26,6 +26,10 @@ log = logging.getLogger(__name__)
 GLOBAL_PORT_POOL = iter(range(10000, 32000))
 GLOBAL_OCTET_POOL = itertools.cycle(range(254, 10, -1))
 
+# Apply fixture(s) in this list to all tests in this module. From
+# pytest docs: "Note that the assigned variable must be called pytestmark"
+pytestmark = [pytest.mark.usefixtures("clean_marathon_state_function_scoped")]
+
 
 class Container(enum.Enum):
     POD = 'POD'


### PR DESCRIPTION
This is a backport of #5896

Description form that below:

## High-level description

This changes `clean_marathon_state` to `module` scoped - so that it can exist in EE and OSS, and coexist with module scoped fixtures which create Marathon resources. See the JIRA issue for alternatives discussed.

## Corresponding DC/OS tickets (required)

  - [DCOS-45746](https://jira.mesosphere.com/browse/DCOS-45746) tests: autouse=True Marathon fixture breaks module-scoped Marathon app fixtures.