### PR TITLE
[master] Bump Mesos to nightly 1.9.x 27e3e8f

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
-* Updated to [Mesos 1.9](https://github.com/apache/mesos/blob/4895d4430f1349dc126fb004102184f8d0e9d2b3/CHANGELOG). (DCOS_OSS-5342)
+* Updated to Mesos [1.9.1-dev](https://github.com/apache/mesos/blob/27e3e8ff1cf0f0b9201a71a6853a1a1da44cb633/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "4895d4430f1349dc126fb004102184f8d0e9d2b3",
+    "ref": "27e3e8ff1cf0f0b9201a71a6853a1a1da44cb633",
     "ref_origin": "1.9.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "5e79a584e6ec3e9e2f96e8bf418411df9dafac2e",
+    "ref": "27e3e8ff1cf0f0b9201a71a6853a1a1da44cb633",
     "ref_origin": "1.9.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/4895d4430f1349dc126fb004102184f8d0e9d2b3...27e3e8ff1cf0f0b9201a71a6853a1a1da44cb633
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
