### PR TITLE
[2.0] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,3 +15,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * DC/OS overlay networks should be compared by-value. (DCOS_OSS-5620)
 
 * Drop labels from Lashup's kv_message_queue_overflows_total metric. (DCOS_OSS-5634)
+
+* Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "c5cf5bd36307c6461e74fc5a4743c27b94c00e75",
-    "ref_origin": "master"
+    "ref": "dad54bd930f50cd73e3d2d9737a3dd84e78b5711",
+    "ref_origin": "2.0"
   }
 }


### PR DESCRIPTION
## High-level description

A fix of bug in the Mesos overlay module that leads to on-disk state inconsistency.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5626](https://jira.mesosphere.com/browse/DCOS_OSS-5626) Reserve all agent VTEP IPs upon recovering from replicated log.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-mesos-modules/compare/e9edd2d93d9fce88c8e3f5536c7f9abc326093d9...dad54bd930f50cd73e3d2d9737a3dd84e78b5711)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/205/)
  - [ ] Code Coverage: none