### PR TITLE
[2.0] Bump dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,5 +8,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* dcos-net: task update leads to two DNS zone updates. (DCOS_OSS-5495)
 
+* DC/OS overlay networks should be compared by-value. (DCOS_OSS-5620)
 
+* Drop labels from Lashup's kv_message_queue_overflows_total metric. (DCOS_OSS-5634)

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,8 +4,8 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "8e3302aa7e3815c5739c7b0460974103217ea161",
-      "ref_origin": "master"
+      "ref": "a48cdf9b5f6a9d6b9c6dd171b6b50f3052c14400",
+      "ref_origin": "2.0.x"
     }
   },
   "sysctl": {


### PR DESCRIPTION
## High-level description

Various `dcos-net` bug-fixes.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5495](https://jira.mesosphere.com/browse/DCOS_OSS-5495) dcos-net: task update leads to two DNS zone updates.
  - [DCOS_OSS-5620](https://jira.mesosphere.com/browse/DCOS_OSS-5620) DC/OS overlay networks should be compared by-value.
  - [DCOS_OSS-5634](https://jira.mesosphere.com/browse/DCOS_OSS-5634) Drop labels from Lashup's kv_message_queue_overflows_total metric.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/8e3302aa7e3815c5739c7b0460974103217ea161...a48cdf9b5f6a9d6b9c6dd171b6b50f3052c14400)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://circleci.com/gh/dcos/dcos-net/1412)
  - [ ] Code Coverage: none