### PR TITLE
[1.12] Bump dcos-net

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Increase number of diagnostics fetchers (DCOS-51483)
 
+* DC/OS overlay networks should be compared by-value. (DCOS_OSS-5620)
+
 ### Security updates
 
 

--- a/packages/dcos-net/buildinfo.json
+++ b/packages/dcos-net/buildinfo.json
@@ -4,7 +4,7 @@
     "dcos-net": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-net.git",
-      "ref": "7ea54b4cb120df974107c2df17466c7a77718acb",
+      "ref": "dd7d8f245f9364414dbb99e75b13c6591c66f0a7",
       "ref_origin": "1.12.x"
     }
   },


### PR DESCRIPTION
## High-level description

A `dcos-net` bugfix.

## Corresponding DC/OS tickets

  - [DCOS_OSS-5620](https://jira.mesosphere.com/browse/DCOS_OSS-5620) DC/OS overlay networks should be compared by-value.

## Checklist for component/package updates:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [diff](https://github.com/dcos/dcos-net/compare/7ea54b4cb120df974107c2df17466c7a77718acb...dd7d8f245f9364414dbb99e75b13c6591c66f0a7)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [job](https://circleci.com/gh/dcos/dcos-net/1408)
  - [ ] Code Coverage: none