### PR TITLE
[1.12] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Metronome post-install configuration can be added to `/var/lib/dcos/metronome/environment` (DCOS_OSS-5509)
 
+* Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
+
 ### Notable changes
 
 * Updated DC/OS UI to [1.12+v2.26.17](https://github.com/dcos/dcos-ui/releases/tag/1.12+v2.26.17).

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "c4a639e1c58f448d60159a7eb5e58d17f93c36f9",
+    "ref": "ce2ab1fa3859413cb4c8f068cab77164c0b12c97",
     "ref_origin": "1.12"
   }
 }


### PR DESCRIPTION
## High-level description

An HTTP endpoint should be introduced that accepts a list of agent IP addresses to remove from the Mesos overlay state. It is needed to drop such records for agents that are gone.

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5536](https://jira.mesosphere.com/browse/DCOS_OSS-5536) Mesos overlay networking: support dropping agents from the state


## Checklist for component/package updates:

  - [x] Change log from the last version integrated: [diff](https://github.com/dcos/dcos-mesos-modules/compare/c4a639e1c58f448d60159a7eb5e58d17f93c36f9...ce2ab1fa3859413cb4c8f068cab77164c0b12c97)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Test Results: No CI job run because CI is broken for backports. Ran tests locally.
  - [ ] Code Coverage (if available): NA
 