### PR TITLE
Bump Mesos modules

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "b7bb3ffce52c5f57e0c29ce08408952aa9971342",
+    "ref": "e9edd2d93d9fce88c8e3f5536c7f9abc326093d9",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

In a typical overlay configuration, there are two overlay networks: `dcos` and `dcos6`, and each of them have the save VXLAN VTEP IP addresses. When dropping agent records from the overlay state, deletion from the replicated log succeeds, but deletion from in-memory data structures fails because the same IP address is deleted twice which leads to a Mesos crash and fail-over.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5597](https://jira.mesosphere.com/browse/DCOS_OSS-5597) Delete each VTEP IP address only once when deleting agent records.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/b7bb3ffce52c5f57e0c29ce08408952aa9971342...e9edd2d93d9fce88c8e3f5536c7f9abc326093d9)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Test Results: [CI job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/195/)
  - [ ] Code Coverage: NA