### PR TITLE
Set the DC/OS Version in master to 1.14.0-dev

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -64,7 +64,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '1.14.0-alphadev',
+        'version': '1.14.0-dev',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '1.14.0-alphadev'
+DCOS_VERSION = '1.14.0-dev'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 


### PR DESCRIPTION
## High-level description

* Revert the change done for DCOS-56899 - Set DC/OS Version to 1.14.0-Alpha. (PR: https://github.com/dcos/dcos/pull/5933) 

* We have a release branch for 1.14.0-alpha https://github.com/dcos/dcos/tree/1.14.0-alpha, and master version can be set to `1.14.0-dev`. 
