### PR TITLE
Add test for CockroachDB config change service

### DIFF
--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=CockroachDB Disable Diagnostics: Disable CockroachDB diagnostic reporting
+Description=CockroachDB Config Change: Ensure `num_replicas` equals the expected number of master nodes.
 Documentation=https://docs.mesosphere.com
 
 [Service]

--- a/packages/dcos-integration-test/extra/test_cockroach_config.py
+++ b/packages/dcos-integration-test/extra/test_cockroach_config.py
@@ -1,0 +1,39 @@
+"""
+Testing the CockroachDB setup in DC/OS.
+"""
+import logging
+import subprocess
+
+from retrying import retry
+
+
+__maintainer__ = 'tweidner'
+__contact__ = 'security-team@mesosphere.io'
+
+
+LOG = logging.getLogger(__name__)
+
+
+def test_config_change_applied():
+    config_change_unit = 'dcos-cockroachdb-config-change'
+    subprocess.check_call(
+        ['sudo', 'systemctl', 'restart', config_change_unit],
+    )
+    assert _wait_for_expected_journal_output(
+        # Indicator for successful config update via CRDB SQL client.
+        expected_output='CONFIGURE ZONE 1',
+        unit=config_change_unit,
+    )
+
+
+@retry(
+    stop_max_delay=30000,
+    wait_fixed=1000,
+    retry_on_result=lambda x: not x,
+)
+def _wait_for_expected_journal_output(expected_output, unit):
+    result = subprocess.check_output(
+        ['sudo', 'journalctl', '-u', unit, '--no-pager'],
+        universal_newlines=True,
+    )
+    return expected_output in result

--- a/packages/dcos-integration-test/extra/test_groups.yaml
+++ b/packages/dcos-integration-test/extra/test_groups.yaml
@@ -59,6 +59,7 @@ groups:
         - test_composition.py
         - test_dcos_diagnostics.py
         - test_exhibitor.py
+        - test_cockroach_config.py
     group_2:
         - test_dcos_log.py
         - test_endpoints.py


### PR DESCRIPTION
## High-level description

This PR adds a test for CockroachDB config changes actually being applied by the corresponding service.

In Enterprise we work around a critical bug that prevented the CockroachDB `num_replicas` being set by the `cockroachdb-config-change.py` script in subsequent runs (after the initial CockroachDB unit start, if unsuccessful) for CockroachDB 2.1.7.

An issue with CockroachDB for the bug has been filed here:
https://github.com/cockroachdb/cockroach/issues/39760


Legacy comments were removed which are no longer true.

## Corresponding DC/OS tickets (required)

  - [DCOS-57769](https://jira.mesosphere.com/browse/DCOS-57769) Fix dcos-cockroachdb-config-change to correctly update num_replicas.


## Related tickets (optional)

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.