### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x ea5e6e8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 1.11.13 (in development)
 
-* Updated to Mesos [1.5.4-dev](https://github.com/apache/mesos/blob/f902fc6f447f3477e137639824ece7cbf3b31fe7/CHANGELOG)
+* Updated to Mesos [1.5.4-dev](https://github.com/apache/mesos/blob/ea5e6e87eb5053dcfbcb11237902d3e2126c41cf/CHANGELOG)
 * Signal now sends telemetry data every 5 minutes instead of every hour. This is to align the frequency with DC/OS Enterprise.
 * Fixed problems when trying to download a diagnostics bundle (COPS-5509)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "f902fc6f447f3477e137639824ece7cbf3b31fe7",
+    "ref": "ea5e6e87eb5053dcfbcb11237902d3e2126c41cf",
     "ref_origin": "1.5.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/f902fc6f447f3477e137639824ece7cbf3b31fe7...ea5e6e87eb5053dcfbcb11237902d3e2126c41cf
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
