### PR TITLE
[1.10] Replace artisanal docer version detect script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* Fix preflight docker version check failing for docker 1.19. (DCOS-56831)
+
 * Fixed a bug in Admin Router's service endpoint as of which the DCOS_SERVICE_REQUEST_BUFFERING setting was not adhered to in all cases. (DCOS_OSS-4999)
 
 * [MARATHON-8493](https://jira.mesosphere.com/browse/MARATHON-8493) Fixed precision bug associated with summing pod resources.


### PR DESCRIPTION
Backports: https://github.com/dcos/dcos/pull/5993
---
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Fix problems with docker version > 1.19 which added new entries to `docker version` output.

Latest docker hase more entries in `docker version` output. See folowing examples

```yaml
Client: Docker Engine - Community
 Version:           19.03.1
 API version:       1.35 (downgraded from 1.40)
 Go version:        go1.12.5
 Git commit:        74b1e89
 Built:             Thu Jul 25 21:21:07 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          17.12.1-ce
  API version:      1.35 (minimum version 1.12)
  Go version:       go1.9.4
  Git commit:       7390fc6
  Built:            Tue Feb 27 22:20:43 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```

```yaml
Client: Docker Engine - Community
 Version:           19.03.1
 API version:       1.40
 Go version:        go1.12.5
 Git commit:        74b1e89
 Built:             Thu Jul 25 21:21:07 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.1
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.5
  Git commit:       74b1e89
  Built:            Thu Jul 25 21:19:36 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.6
  GitCommit:        894b81a4b802e4eb2a91d1ce216b8817763c29fb
 runc:
  Version:          1.0.0-rc8
  GitCommit:        425e105d5a03fabd737a126ad93d62a9eeede87f
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```

The previous script instead of `Engine: Version:` took `docker-init: Version:` and then took lowest version from client and server. This PR removes AWK script and replace it with `sort -V` which can correctly sort versions and `docker version -f` which allow us to use go template to get version in desired output`. Here we are interested only in client and server versions and choosing the lowest.


## Corresponding DC/OS tickets (required)

  - [DCOS-56831](https://jira.mesosphere.com/browse/DCOS-56831)
  - [DCOS-57154](https://jira.mesosphere.com/browse/DCOS-57154)
  - [DCOS-57676](https://jira.mesosphere.com/browse/DCOS-57676)


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
