### PR TITLE
Add marathon_new_group_enforce_role config option to the DC/OS installer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Upgraded Marathon to 1.9.73. Marathon 1.9 brings support for multi-role, enabling you to launch services for different roles (against different Mesos quotas) with the same Marathon instance.
 
+* The configuration option `marathon_new_group_enforce_role` has been added to the installation config, and defaults to "top". This changes the default role for new services posted to non-existent groups, and ultimately affects the ability to deploy to public agents. Consider switching to use a top-level group `/slave_public` for these services. The config option can be changed from "top" to "off".
+
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0). Also, Signal now sends telemetry data every 5 minutes instead of every hour. This is to align the frequency with DC/OS Enterprise.

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -215,6 +215,11 @@ def validate_marathon_gpu_scheduling_behavior(marathon_gpu_scheduling_behavior):
         "marathon_gpu_scheduling_behavior must be 'restricted', 'unrestricted', 'undefined' or ''"
 
 
+def validate_marathon_new_group_enforce_role(marathon_new_group_enforce_role):
+    assert marathon_new_group_enforce_role in ['top', 'off', ''], \
+        "marathon_new_group_enforce_role must be 'top', 'off', or ''"
+
+
 def calculate_mesos_log_retention_count(mesos_log_retention_mb):
     # Determine how many 256 MB log chunks can be fit into the given size.
     # We assume a 90% compression factor; logs are compressed after 2 rotations.
@@ -1171,6 +1176,7 @@ entry = {
         lambda log_offers: validate_true_false(log_offers),
         lambda mesos_cni_root_dir_persist: validate_true_false(mesos_cni_root_dir_persist),
         lambda enable_mesos_input_plugin: validate_true_false(enable_mesos_input_plugin),
+        validate_marathon_new_group_enforce_role,
     ],
     'default': {
         'exhibitor_azure_account_key': '',
@@ -1220,6 +1226,7 @@ entry = {
         'mesos_default_container_shm_size': '',
         'metronome_gpu_scheduling_behavior': 'restricted',
         'marathon_gpu_scheduling_behavior': 'restricted',
+        'marathon_new_group_enforce_role': 'top',
         'oauth_issuer_url': 'https://dcos.auth0.com/',
         'oauth_client_id': '3yF5TOSzdlI45Q1xspxzeoGBe9fNxm9m',
         'oauth_auth_redirector': 'https://auth.dcos.io',
@@ -1374,6 +1381,8 @@ entry = {
         'metronome_port': '9000',
         'has_metronome_gpu_scheduling_behavior':
             lambda metronome_gpu_scheduling_behavior: calculate_set(metronome_gpu_scheduling_behavior),
+        'has_marathon_new_group_enforce_role':
+            lambda marathon_new_group_enforce_role: calculate_set(marathon_new_group_enforce_role),
         'has_marathon_gpu_scheduling_behavior':
             lambda marathon_gpu_scheduling_behavior: calculate_set(marathon_gpu_scheduling_behavior),
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2064,6 +2064,11 @@ package:
       MARATHON_GPU_SCHEDULING_BEHAVIOR={{ marathon_gpu_scheduling_behavior }}
 {% case "false" %}
 {% endswitch %}
+{% switch has_marathon_new_group_enforce_role %}
+{% case "true" %}
+      MARATHON_NEW_GROUP_ENFORCE_ROLE={{ marathon_new_group_enforce_role }}
+{% case "false" %}
+{% endswitch %}
 
   - path: /etc/proxy.env
 {% switch use_proxy %}


### PR DESCRIPTION
## High-level description

This adds a new config option to the DC/OS installer, marathon_new_group_enforce_role, and defaults it to 'top'. This causes new services for not-yet-created groups to default to use the group-role, rather than the default mesos role. The same thing happens when we 

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5532](https://jira.mesosphere.com/browse/DCOS_OSS-5532) Change the default for root marathon to enable enforceRole by default for new top-level groups
