### PR TITLE
Check if the returned JSON from marathon actually is an empty list or nil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated to Boost 1.65.0 (DCOS_OSS-5555)
 
+* Admin Router: Accept nil task list from Marathon when updating cache. (DCOS_OSS-5541)
+
 
 ### Breaking changes
 

--- a/packages/adminrouter/extra/src/lib/cache.lua
+++ b/packages/adminrouter/extra/src/lib/cache.lua
@@ -197,6 +197,10 @@ local function fetch_and_store_marathon_apps(auth_token)
 
        local tasks = app["tasks"]
 
+       if tasks == nil then
+           ngx.log(ngx.NOTICE, "No tasks for app '" .. appId .. "'")
+           goto continue
+       end
        -- Process only tasks in TASK_RUNNING state.
        -- From http://lua-users.org/wiki/TablesTutorial: "inside a pairs loop,
        -- it's safe to reassign existing keys or remove them"


### PR DESCRIPTION
## High-level description
Fix for an edge case where the marathon apps endpoint returns null for the task list instead of an empty array

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5541](https://jira.mesosphere.com/browse/DCOS_OSS-5541) AdminRouter Cache Fails When Marathon returns no task field

  