### PR TITLE
packages/exhibitor: run zkServer.sh stop on system unit exit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,3 +105,5 @@ The Marathon option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES` has been deprecat
 * Added framework ID tags to Mesos framework metrics. (DCOS-53302)
 
 * Fix preflight docker version check failing for docker 1.19. (DCOS-56831)
+
+* Fix leaking Zookeeper instance on `dcos-exhibitor` systemd unit restart. (DCOS-57231)

--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -35,3 +35,13 @@ ExecStartPre=$PKG_PATH/bin/bootstrap_exhibitor_tls.py
 ExecStartPre=$PKG_PATH/bin/set_exhibitor_file_permissions.py
 # Start Exhibitor
 ExecStart=$PKG_PATH/usr/exhibitor/start_exhibitor.py
+
+# Environment variables that are required to run `zkServer.sh` script correctly.
+# Values must be kept in sync wiht `start_exhibitor.py` script.
+Environment=ZOOCFGDIR=/var/lib/dcos/exhibitor/conf
+Environment=ZOO_LOG_DIR=/var/lib/dcos/exhibitor/zookeeper
+Environment=ZOOPIDFILE=/var/lib/dcos/exhibitor/zk.pid
+
+# Ensure that ZK process has been cleaned up correctly and that pid file has
+# been removed
+ExecStop=$PKG_PATH/usr/zookeeper/bin/zkServer.sh stop

--- a/packages/exhibitor/extra/dcos_zk_backup.py
+++ b/packages/exhibitor/extra/dcos_zk_backup.py
@@ -44,6 +44,10 @@ def _is_zookeeper_running(verbose: bool) -> bool:
     Returns whether the ZooKeeper process that Exhibitor controls is running.
     """
     zk_pid_file = Path('/var/lib/dcos/exhibitor/zk.pid')
+
+    # If there is no pid file the ZK is not running
+    if not zk_pid_file.exists():
+        return False
     zk_pid = int(zk_pid_file.read_text())
     try:
         # Check whether the ZooKeeper that Exhibitor controls is running.


### PR DESCRIPTION
## High-level description

Make sure that `zkServer.sh stop` is executed when `systemd` unit is restarted.


## Corresponding DC/OS tickets (required)

  - [DCOS-57231](https://jira.mesosphere.com/browse/DCOS-57231) Exhibitor fails to reestablish quorum after restore

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): n/a
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain: There are no tests for systemd units. This change is potentially fixing a failing test.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]