### PR TITLE
packages/exhibitor: change location of exhibitor bootstrap psk

### DIFF
--- a/packages/exhibitor/extra/bootstrap_exhibitor_tls.py
+++ b/packages/exhibitor/extra/bootstrap_exhibitor_tls.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 
 TLS_ARTIFACT_LOCATION = '/var/lib/dcos/exhibitor-tls-artifacts'
 CSR_SERVICE_CERT_PATH = '/tmp/root-cert.pem'
-PRESHAREDKEY_LOCATION = '/root/.dcos-bootstrap-ca-psk'
+PRESHAREDKEY_LOCATION = '/var/lib/dcos/.dcos-bootstrap-ca-psk'
 EXHIBITOR_TLS_TMP_DIR = '/var/lib/dcos/exhibitor/.pki'
 BOOTSTRAP_CA_BINARY = '/opt/mesosphere/bin/dcos-bootstrap-ca'
 


### PR DESCRIPTION
## High-level description

Changes the location of expected bootstrap PSK


## Corresponding DC/OS tickets (required)

  - [DCOS-57650](https://jira.mesosphere.com/browse/DCOS-57650) automated exhibitor lock-down: expect psk under /var/lib/dcos/... (not /root)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain: Test in EE version
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
 