### PR TITLE
Admin Router invalid Marathon service port fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### Fixed and improved
 
 * Added new diagnostics bundle REST API with performance improvements. (DCOS_OSS-5098)
+* [Admin Router] Improved service routing robustness by omitting Marathon apps with wrongly specified DCOS_SERVICE_PORT_INDEX values. (DCOS_OSS-5491)
 
 ### Security updates
 

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -254,15 +254,48 @@ local function fetch_and_store_marathon_apps(auth_token)
        -- in that case.
        -- In "container/bridge" and "host" networking modes we need to use the
        -- host port for routing (available via task's ports array)
-       if is_container_network(app) and app["container"]["portMappings"][portIdx]["containerPort"] ~= 0 then
-         port = app["container"]["portMappings"][portIdx]["containerPort"]
-       else
-         port = task["ports"][portIdx]
+       local port
+       if is_container_network(app) then
+
+           -- Special case, meaning no ports defined for app in container networking mode.
+           if next(app["container"]["portMappings"]) == nil then
+               goto continue
+           end
+
+           -- In every other case portMappings exist with at least the default.
+           -- Skip routing if DCOS_SERVICE_PORT_INDEX points out of bounds of existing portMappings.
+           if not app["container"]["portMappings"][portIdx] then
+               ngx.log(ngx.NOTICE, "Cannot find port in container portMappings at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
+               goto continue
+           end
+
+           -- If the portMapping exists containerPort always exists.
+           -- https://mesosphere.github.io/marathon/docs/networking.html#port-mappings
+           -- For any other case route to the containerPort in container networking mode.
+           -- NOTE(tweidner): I believe this is unnecessary, containerPort 0 is not a special case.
+           if app["container"]["portMappings"][portIdx]["containerPort"] ~= 0 then
+               port = app["container"]["portMappings"][portIdx]["containerPort"]
+           end
        end
 
+       -- If the containerPort was randomly assigned or any other networking mode is used
+       -- try routing to the task ports assigned by Mesos for the given Marathon app.
        if not port then
-          ngx.log(ngx.NOTICE, "Cannot find port at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
-          goto continue
+
+           -- Skip routing if the Mesos task does not include the ports field.
+           if not task["ports"] then
+               ngx.log(ngx.NOTICE, "Task ports field is not defined for app '" .. appId .. "'")
+               goto continue
+           end
+
+           -- Skip routing if DCOS_SERVICE_PORT_INDEX points out of bounds of existing task ports.
+           if not task["ports"][portIdx] then
+               ngx.log(ngx.NOTICE, "Cannot find port in task ports at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
+               goto continue
+           end
+
+           -- For any other case route to the task port assigned by Mesos.
+           port = task["ports"][portIdx]
        end
 
        -- Details on how Admin Router interprets DCOS_SERVICE_REWRITE_REQUEST_URLS label:

--- a/packages/dcos-integration-test/extra/test_adminrouter_open.py
+++ b/packages/dcos-integration-test/extra/test_adminrouter_open.py
@@ -100,13 +100,13 @@ class TestStateCacheUpdate:
         An invalid `DCOS_SERVICE_PORT_INDEX` will not impact the cache refresh.
         """
         bad_app = _marathon_container_network_nginx_app(port_index=1)
-        with dcos_api_session.marathon.deploy_and_cleanup(bad_app, check_health=False, timeout=30):
+        with dcos_api_session.marathon.deploy_and_cleanup(bad_app, check_health=False, timeout=120):
 
             with pytest.raises(AssertionError):
                 _wait_for_state_cache_refresh(dcos_api_session, bad_app['id'])
 
             good_app = _marathon_container_network_nginx_app(port_index=0)
-            with dcos_api_session.marathon.deploy_and_cleanup(good_app, check_health=False, timeout=30):
+            with dcos_api_session.marathon.deploy_and_cleanup(good_app, check_health=False, timeout=120):
                 _wait_for_state_cache_refresh(dcos_api_session, good_app['id'])
 
 


### PR DESCRIPTION
## High-level description

Previously, specifying an invalid `DCOS_SERVICE_PORT_INDEX` value in a Marathon app definition led to `Admin Router` crash looping on Marathon state cache refresh.
Now this scenario logs an appropriate error and the cache refresh continues by skipping such apps.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5491](https://jira.mesosphere.com/browse/DCOS_OSS-5491) Admin Router: wrong value in DCOS_SERVICE_PORT_INDEX breaks AR cache.


## Related tickets (optional)

  - [COPS-5147](https://jira.mesosphere.com/browse/COPS-5147) Specifying incorrect DCOS_SERVICE_PORT_INDEX breaks /service routing in adminrouter.