### PR TITLE
Bump Marathon to 1.9.71

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,9 +10,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Created new diagnostics bundle REST API with performance improvements. (DCOS_OSS-5098)
 
-* Upgraded Marathon to 1.9.64. Marathon 1.9 brings support for multirole, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
+* Upgraded Marathon to 1.9.71. Marathon 1.9 brings support for multi-role, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
 
-* The command-line flag MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR
+* The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0). Also, Signal now sends telemetry data every 5 minutes instead of every hour. This is to align the frequency with DC/OS Enterprise.
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -1,4 +1,4 @@
-{rat
+{
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -1,9 +1,9 @@
-{
+{rat
   "requires" : [ "java" ],
   "single_source" : {
     "kind" : "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/builds/1.9.64-177e546c5/marathon-1.9.64-177e546c5.tgz",
-    "sha1": "24b8e6a8f4ba32ba02b580f3b2bd8b176c41e570"
+    "url": "https://downloads.mesosphere.io/marathon/builds/1.9.71-3b6769765/marathon-1.9.71-3b6769765.tgz",
+    "sha1": "bb530a7458be4e1421e64ac5c7b079b2a2f2faa7"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [MARATHON-8694](https://jira.mesosphere.com/browse/MARATHON-8694) - Allow modification of enforceRole via the PUT /v2/groups endpoint

  - [MARATHON-8693](https://jira.mesosphere.com/browse/MARATHON-8693) - Fix rare bug in which resident service because stuck and unremovable when Mesos fails to create a reservation

## Related tickets (optional)

  - [MARATHON-8682](https://jira.mesosphere.com/browse/MARATHON-8682) - Internal refactoring to make treatment of paths in Marathon less error-prone.

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/v1.9.64...v1.9.71)
  - [x] Test Results: (Master Build)[https://jenkins.mesosphere.com/service/jenkins/job/marathon-pipelines/job/master/1378/]
