### PR TITLE
Allow post-installation customization of Metronome config 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated to Mesos [1.8.2-dev](https://github.com/apache/mesos/blob/adc958f553c3728aab5529de56b0ddc30c0f9b68/CHANGELOG)
 
+* Metronome post-install configuration can be added to `/var/lib/dcos/metronome/environment` (DCOS_OSS-5509)
 
 ### Notable changes
 

--- a/packages/metronome/build
+++ b/packages/metronome/build
@@ -22,6 +22,8 @@ EnvironmentFile=/opt/mesosphere/etc/check_time.env
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/metronome
 EnvironmentFile=-/run/dcos/etc/metronome/service.env
+# The env file in /var/lib/dcos is for post-install configuration via environment variables, and persists with upgrades.
+EnvironmentFile=-/var/lib/dcos/metronome/environment
 ExecStartPre=/opt/mesosphere/bin/check-time
 ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-metronome


### PR DESCRIPTION
## High-level description

This change modifies the init config file for Metronome to source a post-install configuration file for Metronome, similar to that which exists for Marathon.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5509](https://jira.mesosphere.com/browse/DCOS_OSS-5509) Support adding post-install environment variables to Metronome in `/var/lib/dcos/marathon/environment`

## Checklist for component/package updates:

N/A