### PR TITLE
Pin CLI version

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -216,8 +216,8 @@ def install_dcos_cli(tmpdir_factory: TempdirFactory):
     """
     tmpdir = tmpdir_factory.mktemp('dcos_cli')
     cli = dcos_cli.DcosCli.new_cli(
-        download_url='https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/latest/dcos',
-        core_plugin_url='https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.2.zip',  # noqa: E501
+        download_url='https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/1.1.1/dcos',
+        core_plugin_url='https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.3.zip',  # noqa: E501
         ee_plugin_url='https://downloads.mesosphere.io/cli/releases/plugins/dcos-enterprise-cli/linux/x86-64/dcos-enterprise-cli-1.13-patch.1.zip',  # noqa: E501
         tmpdir=str(tmpdir)
     )


### PR DESCRIPTION
This pins the DC/OS CLI version to a specific tag in order to reduce
moving dependencies in the CI.

We should bump it to the latest version occasionally, possibly having a
way to trigger DC/OS integration tests from CLI PRs.

Related to https://jira.mesosphere.com/browse/DCOS-60349