### PR TITLE
Improve upon initial automated Exhibitor lock-down E2E tests

### DIFF
--- a/packages/exhibitor/extra/bootstrap_exhibitor_tls.py
+++ b/packages/exhibitor/extra/bootstrap_exhibitor_tls.py
@@ -80,7 +80,7 @@ def gen_tls_artifacts(ca_url, artifacts_path):
 
     psk_path = Path(PRESHAREDKEY_LOCATION)
     if psk_path.exists():
-        psk = psk_path.read_text(encoding='ascii')
+        psk = psk_path.read_text(encoding='ascii').strip()
         print('Using preshared key from location `{}`'.format(str(psk_path)))
     else:
         print('No preshared key found at location `{}`'.format(str(psk_path)))


### PR DESCRIPTION
## High-level description

This PR adds new-line stripping to the Exhibitor lock-down PSK reading script.
This PR improves upon existing E2E tests for the automated Exhibitor lock-down feature to make it more easily maintainable.

## Corresponding DC/OS tickets (required)

  - [DCOS-57648](https://jira.mesosphere.com/browse/DCOS-57648) Automated Exhibitor lock-down: Clean up E2E tests.


## Related tickets (optional)


## Checklist for component/package updates:
