### PR TITLE
2.1: Bump Marathon to 1.9.100

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Admin Router: Accept nil task list from Marathon when updating cache. (DCOS_OSS-5541)
 
+* Updated Marathon to 1.9.99
+
+    * Marathon API performance has been improved. JSON serialization is 50% faster and has 50% less memory overhead.
+
 
 ### Breaking changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Admin Router: Accept nil task list from Marathon when updating cache. (DCOS_OSS-5541)
 
-* Updated Marathon to 1.9.99
+* Updated Marathon to 1.9.100
 
     * Marathon API performance has been improved. JSON serialization is 50% faster and has 50% less memory overhead.
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.73-203dd90c8/marathon-1.9.73-203dd90c8.tgz",
-    "sha1": "e5bf455ee6e15bf2ea0c52c993d9ef8ee6e497e5"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.99-3d4fb6897/marathon-1.9.99-3d4fb6897.tgz",
+    "sha1": "46886c399c0240e2a3c6c7391b428e02f08b2f21"
   },
   "username": "dcos_marathon",
   "state_directory": true

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.99-3d4fb6897/marathon-1.9.99-3d4fb6897.tgz",
-    "sha1": "46886c399c0240e2a3c6c7391b428e02f08b2f21"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.100-c2204b998/marathon-1.9.100-c2204b998.tgz",
+    "sha1": "8430154338af6bb66ed46f8cbc2995cb5f402c9c"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

Bump Marathon to 1.99. Fixes blocked issue MARTHON-8706. Also includes some performance improvements and a fix for external volumes.

## Corresponding DC/OS tickets (required)

JIRA Issues:
  - [MARATHON-8707](https://jira.mesosphere.com/browse/MARATHON-8707) - Fix a regression from MARATHON-8706 in which mid-level groups would attempt to enable enforceRole
  - [MARATHON-8706](https://jira.mesosphere.com/browse/MARATHON-8706) - Fixed an issue where `--new_group_enforce_role top` was not abided when auto-creating groups for services posted in not-yet-existing groups.
  - [MARATHON-8703](https://jira.mesosphere.com/browse/MARATHON-8703) - UpgradeIntegrationTest should test upgrades from 1.7 and 1.8
  - [MARATHON-8567](https://jira.mesosphere.com/browse/MARATHON-8567) - Speed up Serialization with Jackson Generator
  - [MARATHON-8698](https://jira.mesosphere.com/browse/MARATHON-8698) - Fix Marathon tries to store Task StatusUpdate without checking the message size
  - [MARATHON-8648](https://jira.mesosphere.com/browse/MARATHON-8648) - Add Jackson Serialization for resource endpoints
  - [MARATHON-8697](https://jira.mesosphere.com/browse/MARATHON-8697) - Removed (another) external volume name validation that prevented the use of configuration parameters for some volume providers.
  - [DCOS-51842](https://jira.mesosphere.com/browse/DCOS-51842) - Integration Tests for Marathon App with Mesos Checks

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [203dd90c8..3d4fb6897](https://github.com/mesosphere/marathon/compare/203dd90c8...3d4fb6897)
  - [ ] Test Results: https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/1410/
