### PR TITLE
[Backport 1.13] Bump DC/OS E2E

### DIFF
--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.06.19.0
+git+https://github.com/dcos/dcos-e2e.git@2019.08.28.0
 cryptography==2.5
 docker==3.7.0
 jwt==0.5.4


### PR DESCRIPTION
## High-level description

Backport of #6169 

Bump DC/OS E2E to version 2019.08.28.0

## Corresponding DC/OS tickets (required)

  - [DCOS-58001](https://jira.mesosphere.com/browse/DCOS-58001) Bump dcos-e2e in 1.12, 1.13 and master branches.