### PR TITLE
Bump Marathon to 1.9.124-e04033c6f

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
- * [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) With UnreachableStrategy, setting `expungeAfterSeconds`
-   and `inactiveAfterSeconds` to the same value will cause the instance to be expunged immediately; this helps with
-   `GROUP_BY` or `UNIQUE` constraints.
+ * With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the 
+   instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
 
 
 ## DC/OS 2.0.2 (2020-01-17)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+ * [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) With UnreachableStrategy, setting `expungeAfterSeconds`
+   and `inactiveAfterSeconds` to the same value will cause the instance to be expunged immediately; this helps with
+   `GROUP_BY` or `UNIQUE` constraints.
+
 
 ## DC/OS 2.0.2 (2020-01-17)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.118-d1bdb0e78/marathon-1.9.118-d1bdb0e78.tgz",
-    "sha1": "a6c99d665ceb01ab9c28b7c8b50e80a006f90d61"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.124-e04033c6f/marathon-1.9.124-e04033c6f.tgz",
+    "sha1": "5b8933377a6b34b2dee2d692b0b9dc7eb33cd62d"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION

## High-level description

## Corresponding DC/OS tickets (required)

  - [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) With UnreachableStrategy, setting expungeAfterSeconds and inactiveAfterSeconds to the same value will cause the instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints.
 - [MARATHON-8720](https://jira.mesosphere.com/browse/MARATHON-8720) Fix regression in `ExpungeOverdueLostTaskActor`.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [Marathon Changelog](https://github.com/mesosphere/marathon/commit/292a7ef0adb57328dfb9ae10432d775556ec4c42)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: [Marathon build](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/marathon-pipelines/job/master/1437/)
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
