### PR TITLE
[1.12] Prune VIPs with no backends in dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The content of `/var/log/mesos-state.tar.gz` is now included in the diagnostics bundle. (DCOS-56403)
 
+* Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes. (DCOS_OSS-5356)
+
 ### Security updates
 
 

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "5361e1d9b3cc5c4e55271fab666c07ca6c3f823b",
+      "ref": "4201b6690bb9504ab6642aed5776e76ceed1093d",
       "ref_origin": "1.12.x"
     }
   },


### PR DESCRIPTION
## High-level description

Prune VIPs with no backends in order to avoid unbounded growth of state and messages exchanged among `dcos-net` processes.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5356](https://jira.mesosphere.com/browse/DCOS_OSS-5356) dcos-net should prune VIP entries with no backends

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/5361e1d9b3cc5c4e55271fab666c07ca6c3f823b...4201b6690bb9504ab6642aed5776e76ceed1093d)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain: there is an integration test in `dcos-net` repo.
  - [x] Test Results: [CI job](https://circleci.com/gh/dcos/dcos-net/1319)
  - [ ] Code Coverage: none.