### PR TITLE
Import Terraform main.tf and define Windows test app.

### DIFF
--- a/packages/dcos-integration-test/README.md
+++ b/packages/dcos-integration-test/README.md
@@ -32,6 +32,8 @@ The ACS token is valid only once.
 Run the simple test with
 
 ```bash
+export DCOS_ACS_TOKEN="$(dcos config show core.dcos_acs_token)"
+export DCOS_SSH_USE=centos
 pytest -v -x --capture=no --full-trace --log-level=DEBUG test_applications.py::test_if_marathon_app_can_be_deployed
 ```
 

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -23,7 +23,6 @@ def dcos_api_session(dcos_api_session_factory):
     exhibitor settings currently used in the cluster
     """
     args = dcos_api_session_factory.get_args_from_env()
-    print(args)
 
     exhibitor_admin_password = None
     expanded_config = get_expanded_config()

--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -23,6 +23,7 @@ def dcos_api_session(dcos_api_session_factory):
     exhibitor settings currently used in the cluster
     """
     args = dcos_api_session_factory.get_args_from_env()
+    print(args)
 
     exhibitor_admin_password = None
     expanded_config = get_expanded_config()

--- a/packages/dcos-integration-test/extra/env_helper.py
+++ b/packages/dcos-integration-test/extra/env_helper.py
@@ -53,7 +53,9 @@ ALL ENVIRONMENT VARIABLES:
     Obtain this token by setting up your cluster with the dcos-cli like this:
     {begin_cmd}dcos cluster setup http://$MASTER_PUBLIC_IP{end_cmd}
     Then your web browser will open a page and you will see the token.
-    It's also stored in ~/.dcos/clusters/<cluster-uuid>/dcos.toml
+    It's also stored in ~/.dcos/clusters/<cluster-uuid>/dcos.toml and
+    can be accessed via the CLI:
+    {begin_cmd}dcos config show core.dcos_acs_token{end_cmd}
     If you run integration tests before setting this variable, you will
     no longer be able to log into your cluster.
 

--- a/packages/dcos-integration-test/extra/test_groups.yaml
+++ b/packages/dcos-integration-test/extra/test_groups.yaml
@@ -84,5 +84,3 @@ groups:
         - test_iam_migration.py
         - test_legacy_user_management.py
         - test_ui_update_service.py
-    group_windows:
-        - test_windows.py

--- a/packages/dcos-integration-test/extra/test_service_discovery.py
+++ b/packages/dcos-integration-test/extra/test_service_discovery.py
@@ -269,13 +269,6 @@ def test_service_discovery_docker_bridge(dcos_api_session):
     assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
 
 
