### PR TITLE
[1.13] Prune VIPs with no backends in dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The content of `/var/log/mesos-state.tar.gz` is now included in the diagnostics bundle. (DCOS-56403)
 
+* Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes. (DCOS_OSS-5356)
+
 ### Security updates
 
 ## DC/OS 1.13.3 (CF - 2019-07-10)

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,8 +4,8 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "295b1b0914f1f9828471d6851b00ad3133174c20",
-      "ref_origin": "master"
+      "ref": "0851520c0849ca80c3e31e65d12e11ccf76d077b",
+      "ref_origin": "1.13.x"
     }
   },
   "sysctl": {


### PR DESCRIPTION
## High-level description

Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5356](https://jira.mesosphere.com/browse/DCOS_OSS-5356) dcos-net should prune VIP entries with no backends

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/295b1b0914f1f9828471d6851b00ad3133174c20...0851520c0849ca80c3e31e65d12e11ccf76d077b)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain: there is an integration test in `dcos-net` repo.
  - [x] Test Results: [CI job](https://circleci.com/gh/dcos/dcos-net/1318)
  - [ ] Code Coverage: none.