### PR TITLE
Enable backport mergebot command in repo config

### DIFF
--- a/mergebot-config.json
+++ b/mergebot-config.json
@@ -3,6 +3,7 @@
    "ship-it": false,
    "test": false,
    "bump-ee": true,
+   "backport": true,
    "changelog-not-required": true,
    "request-review": true,
    "merge-it": true,


### PR DESCRIPTION
A part of preparation for the release of **backport** command for Mergebot. Need to enable it in the repo config.