### PR TITLE
[1.13] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Increase number of diagnostics fetchers (DCOS-51483)
 
+* Delete each VTEP IP address only once when deleting agent records (DCOS_OSS-5597)
+
 ### Security updates
 
 

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "4a795855926ff261d3610acea3c2a9e86f4b6650",
+    "ref": "43250a0e30804d2f28d16c400f7980e6ad7463bc",
     "ref_origin": "1.13"
   }
 }


### PR DESCRIPTION
## High-level description

In a typical overlay configuration, there are two overlay networks: `dcos` and `dcos6`, and each of them have the save VXLAN VTEP IP addresses. When dropping agent records from the overlay state, deletion from the replicated log succeeds, but deletion from in-memory data structures fails because the same IP address is deleted twice which leads to a Mesos crash and fail-over.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5597](https://jira.mesosphere.com/browse/DCOS_OSS-5597) Delete each VTEP IP address only once when deleting agent records.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/4a795855926ff261d3610acea3c2a9e86f4b6650...43250a0e30804d2f28d16c400f7980e6ad7463bc)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [ ] Test Results: The CI is broken.
  - [ ] Code Coverage: NA