### PR TITLE
admin router: prevent adminrouter from passing authrization header to etcd

### DIFF
--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -31,6 +31,10 @@ http {
         # FIXME(prozlach) make port configurable via install option
         listen 12379 http2;
 
+        # It is necessary to clean up the authorization header as it collides
+        # with the etcd's authn
+        grpc_set_header Authorization "";
+
         # FIXME(prozlach) According to the gRPC protocol specification, the
         # first segment of the request path is the package name of the gRPC
         # service definition. So, once we have more than one gRPC backend, we can


### PR DESCRIPTION
## High-level description

etcd does not tollerate the `authorization` header we set to do authn&authz as it expects it's own authorization token there instead of DC/OS authentication token. The solution is to filter it out in AR.

## Corresponding DC/OS tickets (required)

  - https://jira.mesosphere.com/browse/DCOS-62479 `Prevent AR from passing Authorization header to etcd`

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
