### PR TITLE
2.0 - Bump marathon to 1.9.108

### DIFF
--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.108-f3bda3aae/marathon-1.9.108-f3bda3aae.tgz",
-    "sha1": "936e44a9c894637568ea4f7d484a53372e163862"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.109-b9c866838/marathon-1.9.109-b9c866838.tgz",
+    "sha1": "759317cf9ff18ec932a622cc902007a8b0675fa9"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

This fixes a Marathon migration error that would occur during upgrade if a Marathon deployment was in progress during the upgrade attempt.

## Corresponding DC/OS tickets (required)

JIRA Issues:
  - [MARATHON-8712](https://jira.mesosphere.com/browse/MARATHON-8712)
  - [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711)
  - [MARATHON-8713](https://jira.mesosphere.com/browse/MARATHON-8713)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [c2204b998..f3bda3aae](https://github.com/mesosphere/marathon/compare/c2204b998...f3bda3aae)
