### PR TITLE
Replace pytest-xdist by execnet

### DIFF
--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -5,8 +5,8 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
 for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
-    azure-mgmt-network azure-storage beautifulsoup4 docutils keyring msrest \
-    msrestazure pytest-xdist requests-oauthlib schema webob wheel; do
+    azure-mgmt-network azure-storage beautifulsoup4 docutils execnet keyring msrest \
+    msrestazure requests-oauthlib schema webob wheel; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
 done
 

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -62,11 +62,6 @@
       "url": "https://pypi.python.org/packages/cf/23/ef729d6ef3a9d19732d480eaaf94a72799a99a38ed25eda10f8e68ffd408/azure_storage-0.32.0-py3-none-any.whl",
       "sha1": "3cc425a291fe6359f6d786aa040059004082795d"
     },
-    "pytest-xdist": {
-      "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/9f/cc/371b2e6dfbf4e8df07b04e310dd6ea0b3f367e257d1e6cb516b25bc4af1b/pytest_xdist-1.29.0-py2.py3-none-any.whl",
-      "sha1": "bddd3f0f1e00e87c85158bc121900ed798fcb10d"
-    },
     "msrest": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/a4/79/956d2475af557ccc7de76ef67087fc8e7b591162748ab7783d88e9b685d7/msrest-0.4.17-py2.py3-none-any.whl",
@@ -96,6 +91,11 @@
       "kind": "url",
       "url": "https://pypi.python.org/packages/3.4/d/docutils/docutils-0.12-py3-none-any.whl",
       "sha1": "88749802f8d61883da36a5abfca171a4ae60cc71"
+    },
+    "execnet": {
+      "kind": "url",
+      "url": "https://files.pythonhosted.org/packages/9a/73/5be9d235327b3770c330bed707766c8885e8157577db85f11b874b26da34/execnet-1.6.1-py2.py3-none-any.whl",
+      "sha1": "6e212e61c45486798f7a96040820f3aa2e8b46b6"
     },
     "humanfriendly": {
       "kind": "url_extract",

--- a/packages/dcos-integration-test/README.md
+++ b/packages/dcos-integration-test/README.md
@@ -1,0 +1,10 @@
+# How to run the integration tests
+```bash
+pip install virtualenv
+virtualenv venv
+. venv/bin/activate
+pip install -r requirements.txt
+cd extra
+pytest --env-help
+pytest
+```

--- a/packages/dcos-integration-test/requirements.txt
+++ b/packages/dcos-integration-test/requirements.txt
@@ -2,12 +2,26 @@ click==7.0
 cryptography==2.7
 pyjwt==1.7.1
 pytest==4.4.0
-pytest-xdist==1.29.0
 PyYAML==4.2b4
 webtest==2.0.32
 webtest-aiohttp==1.1.0
 schema==0.6.8
 teamcity-messages==1.25
+
+# pytest-xdist and its related dependencies
+apipkg==1.5
+atomicwrites==1.3.0
+attrs==19.1.0
+execnet==1.6.1
+importlib-metadata==0.19
+more-itertools==7.2.0
+pluggy==0.12.0
+py==1.8.0
+pytest-forked==1.0.2
+pytest-xdist==1.29.0
+setuptools==41.1.0
+six==1.12.0
+zipp==0.5.2
 
 # The following should be kept in sync with their panda packages. Don't forget to update enterprise as well.
 

--- a/tox.ini
+++ b/tox.ini
@@ -171,6 +171,6 @@ commands=
 [testenv:collect-integration-tests]
 platform=linux|darwin
 basepython=python3.5
-deps= -rpackages/dcos-integration-test/extra/requirements.txt
+deps= -rpackages/dcos-integration-test/requirements.txt
 commands=
   py.test --xfailflake-report --collect-only packages/dcos-integration-test/extra/


### PR DESCRIPTION
- The only real dependency needed was execnet, not all of pytest-xdist.
- Adding a README for how to run tests
- Pinning all pytest-xdist dependencies because pytest-xdist package doesn't and it sometimes causes errors, like recently when execnet was updated and broke pytest-xdist, even if pytest-xdist version was pinned!
- Moving packages/dcos-integration-test/extra/requirements.txt to packages/dcos-integration-test/requirements.txt so that the whole virtual environment is not copied to the remote cluster when integration tests are ran with pytest-xdist. The whole "extra" directory is synced to the remote cluster when pytest runs.
