### PR TITLE
[1.13] Bump Mesos to nightly 1.8.x b17ed79

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 1.13.8 (in development)
 
+* Updated to Mesos [1.8.2-dev](https://github.com/apache/mesos/blob/b17ed79106b11c5f382006c453b4f885721e3f23/CHANGELOG)
+
 ### Notable changes
 
 ### Fixed and improved

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "c7c716dbc9ee4363ba6267591585b9984d8920b8",
+    "ref": "b17ed79106b11c5f382006c453b4f885721e3f23",
     "ref_origin": "1.8.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "0744bb6185cd181a8f4ab678a9220c5359f0e0f9",
+    "ref": "b17ed79106b11c5f382006c453b4f885721e3f23",
     "ref_origin": "1.8.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/c7c716dbc9ee4363ba6267591585b9984d8920b8...b17ed79106b11c5f382006c453b4f885721e3f23
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
