### PR TITLE
[master] set interfaces as unmanaged by coreos networkd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,3 +50,6 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### Fixed and improved
 
 * Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)
+
+* Set network interfaces as unmanaged for networkd only on coreos. (DCOS-60956)
+

--- a/packages/dcos-net/extra/dcos-net-setup.py
+++ b/packages/dcos-net/extra/dcos-net-setup.py
@@ -19,17 +19,20 @@ import datetime
 import filecmp
 import logging
 import os
+import platform
 import shutil
 import subprocess
 import sys
 
 
 def main():
+    return_code = 0
     if sys.argv[1:4] in [['ip', 'link', 'add'], ['ip', 'addr', 'add'], ['ip', '-6', 'addr']]:
         result = subprocess.run(sys.argv[1:], stderr=subprocess.PIPE)
         sys.stderr.buffer.write(result.stderr)
         if result.stderr.strip().endswith(b'File exists'):
             result.returncode = 0
+        return_code = result.returncode
     elif sys.argv[1] == 'iptables':
         # check whether a rule matching the specification does exist
         argv = ['-C' if arg in ['-A', '-I'] else arg for arg in sys.argv[1:]]
@@ -37,20 +40,32 @@ def main():
         if result.returncode != 0:
             # if it doesn't exist append or insert that rules
             result = subprocess.run(sys.argv[1:])
+        return_code = result.returncode
     elif sys.argv[1] == '--ipv6':
         if os.getenv('DCOS_NET_IPV6', 'true') == 'false':
             sys.exit(0)
         else:
             del sys.argv[1]
             result = subprocess.run(sys.argv)
+            return_code = result.returncode
     elif sys.argv[1:3] == ['networkd', 'add'] and len(sys.argv) == 4:
-        result = add_networkd_config(sys.argv[3])
+        return_code = add_networkd_config_for_coreos(sys.argv[3])
     else:
         result = subprocess.run(sys.argv[1:])
-    sys.exit(result.returncode)
+        return_code = result.returncode
+    sys.exit(return_code)
 
 
-def add_networkd_config(src):
+def add_networkd_config_for_coreos(src: str) -> int:
+    # systemd-networkd, when enabled, will wipe the configurations like IP
+    # address of network interfaces and this behavior happens only on coreos
+    # This problem is tracked by:
+    # https://jira.mesosphere.com/browse/DCOS_OSS-1790
+    # We need to mark interfaces managed by DC/OS as unmanaged when networkd is
+    # enabled on coreos
+    if platform.system() != "Linux" or "coreos" not in platform.release():
+        return 0
+
     networkd = b'systemd-networkd.service'
     networkd_path = '/etc/systemd/network'
 
@@ -58,9 +73,9 @@ def add_networkd_config(src):
     result = subprocess.run(['systemctl', 'list-unit-files', networkd],
                             stdout=subprocess.PIPE)
     if result.returncode != 0:
-        return result
+        return result.returncode
     if networkd not in result.stdout:
-        return result
+        return result.returncode
 
     # Copy the configuration
     bname = os.path.basename(src)
@@ -76,7 +91,7 @@ def add_networkd_config(src):
                             stdout=subprocess.PIPE)
     if result.returncode != 0:
         result.returncode = 0
-        return result
+        return result.returncode
 
     # Restart networkd only if the configuration is updated
     mtime = os.path.getmtime(dst)
@@ -90,13 +105,13 @@ def add_networkd_config(src):
                 active_enter_timestamp,
                 '%a %Y-%m-%d %H:%M:%S %Z')
             if started.timestamp() > mtime:
-                return result
+                return result.returncode
         except ValueError:
             logging.warning('Unexpected ActiveEnterTimestamp value: "%s"',
                             active_enter_timestamp)
 
     # Restart networkd
-    return subprocess.run(['systemctl', 'restart', networkd])
+    return subprocess.run(['systemctl', 'restart', networkd]).returncode
 
 
 def safe_filecmp(src, dst):


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

What features does this change enable? What bugs does this change fix?

This was first introduced in https://github.com/dcos/dcos/pull/2833 which set network interfaces used by DC/OS as unmanaged by networkd on all releases of Linux, and before this happens only on coreos. 
This may bring errors when networkd is enabled on other Linux releases, refer to [cops ticket explanation](https://jira.mesosphere.com/browse/COPS-5575?focusedCommentId=303879&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-303879) for detailed explanation.

Here we change the configuration takes effect only on coreos, and since coreos 1409.x.0, unmanaged link is supported in coreos networkd. But the interfaces are unmanaged by default.
```
[root@osboxes2 ~]# networkctl
IDX LINK             TYPE               OPERATIONAL SETUP
  1 lo               loopback           carrier     unmanaged
  2 enp0s3           ether              routable    unmanaged
  3 enp0s8           ether              routable    unmanaged
  4 virbr0           ether              no-carrier  unmanaged
  5 virbr0-nic       ether              off         unmanaged
  6 m-dcos           ether              routable    unmanaged
  7 docker0          ether              routable    unmanaged
  8 d-dcos           ether              no-carrier  unmanaged
 12 vethfe3cdb4      ether              degraded    unmanaged
 13 tunl0            tunnel             routable    unmanaged
[root@osboxes2 ~]# systemctl --version
systemd 219
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN
[root@osboxes2 ~]# cat /etc/*release
CentOS Linux release 7.6.1810 (Core)
... ...
```

Also I tested on Ubuntu 16.04.6 LTS and Ubuntu 18.04.3 LTS, the interfaces are unmanaged by default when networkd is active.

## Corresponding DC/OS tickets (required)

  - [DCOS-60956](https://jira.mesosphere.com/browse/DCOS-60956) COPS-5575: Nodes and applications are not pingable on DC/OS 2.0.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
