### PR TITLE
Prune VIPs with no backends in dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Added containerizer debug endpoint into the diagnostic bundle. This endpoint is used for tracking data for stuck tasks. (DCOS-55383)
 
+* Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes. (DCOS_OSS-5356)
+
 
 ### Breaking changes
 

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "dbce08db228d1f3fc59874b81558d11f7593dc1e",
+      "ref": "f0f40e0ae588ff67fef32f3f1cd1cd7d322c3272",
       "ref_origin": "master"
     }
   },


### PR DESCRIPTION
## High-level description

Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5356](https://jira.mesosphere.com/browse/DCOS_OSS-5356) dcos-net should prune VIP entries with no backends

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/dbce08db228d1f3fc59874b81558d11f7593dc1e...f0f40e0ae588ff67fef32f3f1cd1cd7d322c3272)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain: there is an integration test in `dcos-net` repo.
  - [x] Test Results: [CI job](https://circleci.com/gh/dcos/dcos-net/1313)
  - [x] Code Coverage: [report](https://codecov.io/gh/dcos/dcos-net/pull/163)