### PR TITLE
[1.12] Bump Mesos to nightly 1.7.x 8af5a6d

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 1.12.6 (in development)
 
+* Updated to Mesos [1.7.3-dev](https://github.com/apache/mesos/blob/8af5a6d50c64abb683b803f25bbc02e320fe70f6/CHANGELOG)
+
 ### Notable changes
 
 ### Fixed and improved

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex \
 # Refs:
 #   https://github.com/docker/docker/issues/12327#issuecomment-188921470
 #   https://github.com/docker/docker/issues/12327#issuecomment-187158265
-RUN python3 -m pip install --upgrade virtualenv
+RUN python3 -m pip install --upgrade 'virtualenv<20'
 RUN set -ex \
     && virtualenv --no-site-packages $VENV_DIR \
     && ${VENV_DIR}/bin/pip install --upgrade setuptools pip

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -8,7 +8,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d8acd9cfacd2edf8500f07f63a8837aa0ddd14ba",
+    "ref": "8af5a6d50c64abb683b803f25bbc02e320fe70f6",
     "ref_origin": "1.7.x"
   },
   "environment": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "d8acd9cfacd2edf8500f07f63a8837aa0ddd14ba",
+    "ref": "8af5a6d50c64abb683b803f25bbc02e320fe70f6",
     "ref_origin": "1.7.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/d8acd9cfacd2edf8500f07f63a8837aa0ddd14ba...8af5a6d50c64abb683b803f25bbc02e320fe70f6
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
