### PR TITLE
Use dcos-core-cli-2.0-patch.2 in tests

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -217,7 +217,7 @@ def install_dcos_cli(tmpdir_factory: TempdirFactory):
     tmpdir = tmpdir_factory.mktemp('dcos_cli')
     cli = dcos_cli.DcosCli.new_cli(
         download_url='https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/latest/dcos',
-        core_plugin_url='https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.14-patch.2.zip',  # noqa: E501
+        core_plugin_url='https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.2.zip',  # noqa: E501
         ee_plugin_url='https://downloads.mesosphere.io/cli/releases/plugins/dcos-enterprise-cli/linux/x86-64/dcos-enterprise-cli-1.13-patch.1.zip',  # noqa: E501
         tmpdir=str(tmpdir)
     )


### PR DESCRIPTION
## High-level description

This bumps the dcos-core-cli used in tests to the latest release.

## Corresponding DC/OS tickets (required)

https://jira.mesosphere.com/browse/DCOS-56863