### PR TITLE
[1.13] Bump Mesos to nightly 1.8.x 1c679e9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ## DC/OS 1.13.6 (in development)
 
 * Signal now sends telemetry data every 5 minutes instead of every hour. This is to align the frequency with DC/OS Enterprise.
-* Updated to Mesos [1.8.2-dev](https://github.com/apache/mesos/blob/ed1c7ee1db94a1c886e3d5a99f66b6abaec30f49/CHANGELOG)
+* Updated to Mesos [1.8.2-dev](https://github.com/apache/mesos/blob/1c679e90f606aa0af948914c3afe8c90bf3bbcd3/CHANGELOG)
 
 
 ### Notable changes

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ed1c7ee1db94a1c886e3d5a99f66b6abaec30f49",
+    "ref": "1c679e90f606aa0af948914c3afe8c90bf3bbcd3",
     "ref_origin": "1.8.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ed1c7ee1db94a1c886e3d5a99f66b6abaec30f49",
+    "ref": "1c679e90f606aa0af948914c3afe8c90bf3bbcd3",
     "ref_origin": "1.8.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/ed1c7ee1db94a1c886e3d5a99f66b6abaec30f49...1c679e90f606aa0af948914c3afe8c90bf3bbcd3
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