-@pytest.mark.supportedwindows
-@pytest.mark.supportedwindowsonly
-def test_service_discovery_docker_windows(dcos_api_session):
-    app_definition, test_uuid = test_helpers.marathon_test_app_windows()
-    assert_service_discovery(dcos_api_session, app_definition, [DNSPortMap])
-
-
 def test_service_discovery_docker_overlay(dcos_api_session):
     app_definition, test_uuid = test_helpers.marathon_test_app(
         container_type=marathon.Container.DOCKER,

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -30,4 +30,4 @@ def test_if_docker_app_can_be_deployed_windows(dcos_api_session):
     Verifies that a marathon app inside of a docker daemon container can be
     deployed and accessed as expected on Windows.
     """
-    deploy_test_app_and_check_windows(dcos_api_session, *test_helpers.marathon_test_app_windows())
+    deploy_test_app_and_check_windows(dcos_api_session, *test_helpers.marathon_test_app_windows("simple-win"))

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -24,6 +24,7 @@ def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: st
             raise Exception(msg.format(r.status_code, r.reason, r.text))
 
 
+@pytest.mark.supportedwindowsonly
 def test_if_docker_app_can_be_deployed_windows(dcos_api_session):
     """Marathon app inside docker deployment integration test.
 

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 import requests
 
 import test_helpers

--- a/packages/dcos-integration-test/requirements.txt
+++ b/packages/dcos-integration-test/requirements.txt
@@ -30,7 +30,7 @@ dnspython3==1.12.0
 # /packages/python-kazoo/buildinfo.json
 kazoo==2.6.1
 # /packages/dcos-test-utils/buildinfo.json
-git+https://github.com/dcos/dcos-test-utils.git@b647d1bcae7de62de06d1a83988c64de5022405c
+git+https://github.com/dcos/dcos-test-utils.git@097251c2872bd5b377e18e7a8b4d81df942c1263
 
 # /packages/python-prometheus_client/buildinfo.json
 prometheus_client==0.5.0

--- a/packages/dcos-integration-test/requirements.txt
+++ b/packages/dcos-integration-test/requirements.txt
@@ -30,7 +30,7 @@ dnspython3==1.12.0
 # /packages/python-kazoo/buildinfo.json
 kazoo==2.6.1
 # /packages/dcos-test-utils/buildinfo.json
-git+https://github.com/dcos/dcos-test-utils.git@f8a76a148c9f92a60c23c6c98b0ea9240ba6a7a9
+git+https://github.com/dcos/dcos-test-utils.git@b647d1bcae7de62de06d1a83988c64de5022405c
 
 # /packages/python-prometheus_client/buildinfo.json
 prometheus_client==0.5.0

--- a/packages/dcos-integration-test/requirements.txt
+++ b/packages/dcos-integration-test/requirements.txt
@@ -30,7 +30,7 @@ dnspython3==1.12.0
 # /packages/python-kazoo/buildinfo.json
 kazoo==2.6.1
 # /packages/dcos-test-utils/buildinfo.json
-git+https://github.com/dcos/dcos-test-utils.git@9a9cafdd509bc9b8c76ab5e9f59849e7f3ace765
+git+https://github.com/dcos/dcos-test-utils.git@f8a76a148c9f92a60c23c6c98b0ea9240ba6a7a9
 
 # /packages/python-prometheus_client/buildinfo.json
 prometheus_client==0.5.0

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "f8a76a148c9f92a60c23c6c98b0ea9240ba6a7a9",
+    "ref": "b647d1bcae7de62de06d1a83988c64de5022405c",
     "ref_origin": "master"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "9a9cafdd509bc9b8c76ab5e9f59849e7f3ace765",
+    "ref": "f8a76a148c9f92a60c23c6c98b0ea9240ba6a7a9",
     "ref_origin": "master"
   }
 }

--- a/packages/dcos-test-utils/buildinfo.json
+++ b/packages/dcos-test-utils/buildinfo.json
@@ -3,7 +3,7 @@
   "single_source" : {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-test-utils.git",
-    "ref": "b647d1bcae7de62de06d1a83988c64de5022405c",
+    "ref": "097251c2872bd5b377e18e7a8b4d81df942c1263",
     "ref_origin": "master"
   }
 }

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -30,8 +30,8 @@ to start a cluster.
 You can change the configuration with
 
 ```
-export TF_VAR_custom_dcos_download_path="https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.sh"
-export TF_VAR_custom_dcos_download_path_win="https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config_win.sh"
+export TF_VAR_custom_dcos_download_path="https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
+export TF_VAR_custom_dcos_download_path_win="https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh"
 export TF_VAT_variant="open"
 terraform init --upgrade
 terraform apply

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -26,6 +26,7 @@ to start a cluster.
 
 Once Terraform finished you can setup the CLI with `dcos cluster setup $(terraform output masters_dns_name) --insecure`.
 
+Do not forget to destroy the cluster again with `terraform destroy`.
 
 ### Configuration
 
@@ -39,3 +40,4 @@ terraform init --upgrade
 terraform apply
 ```
 
