### PR TITLE
[1.13] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Metronome post-install configuration can be added to `/var/lib/dcos/metronome/environment` (DCOS_OSS-5509)
 
+* Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
+
 ### Notable changes
 
 

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "1869381f77ff89e60fba20540e7775cd8d6fdbc2",
+    "ref": "4a795855926ff261d3610acea3c2a9e86f4b6650",
     "ref_origin": "1.13"
   }
 }


### PR DESCRIPTION
## High-level description

An HTTP endpoint should be introduced that accepts a list of agent IP addresses to remove from the Mesos overlay state. It is needed to drop such records for agents that are gone.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5536](https://jira.mesosphere.com/browse/DCOS_OSS-5536) Mesos overlay networking: support dropping agents from the state


## Checklist for component/package updates:

  - [x] Change log from the last version integrated: [diff](https://github.com/dcos/dcos-mesos-modules/compare/1869381f77ff89e60fba20540e7775cd8d6fdbc2...4a795855926ff261d3610acea3c2a9e86f4b6650)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Test Results: No CI job run because CI is broken for backports. Ran tests locally.
  - [ ] Code Coverage (if available): NA
 