### PR TITLE
[2.0] Bump Mesos to nightly 1.9.x 95d34e7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 2.0.1 (in development)
 
-* Updated to Mesos [1.9.1-dev](https://github.com/apache/mesos/blob/c31316814398990abf1013bb0681a907426a4fec/CHANGELOG)
+* Updated to Mesos [1.9.1-dev](https://github.com/apache/mesos/blob/95d34e7f30c6ca8a074bd2af0359ed96310adee3/CHANGELOG)
 
 
 ### What's new

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "c31316814398990abf1013bb0681a907426a4fec",
+    "ref": "95d34e7f30c6ca8a074bd2af0359ed96310adee3",
     "ref_origin": "1.9.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "c31316814398990abf1013bb0681a907426a4fec",
+    "ref": "95d34e7f30c6ca8a074bd2af0359ed96310adee3",
     "ref_origin": "1.9.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/c31316814398990abf1013bb0681a907426a4fec...95d34e7f30c6ca8a074bd2af0359ed96310adee3
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
