### PR TITLE
[1.12] Bump Mesos modules

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "ce2ab1fa3859413cb4c8f068cab77164c0b12c97",
+    "ref": "3f87e3d7d4706decdc20a046fa280a47c2e2954a",
     "ref_origin": "1.12"
   }
 }


### PR DESCRIPTION
## High-level description

In a typical overlay configuration, there are two overlay networks: `dcos` and `dcos6`, and each of them have the save VXLAN VTEP IP addresses. When dropping agent records from the overlay state, deletion from the replicated log succeeds, but deletion from in-memory data structures fails because the same IP address is deleted twice which leads to a Mesos crash and fail-over.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5597](https://jira.mesosphere.com/browse/DCOS_OSS-5597) Delete each VTEP IP address only once when deleting agent records.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/ce2ab1fa3859413cb4c8f068cab77164c0b12c97...3f87e3d7d4706decdc20a046fa280a47c2e2954a)
  - [x] Included a test which will fail if code is reverted but test is not.
  - [ ] Test Results: The CI is broken.
  - [ ] Code Coverage: NA