### PR TITLE
Winpanda App: Tolerate Service Start Failures

### DIFF
--- a/packages/winpanda/extra/src/winpanda/common/utils.py
+++ b/packages/winpanda/extra/src/winpanda/common/utils.py
@@ -18,8 +18,10 @@ unpack(archive, "./tmp/Arc/")
 import os
 from pathlib import Path
 from pprint import pprint as pp
+import random
 import subprocess
 import tarfile
+import time
 
 from pySmartDL import SmartDL
 
@@ -128,3 +130,65 @@ def run_external_command(cl_elements, timeout=30):
         )
 
     return subproc_run
+
+
+def get_retry_interval(attempt, retry_interval_base, retry_interval_cap):
+    """Calculate interval before the next retry of an operation put into
+    retrying loop.
+
+    :param attempt:             int, attempt number
+    :param retry_interval_base: float, lower limit of the retry interval
+    :param retry_interval_cap:  float, upper limit of the retry interval
+
+    :return:                    float, retry interval in seconds
+    """
+    # Implementation of the 'Exponential Backoff' with 'Full Jitter'.
+    # Ref: http://www.awsarchitectureblog.com/2015/03/backoff.html
+    return random.uniform(
+        retry_interval_base,
+        min(retry_interval_cap, pow(2, attempt) * retry_interval_base)
+    )
+
+
+def retry_on_exc(exceptions=(Exception,), max_attempts=0,
+                 retry_interval_base=0.5, retry_interval_cap=5.0):
+    """Apply retrying logic to a function/method being decorated.
+    """
+    def decorator(func):
+        """"""
+        def call_proxy(*args, **kwargs):
+            """"""
+            exc_ = None
+            result = None
+
+            op_name = func.__name__
+
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    result = func(*args, **kwargs)
+                except exceptions as e:
+                    exc_ = e
+                    retry_interval = get_retry_interval(
+                        attempt, retry_interval_base, retry_interval_cap
+                    )
+                    LOG.debug(f'Retrying {op_name}: ERROR: attempt[{attempt}]'
+                              f' cause[{type(e).__name__}: {e}]'
+                              f' next_attempt_in[{retry_interval}]')
+                    time.sleep(retry_interval)
+                else:
+                    LOG.debug(f'Retrying {op_name}: OK:'
+                              f' attempts_spent[{attempt}]')
+                    exc_ = None
+                    break
+
+            if exc_:
+                LOG.error(f'Retrying {op_name}: FAILED:'
+                          f' attempts_spent[{max_attempts}]')
+                raise exc_
+            else:
+                return result
+
+        return call_proxy
+
+    return decorator
+

--- a/packages/winpanda/extra/src/winpanda/svcm/exceptions.py
+++ b/packages/winpanda/extra/src/winpanda/svcm/exceptions.py
@@ -43,3 +43,13 @@ class ServiceConfigError(ServiceError):
 class ServiceSetupError(ServiceError):
     """Service setup error."""
     pass
+
+
+class ServiceFluctuantError(ServiceError):
+    """Service intermittent error."""
+    pass
+
+
+class ServiceHardError(ServiceError):
+    """Service steady error."""
+    pass

--- a/packages/winpanda/extra/src/winpanda/svcm/nssm.py
+++ b/packages/winpanda/extra/src/winpanda/svcm/nssm.py
@@ -81,6 +81,7 @@ class NSSMConfSection(enum.Enum):
 class SVC_STATUS:
     """System service status."""
     STOPPED = 'SERVICE_STOPPED'
+    START_PENDING = 'SERVICE_START_PENDING'
     RUNNING = 'SERVICE_RUNNING'
     PAUSED = 'SERVICE_PAUSED'
 


### PR DESCRIPTION
1) implement operation retrying helper tools
2) rework the winpanda "start" command to support retrying logic for service
   start operation
3) change logic of the winpanda "start" command for not to fail entire
   chain of service start commands, if a single service fails to start

JIRA: DCOS_OSS-5731 - Winpanda App: Tolerate Service Start Failures
