### PR TITLE
[1.13] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Drop labels from Lashup's kv_message_queue_overflows_total metric. (DCOS_OSS-5634)
 
+* Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)
 
 
 ### Security updates

--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "43250a0e30804d2f28d16c400f7980e6ad7463bc",
+    "ref": "26d45a9f43f3c6b6c664c2ca43b74ce24c9f05ca",
     "ref_origin": "1.13"
   }
 }


### PR DESCRIPTION
## High-level description

A fix of bug in the Mesos overlay module that leads to on-disk state inconsistency.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5626](https://jira.mesosphere.com/browse/DCOS_OSS-5626) Reserve all agent VTEP IPs upon recovering from replicated log.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-mesos-modules/compare/43250a0e30804d2f28d16c400f7980e6ad7463bc...26d45a9f43f3c6b6c664c2ca43b74ce24c9f05ca)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/205/)
  - [ ] Code Coverage: none