### PR TITLE
Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Replace [docker-gc](https://github.com/spotify/docker-gc) with `docker system prune`. (DCOS_OSS-5441)
 
+* Port the Mesos Fluent Bit container logger module to Windows. (DCOS-58622)
+
+* Port the Mesos open source metrics module to Windows. (DCOS-58008)
 
 ### Breaking changes
 
@@ -40,3 +43,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Remove the toybox package from DC/OS. Is was used only by Spartan.
 
 * Remove the dcos-history-service from DC/OS. (DCOS-58529)
+
+### Fixed and improved
+
+* Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "e9edd2d93d9fce88c8e3f5536c7f9abc326093d9",
+    "ref": "c5cf5bd36307c6461e74fc5a4743c27b94c00e75",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

- Mesos logger and metrics module ports to Windows.
- A fix of bug in the Mesos overlay module that leads to on-disk state inconsistency.

## Corresponding DC/OS tickets

  - [DCOS-58622](https://jira.mesosphere.com/browse/DCOS-58622) Port the Mesos Fluent Bit container logger module to Windows.
  - [DCOS-58008](https://jira.mesosphere.com/browse/DCOS-58008) Port the Mesos open source metrics module to Windows.
  - [DCOS_OSS-5626](https://jira.mesosphere.com/browse/DCOS_OSS-5626) Reserve all agent VTEP IPs upon recovering from replicated log.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-mesos-modules/compare/e9edd2d93d9fce88c8e3f5536c7f9abc326093d9...c5cf5bd36307c6461e74fc5a4743c27b94c00e75)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/205/)
  - [ ] Code Coverage: none