### PR TITLE
[1.12] Bump Mesos modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * DC/OS overlay networks should be compared by-value. (DCOS_OSS-5620)
 
+* Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)
+
 ### Security updates
 
 


### PR DESCRIPTION
## High-level description

A fix of bug in the Mesos overlay module that leads to on-disk state inconsistency.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5626](https://jira.mesosphere.com/browse/DCOS_OSS-5626) Reserve all agent VTEP IPs upon recovering from replicated log.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-mesos-modules/compare/3f87e3d7d4706decdc20a046fa280a47c2e2954a...e6cd9e3844a666752b4758e383a5d46e965a27db)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://jenkins.mesosphere.com/service/jenkins/job/mesos/job/Modules/job/DCOS_OSS_Mesos_Modules-pr/205/)
  - [ ] Code Coverage: none