### PR TITLE
Remove nogroup group creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### What's new
 
 * Added the ability to drain agent nodes via the DC/OS CLI and UI. (DCOS-53654)
+* Remove nogroup group from installation (COPS-5220)
 
 * Created new diagnostics bundle REST API with performance improvements. (DCOS_OSS-5098)
 

--- a/cloud_images/lib/el7/configure_dcos_system.sh
+++ b/cloud_images/lib/el7/configure_dcos_system.sh
@@ -61,9 +61,6 @@ sed -i'' -E 's/^(Defaults.*requiretty)/#\1/' /etc/sudoers
 
 . /tmp/install_docker.sh
 
-echo ">>> Adding group [nogroup]"
-/usr/sbin/groupadd -f nogroup
-
 echo ">>> Cleaning up SSH host keys"
 shred -u /etc/ssh/*_key /etc/ssh/*_key.pub
 

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -488,12 +488,6 @@ function check_all() {
     # Pick up just the first line of output and get the version from it
     check systemctl 200 $(systemctl --version | head -1 | cut -f2 -d' ') systemd
 
-    echo -e -n "Checking if group 'nogroup' exists: "
-    getent group nogroup > /dev/null
-    RC=$?
-    print_status $RC
-    (( OVERALL_RC += $RC ))
-
     # Run service check on master node only
     if [[ $AGENT_ONLY -eq 0 ]]; then
         # master node service checks


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

ATT&T is blocked from upgrading DC/OS because their security team does not allow non-standard linux group creation. We currently create the `nogroup` group, but it appears that it may not actually be used any longer. It looks like it was originally used by nginx (admin router). Depending where the service was started from, it'd set the nginx configuration to use either the `nobody` group (for Redhat based systems), or the `nogroup` group (for Debian based systems). It looks like we started creating the `nogroup` group on all systems to keep things consistent.


## Corresponding DC/OS tickets (required)

  - [COPS-5220](https://jira.mesosphere.com/browse/COPS-5220)


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->