### PR TITLE
[1.11] Bump Mesos to nightly 1.5.x d440095

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 1.11.14 (in development)
 
+* Updated to Mesos [1.5.4-dev](https://github.com/apache/mesos/blob/d440095b5a94872eabbd66def49a588d6f8f2b38/CHANGELOG)
+
 ## DC/OS 1.11.13 (2019-11-14)
 
 * Updated to Mesos [1.5.4-dev](https://github.com/apache/mesos/blob/ea5e6e87eb5053dcfbcb11237902d3e2126c41cf/CHANGELOG)

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ea5e6e87eb5053dcfbcb11237902d3e2126c41cf",
+    "ref": "d440095b5a94872eabbd66def49a588d6f8f2b38",
     "ref_origin": "1.5.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/ea5e6e87eb5053dcfbcb11237902d3e2126c41cf...d440095b5a94872eabbd66def49a588d6f8f2b38
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
