### PR TITLE
Bump DC/OS Net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * DC/OS Net: Fix support for big sets in the ipset manager. (COPS-5229)
 
+* DC/OS Net: switch to Erlang/OTP's Logger in order to be able to handle log message bursts without compromising the system stability. (DCOS_OSS-5461)
+
+* DC/OS Net: use exponential backoff when retrying failed requests to Mesos in order not to impose additional load onto potentially already overloaded Mesos. (DCOS_OSS-5459)
+
 ### Breaking changes
 
 The following parameters have been removed from the DC/OS installer:

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,8 +4,8 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "f6c0a5bd4e4556234f72531aa6c109c63928dde7",
-      "ref_origin": "master"
+      "ref": "75ba3ccf60ce53cb1b7c9f34795313524b63d03c",
+      "ref_origin": "inc/backoff-dep"
     }
   },
   "sysctl": {

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,8 +4,8 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "7ce680ae0679e3a11e13afd759ddc764150525d7",
-      "ref_origin": "inc/backoff-dep"
+      "ref": "ef0b8b7d6c5690826d77211786e677e9a79bc1c0",
+      "ref_origin": "master"
     }
   },
   "sysctl": {

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "b3acd818f7824cdc8238542c44ebce26f75309b5",
+      "ref": "f6c0a5bd4e4556234f72531aa6c109c63928dde7",
       "ref_origin": "master"
     }
   },

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "75ba3ccf60ce53cb1b7c9f34795313524b63d03c",
+      "ref": "7ce680ae0679e3a11e13afd759ddc764150525d7",
       "ref_origin": "inc/backoff-dep"
     }
   },


### PR DESCRIPTION
## High-level description

Improves stability of DC/OS Net in case of high-load.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5459](https://jira.mesosphere.com/browse/DCOS_OSS-5459) DC/OS Net: use exponential backoff when retrying failed requests to Mesos in order not to impose additional load onto potentially already overloaded Mesos.
  - [DCOS_OSS-5461](https://jira.mesosphere.com/browse/DCOS_OSS-5461) DC/OS Net: switch to Erlang/OTP's Logger in order to be able to handle log message bursts without compromising the system stability.

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/b3acd818f7824cdc8238542c44ebce26f75309b5...ef0b8b7d6c5690826d77211786e677e9a79bc1c0)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [CI job](https://circleci.com/gh/dcos/dcos-net/1383)
  - [x] Code Coverage: [report](https://codecov.io/gh/dcos/dcos-net/pull/176)
