### PR TITLE
Winpanda App: Adjust Log Directory Location

### DIFF
--- a/packages/winpanda/extra/src/winpanda/bin/winpanda.py
+++ b/packages/winpanda/extra/src/winpanda/bin/winpanda.py
@@ -107,7 +107,13 @@ class DCOSInstallationManager:
 def main():
     """"""
     log_level = LOG_LEVEL.DEBUG
-    log_fpath = Path('.', cm_const.APP_LOG_FNAME)
+    # log_fpath = Path('.', cm_const.APP_LOG_FNAME)
+    log_fpath = Path('C:\\d2iq\\dcos\\var\\log\\winpanda',
+                     cm_const.APP_LOG_FNAME)
+    try:
+        log_fpath.parent.mkdir(parents=True, exist_ok=True)
+    except (OSError, RuntimeError):
+        log_fpath = Path('.', cm_const.APP_LOG_FNAME)
     logger.master_setup(
         log_level=log_level, file_path=log_fpath,
         file_size=cm_const.APP_LOG_FSIZE_MAX,

--- a/packages/winpanda/extra/src/winpanda/common/constants.py
+++ b/packages/winpanda/extra/src/winpanda/common/constants.py
@@ -5,7 +5,7 @@ Application-wide constant objects.
 # Application
 APP_NAME = 'winpanda'
 APP_LOG_FNAME = f'{APP_NAME}.log'
-APP_LOG_FSIZE_MAX = 1048576  # 1 MiB
+APP_LOG_FSIZE_MAX = 10485760  # 10 MiB
 APP_LOG_HSIZE_MAX = 10       # Log file history max size
 
 DCOS_CLUSTER_CFG_FNAME_DFT = 'cluster.conf'


### PR DESCRIPTION
1) create applications log directory on fixed location -
   "C:\d2iq\dcos\var\log\winpanda"
2) increase upper limit of the log file size

JIRA: DCOS_OSS-5733 - Winpanda App: Adjust Log Directory Location