### PR TITLE
Winpanda App: Handle Execution Status Of External Commands

### DIFF
--- a/packages/winpanda/extra/src/winpanda/common/utils.py
+++ b/packages/winpanda/extra/src/winpanda/common/utils.py
@@ -119,21 +119,19 @@ def run_external_command(cl_elements, timeout=30):
         )
     except subprocess.CalledProcessError as e:
         raise cm_exc.ExternalCommandError(
-            '{}: {}: Exit code[{}]: {}'.format(
+            '{}: {}: Exit code [{}]: {}'.format(
                 cl_elements, type(e).__name__, e.returncode,
                 e.stderr.replace('\n', ' ')
             )
-        )
+        ) from e
     except subprocess.SubprocessError as e:
         raise cm_exc.ExternalCommandError(
-            '{}: {}: {}'.format(
-                cl_elements, type(e).__name__, str(e)
-            )
-        )
+            '{}: {}: {}'.format(cl_elements, type(e).__name__, e)
+        ) from e
     except (OSError, ValueError) as e:
         raise cm_exc.ExternalCommandError(
             f'{cl_elements}: {type(e).__name__}: {e}'
-        )
+        ) from e
 
     return subproc_run
 

--- a/packages/winpanda/extra/src/winpanda/core/command.py
+++ b/packages/winpanda/extra/src/winpanda/core/command.py
@@ -226,22 +226,23 @@ class CmdSetup(Command):
         :param package: Package, DC/OS package manager object
         """
         msg_src = self.__class__.__name__
+        pkg_id = package.manifest.pkg_id
 
         if package.ext_manager:
-            LOG.debug(f'{msg_src}: Execute: Handle extra install options:'
-                      f' {package.manifest.pkg_id.pkg_name}: ...')
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: ...')
             try:
                 package.ext_manager.handle_install_extras()
             except extm_exc.InstExtrasManagerError as e:
-                err_msg = (f'Execute: Handle extra install options:'
-                           f' {package.manifest.pkg_id.pkg_name}: {e}')
+                err_msg = (f'Execute: {pkg_id.pkg_name}:'
+                           f' Handle extra installation options: {e}')
                 raise cr_exc.SetupCommandError(err_msg) from e
 
-            LOG.debug(f'{msg_src}: Execute: Handle extra install options:'
-                      f' {package.manifest.pkg_id.pkg_name}: OK')
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: OK')
         else:
-            LOG.debug(f'{msg_src}: Execute: Handle extra install options:'
-                      f' {package.manifest.pkg_id.pkg_name}: NOP')
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: NOP')
 
     def _handle_pkg_svc_setup(self, package):
         """Execute steps on package service setup.
@@ -258,8 +259,9 @@ class CmdSetup(Command):
             try:
                 ret_code, stdout, stderr = package.svc_manager.status()
             except svcm_exc.ServiceManagerCommandError as e:
-                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Get initial'
-                          f' service status: {svc_name}: {e}')
+                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                          f' service: Get initial service status: {svc_name}:'
+                          f' {e}')
                 # Try to setup, as a service (expectedly) doesn't exist and
                 # checking it's status naturally would yield an error.
                 try:
@@ -269,8 +271,8 @@ class CmdSetup(Command):
                                f' {svc_name}: {e}')
                     raise cr_exc.SetupCommandError(err_msg) from e
             else:
-                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Get initial'
-                          f' service status: {svc_name}:'
+                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                          f' service: Get initial service status: {svc_name}:'
                           f' stdout[{stdout}] stderr[{stderr}]')
                 svc_status = str(stdout).strip().rstrip('\n')
                 # Try to remove existing service

--- a/packages/winpanda/extra/src/winpanda/core/package/package.py
+++ b/packages/winpanda/extra/src/winpanda/core/package/package.py
@@ -49,9 +49,7 @@ class Package:
                   f' Package configuration manager: {self.cfg_manager}')
 
         if self.manifest.pkg_extcfg:
-            self.ext_manager = PkgInstExtrasManager(
-                ext_conf=self.manifest.pkg_extcfg
-            )
+            self.ext_manager = PkgInstExtrasManager(pkg_manifest=self.manifest)
         else:
             self.ext_manager = None
         LOG.debug(f'{self.msg_src}: {self.manifest.pkg_id.pkg_id}:'

--- a/packages/winpanda/extra/src/winpanda/tests/test_common_utils.py
+++ b/packages/winpanda/extra/src/winpanda/tests/test_common_utils.py
@@ -52,7 +52,7 @@ def test_run_external_command_failure(tmp_path):
     with pytest.raises(ExternalCommandError) as e:
         run_external_command(('powershell', '-executionpolicy', 'Bypass', '-File', str(script)))
     # no way to access returncode, stdout, and stderr
-    assert 'Exit code[4]' in str(e)
+    assert 'Exit code [4]' in str(e)
 
 
 def test_run_external_command_error(tmp_path):


### PR DESCRIPTION
1) check and handle exit code from package extra installation helper
2) catch and save stdout/stderr streams from package extra installtion helper to facilitate debugging process

JIRA: DCOS_OSS-5785 - Winpanda Is To Handle Subprocess Exit Codes
JIRA: DCOS_OSS-5786 - Winpanda App: Redirect stdout and stderr Streams From
                                       an External Command To Dedicated Log Files
