### PR TITLE
Add apipkg dependency

### DIFF
--- a/packages/dcos-image-deps/build
+++ b/packages/dcos-image-deps/build
@@ -4,7 +4,7 @@ export LIB_INSTALL_DIR="$PKG_PATH/lib/python3.6/site-packages"
 mkdir -p "$LIB_INSTALL_DIR"
 
 # Install wheels.
-for package in adal analytics-python azure-nspkg azure-common azure-mgmt-nspkg \
+for package in adal analytics-python apipkg azure-nspkg azure-common azure-mgmt-nspkg \
     azure-mgmt-network azure-storage beautifulsoup4 docutils execnet keyring msrest \
     msrestazure requests-oauthlib schema webob wheel; do
   pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl

--- a/packages/dcos-image-deps/buildinfo.json
+++ b/packages/dcos-image-deps/buildinfo.json
@@ -37,6 +37,11 @@
       "url": "https://pypi.python.org/packages/39/db/ba6ce2c3f13dd046eec3a7767a7d10607c15dc8b23d68bc125ad577f924f/analytics_python-1.2.3-py2.py3-none-any.whl",
       "sha1": "218ff1fdecb2a0d06499618a6d0e65fcecf50c19"
     },
+    "apipkg": {
+      "kind": "url",
+      "url": "https://files.pythonhosted.org/packages/67/08/4815a09603fc800209431bec5b8bd2acf2f95abdfb558a44a42507fb94da/apipkg-1.5-py2.py3-none-any.whl",
+      "sha1": "1e0df1d216243e4cb8bffd21e7ab851d0a629c49"
+    },
     "azure-common": {
       "kind": "url",
       "url": "https://pypi.python.org/packages/32/10/b353b328deb80e81a9288f0c684e4bbc6b022ec29110c4f90d265b07a371/azure_common-1.1.4-py2.py3-none-any.whl",


### PR DESCRIPTION
When pytest-xdist feature was tested, it was determined that execnet had to be installed on the remote host. We have since then added execnet as a dependency to DC/OS. However, it appears pytest-xdist's dependencies are not pinned (moving targets). So without any changes to DC/OS, pytest-xdist feature stopped working. The solution was to not only pin pytest-xdist (was already the case), but also all its dependencies. Those changes went into DC/OS, but there was still an issue that wasn't fixed. Pinning all the dependencies wasn't enough. Adding apipkg on the remote host was also necessary. This was not caught because we don't test pytest-xdist feature in CI. This is about to change with this PR: https://github.com/dcos/dcos/pull/6070
The current PR was also tested with the pytest-xdist feature here: https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&buildTypeId=DcOs_Open_Test_IntegrationTest_TerraformBasedIntegrationTests_PytestXdistTestAws&buildId=2180311