### PR TITLE
Revert "Compile Admin Router without SSE4.2 instructions"

### DIFF
--- a/packages/adminrouter/docker/build-resty.sh
+++ b/packages/adminrouter/docker/build-resty.sh
@@ -16,7 +16,6 @@ cd $OPENRESTY_DIR
     --without-mail_smtp_module \
     --with-http_ssl_module \
     --with-luajit \
-    --with-luajit-xcflags='-mno-sse4.2' \
     "$@"
 
 make -j${NUM_CORES}


### PR DESCRIPTION
This reverts commit 98f935e36ce8be64cfc42517679367f934efe1d7.

With the suspicion if this change is related to failure observed in  https://jira.mesosphere.com/browse/DCOS-62478