### PR TITLE
Bump Marathon to 1.8.239

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Fix Telegraf migration when no containers present. (D2IQ-64507)
 
+* Marathon version bumped to 1.7.236
+
+    * /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
+    * Unreachable instances would interfere with replacements when using GROUP_BY / UNIQUE placement constraints, even if expungeAfter is configured the same as inactiveAfter (MARATHON-8719)
+
 ### Security updates
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Fix Telegraf migration when no containers present. (D2IQ-64507)
 
-* Marathon version bumped to 1.7.236
+* Marathon version bumped to 1.8.239
 
     * /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
     * Unreachable instances would interfere with replacements when using GROUP_BY / UNIQUE placement constraints, even if expungeAfter is configured the same as inactiveAfter (MARATHON-8719)
@@ -327,4 +327,3 @@ No breaking changes are known to date.
 * Added a warning to the installer to let the user know in case kernel modules required by the DC/OS storage service are not loaded. (DCOS-49088)
 
 * Set network interfaces as unmanaged for networkd only on coreos. (DCOS-60956)
-

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.233-4b02f3462/marathon-1.8.233-4b02f3462.tgz",
-    "sha1": "00badc182c131c3e0151ef5fe04ce3bca0ae39ad"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.239-a6095a83d/marathon-1.8.239-a6095a83d.tgz",
+    "sha1": "0ef14c134b08e4ad891206ee0e4c5e5a3a4e47c0"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.8.239

## Corresponding DC/OS tickets (required)

JIRA Issues:
  - [MARATHON-8721](https://jira.mesosphere.com/browse/MARATHON-8721)
  - [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719)

## Related tickets (optional)

  - [MARATHON-8725](https://jira.mesosphere.com/browse/MARATHON-8725)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [4b02f3462..a6095a83d](https://github.com/mesosphere/marathon/compare/4b02f3462...a6095a83d)
  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [x] Test Results: Marathon release artifacts are only published if tests succeed  