+If you want to launch the build of a specific pull request simply replace `master` with `pull/<PR#>`.

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -3,3 +3,37 @@
 The dcos-integration-test harness and cloud deployment utilities that were previously hosted in this directory have been moved to: [DC/OS Test Utils](https://github.com/mesosphere/dcos-test-utils)
 
 Currently, this directory contains terraform helpers.
+
+## Lauching a Cluster
+
+You must have an active AWS CLI session. The easiest way is to use [maws](https://github.com/mesosphere/maws).
+
+```
+$(maws li "eng-mesosphere-marathon")
+export AWS_REGION="us-east-1"
+```
+
+The private SSH key for the public key defined in `main.tf` must be added with `ssh-add ~/.ssh/id_rsa`.
+
+Terraform 0.11 must also be on your machine. Then call
+
+```
+terraform init --upgrade
+terraform apply
+```
+
+to start a cluster.
+
+
+### Configuration
+
+You can change the configuration with
+
+```
+export TF_VAR_custom_dcos_download_path="https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.sh"
+export TF_VAR_custom_dcos_download_path_win="https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config_win.sh"
+export TF_VAT_variant="open"
+terraform init --upgrade
+terraform apply
+```
+

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -24,6 +24,8 @@ terraform apply
 
 to start a cluster.
 
+Once Terraform finished you can setup the CLI with `dcos cluster setup $(terraform output masters_dns_name) --insecure`.
+
 
 ### Configuration
 

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -9,7 +9,7 @@ variable "custom_dcos_download_path" {
 #Windows Installer path - place url with "pull/PR#" or "master" suffix here:
 variable "custom_dcos_download_path_win" {
   type = "string"
-  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config_win.ee.sh"
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/windows/dcos_generate_config_win.ee.sh"
 }
 
 variable "variant" {

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -1,15 +1,20 @@
 provider "aws" {}
 
 #Linux Installer path - place url with "pull/PR#" or "master" suffix here:
-variable "dcos_generate_config" {
-  type = string
-  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/2.1.0-beta1/dcos_generate_config.ee.sh"
+variable "custom_dcos_download_path" {
+  type = "string"
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh"
 }
 
 #Windows Installer path - place url with "pull/PR#" or "master" suffix here:
-variable "dcos_generate_config_win" {
-  type = string
-  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/2.1.0-beta1/dcos_generate_config_win.ee.sh"
+variable "custom_dcos_download_path_win" {
+  type = "string"
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config_win.ee.sh"
+}
+
+variable "variant" {
+  type = "string"
+  default = "ee"
 }
 
 # Used to determine your public IP for forwarding rules
@@ -40,12 +45,12 @@ module "dcos" {
   dcos_instance_os        = "centos_7.5"
   bootstrap_instance_type = "m4.xlarge"
 
-  dcos_variant              = "ee"
+  dcos_variant              = "${var.variant}"
   dcos_version              = "2.1.0-beta1"
   dcos_license_key_contents = "${file("~/license.txt")}"
   ansible_bundled_container = "mesosphere/dcos-ansible-bundle:windows-beta-support"
 
-  custom_dcos_download_path = var.dcos_generate_config
+  custom_dcos_download_path = "${var.custom_dcos_download_path}"
 
   # provide a SHA512 hashed password, here "deleteme"
   dcos_superuser_password_hash = "$6$rounds=656000$YSvuFmasQDXheddh$TpYlCxNHF6PbsGkjlK99Pwxg7D0mgWJ.y0hE2JKoa61wHx.1wtxTAHVRHfsJU9zzHWDoE08wpdtToHimNR9FJ/"
@@ -59,7 +64,7 @@ enable_windows_agents: true
 
 ansible_additional_config = <<-EOF
 dcos:
- download_win: var.dcos_generate_config_win
+ download_win: "${var.custom_dcos_download_path_win}"
 -EOF
 }
 

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -1,0 +1,129 @@
+provider "aws" {}
+
+#Linux Installer path - place url with "pull/PR#" or "master" suffix here:
+variable "dcos_generate_config" {
+  type = string
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/2.1.0-beta1/dcos_generate_config.ee.sh"
+}
+
+#Windows Installer path - place url with "pull/PR#" or "master" suffix here:
+variable "dcos_generate_config_win" {
+  type = string
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/2.1.0-beta1/dcos_generate_config_win.ee.sh"
+}
+
+# Used to determine your public IP for forwarding rules
+data "http" "whatismyip" {
+  url = "http://whatismyip.akamai.com/"
+}
+
+locals {
+  cluster_name = "generic-dcos-ee-demo"
+}
+
+module "dcos" {
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.2.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  cluster_name        = "${local.cluster_name}"
+  ssh_public_key_file = "~/.ssh/id_rsa.pub"
+  admin_ips           = ["${data.http.whatismyip.body}/32"]
+
+  num_masters        = "1"
+  num_private_agents = "1"
+  num_public_agents  = "1"
+
+  dcos_instance_os        = "centos_7.5"
+  bootstrap_instance_type = "m4.xlarge"
+
+  dcos_variant              = "ee"
+  dcos_version              = "2.1.0-beta1"
+  dcos_license_key_contents = "${file("~/license.txt")}"
+  ansible_bundled_container = "mesosphere/dcos-ansible-bundle:windows-beta-support"
+
+  custom_dcos_download_path = var.dcos_generate_config
+
+  # provide a SHA512 hashed password, here "deleteme"
+  dcos_superuser_password_hash = "$6$rounds=656000$YSvuFmasQDXheddh$TpYlCxNHF6PbsGkjlK99Pwxg7D0mgWJ.y0hE2JKoa61wHx.1wtxTAHVRHfsJU9zzHWDoE08wpdtToHimNR9FJ/"
+  dcos_superuser_username      = "demo-super"
+  additional_windows_private_agent_ips       = ["${concat(module.windowsagent.private_ips)}"]
+  additional_windows_private_agent_passwords = ["${concat(module.windowsagent.windows_passwords)}"]
+
+  dcos_config = <<-EOF
+enable_windows_agents: true
+-EOF
+
+ansible_additional_config = <<-EOF
+dcos:
+ download_win: var.dcos_generate_config_win
+-EOF
+}
+
+module "windowsagent" {
+  source  = "dcos-terraform/windows-instance/aws"
+  version = "~> 0.2.0"
+
+  cluster_name           = "${local.cluster_name}"
+  hostname_format        = "%[3]s-winagent%[1]d-%[2]s"
+  aws_subnet_ids         = ["${module.dcos.infrastructure.vpc.subnet_ids}"]
+  aws_security_group_ids = ["${module.dcos.infrastructure.security_groups.internal}", "${module.dcos.infrastructure.security_groups.admin}"]
+  aws_key_name           = "${module.dcos.infrastructure.aws_key_name}"
+
+  # provide the number of windows agents that should be provisioned.
+  num = "1"
+}
+
+resource "local_file" "ansible_inventory" {
+  filename = "./inventory"
+
+  content = <<EOF
+[bootstraps]
+${module.dcos.infrastructure.bootstrap.public_ip}
+[masters]
+${join("\n", module.dcos.infrastructure.masters.public_ips)}
+[agents_private]
+${join("\n", module.dcos.infrastructure.private_agents.public_ips)}
+[agents_public]
+${join("\n", module.dcos.infrastructure.public_agents.public_ips)}
+[agents_windows]
+${join("\n",formatlist("%s ansible_user=${module.windowsagent.os_user} ansible_password=%s", module.windowsagent.public_ips, module.windowsagent.windows_passwords))}
+[bootstraps:vars]
+node_type=bootstrap
+[masters:vars]
+node_type=master
+dcos_legacy_node_type_name=master
+[agents_private:vars]
+node_type=agent
+dcos_legacy_node_type_name=slave
+[agents_public:vars]
+node_type=agent_public
+dcos_legacy_node_type_name=slave_public
+[agents_windows:vars]
+ansible_connection=winrm
+ansible_winrm_transport=basic
+ansible_winrm_server_cert_validation=ignore
+[agents:children]
+agents_private
+agents_public
+agents_windows
+[dcos:children]
+bootstraps
+masters
+agents
+agents_public
+EOF
+}
+
+output "masters_dns_name" {
+  description = "This is the load balancer address to access the DC/OS UI"
+  value       = "${module.dcos.masters-loadbalancer}"
+}
+
+output "passwords" {
+  description = "This is the load balancer address to access the DC/OS UI"
+  value       = "${module.windowsagent.windows_passwords}"
+}

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -17,6 +17,12 @@ variable "variant" {
   default = "ee"
 }
 
+variable "windowsagent_num" {
+  type = "string"
+  default = "0"
+  description = "Defines the number of Windows agents for the cluster."
+}
+
 # Used to determine your public IP for forwarding rules
 data "http" "whatismyip" {
   url = "http://whatismyip.akamai.com/"
@@ -79,7 +85,7 @@ module "windowsagent" {
   aws_key_name           = "${module.dcos.infrastructure.aws_key_name}"
 
   # provide the number of windows agents that should be provisioned.
-  num = "1"
+  num = "${var.windowsagent_num}"
 }
 
 resource "local_file" "ansible_inventory" {


### PR DESCRIPTION
## High-level description

This imports a parameterized `main.tf` that can be used for local and CI testing.

Furthermore the Windows test app is adapted to it launches a simple ASP app with
health checks.

Outstanding:
- [x] At README with example usage.
- [x] dcos-test-utils changes in https://github.com/dcos/dcos-test-utils/pull/103