### PR TITLE
[Backport 1.12] Bump DC/OS E2E

### DIFF
--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/dcos/dcos-e2e.git@2019.06.19.0
+git+https://github.com/dcos/dcos-e2e.git@2019.08.28.0
 git+https://github.com/dcos/dcos-test-utils.git@3ebfc18ff9c5a1aa382311474a9192a68c98b0a7
 docker==3.7.0
 kazoo==2.6.1


### PR DESCRIPTION
## High-level description

Backport of #6169 

Bump DC/OS E2E to version 2019.08.28.0

## Corresponding DC/OS tickets (required)

  - [DCOS-58001](https://jira.mesosphere.com/browse/DCOS-58001) Bump dcos-e2e in 1.12, 1.13 and master branches.