### PR TITLE
[2.0] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -81,6 +81,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * DC/OS Net: use exponential backoff when retrying failed requests to Mesos in order not to impose additional load onto potentially already overloaded Mesos. (DCOS_OSS-5459)
 
+* Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
+
 ### Breaking changes
 
 The following parameters have been removed from the DC/OS installer:

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "694479cfdb0b461e486ab7d51147baaba2621883",
+    "ref": "b7bb3ffce52c5f57e0c29ce08408952aa9971342",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

An HTTP endpoint should be introduced that accepts a list of agent IP addresses to remove from the Mesos overlay state. It is needed to drop such records for agents that are gone.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5536](https://jira.mesosphere.com/browse/DCOS_OSS-5536) Mesos overlay networking: support dropping agents from the state


## Checklist for component/package updates:

  - [x] Change log from the last version integrated: [diff](https://github.com/dcos/dcos-mesos-modules/compare/694479cfdb0b461e486ab7d51147baaba2621883...b7bb3ffce52c5f57e0c29ce08408952aa9971342)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Test Results: [CI job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/177/)
  - [ ] Code Coverage (if available): NA
 