### PR TITLE
Modify Admin Router log format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Remove the dcos-history-service from DC/OS. (DCOS-58529)
 
+* New format for Admin Router access logs. (DCOS-59598)
+
+
 ### Fixed and improved
 
 * Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)

--- a/packages/adminrouter/extra/src/includes/http/common-windows.conf
+++ b/packages/adminrouter/extra/src/includes/http/common-windows.conf
@@ -87,10 +87,10 @@
 client_max_body_size 1024M;
 
 # Define custom log format.
-log_format customformat '$remote_addr:$remote_port $http_user_agent $http_referer '
+log_format customformat '$time_local $pid *$connection '
+    '<$remote_addr:$remote_port $http_user_agent $http_referer '
     '$request len=$request_length '
-    '<$time_local $pid *$connection> '
-    '$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
+    '>$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
     '$upstream_connect_time $upstream_header_time-$upstream_response_time $request_time';
 
 # The syslog facility here is set to daemon because

--- a/packages/adminrouter/extra/src/includes/http/common-windows.conf
+++ b/packages/adminrouter/extra/src/includes/http/common-windows.conf
@@ -86,19 +86,12 @@
 
 client_max_body_size 1024M;
 
-# Define custom log format. Use the default 'combined'
-# format and append easily parsable timing information
-# for performance analysis, and other relevant debugging
-# information.
-log_format customformat '$remote_addr - $remote_user [$time_local] '
-    '"$request" $status $body_bytes_sent '
-    '"$http_referer" "$http_user_agent" '
-    'logtime_msec=$msec '
-    'upstream_addr=$upstream_addr '
-    'request_time=$request_time '
-    'upstream_response_time=$upstream_response_time '
-    'upstream_connect_time=$upstream_connect_time '
-    'upstream_header_time=$upstream_header_time';
+# Define custom log format.
+log_format customformat '$remote_addr:$remote_port $http_user_agent $http_referer '
+    '$request len=$request_length '
+    '<$time_local $pid *$connection> '
+    '$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
+    '$upstream_connect_time $upstream_header_time-$upstream_response_time $request_time';
 
 # The syslog facility here is set to daemon because
 # systemd SyslogFacility defaults to daemon and

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -86,19 +86,12 @@ vhost_traffic_status_filter_max_node 2700;
 
 client_max_body_size 1024M;
 
-# Define custom log format. Use the default 'combined'
-# format and append easily parsable timing information
-# for performance analysis, and other relevant debugging
-# information.
-log_format customformat '$remote_addr - $remote_user [$time_local] '
-    '"$request" $status $body_bytes_sent '
-    '"$http_referer" "$http_user_agent" '
-    'logtime_msec=$msec '
-    'upstream_addr=$upstream_addr '
-    'request_time=$request_time '
-    'upstream_response_time=$upstream_response_time '
-    'upstream_connect_time=$upstream_connect_time '
-    'upstream_header_time=$upstream_header_time';
+# Define custom log format.
+log_format customformat '$remote_addr:$remote_port $http_user_agent $http_referer '
+    '$request len=$request_length '
+    '<$time_local $pid *$connection> '
+    '$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
+    '$upstream_connect_time $upstream_header_time-$upstream_response_time $request_time';
 
 # The syslog facility here is set to daemon because
 # systemd SyslogFacility defaults to daemon and

--- a/packages/adminrouter/extra/src/includes/http/common.conf
+++ b/packages/adminrouter/extra/src/includes/http/common.conf
@@ -87,10 +87,10 @@ vhost_traffic_status_filter_max_node 2700;
 client_max_body_size 1024M;
 
 # Define custom log format.
-log_format customformat '$remote_addr:$remote_port $http_user_agent $http_referer '
+log_format customformat '$time_local $pid *$connection '
+    '<$remote_addr:$remote_port $http_user_agent $http_referer '
     '$request len=$request_length '
-    '<$time_local $pid *$connection> '
-    '$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
+    '>$upstream_addr code=$status len=$bytes_sent($body_bytes_sent) '
     '$upstream_connect_time $upstream_header_time-$upstream_response_time $request_time';
 
 # The syslog facility here is set to daemon because


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This format provides a clearer layout for Admin Router logs:
- AR worker
- `<` client identity and request
- `>` proxy server identity and response, with `code=xxx` to make searching for response statuses easier

It also adds the connection ID which is useful for matching access logs to error logs, and the source port which can be useful for matching with client logs.

With these changes, logs now look like:
```
Jan 10 14:53:00 master1 nginx[3632]: master1 nginx: 2020/01/10 14:53:00 [notice] 3632#0: *77 [lua] common.lua:183: validate_jwt(): UID from the valid DC/OS authentication token: `dcos_checks_master`, client: 172.17.0.2, server: master.mesos, request: "GET /exhibitor/exhibitor/v1/ui/index.html HTTP/1.1", host: "172.17.0.2:443"
Jan 10 14:53:00 master1 nginx[3632]: master1 nginx: 2020/01/10 14:53:00 [notice] 3632#0: *77 [lua] ee.lua:201: check_access_control_entry_or_exit(): Consult policyquery via `/acs/api/v1/internal/policyquery?rid=dcos:adminrouter:ops:exhibitor&uid=dcos_checks_master&action=full`, client: 172.17.0.2, server: master.mesos, request: "GET /exhibitor/exhibitor/v1/ui/index.html HTTP/1.1", host: "172.17.0.2:443"
Jan 10 14:53:00 master1 nginx[3632]: master1 nginx: 2020/01/10 14:53:00 [notice] 3632#0: *77 [lua] ee.lua:60: auditlog(): type=audit timestamp=2020-01-10T14:53:00Z authorizer=adminrouter object=dcos:adminrouter:ops:exhibitor action=full result=allow reason="IAM PQ response" srcip=172.17.0.2 srcport=41066 request_uri=/exhibitor/exhibitor/v1/ui/index.html uid=dcos_checks_master, client: 172.17.0.2, server: master.mesos, request: "GET /exhibitor/exhibitor/v1/ui/index.html HTTP/1.1", host: "172.17.0.2:443"
Jan 10 14:53:00 master1 nginx[3632]: master1 nginx: 10/Jan/2020:14:53:00 +0000 3632 *77 <172.17.0.2:41066 Go-http-client/1.1 - GET /exhibitor/exhibitor/v1/ui/index.html HTTP/1.1 len=594 >127.0.0.1:8181 code=200 len=28983(28831) 0.000 0.008-0.008 0.025
Jan 10 14:53:00 master1 nginx[3632]: master1 nginx: 2020/01/10 14:53:00 [info] 3632#0: *77 client 172.17.0.2 closed keepalive connection
```

All of these lines are part of the nginx error_log, except the second-last, which is part of the access_log. The `*77` ties these lines together so that we can see they are the same request.

The access log line (after the journald prefix) is 200 characters, the previous equivalent was 292 characters. This is significant in that we also have customer requests to reduce Admin Router log sizes.

## Corresponding DC/OS tickets (required)

  - [DCOS-59598](https://jira.mesosphere.com/browse/DCOS-59598) Add connection id to Admin Router log lines.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
