### PR TITLE
[1.12] Bump Mesos to nightly 1.7.x ccecf11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated DC/OS UI to [1.12+v2.26.16](https://github.com/dcos/dcos-ui/releases/tag/1.12+v2.26.16).
 
+* Updated to Mesos [1.7.x](https://github.com/apache/mesos/blob/ccecf11e250621aad286564ecc1e98c307777277/CHANGELOG).
+
 ### Notable changes
 
 * Updated DC/OS UI to [1.12+v2.26.16](https://github.com/dcos/dcos-ui/releases/tag/1.12+v2.26.16)

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "33a1ba97041f178f8be53cdeb7cbeb7c78b89798",
+    "ref": "ccecf11e250621aad286564ecc1e98c307777277",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
+++ b/packages/mesos/extra/patches/0001-Set-LIBPROCESS_IP-into-docker-container.patch
@@ -1,7 +1,7 @@
-From 0a6070b7f5b1427cb727e7bae8495a522348ca6d Mon Sep 17 00:00:00 2001
+From 2444ea336c7c611942243e807335eab61aaf4f32 Mon Sep 17 00:00:00 2001
 From: Michael Park <mpark@apache.org>
 Date: Thu, 15 Oct 2015 19:54:02 -0700
-Subject: [PATCH] Set LIBPROCESS_IP into docker container.
+Subject: [PATCH 01/16] Set LIBPROCESS_IP into docker container.
 
 ---
  src/docker/docker.cpp | 5 +++++

--- a/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
+++ b/packages/mesos/extra/patches/0002-Updated-mesos-containerizer-to-ignore-GPU-isolator-c.patch
@@ -1,8 +1,8 @@
-From 84000895ce62ce6fe178bf33ad19b4591630106f Mon Sep 17 00:00:00 2001
+From 1799d6a70812f07038ed7dc264666d6309b878eb Mon Sep 17 00:00:00 2001
 From: Kevin Klues <klueska@gmail.com>
 Date: Thu, 9 Feb 2017 19:39:42 -0800
-Subject: [PATCH] Updated mesos containerizer to ignore GPU isolator creation
- failure.
+Subject: [PATCH 02/16] Updated mesos containerizer to ignore GPU isolator
+ creation failure.
 
 This cherry-pick will be maintained in DC/OS to avoid the problem of
 requiring NVML to be installed on *every* node in the cluster, even if
@@ -23,10 +23,10 @@ by https://reviews.apache.org/r/62472/
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/src/slave/containerizer/mesos/containerizer.cpp b/src/slave/containerizer/mesos/containerizer.cpp
-index 321d04c27..88d9768c8 100644
+index e8a4ab380..66d5e5918 100644
 --- a/src/slave/containerizer/mesos/containerizer.cpp
 +++ b/src/slave/containerizer/mesos/containerizer.cpp
-@@ -451,8 +451,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -453,8 +453,10 @@ Try<MesosContainerizer*> MesosContainerizer::create(
      {"gpu/nvidia",
        [&nvidia] (const Flags& flags) -> Try<Isolator*> {
          if (!nvml::isAvailable()) {
@@ -39,7 +39,7 @@ index 321d04c27..88d9768c8 100644
          }
  
          CHECK_SOME(nvidia)
-@@ -512,7 +514,9 @@ Try<MesosContainerizer*> MesosContainerizer::create(
+@@ -514,7 +516,9 @@ Try<MesosContainerizer*> MesosContainerizer::create(
                     isolator.error());
      }
  

--- a/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
+++ b/packages/mesos/extra/patches/0003-Mesos-UI-updated-the-URL-generation-to-make-it-work-.patch
@@ -1,8 +1,8 @@
-From 2706c5fbddc6fa2baabda8b213c1b59ce7524531 Mon Sep 17 00:00:00 2001
+From cd855187a0d62b8989d6166fdf8dc4e085009413 Mon Sep 17 00:00:00 2001
 From: Armand Grillet <armand.grillet@outlook.com>
 Date: Wed, 28 Feb 2018 21:00:24 +0100
-Subject: [PATCH] Mesos UI: updated the URL generation to make it work with
- adminrouter.
+Subject: [PATCH 03/16] Mesos UI: updated the URL generation to make it work
+ with adminrouter.
 
 - Use /mesos as the leading master URL prefix.
 - Use /mesos/agent/{agent_id}/{process_name} as the agent URL prefix.

--- a/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
+++ b/packages/mesos/extra/patches/0004-Added-received-timestamp-into-process-Request.patch
@@ -1,7 +1,7 @@
-From e0420b6fb29dadab0fdb5f001b2ad8a80a906b76 Mon Sep 17 00:00:00 2001
+From 8fcf6db6d06c3eb950d62c440786d987558fd2b4 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Mon, 13 Aug 2018 20:05:26 +0200
-Subject: [PATCH] Added 'received' timestamp into `process::Request`.
+Subject: [PATCH 04/16] Added 'received' timestamp into `process::Request`.
 
 This allows us to note when a request comes in and
 hence calculate request processing time.

--- a/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
+++ b/packages/mesos/extra/patches/0005-Added-task-health-check-definitions-to-master-API-re.patch
@@ -1,7 +1,8 @@
-From 227f182d2ce169118d5c4bf4383cbc77fd28ad2c Mon Sep 17 00:00:00 2001
+From e76f55547ee342e7b6f1b052ac2b864ddd593e5a Mon Sep 17 00:00:00 2001
 From: Greg Mann <gregorywmann@gmail.com>
 Date: Mon, 29 Oct 2018 11:25:58 -0700
-Subject: [PATCH] Added task health check definitions to master API responses.
+Subject: [PATCH 05/16] Added task health check definitions to master API
+ responses.
 
 The `Task` protobuf message is updated to include the health check
 definition of a task when it is specified, along with associated
@@ -85,7 +86,7 @@ index 932111dde..81102d845 100644
  
  
 diff --git a/src/common/protobuf_utils.cpp b/src/common/protobuf_utils.cpp
-index b9289a206..fa949cc5e 100644
+index 138bee6bd..f02f4646b 100644
 --- a/src/common/protobuf_utils.cpp
 +++ b/src/common/protobuf_utils.cpp
 @@ -341,6 +341,10 @@ Task createTask(

--- a/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
+++ b/packages/mesos/extra/patches/0006-Introduced-logResponse-for-http-handlers.patch
@@ -1,7 +1,7 @@
-From f61e78cedb22a50e82de9d8fa1f6ec35c0ce6722 Mon Sep 17 00:00:00 2001
+From a4bb75b78fddd821af83b9013aa26506c43e757f Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:40:37 +0200
-Subject: [PATCH] Introduced `logResponse` for http handlers.
+Subject: [PATCH 06/16] Introduced `logResponse` for http handlers.
 
 Currently we use `logRequest` function to log requests to endpoints
 in Mesos `MasterProcess`, `SlaveProcess`, and `FilesProcess`. Each

--- a/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
+++ b/packages/mesos/extra/patches/0007-Logged-request-processing-time-for-some-endpoints.patch
@@ -1,7 +1,7 @@
-From 98f906e25b1363ec6e9c1eec0fd8ffa99ce87451 Mon Sep 17 00:00:00 2001
+From 74a7fd63298ec92598427ffce2fd8c1cdd93aeb8 Mon Sep 17 00:00:00 2001
 From: Alexander Rukletsov <alexr@apache.org>
 Date: Thu, 11 Oct 2018 15:58:41 +0200
-Subject: [PATCH] Logged request processing time for some endpoints.
+Subject: [PATCH 07/16] Logged request processing time for some endpoints.
 
 This patch leverages `logResponse()` function to print response status
 code together with the request processing time for some endpoints on
@@ -21,7 +21,7 @@ Review: https://reviews.apache.org/r/68994
  2 files changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index ed072d39b..0c60f819f 100644
+index 3f0c8c0ce..392057583 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -929,7 +929,10 @@ void Master::initialize()
@@ -85,7 +85,7 @@ index ed072d39b..0c60f819f 100644
    route("/maintenance/schedule",
          READWRITE_HTTP_AUTHENTICATION_REALM,
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index c0b538852..60f870820 100644
+index f8aa7db2c..97bb48f64 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -803,7 +803,10 @@ void Slave::initialize()

--- a/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
+++ b/packages/mesos/extra/patches/0008-Changed-sandbox-mode-to-0755-in-docker-containerizer.patch
@@ -1,7 +1,7 @@
-From 47884fe26233e7ebea13cc2a53711a4b8ffc902e Mon Sep 17 00:00:00 2001
+From 1a35a796e34759dbee8e167a0d14318f9f860999 Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Fri, 23 Nov 2018 10:54:58 +0800
-Subject: [PATCH] Changed sandbox mode to 0755 in docker containerizer
+Subject: [PATCH 08/16] Changed sandbox mode to 0755 in docker containerizer
  container launch.
 
 Starting from Mesos 1.6.0, sandbox permission was changed from 0755
@@ -20,10 +20,10 @@ removed in DC/OS 1.15.
  1 file changed, 12 insertions(+)
 
 diff --git a/src/slave/containerizer/docker.cpp b/src/slave/containerizer/docker.cpp
-index 192dc2957..7c3575a6c 100644
+index dacf4de78..103315f7b 100644
 --- a/src/slave/containerizer/docker.cpp
 +++ b/src/slave/containerizer/docker.cpp
-@@ -1176,6 +1176,18 @@ Future<Containerizer::LaunchResult> DockerContainerizerProcess::launch(
+@@ -1161,6 +1161,18 @@ Future<Containerizer::LaunchResult> DockerContainerizerProcess::launch(
      return Containerizer::LaunchResult::NOT_SUPPORTED;
    }
  

--- a/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
+++ b/packages/mesos/extra/patches/0009-Added-HEARTBEAT-events-and-calls-for-the-executor-HT.patch
@@ -1,7 +1,8 @@
-From a0b9a1fb022eb80768b1130713291573509e04fb Mon Sep 17 00:00:00 2001
+From 41fb2cf00f30ca8f41b8cf4ec0ec418f94ea96dc Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:21 -0800
-Subject: [PATCH] Added HEARTBEAT events and calls for the executor HTTP API.
+Subject: [PATCH 09/16] Added HEARTBEAT events and calls for the executor HTTP
+ API.
 
 These new messages are meant to be backwards compatible, in that
 they won't cause crashes when new executors send heartbeats to old

--- a/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
+++ b/packages/mesos/extra/patches/0010-Refactored-master-and-agent-streaming-connections.patch
@@ -1,7 +1,7 @@
-From 6ff9adaec89066c8022ad8201524fb39743bed32 Mon Sep 17 00:00:00 2001
+From d7dbe9885b9bf360353b14da53239fc0784f4a04 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:24 -0800
-Subject: [PATCH] Refactored master and agent streaming connections.
+Subject: [PATCH 10/16] Refactored master and agent streaming connections.
 
 This moves the very similar `HttpConnection` classes inside the
 master and agent into a common header.  The refactored
@@ -31,10 +31,10 @@ Review: https://reviews.apache.org/r/69472/
  create mode 100644 src/common/heartbeater.hpp
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index aa343ab68..2f8cb0129 100644
+index fb2a27e28..d4f28adb8 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -989,6 +989,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
+@@ -995,6 +995,7 @@ libmesos_no_3rdparty_la_SOURCES +=					\
    checks/health_checker.cpp						\
    common/attributes.cpp							\
    common/command_utils.cpp						\
@@ -371,7 +371,7 @@ index e2773ed78..0e2c2bb78 100644
  
      return ok;
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 0c60f819f..588f4219d 100644
+index 392057583..a9dc4fc42 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -1276,7 +1276,9 @@ void Master::finalize()
@@ -412,7 +412,7 @@ index 0c60f819f..588f4219d 100644
      const FrameworkInfo& frameworkInfo,
      bool force,
      const set<string>& suppressedRoles,
-@@ -10032,7 +10034,8 @@ void Master::addFramework(
+@@ -10060,7 +10062,8 @@ void Master::addFramework(
      } else {
        CHECK_SOME(framework->http);
  
@@ -422,7 +422,7 @@ index 0c60f819f..588f4219d 100644
  
        http.closed()
          .onAny(defer(self(), &Self::exited, framework->id(), http));
-@@ -10122,7 +10125,7 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10157,7 +10160,7 @@ Try<Nothing> Master::activateRecoveredFramework(
      Framework* framework,
      const FrameworkInfo& frameworkInfo,
      const Option<UPID>& pid,
@@ -431,7 +431,7 @@ index 0c60f819f..588f4219d 100644
      const set<string>& suppressedRoles)
  {
    // Exactly one of `pid` or `http` must be provided.
-@@ -10200,7 +10203,9 @@ Try<Nothing> Master::activateRecoveredFramework(
+@@ -10235,7 +10238,9 @@ Try<Nothing> Master::activateRecoveredFramework(
  }
  
  
@@ -442,7 +442,7 @@ index 0c60f819f..588f4219d 100644
  {
    CHECK_NOTNULL(framework);
  
-@@ -12084,7 +12089,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12130,7 +12135,7 @@ void Master::Subscribers::Subscriber::send(
        if (approvers->approved<VIEW_TASK>(
                event->task_added().task(), *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -451,7 +451,7 @@ index 0c60f819f..588f4219d 100644
        }
        break;
      }
-@@ -12094,7 +12099,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12140,7 +12145,7 @@ void Master::Subscribers::Subscriber::send(
  
        if (approvers->approved<VIEW_TASK>(*task, *frameworkInfo) &&
            approvers->approved<VIEW_FRAMEWORK>(*frameworkInfo)) {
@@ -460,7 +460,7 @@ index 0c60f819f..588f4219d 100644
        }
        break;
      }
-@@ -12125,7 +12130,7 @@ void Master::Subscribers::Subscriber::send(
+@@ -12171,7 +12176,7 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -469,7 +469,7 @@ index 0c60f819f..588f4219d 100644
        }
        break;
      }
-@@ -12156,14 +12161,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12202,14 +12207,14 @@ void Master::Subscribers::Subscriber::send(
            }
          }
  
@@ -486,7 +486,7 @@ index 0c60f819f..588f4219d 100644
        }
        break;
      }
-@@ -12181,14 +12186,14 @@ void Master::Subscribers::Subscriber::send(
+@@ -12227,14 +12232,14 @@ void Master::Subscribers::Subscriber::send(
          }
        }
  
@@ -503,7 +503,7 @@ index 0c60f819f..588f4219d 100644
        break;
    }
  }
-@@ -12209,7 +12214,7 @@ void Master::exited(const id::UUID& id)
+@@ -12255,7 +12260,7 @@ void Master::exited(const id::UUID& id)
  
  
  void Master::subscribe(
@@ -513,10 +513,10 @@ index 0c60f819f..588f4219d 100644
  {
    LOG(INFO) << "Added subscriber " << http.streamId
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 2bfe2557e..2050f054d 100644
+index 6830e3b63..23fb65b48 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -75,6 +75,7 @@
+@@ -76,6 +76,7 @@
  #include <stout/try.hpp>
  #include <stout/uuid.hpp>
  
@@ -524,7 +524,7 @@ index 2bfe2557e..2050f054d 100644
  #include "common/http.hpp"
  #include "common/resources_utils.hpp"
  
-@@ -336,109 +337,6 @@ inline std::ostream& operator<<(std::ostream& stream, const Slave& slave)
+@@ -337,109 +338,6 @@ inline std::ostream& operator<<(std::ostream& stream, const Slave& slave)
  }
  
  
@@ -634,7 +634,7 @@ index 2bfe2557e..2050f054d 100644
  class Master : public ProtobufProcess<Master>
  {
  public:
-@@ -609,7 +507,10 @@ protected:
+@@ -610,7 +508,10 @@ protected:
    void consume(process::ExitedEvent&& event) override;
  
    void exited(const process::UPID& pid) override;
@@ -646,7 +646,7 @@ index 2bfe2557e..2050f054d 100644
    void _exited(Framework* framework);
  
    // Invoked upon noticing a subscriber disconnection.
-@@ -716,7 +617,7 @@ protected:
+@@ -717,7 +618,7 @@ protected:
        Framework* framework,
        const FrameworkInfo& frameworkInfo,
        const Option<process::UPID>& pid,
@@ -655,7 +655,7 @@ index 2bfe2557e..2050f054d 100644
        const std::set<std::string>& suppressedRoles);
  
    // Replace the scheduler for a framework with a new process ID, in
-@@ -725,7 +626,9 @@ protected:
+@@ -726,7 +627,9 @@ protected:
  
    // Replace the scheduler for a framework with a new HTTP connection,
    // in the event of a scheduler failover.
@@ -666,7 +666,7 @@ index 2bfe2557e..2050f054d 100644
  
    void _failoverFramework(Framework* framework);
  
-@@ -1086,11 +989,11 @@ private:
+@@ -1087,11 +990,11 @@ private:
        scheduler::Call&& call);
  
    void subscribe(
@@ -681,7 +681,7 @@ index 2bfe2557e..2050f054d 100644
        const FrameworkInfo& frameworkInfo,
        bool force,
        const std::set<std::string>& suppressedRoles,
-@@ -1109,7 +1012,7 @@ private:
+@@ -1110,7 +1013,7 @@ private:
  
    // Subscribes a client to the 'api/vX' endpoint.
    void subscribe(
@@ -690,7 +690,7 @@ index 2bfe2557e..2050f054d 100644
        const Option<process::http::authentication::Principal>& principal);
  
    void teardown(Framework* framework);
-@@ -2110,25 +2013,20 @@ private:
+@@ -2111,25 +2014,20 @@ private:
      struct Subscriber
      {
        Subscriber(
@@ -728,7 +728,7 @@ index 2bfe2557e..2050f054d 100644
  
        // Not copyable, not assignable.
        Subscriber(const Subscriber&) = delete;
-@@ -2149,14 +2047,10 @@ private:
+@@ -2156,14 +2054,10 @@ private:
          // after passing ownership to the `Subscriber` object. See MESOS-5843
          // for more details.
          http.close();
@@ -743,9 +743,9 @@ index 2bfe2557e..2050f054d 100644
 +      StreamingHttpConnection<v1::master::Event> http;
 +      ResponseHeartbeater<mesos::master::Event, v1::master::Event> heartbeater;
        const Option<process::http::authentication::Principal> principal;
-     };
  
-@@ -2343,7 +2237,7 @@ struct Framework
+       // We maintain a sequence to coordinate the creation of object approvers
+@@ -2354,7 +2248,7 @@ struct Framework
    Framework(Master* const master,
              const Flags& masterFlags,
              const FrameworkInfo& info,
@@ -754,7 +754,7 @@ index 2bfe2557e..2050f054d 100644
              const process::Time& time = process::Clock::now());
  
    Framework(Master* const master,
-@@ -2412,7 +2306,8 @@ struct Framework
+@@ -2423,7 +2317,8 @@ struct Framework
  
    void updateConnection(const process::UPID& newPid);
  
@@ -764,7 +764,7 @@ index 2bfe2557e..2050f054d 100644
  
    // Closes the HTTP connection and stops the heartbeat.
    //
-@@ -2444,7 +2339,7 @@ struct Framework
+@@ -2455,7 +2350,7 @@ struct Framework
    // (scheduler driver). At most one of `http` and `pid` will be set
    // according to the last connection made by the framework; neither
    // field will be set if the framework is in state `RECOVERED`.
@@ -773,7 +773,7 @@ index 2bfe2557e..2050f054d 100644
    Option<process::UPID> pid;
  
    State state;
-@@ -2525,7 +2420,7 @@ struct Framework
+@@ -2536,7 +2431,7 @@ struct Framework
    hashmap<SlaveID, Resources> offeredResources;
  
    // This is only set for HTTP frameworks.
@@ -798,7 +798,7 @@ index f7be16ebe..94aabba17 100644
  
        return ok;
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 60f870820..265deb2bf 100644
+index 97bb48f64..13c5ec6ee 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -4627,7 +4627,7 @@ void Slave::operationStatusAcknowledgement(

--- a/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
+++ b/packages/mesos/extra/patches/0011-Added-heartbeaters-for-agent-and-HTTP-executors.patch
@@ -1,7 +1,7 @@
-From 2b0793392a16cb0ee1056760e006079cf7a2b6ce Mon Sep 17 00:00:00 2001
+From 4c3533e78bff4e9d18c6982f36ffd5f87b7ce1c2 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:36 -0800
-Subject: [PATCH] Added heartbeaters for agent and HTTP executors.
+Subject: [PATCH 11/16] Added heartbeaters for agent and HTTP executors.
 
 This implements two separate heartbeaters for Executor Events (agent
 to executor) and Executor Calls (executor to agent).  Both are set to
@@ -159,7 +159,7 @@ index 94aabba17..aae030469 100644
        LOG(WARNING) << "Received 'UNKNOWN' call";
        return NotImplemented();
 diff --git a/src/slave/slave.cpp b/src/slave/slave.cpp
-index 265deb2bf..e58f9f1bb 100644
+index 13c5ec6ee..51c927401 100644
 --- a/src/slave/slave.cpp
 +++ b/src/slave/slave.cpp
 @@ -4688,6 +4688,18 @@ void Slave::subscribe(

--- a/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
+++ b/packages/mesos/extra/patches/0012-Added-tests-for-agent-executor-heartbeating.patch
@@ -1,7 +1,7 @@
-From 015cfa10f84eaa43e33ce9e399d4ce61c438ab27 Mon Sep 17 00:00:00 2001
+From e103d94e0860fb21078fc8ec6d21a95fa13a7991 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:34:43 -0800
-Subject: [PATCH] Added tests for agent/executor heartbeating.
+Subject: [PATCH 12/16] Added tests for agent/executor heartbeating.
 
 This adds two separate tests which check if the Agent sends heartbeats
 to HTTP executors, and if the HTTP executor driver sends heartbeats

--- a/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
+++ b/packages/mesos/extra/patches/0013-Changed-master-to-hold-subscribers-in-a-circular-buf.patch
@@ -1,7 +1,8 @@
-From 8ef88e8017d238c0a6362e1a143a3fc0263e119a Mon Sep 17 00:00:00 2001
+From c77cce8448058e7732f7ea1418fd94c5fb73e52b Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:35:03 -0800
-Subject: [PATCH] Changed master to hold subscribers in a circular buffer.
+Subject: [PATCH 13/16] Changed master to hold subscribers in a circular
+ buffer.
 
 This adds a flag (--max_operator_event_stream_subscribers) to the
 master which controls how many active subscribers on the Master's
@@ -100,7 +101,7 @@ index 4a260155b..c29cebf7b 100644
    size_t max_completed_tasks_per_framework;
    size_t max_unreachable_tasks_per_framework;
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 588f4219d..21e7937cd 100644
+index a9dc4fc42..eb23cb33e 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
 @@ -326,7 +326,7 @@ Master::Master(
@@ -112,7 +113,7 @@ index 588f4219d..21e7937cd 100644
      authenticator(None()),
      metrics(new Metrics(*this)),
      electedTime(None())
-@@ -12202,7 +12202,9 @@ void Master::Subscribers::Subscriber::send(
+@@ -12248,7 +12248,9 @@ void Master::Subscribers::Subscriber::send(
  void Master::exited(const id::UUID& id)
  {
    if (!subscribers.subscribed.contains(id)) {
@@ -123,7 +124,7 @@ index 588f4219d..21e7937cd 100644
      return;
    }
  
-@@ -12226,7 +12228,16 @@ void Master::subscribe(
+@@ -12272,7 +12274,16 @@ void Master::subscribe(
               exited(http.streamId);
             }));
  
@@ -142,10 +143,10 @@ index 588f4219d..21e7937cd 100644
        Owned<Subscribers::Subscriber>(
            new Subscribers::Subscriber{http, principal}));
 diff --git a/src/master/master.hpp b/src/master/master.hpp
-index 2050f054d..980358e62 100644
+index 23fb65b48..09f3cee2d 100644
 --- a/src/master/master.hpp
 +++ b/src/master/master.hpp
-@@ -2004,7 +2004,9 @@ private:
+@@ -2005,7 +2005,9 @@ private:
  
    struct Subscribers
    {
@@ -156,7 +157,7 @@ index 2050f054d..980358e62 100644
  
      // Represents a client subscribed to the 'api/vX' endpoint.
      //
-@@ -2064,7 +2066,7 @@ private:
+@@ -2075,7 +2077,7 @@ private:
  
      // Active subscribers to the 'api/vX' endpoint keyed by the stream
      // identifier.
@@ -166,7 +167,7 @@ index 2050f054d..980358e62 100644
  
    Subscribers subscribers;
 diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
-index b42628ac9..9d61ff59d 100644
+index 0cfc8e3ee..0230c29e0 100644
 --- a/src/tests/api_tests.cpp
 +++ b/src/tests/api_tests.cpp
 @@ -36,6 +36,7 @@
@@ -177,7 +178,7 @@ index b42628ac9..9d61ff59d 100644
  #include <stout/recordio.hpp>
  #include <stout/stringify.hpp>
  #include <stout/try.hpp>
-@@ -3519,6 +3520,172 @@ TEST_P(MasterAPITest, Heartbeat)
+@@ -3534,6 +3535,172 @@ TEST_P(MasterAPITest, Heartbeat)
  }
  
  

--- a/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
+++ b/packages/mesos/extra/patches/0014-Added-gauge-metric-for-operator-event-stream-subscri.patch
@@ -1,7 +1,8 @@
-From ad521092a2da381c6307d0c9aabec38d2bea3b5c Mon Sep 17 00:00:00 2001
+From 67cd7e51dde46ae95f11cc5a3db071bbf48f8430 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <joseph@mesosphere.io>
 Date: Thu, 13 Dec 2018 16:35:12 -0800
-Subject: [PATCH] Added gauge metric for operator event stream subscribers.
+Subject: [PATCH 14/16] Added gauge metric for operator event stream
+ subscribers.
 
 This metric "master/operator_event_stream_subscribers" returns
 the total number of subscribers to the master's operator event stream.
@@ -51,10 +52,10 @@ index 6edf36104..2d4a9b66e 100644
          "name": "master/frameworks_active",
          "value": 0.0
 diff --git a/src/master/master.cpp b/src/master/master.cpp
-index 21e7937cd..354a97cc2 100644
+index eb23cb33e..c29a19668 100644
 --- a/src/master/master.cpp
 +++ b/src/master/master.cpp
-@@ -12212,6 +12212,9 @@ void Master::exited(const id::UUID& id)
+@@ -12258,6 +12258,9 @@ void Master::exited(const id::UUID& id)
              << " from the list of active subscribers";
  
    subscribers.subscribed.erase(id);
@@ -64,7 +65,7 @@ index 21e7937cd..354a97cc2 100644
  }
  
  
-@@ -12241,6 +12244,9 @@ void Master::subscribe(
+@@ -12287,6 +12290,9 @@ void Master::subscribe(
        http.streamId,
        Owned<Subscribers::Subscriber>(
            new Subscribers::Subscriber{http, principal}));
@@ -119,10 +120,10 @@ index a8055159b..1cf03301e 100644
    process::metrics::PullGauge tasks_staging;
    process::metrics::PullGauge tasks_starting;
 diff --git a/src/tests/api_tests.cpp b/src/tests/api_tests.cpp
-index 9d61ff59d..00c2ce77f 100644
+index 0230c29e0..3a8251a59 100644
 --- a/src/tests/api_tests.cpp
 +++ b/src/tests/api_tests.cpp
-@@ -3527,6 +3527,7 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+@@ -3542,6 +3542,7 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
    Clock::pause();
  
    ContentType contentType = GetParam();
@@ -130,7 +131,7 @@ index 9d61ff59d..00c2ce77f 100644
  
    // Lower the max number of connections for this test.
    master::Flags masterFlags = CreateMasterFlags();
-@@ -3592,6 +3593,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+@@ -3607,6 +3608,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
    AWAIT_READY(event);
    ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
  
@@ -141,7 +142,7 @@ index 9d61ff59d..00c2ce77f 100644
    // Start a third connection.
    {
      // This is basically `http::streaming::post` unwrapped inside the
-@@ -3651,6 +3656,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
+@@ -3666,6 +3671,10 @@ TEST_P(MasterAPITest, MaxEventStreamSubscribers)
    ASSERT_TRUE(event->isSome());
    ASSERT_EQ(v1::master::Event::HEARTBEAT, event->get().type());
  

--- a/packages/mesos/extra/patches/0015-Reverted-the-container-sandbox-permission-from-0750-.patch
+++ b/packages/mesos/extra/patches/0015-Reverted-the-container-sandbox-permission-from-0750-.patch
@@ -1,8 +1,8 @@
-From 4bc0c96dbc8352cc418cd587ae103719bb07ecf0 Mon Sep 17 00:00:00 2001
+From 7b9d4889f2788ac5def5e959c4ed703d3b37db2e Mon Sep 17 00:00:00 2001
 From: Gilbert Song <songzihao1990@gmail.com>
 Date: Fri, 25 Jan 2019 10:40:07 -0800
-Subject: [PATCH] Reverted the container sandbox permission from 0750 back to
- 0755.
+Subject: [PATCH 15/16] Reverted the container sandbox permission from 0750
+ back to 0755.
 
 This patch is used to revert the sandbox permission semantic change
 in Mesos 1.6.0 (caused by this commit 04dd7f32). 04dd7f32 caused

--- a/packages/mesos/extra/patches/0016-Special-cased-HEARTBEAT-call-handling-in-agent.patch
+++ b/packages/mesos/extra/patches/0016-Special-cased-HEARTBEAT-call-handling-in-agent.patch
@@ -1,7 +1,7 @@
-From f44285d563733a752983af1238c77feff31bb8d6 Mon Sep 17 00:00:00 2001
+From 7be30368232c5fc727ac51070ff3389b832b6a67 Mon Sep 17 00:00:00 2001
 From: Joseph Wu <josephwu@apache.org>
 Date: Wed, 10 Apr 2019 16:39:08 -0700
-Subject: [PATCH] Special cased HEARTBEAT call handling in agent.
+Subject: [PATCH 16/16] Special cased HEARTBEAT call handling in agent.
 
 This silences a '400 Bad Request' response by the agent whenever an
 executor sends a HEARTBEAT call.  These HEARTBEATs do not include a

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "33a1ba97041f178f8be53cdeb7cbeb7c78b89798",
+    "ref": "ccecf11e250621aad286564ecc1e98c307777277",
     "ref_origin": "1.7.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/33a1ba97041f178f8be53cdeb7cbeb7c78b89798...ccecf11e250621aad286564ecc1e98c307777277
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
