### PR TITLE
[master] Bump Mesos to nightly master 978c760

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Added L4LB metrics in DC/OS Net. (DCOS_OSS-5011)
 
-* Updated to [Mesos 1.9.x](https://github.com/apache/mesos/blob/ea953482f82131fcf033aca60145b1471ce4fcb2/CHANGELOG). (DCOS_OSS-5342)
+* Updated to Mesos [1.9.0-dev](https://github.com/apache/mesos/blob/978c7609e7fd2a26fbefe2e4a3712a665cad5d70/CHANGELOG)
 
 * Bumped Mesos modules to have overlay metrics exposed. (DCOS_OSS-5322)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ea953482f82131fcf033aca60145b1471ce4fcb2",
+    "ref": "978c7609e7fd2a26fbefe2e4a3712a665cad5d70",
     "ref_origin": "master"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ea953482f82131fcf033aca60145b1471ce4fcb2",
+    "ref": "978c7609e7fd2a26fbefe2e4a3712a665cad5d70",
     "ref_origin": "master"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/ea953482f82131fcf033aca60145b1471ce4fcb2...978c7609e7fd2a26fbefe2e4a3712a665cad5d70
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
