### PR TITLE
Add unix domain socket support for Mesos agents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
 * Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/d46ae94b49b452ed3fbfdf99dfb501e09675a311/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/21ccad220f04369a7accf2bafae8f1d5002646bb/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### What's new
 
+* Added a new configuration option `mesos_http_executors_domain_sockets`, which will cause the mesos-agent to use
+  domain sockets when communicating with executors. While this change should not have any visible impact on users
+  in itself, it does enable administrators to write firewall rules blocking unauthorized access to the agent port
+  5051 since access to this will not be required anymore for executors to work.
+
 * Switched from Oracle Java 8 to OpenJDK 8 (DCOS-54902)
 
 * Updated DC/OS UI to [master+v2.150.2](https://github.com/dcos/dcos-ui/releases/tag/master+v2.150.2).

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -1274,6 +1274,7 @@ entry = {
         'master_dns_bindall': 'true',
         'mesos_dns_ip_sources': '["host", "netinfo"]',
         'mesos_dns_set_truncate_bit': 'true',
+        'mesos_http_executor_domain_sockets': 'true',
         'master_external_loadbalancer': '',
         'mesos_log_retention_mb': '4000',
         'mesos_container_log_sink': 'fluentbit+logrotate',

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1386,6 +1386,15 @@ package:
       MESOS_DEFAULT_CONTAINER_SHM_SIZE={{ mesos_default_container_shm_size }}
 {% case "false" %}
 {% endswitch %}
+{% switch mesos_http_executor_domain_sockets %}
+{% case "true" %}
+      MESOS_HTTP_EXECUTOR_DOMAIN_SOCKETS=true
+      # TODO(bevers): With systemd versions before 227, named sockets are not supported and
+      # all socket names are rendered as "unknown". Change this to a named socket (i.e.
+      # `systemd:mesos-agent.socket`) once we switch to  more modern platforms.
+      MESOS_DOMAIN_SOCKET_LOCATION=systemd:unknown
+{% case "false" %}
+{% endswitch %}
       MESOS_SLAVE_SUBSYSTEMS=cpu,memory
       MESOS_WORK_DIR={{ mesos_agent_work_dir }}
 {% switch use_mesos_hooks %}

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1388,6 +1388,7 @@ package:
 {% endswitch %}
 {% switch mesos_http_executor_domain_sockets %}
 {% case "true" %}
+      MESOS_HTTP_COMMAND_EXECUTOR=true
       MESOS_HTTP_EXECUTOR_DOMAIN_SOCKETS=true
       # TODO(bevers): With systemd versions before 227, named sockets are not supported and
       # all socket names are rendered as "unknown". Change this to a named socket (i.e.

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -168,9 +168,11 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
         'dcos-telegraf.socket',
         'dcos-fluent-bit.service']
     slave_units = [
-        'dcos-mesos-slave.service']
+        'dcos-mesos-slave.service',
+        'dcos-mesos-slave.socket']
     public_slave_units = [
-        'dcos-mesos-slave-public.service']
+        'dcos-mesos-slave-public.service',
+        'dcos-mesos-slave-public.socket']
     all_slave_units = [
         'dcos-docker-gc.service',
         'dcos-docker-gc.timer',

--- a/packages/mesos/build
+++ b/packages/mesos/build
@@ -64,9 +64,18 @@ systemd_slave="$PKG_PATH"/dcos.target.wants_slave/dcos-mesos-slave.service
 mkdir -p "$(dirname "$systemd_slave")"
 envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave.service > "$systemd_slave"
 
+systemd_slave_socket="$PKG_PATH"/dcos.target.wants_slave/dcos-mesos-slave.socket
+mkdir -p "$(dirname "$systemd_slave_socket")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave.socket > "$systemd_slave_socket"
+
 systemd_slave_public="$PKG_PATH"/dcos.target.wants_slave_public/dcos-mesos-slave-public.service
 mkdir -p "$(dirname "$systemd_slave_public")"
 envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave-public.service > "$systemd_slave_public"
+
+systemd_slave_public_socket="$PKG_PATH"/dcos.target.wants_slave_public/dcos-mesos-slave-public.socket
+mkdir -p "$(dirname "$systemd_slave_public_socket")"
+envsubst '$PKG_PATH' < /pkg/extra/dcos-mesos-slave-public.socket > "$systemd_slave_public_socket"
+
 
 # setup additonal volume service which discovers /dcos/volumeN mounts and creates an optional
 # EnvironmentFile that contains a MESOS_RESOURCES env variable. This MESOS_RESOURCES adds

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,7 +10,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "d46ae94b49b452ed3fbfdf99dfb501e09675a311",
+      "ref": "21ccad220f04369a7accf2bafae8f1d5002646bb",
       "ref_origin": "master"
     },
     "mesos-modules": {

--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mesos Agent Public: distributed systems kernel public agent
+Requires=dcos-mesos-slave-public.socket
 
 [Service]
 Restart=always

--- a/packages/mesos/extra/dcos-mesos-slave-public.socket
+++ b/packages/mesos/extra/dcos-mesos-slave-public.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=DC/OS Executors Socket: socket for communication between Mesos agent and v1 executors
+
+[Socket]
+ListenStream=/var/run/mesos/mesos-executors.sock
+Accept=no
+
+# Set a custom file descriptor name so we get the same socket
+# name for both public and non-public slaves.
+FileDescriptorName=dcos-mesos-slave

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mesos Agent: distributed systems kernel agent
+Requires=dcos-mesos-slave.socket
 
 [Service]
 Restart=always

--- a/packages/mesos/extra/dcos-mesos-slave.socket
+++ b/packages/mesos/extra/dcos-mesos-slave.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=DC/OS Executors Socket: socket for communication between Mesos agent and v1 executors
+
+[Socket]
+ListenStream=/var/run/mesos/mesos-executors.sock
+Accept=no
+
+# Note that this requires systemd >= 227, which is not
+# available on CentOS 7. We still set it though, because
+# it does not hurt and this way we cannot forget to
+# set a name when systemd is finally upgraded.
+FileDescriptorName=dcos-mesos-slave
+


### PR DESCRIPTION
## High-level description
This PR enables support for the mesos agent to communicate with executors via domain sockets, to enable operators to enable stricter firewall settings on their mesos agents.


## Corresponding DC/OS tickets (required)
https://jira.mesosphere.com/browse/DCOS-58820
  - [DCOS-58820](https://jira.mesosphere.com/browse/DCOS-58820) Domain socket based agent/executor communication.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
