### PR TITLE
[DCOS-57291] make DC/OS Signal report the license ID

### DIFF
--- a/packages/dcos-signal/extra/dcos-signal.service
+++ b/packages/dcos-signal/extra/dcos-signal.service
@@ -8,6 +8,7 @@ RestartSec=20
 LimitNOFILE=16384
 PermissionsStartOnly=True
 User=dcos_signal
+SupplementaryGroups=dcos_adminrouter
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=-/opt/mesosphere/etc/cfn_signal_metadata
 ExecStartPre=/bin/ping -c1 leader.mesos


### PR DESCRIPTION
## High-level description

DC/OS Signal must be able to read the license ID from the socket file `/run/dcos/dcos-licensing.sock` that's owned by the group `dcos_adminrouter`.

## Corresponding DC/OS tickets (required)

  - [DCOS-57291](https://jira.mesosphere.com/browse/DCOS-57291) DC/OS Signal doesn't report license ID

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): no change log necessary
  - [] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
