### PR TITLE
Remove CockroachDB poststart commands

### DIFF
--- a/packages/cockroach/extra/dcos-cockroach.service
+++ b/packages/cockroach/extra/dcos-cockroach.service
@@ -21,8 +21,6 @@ ExecStartPre=/bin/chown -R dcos_cockroach /run/dcos/cockroach
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach
 ExecStartPre=/opt/mesosphere/active/cockroach/bin/register.py
 ExecStart=/opt/mesosphere/active/cockroach/bin/cockroach.sh
-ExecStartPost=-/bin/sleep 15
-ExecStartPost=-/opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
 PIDFile=/run/dcos/cockroach/cockroach.pid
 TimeoutStartSec=60s
 

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=CockroachDB Config Change: Ensure `num_replicas` equals the expected number of master nodes.
 Documentation=https://docs.mesosphere.com
+BindsTo=dcos-cockroach.service
+After=dcos-cockroach.service
 
 [Service]
-Type=oneshot
+Type=simple
 User=dcos_cockroach
 PermissionsStartOnly=True
 StartLimitInterval=0

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -7,8 +7,6 @@ Type=simple
 User=dcos_cockroach
 PermissionsStartOnly=True
 StartLimitInterval=0
-Restart=on-failure
-RestartSec=5
 LimitNOFILE=16384
 # The TMPDIR is created by the bootstrapper.
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach-config-change

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=CockroachDB Config Change: Ensure `num_replicas` equals the expected number of master nodes.
 Documentation=https://docs.mesosphere.com
-BindsTo=dcos-cockroach.service
-After=dcos-cockroach.service
 
 [Service]
 Type=simple

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -3,7 +3,7 @@ Description=CockroachDB Config Change: Ensure `num_replicas` equals the expected
 Documentation=https://docs.mesosphere.com
 
 [Service]
-Type=simple
+Type=oneshot
 User=dcos_cockroach
 PermissionsStartOnly=True
 StartLimitInterval=0

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.service
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.service
@@ -1,12 +1,15 @@
 [Unit]
 Description=CockroachDB Config Change: Ensure `num_replicas` equals the expected number of master nodes.
 Documentation=https://docs.mesosphere.com
+After=dcos-cockroach.service
 
 [Service]
 Type=simple
 User=dcos_cockroach
 PermissionsStartOnly=True
 StartLimitInterval=0
+Restart=on-failure
+RestartSec=5
 LimitNOFILE=16384
 # The TMPDIR is created by the bootstrapper.
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach-config-change

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -1,7 +1,8 @@
 [Unit]
 Description=CockroachDB Set Configuration Timer: Timer to periodically set the CockroachDB configuration
 Documentation=https://docs.mesosphere.com
-# Start the timer after CockroachDB has started
+# Run the timer only when CockroachDB is running
+BindsTo=dcos-cockroach.service
 After=dcos-cockroach.service
 
 [Timer]

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -1,7 +1,6 @@
 [Unit]
 Description=CockroachDB Set Configuration Timer: Timer to periodically set the CockroachDB configuration
 Documentation=https://docs.mesosphere.com
-Requisite=dcos-cockroach.service
 After=dcos-cockroach.service
 
 [Timer]

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -1,8 +1,11 @@
 [Unit]
 Description=CockroachDB Set Configuration Timer: Timer to periodically set the CockroachDB configuration
 Documentation=https://docs.mesosphere.com
+# Start the timer after CockroachDB has started
+After=dcos-cockroach.service
 
 [Timer]
-OnBootSec=5sec
-OnStartupSec=5min
+# 15 seconds after CockroachDB has started, connect to ensure correct configuration
+OnActiveSec=15
+# Every 10 minutes, ensure correct configuration
 OnUnitActiveSec=10min

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -1,7 +1,7 @@
 [Unit]
 Description=CockroachDB Set Configuration Timer: Timer to periodically set the CockroachDB configuration
 Documentation=https://docs.mesosphere.com
-BindsTo=dcos-cockroach.service
+Requisite=dcos-cockroach.service
 After=dcos-cockroach.service
 
 [Timer]

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -1,7 +1,6 @@
 [Unit]
 Description=CockroachDB Set Configuration Timer: Timer to periodically set the CockroachDB configuration
 Documentation=https://docs.mesosphere.com
-# Run the timer only when CockroachDB is running
 BindsTo=dcos-cockroach.service
 After=dcos-cockroach.service
 


### PR DESCRIPTION

## High-level description

If an ExecStartPost command times-out, then the unit is killed,
even when the command starts with `-`.  As the post-start steps
here are also executed by a periodic timer, we remove them here
to prevent the post-start timing out while waiting for Cockroach
to start, and then preventing Cockroach from starting.

## Corresponding DC/OS tickets (required)

  - [DCOS-62292](https://jira.mesosphere.com/browse/DCOS-62292) Remove possibility of timeouts in systemd ExecStartPost


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
