### PR TITLE
[Forward port master] Fix Admin Router: Error on invalid Marathon service port label

### DIFF
--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -100,13 +100,13 @@ class TestStateCacheUpdate:
         An invalid `DCOS_SERVICE_PORT_INDEX` will not impact the cache refresh.
         """
         bad_app = _marathon_container_network_nginx_app(port_index=1)
-        with dcos_api_session.marathon.deploy_and_cleanup(bad_app, check_health=False, timeout=30):
+        with dcos_api_session.marathon.deploy_and_cleanup(bad_app, check_health=False, timeout=120):
 
             with pytest.raises(AssertionError):
                 _wait_for_state_cache_refresh(dcos_api_session, bad_app['id'])
 
             good_app = _marathon_container_network_nginx_app(port_index=0)
-            with dcos_api_session.marathon.deploy_and_cleanup(good_app, check_health=False, timeout=30):
+            with dcos_api_session.marathon.deploy_and_cleanup(good_app, check_health=False, timeout=120):
                 _wait_for_state_cache_refresh(dcos_api_session, good_app['id'])
 
 


### PR DESCRIPTION
## High-level description

Forward port of #6139

Previously, specifying an invalid `DCOS_SERVICE_PORT_INDEX` value in a Marathon app definition led to `Admin Router` crash looping on Marathon state cache refresh.
Now this scenario logs an appropriate error and the cache refresh continues by skipping such apps.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5491](https://jira.mesosphere.com/browse/DCOS_OSS-5491) Admin Router: wrong value in DCOS_SERVICE_PORT_INDEX breaks AR cache.


## Related tickets (optional)

  - [COPS-5147](https://jira.mesosphere.com/browse/COPS-5147) Specifying incorrect DCOS_SERVICE_PORT_INDEX breaks /service routing in adminrouter.