### PR TITLE
Backport of PR#5766: xfs_info - use mount point instead of a device

### DIFF
--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -392,12 +392,12 @@ function d_type_enabled_if_xfs()
     while [[ ! -d "$DIRNAME" ]]; do
         DIRNAME="$(dirname "$DIRNAME")"
     done
-    read -r filesystem_device filesystem_type <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2}')"
+    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
     # -b $filesystem_device check is there prevent this from failing in certain special dcos-docker configs
     # see https://jira.mesosphere.com/browse/DCOS_OSS-3549
     if [[ "$filesystem_type" == "xfs" && -b "$filesystem_device" ]]; then
         echo -n -e "Checking if $DIRNAME is mounted with \"ftype=1\": "
-        ftype_value="$(xfs_info $filesystem_device | grep -oE ftype=[0-9])"
+        ftype_value="$(xfs_info $filesystem_mount | grep -oE ftype=[0-9])"
         if [[ "$ftype_value" != "ftype=1" ]]; then
             RC=1
         fi

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -392,7 +392,8 @@ function d_type_enabled_if_xfs()
     while [[ ! -d "$DIRNAME" ]]; do
         DIRNAME="$(dirname "$DIRNAME")"
     done
-    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
+    read -r filesystem_device filesystem_type filesystem_mount <<<"$(df --portability \
+        --print-type "$DIRNAME" | awk 'END{print $1,$2,$7}')"
     # -b $filesystem_device check is there prevent this from failing in certain special dcos-docker configs
     # see https://jira.mesosphere.com/browse/DCOS_OSS-3549
     if [[ "$filesystem_type" == "xfs" && -b "$filesystem_device" ]]; then


### PR DESCRIPTION
Corresponding JIRA ticket: 
https://jira.mesosphere.com/browse/DCOS-59406

Backport of https://github.com/dcos/dcos/pull/5766
xfs_info - use mount point instead of a device

Back-porting this fix specifically to 1.12.3 as per customer request: https://jira.mesosphere.com/browse/COPS-5604