### PR TITLE
DCOS-59103 - Set the 2.0 DC/OS version to 2.0.0-dev

### DIFF
--- a/dcos_installer/test_backend.py
+++ b/dcos_installer/test_backend.py
@@ -64,7 +64,7 @@ def test_version(monkeypatch):
     monkeypatch.setenv('BOOTSTRAP_VARIANT', 'some-variant')
     version_data = subprocess.check_output(['dcos_installer', '--version']).decode()
     assert json.loads(version_data) == {
-        'version': '2.0.0-beta',
+        'version': '2.0.0-dev',
         'variant': 'some-variant'
     }
 

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -37,7 +37,7 @@ import yaml
 import gen.internals
 
 
-DCOS_VERSION = '2.0.0-beta'
+DCOS_VERSION = '2.0.0-dev'
 
 CHECK_SEARCH_PATH = '/opt/mesosphere/bin:/usr/bin:/bin:/sbin'
 


### PR DESCRIPTION
* DCOS-59103 - Set the 2.0 DC/OS version to 2.0.0-dev