### PR TITLE
[1.13] Bump dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * [Marathon] Very-large Mesos TaskStatus updates no longer  cause Marathon to crash loop (MARATHON-8698)
 
+* DC/OS overlay networks should be compared by-value. (DCOS_OSS-5620)
+
+* Drop labels from Lashup's kv_message_queue_overflows_total metric. (DCOS_OSS-5634)
+
 
 
 ### Security updates

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "ea556b2c424191d66167a5f90eab66dec657abd6",
+      "ref": "0e892527899b8b789629bf1896e9f83b5acb8982",
       "ref_origin": "1.13.x"
     }
   },


### PR DESCRIPTION
## High-level description

Various `dcos-net` bug-fixes.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5620](https://jira.mesosphere.com/browse/DCOS_OSS-5620) DC/OS overlay networks should be compared by-value.
  - [DCOS_OSS-5634](https://jira.mesosphere.com/browse/DCOS_OSS-5634) Drop labels from Lashup's kv_message_queue_overflows_total metric.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/ea556b2c424191d66167a5f90eab66dec657abd6...0e892527899b8b789629bf1896e9f83b5acb8982)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://circleci.com/gh/dcos/dcos-net/1407)
  - [ ] Code Coverage: none