### PR TITLE
Fix Exhibitor clients

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2593,7 +2593,8 @@ package:
       # Read exhibitor status metrics from HTTP endpoint
       [[inputs.http]]
         name_override = "exhibitor_status"
-        urls = ["http://localhost:{{ exhibitor_port }}/exhibitor/v1/cluster/status"]
+        urls = ["https://127.0.0.1/exhibitor/exhibitor/v1/cluster/status"]
+        insecure_skip_verify = true
         data_format = "json"
         tag_keys = ["hostname"]
         json_string_fields = ["isLeader"]

--- a/packages/dcos-diagnostics/extra/dcos-diagnostics-master.service
+++ b/packages/dcos-diagnostics/extra/dcos-diagnostics-master.service
@@ -12,8 +12,8 @@ LimitNOFILE=16384
 PermissionsStartOnly=True
 User=root
 ExecStartPre=/bin/bash -c 'mkdir -p /run/dcos/etc/dcos-diagnostics'
-# Mesos is listening only on this IP so we need to use it in order to acces its endpoints
+# Mesos is listening only on this IP so we need to use it in order to access its endpoints
 ExecStartPre=/bin/bash -c 'echo "LIBPROCESS_IP=$($MESOS_IP_DISCOVERY_COMMAND)" > /run/dcos/etc/dcos-diagnostics/service.env'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-diagnostics-master
-ExecStart=/opt/mesosphere/bin/dcos-diagnostics daemon --config ${DCOS_DIAGNOSTICS_CONFIG_PATH} --hostname $LIBPROCESS_IP
+ExecStart=/opt/mesosphere/bin/dcos-diagnostics daemon --config ${DCOS_DIAGNOSTICS_CONFIG_PATH} --hostname $LIBPROCESS_IP --exhibitor-url https://127.0.0.1:443/exhibitor/exhibitor/v1/cluster/status
 Sockets=dcos-diagnostics.socket

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -186,10 +186,6 @@ def test_metrics_master_adminrouter_nginx_vts(dcos_api_session):
     check_adminrouter_metrics()
 
 
-@pytest.mark.xfailflake(
-    jira="DCOS-57896",
-    reason="Does not find expected metrics 'exhibitor_status_isleader', 'exhibitor_status_code'",
-    since="2019-08-23")
 def test_metrics_master_exhibitor_status(dcos_api_session):
     """Assert that Exhibitor status metrics on master are present."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)


### PR DESCRIPTION
## High-level description

This PR redirects Exhibitor clients through Admin Router because with Exhibitor TLS enabled they no longer have direct access.


## Corresponding DC/OS tickets (required)

  - [DCOS-57704](https://jira.mesosphere.com/browse/DCOS-57704) Fix DC/OS clients that do not adhere to Exhibitor TLS.
