### PR TITLE
Bump Marathon to 1.8.230 (and include pod instances in diagnostic bundle)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,12 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Delete each VTEP IP address only once when deleting agent records (DCOS_OSS-5597)
 
+* Marathon pod instances are now included in the DC/OS diagnostic bundle (DCOS_OSS-5616)
+
+* [Marathon] Very-large Mesos TaskStatus updates no longer  cause Marathon to crash loop (MARATHON-8698)
+
+
+
 ### Security updates
 
 

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1654,6 +1654,11 @@ package:
                   "Role": ["master"]
               },
               {
+                  "Port": {{ marathon_port }},
+                  "Uri": "/v2/pods/::status",
+                  "Role": ["master"]
+              },
+              {
                   "Port": 8181,
                   "Uri": "/exhibitor/v1/cluster/list",
                   "Role": ["master"]

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://downloads.mesosphere.io/marathon/builds/1.8.227-8615e776b/marathon-1.8.227-8615e776b.tgz",
-    "sha1": "baccf81c2c62ed956b756e5b0291d8767fb1ca2d"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.230-dd7806a1f/marathon-1.8.230-dd7806a1f.tgz",
+    "sha1": "15044eb73fa906685aeec1b896be498eb7827944"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.8.230

Also, backport pod-status change

## Corresponding DC/OS tickets (required)

  - [MARATHON-8698](https://jira.mesosphere.com/browse/MARATHON-8698) - Marathon tries to store Task StatusUpdate without checking the message size
  - [DCOS_OSS-5616](https://jira.mesosphere.com/browse/DCOS_OSS-5616) - Include Marathon pod instances in diagnostic bundle

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [8615e776b..dd7806a1f](https://github.com/mesosphere/marathon/compare/8615e776b...dd7806a1f)
  