### PR TITLE
[2.0] Bump DC/OS Net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,3 +105,5 @@ The Marathon option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES` has been deprecat
 * Added framework ID tags to Mesos framework metrics. (DCOS-53302)
 
 * Fix preflight docker version check failing for docker 1.19. (DCOS-56831)
+
+* DC/OS Net: wait till agents become active before fanning out Mesos tasks. (DCOS_OSS-5463)

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "ef0b8b7d6c5690826d77211786e677e9a79bc1c0",
+      "ref": "8e3302aa7e3815c5739c7b0460974103217ea161",
       "ref_origin": "master"
     }
   },


### PR DESCRIPTION
## High-level description

Upon a Mesos failover or simple reconnect to Mesos, `dcos-net`'s Mesos listener waits for some time till agents are registered and tasks accumulated before publishing updates to its subscribers in order to avoid flushing of DNS records, which might cause unavailability.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5463](https://jira.mesosphere.com/browse/DCOS_OSS-5463) dcos-net: use cached Mesos state in case of Mesos instability
  - [DCOS_OSS-5523](https://jira.mesosphere.com/browse/DCOS_OSS-5523) dcos-dns polls Mesos DNS on each DC/OS master node

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-net/compare/ef0b8b7d6c5690826d77211786e677e9a79bc1c0...8e3302aa7e3815c5739c7b0460974103217ea161)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Test Results: [CI job](https://circleci.com/gh/dcos/dcos-net/1395)
  - [x] Code Coverage: [report](https://codecov.io/gh/dcos/dcos-net/pull/181)