### PR TITLE
[1.12] Bump Mesos to nightly 1.7.x 869df35

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Updated Signal service to release [1.6.0](https://github.com/dcos/dcos-signal/releases/tag/1.6.0)
 * Signal now sends telemetry data every 5 minutes instead of every hour. This is to align the frequency with DC/OS Enterprise.
 
-* Updated to Mesos [1.7.3-dev](https://github.com/apache/mesos/blob/71685b5c807e4d4d1a5ebe33a3c3c0a2f824b9b4/CHANGELOG)
+* Updated to Mesos [1.7.3-dev](https://github.com/apache/mesos/blob/869df3552dcd97db2b62d2207eba3099ea823084/CHANGELOG)
 
 * Metronome post-install configuration can be added to `/var/lib/dcos/metronome/environment` (DCOS_OSS-5509)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "71685b5c807e4d4d1a5ebe33a3c3c0a2f824b9b4",
+    "ref": "869df3552dcd97db2b62d2207eba3099ea823084",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "71685b5c807e4d4d1a5ebe33a3c3c0a2f824b9b4",
+    "ref": "869df3552dcd97db2b62d2207eba3099ea823084",
     "ref_origin": "1.7.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/71685b5c807e4d4d1a5ebe33a3c3c0a2f824b9b4...869df3552dcd97db2b62d2207eba3099ea823084
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
