### PR TITLE
Winpanda App: Add the Upgrade command

### DIFF
--- a/packages/winpanda/extra/src/winpanda/bin/winpanda.py
+++ b/packages/winpanda/extra/src/winpanda/bin/winpanda.py
@@ -35,9 +35,8 @@ class DCOSInstallationManager:
         """Retrieve set of CLI arguments."""
         cli_argspec = CLI_ARGSPEC.format(
             cmd_setup=CLI_COMMAND.SETUP,
-            cmd_teardown=CLI_COMMAND.TEARDOWN,
+            cmd_upgrade=CLI_COMMAND.UPGRADE,
             cmd_start=CLI_COMMAND.START,
-            cmd_stop=CLI_COMMAND.STOP,
             valid_cmd_targets=', '.join(VALID_CLI_CMDTARGETS),
             default_cmd_target=CLI_CMDTARGET.PKGALL,
             default_root_dpath=storage.DCOS_INST_ROOT_DPATH_DFT,
@@ -69,12 +68,10 @@ class DCOSInstallationManager:
 
         if self.cli_args[CLI_COMMAND.SETUP] is True:
             command_name = CLI_COMMAND.SETUP
-        elif self.cli_args[CLI_COMMAND.TEARDOWN] is True:
-            command_name = CLI_COMMAND.TEARDOWN
+        elif self.cli_args[CLI_COMMAND.UPGRADE] is True:
+            command_name = CLI_COMMAND.UPGRADE
         elif self.cli_args[CLI_COMMAND.START] is True:
             command_name = CLI_COMMAND.START
-        elif self.cli_args[CLI_COMMAND.STOP] is True:
-            command_name = CLI_COMMAND.STOP
 
         cmd_opts = {
             CLI_CMDOPT.CMD_NAME: command_name,
@@ -107,7 +104,6 @@ class DCOSInstallationManager:
 def main():
     """"""
     log_level = LOG_LEVEL.DEBUG
-    # log_fpath = Path('.', cm_const.APP_LOG_FNAME)
     log_fpath = Path('C:\\d2iq\\dcos\\var\\log\\winpanda',
                      cm_const.APP_LOG_FNAME)
     try:

--- a/packages/winpanda/extra/src/winpanda/common/cli.py
+++ b/packages/winpanda/extra/src/winpanda/common/cli.py
@@ -7,9 +7,10 @@ Application CLI specification.
 class CLI_COMMAND:
     """CLI command set."""
     SETUP = 'setup'
-    TEARDOWN = 'teardown'
+    TEARDOWN = 'teardown'  # Not implemented
+    UPGRADE = 'upgrade'
     START = 'start'
-    STOP = 'stop'
+    STOP = 'stop'  # Not implemented
 
 
 class CLI_CMDTARGET:
@@ -45,9 +46,8 @@ CLI_ARGSPEC = '''Panda package management for Windows
 
 Usage:
   winpanda {cmd_setup} [options]
-  winpanda {cmd_teardown} [options]
+  winpanda {cmd_upgrade} [options]
   winpanda {cmd_start} [options]
-  winpanda {cmd_stop} [options]
 
 Options:
   --target=<target>                 target operational scope for a command

--- a/packages/winpanda/extra/src/winpanda/common/constants.py
+++ b/packages/winpanda/extra/src/winpanda/common/constants.py
@@ -2,11 +2,15 @@
 
 Application-wide constant objects.
 """
+import logging
+
 # Application
 APP_NAME = 'winpanda'
+APP_LOG_LEVEL_DFT = logging.INFO
 APP_LOG_FNAME = f'{APP_NAME}.log'
 APP_LOG_FSIZE_MAX = 10485760  # 10 MiB
 APP_LOG_HSIZE_MAX = 10       # Log file history max size
 
 DCOS_CLUSTER_CFG_FNAME_DFT = 'cluster.conf'
+DCOS_INST_STATE_FNAME_DFT = 'inst_state.json'
 ZK_CLIENTPORT_DFT = 2181

--- a/packages/winpanda/extra/src/winpanda/common/storage.py
+++ b/packages/winpanda/extra/src/winpanda/common/storage.py
@@ -209,7 +209,7 @@ class InstallationStorage:
                     LOG.error(f'{self.__class__.__name__}: Construction:'
                               f' Rollback: {path}: {type(e).__name__}: {e}')
 
-        for path in self.istor_nodes[1:]:
+        for path in self.istor_nodes:
             if path.exists():
                 if path.is_symlink():
                     rollback()

--- a/packages/winpanda/extra/src/winpanda/core/cmdconf.py
+++ b/packages/winpanda/extra/src/winpanda/core/cmdconf.py
@@ -8,14 +8,15 @@ import posixpath
 import tempfile as tf
 
 from common import constants as cm_const
+from common import exceptions as cm_exc
 from common import logger
+from common import utils as cm_utl
 from common.cli import CLI_COMMAND, CLI_CMDOPT, CLI_CMDTARGET
 from common.storage import InstallationStorage
 from core import exceptions as cr_exc
 from core import template
 from core import utils as cr_utl
-
-from common import utils as cm_utl
+from core.istate import ISTATE, InstallationState
 
 
 LOG = logger.get_logger(__name__)
@@ -55,7 +56,47 @@ class CommandConfig(metaclass=abc.ABCMeta):
 
     def __init__(self, **cmd_opts):
         """Constructor."""
+        self.msg_src = self.__class__.__name__
         self.cmd_opts = cmd_opts
+
+        # DC/OS installation storage manager
+        self.inst_storage = InstallationStorage(
+            root_dpath=self.cmd_opts.get(CLI_CMDOPT.INST_ROOT),
+            cfg_dpath=self.cmd_opts.get(CLI_CMDOPT.INST_CONF),
+            pkgrepo_dpath=self.cmd_opts.get(CLI_CMDOPT.INST_PKGREPO),
+            state_dpath=self.cmd_opts.get(CLI_CMDOPT.INST_STATE),
+            var_dpath=self.cmd_opts.get(CLI_CMDOPT.INST_VAR),
+        )
+        LOG.debug(f'{self.msg_src}: istor_nodes:'
+                  f' {self.inst_storage.istor_nodes}')
+
+        # DC/OS installation state descriptor
+        self.inst_state = self._get_inst_state()
+
+    def _get_inst_state(self):
+        """"""
+        istate_fpath = self.inst_storage.state_dpath.joinpath(
+            cm_const.DCOS_INST_STATE_FNAME_DFT
+        )
+        try:
+            inst_state = InstallationState.load(istate_fpath)
+            LOG.debug(f'{self.msg_src}: DC/OS installation state descriptor:'
+                      f' Load: {inst_state}')
+        except cr_exc.RCNotFoundError:
+            inst_state = None
+
+        if inst_state is None:
+            msg_base = (f'{self.msg_src}:'
+                        f' DC/OS installation state descriptor: Create')
+            try:
+                inst_state = InstallationState(self.inst_storage.istor_nodes)
+                LOG.debug(f'{msg_base}: {inst_state}')
+            except AssertionError as e:
+                raise cr_exc.RCError(f'{msg_base}: {type(e).__name__}: {e}')
+            except cr_exc.RCError as e:
+                raise cr_exc.RCError(f'{msg_base}: {e}')
+
+        return inst_state
 
     def __repr__(self):
         return (
@@ -72,40 +113,51 @@ class CmdConfigSetup(CommandConfig):
 
     def __init__(self, **cmd_opts):
         """"""
-        self.msg_src = self.__class__.__name__
         super(CmdConfigSetup, self).__init__(**cmd_opts)
-        # DC/OS installation storage manager
-        self.inst_storage = InstallationStorage(
-            root_dpath=cmd_opts.get(CLI_CMDOPT.INST_ROOT),
-            cfg_dpath=cmd_opts.get(CLI_CMDOPT.INST_CONF),
-            pkgrepo_dpath=cmd_opts.get(CLI_CMDOPT.INST_PKGREPO),
-            state_dpath=cmd_opts.get(CLI_CMDOPT.INST_STATE),
-            var_dpath=cmd_opts.get(CLI_CMDOPT.INST_VAR),
-        )
-        LOG.debug(f'{self.msg_src}: istor_nodes:'
-                  f' {self.inst_storage.istor_nodes}')
-        if cmd_opts.get(CLI_CMDOPT.CMD_TARGET) == CLI_CMDTARGET.PKGALL:
-            # Make sure that the installation storage is in consistent state
-            self.inst_storage.construct()
 
-        # DC/OS cluster setup parameters
-        self.cluster_conf_nop = False
-        self.cluster_conf = self.get_cluster_conf()
-        LOG.debug(f'{self.msg_src}: cluster_conf: {self.cluster_conf}')
+        if self.inst_state.istate == ISTATE.UNDEFINED:
+            self.inst_state.istate = ISTATE.INSTALLATION_IN_PROGRESS
+            try:
+                if cmd_opts.get(CLI_CMDOPT.CMD_TARGET) == CLI_CMDTARGET.PKGALL:
+                    # Make sure that the installation storage is in consistent state
+                    self.inst_storage.construct()
 
-        # Reference list of DC/OS packages
-        self.ref_pkg_list = self.get_ref_pkg_list()
-        LOG.debug(f'{self.msg_src}: ref_pkg_list: {self.ref_pkg_list}')
+                # DC/OS cluster setup parameters
+                self.cluster_conf_nop = False
+                self.cluster_conf = self.get_cluster_conf()
+                LOG.debug(f'{self.msg_src}: cluster_conf: {self.cluster_conf}')
 
-        # DC/OS aggregated configuration object
-        self.dcos_conf = self.get_dcos_conf()
-        LOG.debug(f'{self.msg_src}: dcos_conf: {self.dcos_conf}')
+                # Reference list of DC/OS packages
+                self.ref_pkg_list = self.get_ref_pkg_list()
+                LOG.debug(f'{self.msg_src}: ref_pkg_list: {self.ref_pkg_list}')
+
+                # DC/OS aggregated configuration object
+                self.dcos_conf = self.get_dcos_conf()
+                LOG.debug(f'{self.msg_src}: dcos_conf: {self.dcos_conf}')
+            except cm_exc.WinpandaError:
+                self.inst_state.istate = ISTATE.INSTALLATION_FAILED
+                raise
+        else:
+            LOG.info(f'{self.msg_src}: Invalid DC/OS installation state'
+                     f' detected: {self.inst_state.istate}: NOP'
+                     )
+            self.cluster_conf_nop = False
+            self.cluster_conf = {}
+            self.ref_pkg_list = []
+            self.dcos_conf = {}
 
     def get_cluster_conf(self):
         """"Get a collection of DC/OS cluster configuration options.
 
         :return: dict, configparser.ConfigParser.read_dict() compatible data
         """
+        # TODO: Functionality implemented in this method needs to be reused
+        #       in other application parts (e.g. CmdConfigUpgrade) and so, it
+        #       has been arranged as a standalone function get_cluster_conf().
+        #       Thus the CmdConfigSetup is to be moved to use that standalone
+        #       function instead of this method to avoid massive code
+        #       duplication.
+
         # Load cluster configuration file
         fpath = Path(self.cmd_opts.get(CLI_CMDOPT.DCOS_CLUSTERCFGPATH))
 
@@ -212,6 +264,12 @@ class CmdConfigSetup(CommandConfig):
 
         :return: list, JSON-formatted data
         """
+        # TODO: Functionality implemented in this method needs to be reused
+        #       in other application parts (e.g. CmdConfigUpgrade) and so, it
+        #       has been arranged as a standalone function get_ref_pkg_list().
+        #       Thus the CmdConfigSetup is to be moved to use that standalone
+        #       function instead of this method to avoid massive code
+        #       duplication.
         dstor_root_url = (
             self.cluster_conf.get('distribution-storage', {}).get(
                 'rooturl', ''
@@ -269,7 +327,12 @@ class CmdConfigSetup(CommandConfig):
                     }
                  }
         """
-
+        # TODO: Functionality implemented in this method needs to be reused
+        #       in other application parts (e.g. CmdConfigUpgrade) and so, it
+        #       has been arranged as a standalone function get_dcos_conf().
+        #       Thus the CmdConfigSetup is to be moved to use that standalone
+        #       function instead of this method to avoid massive code
+        #       duplication.
         dstor_root_url = (
             self.cluster_conf.get('distribution-storage', {}).get(
                 'rooturl', ''
@@ -367,6 +430,13 @@ class CmdConfigSetup(CommandConfig):
                                        config package at the DC/OS distribution
                                        storage
         """
+        # TODO: Functionality implemented in this method needs to be reused
+        #       in other application parts (e.g. CmdConfigUpgrade) and so, it
+        #       has been arranged as a standalone function
+        #       get_dstor_dcoscfgpkg_path().
+        #       Thus the CmdConfigSetup is to be moved to use that standalone
+        #       function instead of this method to avoid massive code
+        #       duplication.
         dcos_conf_pkg_name = 'dcos-config-win'
 
         # Linux package index direct URL
@@ -434,12 +504,66 @@ class CmdConfigSetup(CommandConfig):
 
         :param fpath: pathlib.Path, path to template
         """
+        # TODO: Functionality implemented in this method needs to be reused
+        #       in other application parts (e.g. CmdConfigUpgrade) and so, it
+        #       has been arranged as a standalone function
+        #       load_dcos_conf_template().
+        #       Thus the CmdConfigSetup is to be moved to use that standalone
+        #       function instead of this method to avoid massive code
+        #       duplication.
         try:
             with fpath.open() as f:
                 return template.parse_str(f.read())
         except (OSError, RuntimeError) as e:
             raise cr_exc.RCError(f'DC/OS aggregated config: Template: Load:'
                                  f' {fpath}: {type(e).__name__}: {e}') from e
+
+
+@cmdconf_type(CLI_COMMAND.UPGRADE)
+class CmdConfigUpgrade(CommandConfig):
+    """Configuration manager for the 'upgrade' command."""
+
+    def __init__(self, **cmd_opts):
+        """"""
+        super(CmdConfigUpgrade, self).__init__(**cmd_opts)
+
+        # DC/OS installation state
+        if self.inst_state.istate == ISTATE.INSTALLED:
+            self.inst_state.istate = ISTATE.UPGRADE_IN_PROGRESS
+            try:
+                # DC/OS cluster setup parameters
+                self.cluster_conf = get_cluster_conf(
+                    self.inst_storage.cfg_dpath, **cmd_opts
+                )
+                if not self.cluster_conf:
+                    LOG.info(f'{self.msg_src}: cluster_conf: NOP')
+                LOG.debug(f'{self.msg_src}: cluster_conf: {self.cluster_conf}')
+
+                # Reference list of DC/OS packages
+                self.ref_pkg_list = get_ref_pkg_list(
+                    self.cluster_conf, self.inst_storage.tmp_dpath
+                )
+                if not self.ref_pkg_list:
+                    LOG.info(f'{self.msg_src}: ref_pkg_list: NOP')
+                LOG.debug(f'{self.msg_src}: ref_pkg_list: {self.ref_pkg_list}')
+
+                # DC/OS aggregated configuration object
+                self.dcos_conf = get_dcos_conf(
+                    self.cluster_conf, self.inst_storage.tmp_dpath
+                )
+                if not self.dcos_conf:
+                    LOG.info(f'{self.msg_src}: dcos_conf: NOP')
+                LOG.debug(f'{self.msg_src}: dcos_conf: {self.dcos_conf}')
+            except cm_exc.WinpandaError:
+                self.inst_state.istate = ISTATE.UPGRADE_FAILED
+                raise
+        else:
+            LOG.info(f'{self.msg_src}: Invalid DC/OS installation state'
+                     f' detected: {self.inst_state.istate}: NOP'
+                     )
+            self.cluster_conf = {}
+            self.ref_pkg_list = []
+            self.dcos_conf = {}
 
 
 @cmdconf_type(CLI_COMMAND.START)
@@ -449,21 +573,337 @@ class CmdConfigStart(CommandConfig):
     def __init__(self, **cmd_opts):
         """"""
         super(CmdConfigStart, self).__init__(**cmd_opts)
-        # Create DC/OS installation storage manager
-        self.inst_storage = InstallationStorage(
-            root_dpath=cmd_opts.get(CLI_CMDOPT.INST_ROOT),
-            cfg_dpath=cmd_opts.get(CLI_CMDOPT.INST_CONF),
-            pkgrepo_dpath=cmd_opts.get(CLI_CMDOPT.INST_PKGREPO),
-            state_dpath=cmd_opts.get(CLI_CMDOPT.INST_STATE),
-            var_dpath=cmd_opts.get(CLI_CMDOPT.INST_VAR)
-        )
-        LOG.debug(f'{self.__class__.__name__}: inst_storage: istor_nodes:'
-                  f' {self.inst_storage.istor_nodes}')
+
         # Make sure that the installation storage is in consistent state
         self.inst_storage.construct()
 
-        # DC/OS cluster setup parameters
-        self.cluster_conf = {}
-        LOG.debug(
-            f'{self.__class__.__name__}: cluster_conf: {self.cluster_conf}'
+
+#
+# Configuration utility functions
+#
+def get_cluster_conf(istor_cfg_dpath, **cmd_opts):
+    """"Get a collection of DC/OS cluster configuration options.
+
+    :param istor_cfg_dpath: pathlib.Path, absolute path to the DC/OS
+                            configuration directory within the local DC/OS
+                            installation storage
+
+    :return: dict, configparser.ConfigParser.read_dict() compatible data
+    """
+    # Load cluster configuration file
+    fpath = Path(cmd_opts.get(CLI_CMDOPT.DCOS_CLUSTERCFGPATH))
+
+    # Unblock irrelevant local operations
+    if str(fpath) == 'NOP':
+        return {}
+
+    if not fpath.is_absolute():
+        if istor_cfg_dpath.exists():
+            fpath = istor_cfg_dpath.joinpath(fpath)
+        else:
+            fpath = Path('.').resolve().joinpath(fpath)
+
+    cluster_conf = cr_utl.rc_load_ini(
+        fpath, emheading='Cluster setup descriptor'
+    )
+
+    # CLI options take precedence, if any.
+    # list(tuple('ipaddr', 'port'))
+    cli_master_priv_ipaddrs = [
+        ipaddr.partition(':')[::2] for ipaddr in
+        cmd_opts.get(CLI_CMDOPT.MASTER_PRIVIPADDR, '').split(' ') if
+        ipaddr != ''
+    ]
+    mnode_sects = [
+        sect for sect in cluster_conf if sect.startswith('master-node')
+    ]
+    # iterator(tuple('ipaddr', 'port'), str)
+    change_map = zip(cli_master_priv_ipaddrs, mnode_sects)
+    for item in change_map:
+        if item[0][0]:
+            cluster_conf[item[1]]['privateipaddr'] = item[0][0]
+            if item[0][1]:
+                try:
+                    port = int(item[0][1])
+                except (ValueError, TypeError):
+                    port = cm_const.ZK_CLIENTPORT_DFT
+                port = (port if 0 < port < 65536 else
+                        cm_const.ZK_CLIENTPORT_DFT)
+                cluster_conf[item[1]]['zookeeperclientport'] = port
+
+    # Add extra 'master-node' sections, if CLI provides extra arguments
+    extra_cli_items = cli_master_priv_ipaddrs[len(mnode_sects):]
+    for n, item in enumerate(extra_cli_items):
+        if item[0]:
+            # TODO: Implement collision tolerance for section names.
+            cluster_conf[f'master-node-extra{n}'] = {}
+            cluster_conf[f'master-node-extra{n}']['privateipaddr'] = (
+                item[0]
+            )
+            if item[1]:
+                try:
+                    port = int(item[1])
+                except (ValueError, TypeError):
+                    port = cm_const.ZK_CLIENTPORT_DFT
+                port = (port if 0 < port < 65536 else
+                        cm_const.ZK_CLIENTPORT_DFT)
+                cluster_conf[f'master-node-extra{n}'][
+                    'zookeeperclientport'
+                ] = port
+    # DC/OS storage distribution parameters
+    cli_dstor_url = cmd_opts.get(CLI_CMDOPT.DSTOR_URL)
+    cli_dstor_pkgrepo_path = cmd_opts.get(CLI_CMDOPT.DSTOR_PKGREPOPATH)
+    cli_dstor_pkglist_path = cmd_opts.get(CLI_CMDOPT.DSTOR_PKGLISTPATH)
+    cli_dstor_dcoscfg_path = cmd_opts.get(CLI_CMDOPT.DSTOR_DCOSCFGPATH)
+
+    if not cluster_conf.get('distribution-storage'):
+        cluster_conf['distribution-storage'] = {}
+
+    if cli_dstor_url:
+        cluster_conf['distribution-storage']['rooturl'] = cli_dstor_url
+
+    if cli_dstor_pkgrepo_path:
+        cluster_conf['distribution-storage']['pkgrepopath'] = (
+            cli_dstor_pkgrepo_path
         )
+
+    if cli_dstor_pkglist_path:
+        cluster_conf['distribution-storage']['pkglistpath'] = (
+            cli_dstor_pkglist_path
+        )
+
+    if cli_dstor_dcoscfg_path:
+        cluster_conf['distribution-storage']['dcoscfgpath'] = (
+            cli_dstor_dcoscfg_path
+        )
+
+    # Local parameters of DC/OS node
+    cli_local_priv_ipaddr = cmd_opts.get(CLI_CMDOPT.LOCAL_PRIVIPADDR)
+
+    if not cluster_conf.get('local'):
+        cluster_conf['local'] = {}
+
+    if cli_local_priv_ipaddr:
+        cluster_conf['local']['privateipaddr'] = cli_local_priv_ipaddr
+
+    return cluster_conf
+
+
+def get_ref_pkg_list(cluster_conf, tmp_dpath):
+    """Get the current reference package list.
+
+    :return: list, JSON-formatted data
+    """
+    dstor_root_url = (
+        cluster_conf.get('distribution-storage', {}).get('rooturl', '')
+    )
+    dstor_pkglist_path = (
+        cluster_conf.get('distribution-storage', {}).get('pkglistpath', '')
+    )
+    # Unblock irrelevant local operations
+    if not cluster_conf or dstor_pkglist_path == 'NOP':
+        return []
+
+    rpl_url = posixpath.join(dstor_root_url, dstor_pkglist_path)
+    rpl_fname = Path(dstor_pkglist_path).name
+
+    try:
+        cm_utl.download(rpl_url, str(tmp_dpath))
+        LOG.debug(f'Reference package list: Download: {rpl_fname}: {rpl_url}')
+    except Exception as e:
+        raise cr_exc.RCDownloadError(
+            f'Reference package list: Download: {rpl_fname}: {rpl_url}:'
+            f' {type(e).__name__}: {e}'
+        ) from e
+
+    rpl_fpath = tmp_dpath.joinpath(rpl_fname)
+    try:
+        return cr_utl.rc_load_json(
+            rpl_fpath, emheading=f'Reference package list: {rpl_fname}'
+        )
+    except cr_exc.RCError as e:
+        raise e
+    finally:
+        rpl_fpath.unlink()
+
+
+def get_dcos_conf(cluster_conf, tmp_dpath):
+    """Get the DC/OS aggregated configuration object.
+
+    :return: dict, set of DC/OS shared and package specific configuration
+             templates coupled with 'key=value' substitution data
+             container:
+             {
+                'template': {
+                    'package': [
+                        {'path': <str>, 'content': <str>},
+                         ...
+                    ]
+                },
+                'values': {
+                    key: value,
+                    ...
+                }
+             }
+    """
+
+    dstor_root_url = (
+        cluster_conf.get('distribution-storage', {}).get('rooturl', '')
+    )
+    dstor_linux_pkg_index_path = (
+        cluster_conf.get('distribution-storage', {}).get(
+            'dcosclusterpkginfopath', ''
+        )
+    )
+    template_fname = 'dcos-config-windows.yaml'
+    values_fname = 'expanded.config.full.json'
+
+    # Unblock irrelevant local operations
+    if not cluster_conf or dstor_linux_pkg_index_path == 'NOP':
+        return {}
+
+    # Discover relative URL to the DC/OS aggregated configuration package.
+    dstor_dcoscfg_pkg_path = get_dstor_dcoscfgpkg_path(
+        dstor_root_url, dstor_linux_pkg_index_path, tmp_dpath
+    )
+
+    dcoscfg_pkg_url = posixpath.join(dstor_root_url, dstor_dcoscfg_pkg_path)
+    dcoscfg_pkg_fname = Path(dstor_dcoscfg_pkg_path).name
+
+    # Download DC/OS aggregated configuration package ...
+    try:
+        cm_utl.download(dcoscfg_pkg_url, str(tmp_dpath))
+        LOG.debug(f'DC/OS aggregated config package:'
+                  f' Download: {dcoscfg_pkg_url}')
+    except Exception as e:
+        raise cr_exc.RCDownloadError(
+            f'DC/OS aggregated config package: {dcoscfg_pkg_url}:'
+            f' {type(e).__name__}: {e}'
+        ) from e
+
+    # Process DC/OS aggregated configuration package.
+    dcoscfg_pkg_fpath = tmp_dpath.joinpath(dcoscfg_pkg_fname)
+
+    try:
+        with tf.TemporaryDirectory(dir=str(tmp_dpath)) as tmp_dpath_:
+            cm_utl.unpack(str(dcoscfg_pkg_fpath), tmp_dpath_)
+            LOG.debug(f'DC/OS aggregated config package:'
+                      f' {dcoscfg_pkg_fpath}: Extract: OK')
+
+            values_fpath = Path(tmp_dpath_).joinpath(values_fname)
+            values = cr_utl.rc_load_json(
+                values_fpath,
+                emheading=f'DC/OS aggregated config: Values'
+            )
+            template_fpath = Path(tmp_dpath_).joinpath(template_fname)
+            template = load_dcos_conf_template(template_fpath)
+    except Exception as e:
+        if not isinstance(e, cr_exc.RCError):
+            raise cr_exc.RCExtractError(
+                f'DC/OS aggregated config package: {dcoscfg_pkg_fpath}:'
+                f' {type(e).__name__}: {e}'
+            )
+        else:
+            raise
+    else:
+        LOG.debug(f'DC/OS aggregated config package:'
+                  f' {dcoscfg_pkg_fpath}: Preprocess: OK')
+        return {'template': template, 'values': values}
+    finally:
+        dcoscfg_pkg_fpath.unlink()
+
+
+def get_dstor_dcoscfgpkg_path(dstor_root_url, dstor_lpi_path, tmp_dpath):
+    """Retrieve the Linux Package Index (LPI) object from the DC/OS
+    distribution storage and discover a relative URL to the DC/OS
+    aggregated configuration package.
+    LPI is expected to be a JSON-formatted file containing descriptors for
+    DC/OS distribution packages:
+
+    {
+        "<pkg-name>":{
+            "filename":"<base-path>/<pkg-name>--<pkg-version>.tar.xz",
+            "id":"<pkg-name>--<pkg-version>"
+        },
+        ...
+    }
+
+    :param dstor_root_url:         str, DC/OS distribution storage root URL
+    :param dstor_lpi_path:         str, URL path to the DC/OS Linux package
+                                   index object at the DC/OS distribution
+                                   storage
+    :return dstor_dcoscfgpkg_path: str, URL path to the DC/OS aggregated
+                                   config package at the DC/OS distribution
+                                   storage
+    """
+    dcos_conf_pkg_name = 'dcos-config-win'
+
+    # Linux package index direct URL
+    lpi_url = posixpath.join(dstor_root_url, dstor_lpi_path)
+    lpi_fname = Path(dstor_lpi_path).name
+
+    try:
+        cm_utl.download(lpi_url, str(tmp_dpath))
+        LOG.debug(f'DC/OS Linux package index: Download: {lpi_url}')
+    except Exception as e:
+        raise cr_exc.RCDownloadError(
+            f'DC/OS Linux package index: {lpi_url}: {type(e).__name__}: {e}'
+        ) from e
+
+    lpi_fpath = tmp_dpath.joinpath(lpi_fname)
+
+    try:
+        lpi = cr_utl.rc_load_json(lpi_fpath,
+                                  emheading='DC/OS Linux package index')
+
+        if not isinstance(lpi, dict):
+            raise cr_exc.RCInvalidError(
+                f'DC/OS Linux package index: {lpi_url}: Invalid structure'
+            )
+
+        dcos_conf_pkg_desc = lpi.get(dcos_conf_pkg_name)
+
+        if dcos_conf_pkg_desc is None:
+            raise cr_exc.RCElementError(
+                f'DC/OS Linux package index: {lpi_url}: DC/OS aggregated'
+                f' config package descriptor is missed:'
+                f' {dcos_conf_pkg_name}'
+            )
+
+        if not isinstance(dcos_conf_pkg_desc, dict):
+            raise cr_exc.RCElementError(
+                f'DC/OS Linux package index: {lpi_url}: Invalid DC/OS'
+                f' aggregated config package descriptor:'
+                f' {dcos_conf_pkg_desc}'
+            )
+
+        dstor_dcoscfgpkg_path = dcos_conf_pkg_desc.get('filename')
+        if dstor_dcoscfgpkg_path is None:
+            raise cr_exc.RCElementError(
+                f'DC/OS Linux package index: {lpi_url}: DC/OS aggregated'
+                f' config package descriptor: Distribution storage path is'
+                f' missed: {dcos_conf_pkg_desc}'
+            )
+        if not isinstance(dstor_dcoscfgpkg_path, str):
+            raise cr_exc.RCElementError(
+                f'DC/OS Linux package index: {lpi_url}: DC/OS aggregated'
+                f' config package descriptor: Distribution storage path:'
+                f' Invalid type: {dstor_dcoscfgpkg_path}'
+            )
+    finally:
+        lpi_fpath.unlink()
+
+    return dstor_dcoscfgpkg_path
+
+
+def load_dcos_conf_template(fpath):
+    """Load the DC/OS aggregated configuration template from disk.
+
+    :param fpath: pathlib.Path, path to template
+    """
+    try:
+        with fpath.open() as f:
+            return template.parse_str(f.read())
+    except (OSError, RuntimeError) as e:
+        raise cr_exc.RCError(f'DC/OS aggregated config: Template: Load:'
+                             f' {fpath}: {type(e).__name__}: {e}') from e

--- a/packages/winpanda/extra/src/winpanda/core/command.py
+++ b/packages/winpanda/extra/src/winpanda/core/command.py
@@ -5,15 +5,19 @@ DC/OS package management command definitions.
 import abc
 import os
 from pathlib import Path
+import shutil
 import yaml
 
 from cfgm import exceptions as cfgm_exc
+from common import exceptions as cm_exc
 from common import logger
-from common.cli import CLI_COMMAND, CLI_CMDTARGET, CLI_CMDOPT
+from common import storage
 from common import utils as cm_utl
+from common.cli import CLI_COMMAND, CLI_CMDTARGET, CLI_CMDOPT
 from common.storage import ISTOR_NODE
 from core import cmdconf
 from core import exceptions as cr_exc
+from core.istate import ISTATE
 from core.package.id import PackageId
 from core.package.manifest import PackageManifest
 from core.package.package import Package
@@ -60,6 +64,7 @@ class Command(metaclass=abc.ABCMeta):
     """
     def __init__(self, **cmd_opts):
         """Constructor."""
+        self.msg_src = self.__class__.__name__
         self.cmd_opts = cmd_opts
 
     def __repr__(self):
@@ -86,13 +91,13 @@ class CmdSetup(Command):
     """Setup command implementation."""
     def __init__(self, **cmd_opts):
         """"""
-        self.msg_src = self.__class__.__name__
         super(CmdSetup, self).__init__(**cmd_opts)
         if self.cmd_opts.get(CLI_CMDOPT.CMD_TARGET) == CLI_CMDTARGET.STORAGE:
             # Deactivate cluster-related configuration steps
             self.cmd_opts[CLI_CMDOPT.DCOS_CLUSTERCFGPATH] = 'NOP'
 
         self.config = cmdconf.create(**self.cmd_opts)
+
         LOG.debug(f'{self.msg_src}: cmd_opts: {self.cmd_opts}')
 
     def verify_cmd_options(self):
@@ -104,85 +109,140 @@ class CmdSetup(Command):
         LOG.debug(f'{self.msg_src}: Execute: Target:'
                   f' {self.cmd_opts.get(CLI_CMDOPT.CMD_TARGET)}')
 
-        if self.cmd_opts.get(CLI_CMDOPT.CMD_TARGET) == CLI_CMDTARGET.STORAGE:
-            # (Re)build/repair the installation storage structure.
-            self.config.inst_storage.construct(
-                clean=self.cmd_opts.get(CLI_CMDOPT.INST_CLEAN)
-            )
-        elif self.cmd_opts.get(CLI_CMDOPT.CMD_TARGET) == CLI_CMDTARGET.PKGALL:
-            dstor_root_url = self.config.cluster_conf.get(
-                'distribution-storage', {}
-            ).get('rooturl', '')
-            dstor_pkgrepo_path = self.config.cluster_conf.get(
-                'distribution-storage', {}
-            ).get('pkgrepopath', '')
-
-            # Add packages to the local package repository and initialize their
-            # manager objects
-            packages_bulk = {}
-
-            for item in self.config.ref_pkg_list:
-                pkg_id = PackageId(pkg_id=item)
-
-                try:
-                    self.config.inst_storage.add_package(
-                        pkg_id=pkg_id,
-                        dstor_root_url=dstor_root_url,
-                        dstor_pkgrepo_path=dstor_pkgrepo_path
+        try:
+            cmd_target = self.cmd_opts.get(CLI_CMDOPT.CMD_TARGET)
+            if cmd_target == CLI_CMDTARGET.STORAGE:
+                # (Re)build/repair the installation storage structure.
+                self.config.inst_storage.construct(
+                    clean=self.cmd_opts.get(CLI_CMDOPT.INST_CLEAN)
+                )
+            elif cmd_target == CLI_CMDTARGET.PKGALL:
+                istate = self.config.inst_state.istate
+                if istate == ISTATE.INSTALLATION_IN_PROGRESS:
+                    self._handle_cmdtarget_pkgall()
+                    self._register_istate(ISTATE.INSTALLED)
+                else:
+                    LOG.info(
+                        f'{self.msg_src}: Execute: Invalid DC/OS installation'
+                        f' state detected: {istate}: NOP'
                     )
-                except cr_exc.RCError as e:
-                    err_msg = (f'{self.msg_src}: Execute: Add package to local'
-                               f' repository: {pkg_id.pkg_id}: {e}')
-                    raise cr_exc.SetupCommandError(err_msg) from e
 
-                try:
-                    package = Package(
-                        pkg_id=pkg_id,
-                        istor_nodes=self.config.inst_storage.istor_nodes,
-                        cluster_conf=self.config.cluster_conf,
-                        extra_context=self.config.dcos_conf.get('values')
-                    )
-                except cr_exc.RCError as e:
-                    err_msg = (f'{self.msg_src}: Execute: Initialize package:'
-                               f' {pkg_id.pkg_id}: {e}')
-                    raise cr_exc.SetupCommandError(err_msg) from e
+            LOG.info(f'{self.msg_src}: Execute: OK')
+        except cm_exc.WinpandaError:
+            self._register_istate(ISTATE.INSTALLATION_FAILED)
+            raise
 
-                packages_bulk[pkg_id.pkg_name] = package
+    def _register_istate(self, inst_state):
+        """"""
+        # TODO: Move this method to the abstract base parent class Command to
+        #       avoid code duplication in command manager classes.
+        msg_base = (f'{self.msg_src}:'
+                    f' Execute: Register installation state: {inst_state}')
+        try:
+            self.config.inst_state.istate = inst_state
+            LOG.debug(f'{msg_base}: OK')
+        except cr_exc.RCError as e:
+            raise cr_exc.SetupCommandError(f'Execute: {type(e).__name__}: {e}')
 
-            # Finalize package setup procedures taking package mutual
-            # dependencies into account.
+    def _handle_cmdtarget_pkgall(self):
+        """"""
+        # TODO: This code is duplicated in the CmdUpgrade._handle_clean_setup()
+        #       stuff and so should be made standalone to be reused in both
+        #       classes avoiding massive code duplication.
+        dstor_root_url = self.config.cluster_conf.get(
+            'distribution-storage', {}
+        ).get('rooturl', '')
+        dstor_pkgrepo_path = self.config.cluster_conf.get(
+            'distribution-storage', {}
+        ).get('pkgrepopath', '')
 
-            packages_sorted_by_deps = cr_utl.pkg_sort_by_deps(packages_bulk)
+        # Add packages to the local package repository and initialize their
+        # manager objects
+        packages_bulk = {}
 
-            # Prepare base per package configuration objects
-            for package in packages_sorted_by_deps:
-                self._handle_pkg_dir_setup(package)
-                self._handle_pkg_cfg_setup(package)
+        for item in self.config.ref_pkg_list:
+            pkg_id = PackageId(pkg_id=item)
 
-            # Deploy DC/OS aggregated configuration object
-            self._deploy_dcos_conf()
+            try:
+                self.config.inst_storage.add_package(
+                    pkg_id=pkg_id,
+                    dstor_root_url=dstor_root_url,
+                    dstor_pkgrepo_path=dstor_pkgrepo_path
+                )
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Add package to local'
+                           f' repository: {pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg) from e
 
-            # Run per package extra installation helpers, setup services and
-            # save manifests
-            for package in packages_sorted_by_deps:
-                self._handle_pkg_inst_extras(package)
-                self._handle_pkg_svc_setup(package)
+            try:
+                package = Package(
+                    pkg_id=pkg_id,
+                    istor_nodes=self.config.inst_storage.istor_nodes,
+                    cluster_conf=self.config.cluster_conf,
+                    extra_context=self.config.dcos_conf.get('values')
+                )
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Initialize package:'
+                           f' {pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg) from e
 
-                try:
-                    package.manifest.save()
-                except cr_exc.RCError as e:
-                    err_msg = (f'{self.msg_src}: Execute: Register package:'
-                               f' {package.manifest.pkg_id.pkg_id}: {e}')
-                    raise cr_exc.SetupCommandError(err_msg)
+            packages_bulk[pkg_id.pkg_name] = package
 
-                LOG.info(f'{self.msg_src}: Setup package:'
-                         f' {package.manifest.pkg_id.pkg_id}: OK')
+        # Finalize package setup procedures taking package mutual
+        # dependencies into account.
+
+        packages_sorted_by_deps = cr_utl.pkg_sort_by_deps(packages_bulk)
+
+        # Prepare base per package configuration objects
+        for package in packages_sorted_by_deps:
+            # TODO: This method moves parts of individual packages which should
+            #       be shared with other packages to DC/OS installation shared
+            #       directories (<inst_root>\[bin|etc|lib]). It should be
+            #       redesigned to deal with only required parts of packages and
+            #       not populating shared DC/OS installation directories with
+            #       unnecessary stuff.
+            self._handle_pkg_dir_setup(package)
+            # TODO: This should be replaced with Package.handle_config_setup()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_cfg_setup(package)
+
+        # Deploy DC/OS aggregated configuration object
+        self._deploy_dcos_conf()
+
+        # Run per package extra installation helpers, setup services and
+        # save manifests
+        for package in packages_sorted_by_deps:
+            # TODO: This should be replaced with Package.handle_inst_extras()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_inst_extras(package)
+            # TODO: This should be replaced with Package.handle_svc_setup()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_svc_setup(package)
+
+            # TODO: This part should be replaced with Package.save_manifest()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            try:
+                package.manifest.save()
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Register package:'
+                           f' {package.manifest.pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg)
+
+            LOG.info(f'{self.msg_src}: Setup package:'
+                     f' {package.manifest.pkg_id.pkg_id}: OK')
 
     def _handle_pkg_dir_setup(self, package):
         """Transfer files from special directories into location.
 
         :param package: Package, DC/OS package manager object
         """
+        # TODO: Move this functionality to a method of the Package class and
+        #       reuse it in CmdSetup and CmdUpgrade classes to avoid code
+        #       duplication.
         pkg_path = getattr(
             package.manifest.istor_nodes, ISTOR_NODE.PKGREPO
         ).joinpath(package.manifest.pkg_id.pkg_id)
@@ -202,6 +262,8 @@ class CmdSetup(Command):
 
         :param package: Package, DC/OS package manager object
         """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_config_setup()
         pkg_id = package.manifest.pkg_id
 
         LOG.debug(f'{self.msg_src}: Execute: {pkg_id.pkg_name}: Setup'
@@ -224,6 +286,8 @@ class CmdSetup(Command):
 
         :param package: Package, DC/OS package manager object
         """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_inst_extras()
         msg_src = self.__class__.__name__
         pkg_id = package.manifest.pkg_id
 
@@ -248,6 +312,8 @@ class CmdSetup(Command):
 
         :param package: Package, DC/OS package manager object
         """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_svc_setup()
         msg_src = self.__class__.__name__
         pkg_id = package.manifest.pkg_id
 
@@ -310,6 +376,9 @@ class CmdSetup(Command):
 
     def _deploy_dcos_conf(self):
         """Deploy aggregated DC/OS configuration object."""
+        # TODO: This should be made standalone and then reused in command
+        #       manager classes CmdSetup and CmdUpgrade to avoid code
+        #       duplication
         LOG.debug(f'{self.msg_src}: Execute: Deploy aggregated config: ...')
 
         template = self.config.dcos_conf.get('template')
@@ -331,6 +400,446 @@ class CmdSetup(Command):
         LOG.debug(f'{self.msg_src}: Execute: Deploy aggregated config: OK')
 
 
+@command_type(CLI_COMMAND.UPGRADE)
+class CmdUpgrade(Command):
+    """Implementation of the Upgrade command manager."""
+    def __init__(self, **cmd_opts):
+        """"""
+        super(CmdUpgrade, self).__init__(**cmd_opts)
+
+        self.config = cmdconf.create(**self.cmd_opts)
+
+        LOG.debug(f'{self.msg_src}: cmd_opts: {self.cmd_opts}')
+
+    def verify_cmd_options(self):
+        """Verify command options."""
+        pass
+
+    def execute(self):
+        """Execute command."""
+        LOG.debug(f'{self.msg_src}: Execute ...')
+
+        try:
+            istate = self.config.inst_state.istate
+            if istate == ISTATE.UPGRADE_IN_PROGRESS:
+                self._handle_upgrade()
+                self._register_istate(ISTATE.INSTALLED)
+            else:
+                LOG.info(
+                    f'{self.msg_src}: Execute: Invalid DC/OS installation'
+                    f' state detected: {istate}: NOP'
+                )
+
+            LOG.info(f'{self.msg_src}: Execute: OK')
+        except cm_exc.WinpandaError:
+            self._register_istate(ISTATE.UPGRADE_FAILED)
+            raise
+
+    def _register_istate(self, inst_state):
+        """"""
+        # TODO: Move this method to the abstract base parent class Command to
+        #       avoid code duplication in command manager classes.
+        msg_base = (f'{self.msg_src}:'
+                    f' Execute: Register installation state: {inst_state}')
+        try:
+            self.config.inst_state.istate = inst_state
+            LOG.debug(f'{msg_base}: OK')
+        except cr_exc.RCError as e:
+            raise cr_exc.SetupCommandError(f'Execute: {type(e).__name__}: {e}')
+
+    def _handle_upgrade(self):
+        """"""
+        self._handle_upgrade_pre()
+        self._handle_teardown()
+        self._handle_teardown_post()
+        self._handle_clean_setup()
+
+    def _handle_upgrade_pre(self):
+        """"""
+        mheading = f'{self.msg_src}: Execute'
+        # TODO: Add all the upgrade preparation steps (package download,
+        # TODO: rendering configs, etc.) here. I.e. everything that can be
+        # TODO: done without affecting the currently running system.
+
+    def _handle_teardown(self):
+        """Teardown the currently installed DC/OS."""
+        mheading = f'{self.msg_src}: Execute'
+        pkg_manifests = (
+            self.config.inst_storage.get_pkgactive(PackageManifest.load)
+        )
+        packages_bulk = {
+            m.pkg_id.pkg_name: Package(manifest=m) for m in pkg_manifests
+        }
+
+        iroot_dpath = self.config.inst_storage.root_dpath
+        itmp_dpath = self.config.inst_storage.tmp_dpath
+        pkgactive_old_dpath = itmp_dpath.joinpath(
+            f'{storage.DCOS_PKGACTIVE_DPATH_DFT}.old'
+        )
+        sh_conf_dname = storage.DCOS_INST_CFG_DPATH_DFT
+        sh_exec_dname = storage.DCOS_INST_BIN_DPATH_DFT
+        sh_lib__dname = storage.DCOS_INST_LIB_DPATH_DFT
+
+        # Teardown installed packages
+        for package in cr_utl.pkg_sort_by_deps(packages_bulk):
+            package.handle_svc_wipe(mheading)
+            package.handle_uninst_extras(mheading)
+            package.handle_vardata_wipe(mheading)
+            package.save_manifest(mheading, pkgactive_old_dpath)
+            package.delete_manifest(mheading)
+
+        # Remove/preserve shared directories
+        for dname in sh_conf_dname, sh_exec_dname, sh_lib__dname:
+            active_dpath = iroot_dpath.joinpath(dname)
+            preserve_dpath = itmp_dpath.joinpath(f'{dname}.old')
+            try:
+                active_dpath.rename(preserve_dpath)
+            except (OSError, RuntimeError) as e:
+                err_msg = (f'{mheading}: Preserve shared directory:'
+                           f' {active_dpath}: {type(e).__name__}: {e}')
+                raise cr_exc.RCError(err_msg) from e
+
+            LOG.debug(f'{mheading}: Preserve hared directory: {active_dpath}:'
+                      f' {preserve_dpath}')
+
+    def _handle_teardown_post(self):
+        """Perform extra steps on cleaning up unplanned (diverging from initial
+        winpanda design and so, not removed by normal teardown procedure) DC/OS
+        installation leftovers (see the CmdSetup._handle_pkg_dir_setup() and
+        workaround for dcos-diagnostics part in the
+        InstallationStorage.add_package()).
+        """
+        mheading = f'{self.msg_src}: Execute'
+        LOG.debug(f'{mheading}: After steps: ...')
+
+        iroot_dpath = self.config.inst_storage.root_dpath
+        ivar_dpath = self.config.inst_storage.var_dpath
+        itmp_dpath = self.config.inst_storage.tmp_dpath
+
+        wipe_dirs = [
+            iroot_dpath.joinpath('include'),
+            iroot_dpath.joinpath('mesos-logs'),
+            ivar_dpath.joinpath('lib'),
+        ]
+
+        for dpath in wipe_dirs:
+            try:
+                cm_utl.rmdir(str(dpath), recursive=True)
+                LOG.debug(f'{mheading}: After steps: Remove dir: {dpath}: OK')
+            except (OSError, RuntimeError) as e:
+                LOG.warning(f'{mheading}: After steps: Remove dir: {dpath}:'
+                            f' {type(e).__name__}: {e}')
+
+        wipe_files = [
+            iroot_dpath.joinpath('dcos-diagnostics.exe'),
+            iroot_dpath.joinpath('servicelist.txt'),
+        ]
+
+        for fpath in wipe_files:
+            try:
+                fpath.unlink()
+                LOG.debug(f'{mheading}: After steps: Remove file: {fpath}: OK')
+            except (OSError, RuntimeError) as e:
+                LOG.warning(f'{mheading}: After steps: Remove file: {fpath}:'
+                            f' {type(e).__name__}: {e}')
+
+        # Restoreobjects created/populated by entities/processes outside
+        # of winpanda routines, but required for winpanda to do it's stuff.
+
+        restore_dirs = [
+            iroot_dpath.joinpath('bin'),
+            iroot_dpath.joinpath('etc'),
+        ]
+
+        for dpath in restore_dirs:
+            try:
+                dpath.mkdir(parents=True, exist_ok=True)
+                LOG.debug(f'{mheading}: After steps: Restore dir: {dpath}: OK')
+            except (OSError, RuntimeError) as e:
+                LOG.warning(f'{mheading}: After steps: Restore dir: {dpath}:'
+                            f' {type(e).__name__}: {e}')
+
+        restore_files = [
+            (itmp_dpath.joinpath('bin.old', 'detect_ip.ps1'),
+             iroot_dpath.joinpath('bin')),
+            (itmp_dpath.joinpath('bin.old', 'detect_ip_public.ps1'),
+             iroot_dpath.joinpath('bin')),
+            (itmp_dpath.joinpath('bin.old', 'fault-domain-detect-win.ps1'),
+             iroot_dpath.joinpath('bin')),
+            (itmp_dpath.joinpath('etc.old', 'cluster.conf'),
+             iroot_dpath.joinpath('etc')),
+            (itmp_dpath.joinpath('etc.old', 'paths.json'),
+             iroot_dpath.joinpath('etc')),
+        ]
+
+        for fspec in restore_files:
+            try:
+                shutil.copy(str(fspec[0]), str(fspec[1]), follow_symlinks=False)
+                LOG.debug(f'{mheading}: After steps: Restore file: {fspec}: OK')
+            except (OSError, RuntimeError) as e:
+                LOG.warning(f'{mheading}: After steps: Restore file: {fspec}:'
+                            f' {type(e).__name__}: {e}')
+
+        LOG.debug(f'{mheading}: After steps: OK')
+
+    def _handle_clean_setup(self):
+        """Perform all the steps on DC/OS installation remaining after the
+        preparation stage is done (the CmdUpgrade._handle_upgrade_pre()).
+        """
+        # TODO: This code duplicates the CmdSetup._handle_cmdtarget_pkgall()
+        #       stuff and so should be made standalone to be reused in both
+        #       classes avoiding massive code duplication.
+        mheading = f'{self.msg_src}: Execute'
+        dstor_root_url = self.config.cluster_conf.get(
+            'distribution-storage', {}
+        ).get('rooturl', '')
+        dstor_pkgrepo_path = self.config.cluster_conf.get(
+            'distribution-storage', {}
+        ).get('pkgrepopath', '')
+
+        # Add packages to the local package repository and initialize their
+        # manager objects
+        packages_bulk = {}
+
+        for item in self.config.ref_pkg_list:
+            pkg_id = PackageId(pkg_id=item)
+
+            try:
+                self.config.inst_storage.add_package(
+                    pkg_id=pkg_id,
+                    dstor_root_url=dstor_root_url,
+                    dstor_pkgrepo_path=dstor_pkgrepo_path
+                )
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Add package to local'
+                           f' repository: {pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg) from e
+
+            try:
+                package = Package(
+                    pkg_id=pkg_id,
+                    istor_nodes=self.config.inst_storage.istor_nodes,
+                    cluster_conf=self.config.cluster_conf,
+                    extra_context=self.config.dcos_conf.get('values')
+                )
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Initialize package:'
+                           f' {pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg) from e
+
+            packages_bulk[pkg_id.pkg_name] = package
+
+        # Finalize package setup procedures taking package mutual
+        # dependencies into account.
+
+        packages_sorted_by_deps = cr_utl.pkg_sort_by_deps(packages_bulk)
+
+        # Prepare base per package configuration objects
+        for package in packages_sorted_by_deps:
+            # TODO: This method moves parts of individual packages which should
+            #       be shared with other packages to DC/OS installation shared
+            #       directories (<inst_root>\[bin|etc|lib]). It should be
+            #       redesigned to deal with only required parts of packages and
+            #       not populating shared DC/OS installation directories with
+            #       unnecessary stuff.
+            self._handle_pkg_dir_setup(package)
+            # TODO: This should be replaced with Package.handle_config_setup()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_cfg_setup(package)
+
+        # Deploy DC/OS aggregated configuration object
+        self._deploy_dcos_conf()
+
+        # Run per package extra installation helpers, setup services and
+        # save manifests
+        for package in packages_sorted_by_deps:
+            # TODO: This should be replaced with Package.handle_inst_extras()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_inst_extras(package)
+            # TODO: This should be replaced with Package.handle_svc_setup()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            self._handle_pkg_svc_setup(package)
+
+            # TODO: This part should be replaced with Package.save_manifest()
+            #       method to avoid code duplication in command manager classes
+            #       CmdSetup and CmdUpgrade
+            try:
+                package.manifest.save()
+            except cr_exc.RCError as e:
+                err_msg = (f'{self.msg_src}: Execute: Register package:'
+                           f' {package.manifest.pkg_id.pkg_id}: {e}')
+                raise cr_exc.SetupCommandError(err_msg)
+
+            LOG.info(f'{self.msg_src}: Setup package:'
+                     f' {package.manifest.pkg_id.pkg_id}: OK')
+
+    def _handle_pkg_dir_setup(self, package):
+        """Transfer files from special directories into location.
+
+        :param package: Package, DC/OS package manager object
+        """
+        # TODO: Move this functionality to a method of the Package class and
+        #       reuse it in CmdSetup and CmdUpgrade classes to avoid code
+        #       duplication.
+        pkg_path = getattr(
+            package.manifest.istor_nodes, ISTOR_NODE.PKGREPO
+        ).joinpath(package.manifest.pkg_id.pkg_id)
+        root = getattr(
+            package.manifest.istor_nodes, ISTOR_NODE.ROOT
+        )
+
+        for name in ('bin', 'etc', 'include', 'lib'):
+            srcdir = pkg_path / name
+            if srcdir.exists():
+                dstdir = root / name
+                dstdir.mkdir(exist_ok=True)
+                cm_utl.transfer_files(str(srcdir), str(dstdir))
+
+    def _handle_pkg_cfg_setup(self, package):
+        """Execute steps on package configuration files setup.
+
+        :param package: Package, DC/OS package manager object
+        """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_config_setup()
+        pkg_id = package.manifest.pkg_id
+
+        LOG.debug(f'{self.msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                  f' configuration: ...')
+        try:
+            package.cfg_manager.setup_conf()
+        except cfgm_exc.PkgConfNotFoundError as e:
+            LOG.debug(f'{self.msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                      f' configuration: NOP')
+        except cfgm_exc.PkgConfManagerError as e:
+            err_msg = (f'Execute: {pkg_id.pkg_name}: Setup configuration:'
+                       f'{type(e).__name__}: {e}')
+            raise cr_exc.SetupCommandError(err_msg) from e
+        else:
+            LOG.debug(f'{self.msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                      f' configuration: OK')
+
+    def _handle_pkg_inst_extras(self, package):
+        """Process package extra installation options.
+
+        :param package: Package, DC/OS package manager object
+        """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_inst_extras()
+        msg_src = self.__class__.__name__
+        pkg_id = package.manifest.pkg_id
+
+        if package.ext_manager:
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: ...')
+            try:
+                package.ext_manager.handle_install_extras()
+            except extm_exc.InstExtrasManagerError as e:
+                err_msg = (f'Execute: {pkg_id.pkg_name}:'
+                           f' Handle extra installation options: {e}')
+                raise cr_exc.SetupCommandError(err_msg) from e
+
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: OK')
+        else:
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}:'
+                      f' Handle extra installation options: NOP')
+
+    def _handle_pkg_svc_setup(self, package):
+        """Execute steps on package service setup.
+
+        :param package: Package, DC/OS package manager object
+        """
+        # TODO: This method should be removed after transition to use of
+        #       Package.handle_svc_setup()
+        msg_src = self.__class__.__name__
+        pkg_id = package.manifest.pkg_id
+
+        if package.svc_manager:
+            svc_name = package.svc_manager.svc_name
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup service:'
+                      f' {svc_name}: ...')
+            try:
+                ret_code, stdout, stderr = package.svc_manager.status()
+            except svcm_exc.ServiceManagerCommandError as e:
+                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                          f' service: Get initial service status: {svc_name}:'
+                          f' {e}')
+                # Try to setup, as a service (expectedly) doesn't exist and
+                # checking it's status naturally would yield an error.
+                try:
+                    package.svc_manager.setup()
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'Execute: {pkg_id.pkg_name}: Setup service:'
+                               f' {svc_name}: {e}')
+                    raise cr_exc.SetupCommandError(err_msg) from e
+            else:
+                LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup'
+                          f' service: Get initial service status: {svc_name}:'
+                          f' stdout[{stdout}] stderr[{stderr}]')
+                svc_status = str(stdout).strip().rstrip('\n')
+                # Try to remove existing service
+                try:
+                    if svc_status == SVC_STATUS.RUNNING:
+                        package.svc_manager.stop()
+
+                    package.svc_manager.remove()
+                    LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Remove'
+                              f' existing service: {svc_name}: OK')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'Execute: {pkg_id.pkg_name}: Remove existing'
+                               f' service: {svc_name}: {e}')
+                    raise cr_exc.SetupCommandError(err_msg) from e
+                # Setup a replacement service
+                try:
+                    package.svc_manager.setup()
+                    ret_code, stdout, stderr = (package.svc_manager.status())
+                    svc_status = str(stdout).strip().rstrip('\n')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'Execute: {pkg_id.pkg_name}: Setup replacement'
+                               f' service: {svc_name}: {e}')
+                    raise cr_exc.SetupCommandError(err_msg) from e
+                else:
+                    if svc_status != SVC_STATUS.STOPPED:
+                        err_msg = (f'Execute: {pkg_id.pkg_name}: Setup'
+                                   f' replacement service: {svc_name}:'
+                                   f' Invalid status: {svc_status}')
+                        raise cr_exc.SetupCommandError(err_msg)
+
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup service:'
+                      f' {svc_name}: OK')
+        else:
+            LOG.debug(f'{msg_src}: Execute: {pkg_id.pkg_name}: Setup service:'
+                      f' NOP')
+
+    def _deploy_dcos_conf(self):
+        """Deploy aggregated DC/OS configuration object."""
+        # TODO: This should be made standalone and then reused in command
+        #       manager classes CmdSetup and CmdUpgrade to avoid code
+        #       duplication
+        LOG.debug(f'{self.msg_src}: Execute: Deploy aggregated config: ...')
+
+        template = self.config.dcos_conf.get('template')
+        values = self.config.dcos_conf.get('values')
+
+        rendered = template.render(values)
+        config = yaml.safe_load(rendered)
+
+        assert config.keys() == {"package"}
+
+        # Write out the individual files
+        for file_info in config["package"]:
+            assert file_info.keys() <= {"path", "content", "permissions"}
+            path = Path(file_info['path'].replace('\\', os.path.sep))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(file_info['content'] or '')
+            # On Windows, we don't interpret permissions yet
+
+        LOG.debug(f'{self.msg_src}: Execute: Deploy aggregated config: OK')
+
 @command_type(CLI_COMMAND.START)
 class CmdStart(Command):
     """Start command implementation."""
@@ -348,6 +857,11 @@ class CmdStart(Command):
 
     def execute(self):
         """Execute command."""
+        # TODO: Implement DC/OS installation state detection here (alike how
+        #       it's done in CmdSetup.execute() or CmdSetup.execute()) to
+        #       allow attempts to start services only if
+        #       istate == ISTATE.INSTALLED:
+
         pkg_manifests = (
             self.config.inst_storage.get_pkgactive(PackageManifest.load)
         )
@@ -359,6 +873,8 @@ class CmdStart(Command):
             pkg_id = package.manifest.pkg_id
             mheading = f'{self.msg_src}: Execute: {pkg_id.pkg_name}'
 
+            # TODO: This part should be replaced with
+            #       Package.handle_svc_start() method
             if package.svc_manager:
                 svc_name = package.svc_manager.svc_name
                 LOG.debug(f'{mheading}: Start service: {svc_name}: ...')
@@ -381,6 +897,8 @@ class CmdStart(Command):
 
         :param svc_manager: WindowsServiceManager, service manager object
         """
+        # TODO: Functionality of this method should be moved to the
+        #       Package.handle_svc_start() method
         svc_name = svc_manager.svc_name
 
         # Discover initial service status

--- a/packages/winpanda/extra/src/winpanda/core/exceptions.py
+++ b/packages/winpanda/extra/src/winpanda/core/exceptions.py
@@ -36,6 +36,11 @@ class RCExtractError(RCError):
     """
 
 
+class RCCreateError(RCError):
+    """Resource creation error.
+    """
+
+
 class RCRemoveError(RCError):
     """Resource removal error.
     """

--- a/packages/winpanda/extra/src/winpanda/core/istate.py
+++ b/packages/winpanda/extra/src/winpanda/core/istate.py
@@ -1,0 +1,219 @@
+"""Panda package management for Windows.
+
+DC/OS installation state descriptor type definition.
+"""
+import json
+from pathlib import Path
+
+from common import logger
+from common import constants as cm_const
+from common.storage import ISTOR_NODE, IStorNodes
+from core import exceptions as cr_exc
+from core import utils as cr_utl
+
+
+LOG = logger.get_logger(__name__)
+
+
+class ISTATE:
+    """DC/OS installation states codes."""
+    UNDEFINED = 'UNDEFINED'
+    INSTALLATION_IN_PROGRESS = 'INSTALLATION_IN_PROGRESS'
+    INSTALLATION_FAILED = 'INSTALLATION_FAILED'
+    INSTALLED = 'INSTALLED'
+    UPGRADE_IN_PROGRESS = 'UPGRADE_IN_PROGRESS'
+    UPGRADE_FAILED = 'UPGRADE_FAILED'
+
+
+VALID_ISTATES = [
+    getattr(ISTATE, i) for i in ISTATE.__dict__ if not i.startswith('__')
+]
+
+
+class InstallationState:
+    """DC/OS installation state descriptor."""
+    def __init__(self, istor_nodes=None,
+                 istate=ISTATE.UNDEFINED, istate_dpath=None, save=True):
+        """Constructor.
+
+        :param istor_nodes:  IStorNodes, DC/OS installation storage nodes (set
+                             of pathlib.Path objects)
+        :param istate:       str, DC/OS installation state code
+        :param istate_dpath: pathlib.Path, absolute path to the DC/OS state
+                             directory within the local DC/OS installation
+                             storage
+        :param save:         bool, save DC/OS installation state descriptor to
+                             file, if True
+        """
+        self.msg_src = self.__class__.__name__
+
+        if istor_nodes is not None:
+            assert isinstance(istor_nodes, IStorNodes), (
+                f'{self.msg_src}: Argument: istor_nodes:'
+                f' Got {type(istor_nodes).__name__} instead of IStorNodes'
+            )
+            istate_dpath = getattr(istor_nodes, ISTOR_NODE.STATE)
+        elif istate_dpath is not None:
+            assert (
+                isinstance(istate_dpath, Path) and istate_dpath.is_absolute()
+            ), (
+                f'{self.msg_src}: Argument: istate_dpath: Absolute'
+                f' pathlib.Path is required: {istate_dpath}'
+            )
+        else:
+            assert False, (
+                f'{self.msg_src}: Argument: Either istor_nodes or istate_dpath'
+                f'must be specified'
+            )
+        assert isinstance(istate, str), (
+            f'{self.msg_src}: Argument: istate:'
+            f' Got {type(istate).__name__} instead of str'
+        )
+        assert istate in VALID_ISTATES, (
+            f'{self.msg_src}: Argument: istate: Invalid value: {istate}'
+        )
+
+        self._istor_nodes = istor_nodes
+        self._istate = istate
+        self._istate_dpath = istate_dpath
+
+        if save is True:
+            self.save()
+
+    def __str__(self):
+        return str(self.body)
+
+    def __eq__(self, other):
+        if not isinstance(other, InstallationState):
+            return False
+
+        return (self._istor_nodes == other._istor_nodes and
+                self._istate == other._istate and
+                self._istate_dpath == other._istate_dpath)
+
+    @property
+    def body(self):
+        """Construct JSON-compatible dict representation of DC/OS installation
+        state descriptor.
+        """
+        if self._istor_nodes is None:
+            istor_nodes = self._istor_nodes
+        else:
+            istor_nodes = {
+                k: str(v) for k, v in self._istor_nodes._asdict().items()
+            }
+
+        return {
+            'istor_nodes': istor_nodes,
+            'istate': self._istate,
+            'istate_dpath': str(self._istate_dpath),
+        }
+
+    @ classmethod
+    def load(cls, fpath):
+        """Load DC/OS installation state descriptor from a file.
+
+        :param fpath: pathlib.Path, path to a JSON-formatted descriptor file.
+        :return:      InstallationState, DC/OS installation state descriptor
+                      object.
+        """
+        isd_body = cr_utl.rc_load_json(fpath, emheading=cls.__name__)
+
+        # TODO: Add content verification (jsonschema) for m_body. Raise
+        #       ValueError, if conformance was not confirmed.
+
+        try:
+            istor_nodes = IStorNodes(**{
+                k: Path(v) for k, v in isd_body.get('istor_nodes').items()
+            }) if isinstance(isd_body.get('istor_nodes'), dict) else None
+
+            istate_desc = cls(
+                istor_nodes=istor_nodes,
+                istate=isd_body.get('istate'),
+                istate_dpath=Path(isd_body.get('istate_dpath')),
+                save=False,
+            )
+            LOG.debug(f'{cls.__name__}: Load: {fpath}')
+        except (ValueError, AssertionError, TypeError) as e:
+            err_msg = (f'{cls.__name__}: Load:'
+                       f' {fpath}: {type(e).__name__}: {e}')
+            raise cr_exc.RCInvalidError(err_msg) from e
+
+        return istate_desc
+
+    def save(self):
+        """Save DC/OS installation state descriptor to a file within the
+        installation's state directory."""
+        fpath = self._istate_dpath.joinpath(cm_const.DCOS_INST_STATE_FNAME_DFT)
+
+        try:
+            self._istate_dpath.mkdir(parents=True, exist_ok=True)
+            with fpath.open(mode='w') as fp:
+                json.dump(self.body, fp)
+        except (OSError, RuntimeError) as e:
+            err_msg = f'{self.msg_src}: Save: {type(e).__name__}: {e}'
+            raise cr_exc.RCError(err_msg) from e
+
+        LOG.debug(f'{self.msg_src}: Save: {fpath}')
+
+    @property
+    def istor_nodes(self):
+        """"""
+        return self._istor_nodes
+
+    @istor_nodes.setter
+    def istor_nodes(self, istor_nodes):
+        """Set DC/OS installation storage layout part of the DC/OS installation
+        state descriptor.
+
+        :param istor_nodes: IStorNodes, DC/OS installation storage nodes (set
+                            of pathlib.Path objects)
+        """
+        err_msg_base = f'{self.msg_src}: Set storage layout'
+
+        if self._istor_nodes is not None:
+            raise RuntimeError(f'{err_msg_base}: Already set')
+        elif not isinstance(istor_nodes, IStorNodes):
+            raise TypeError(f'{err_msg_base}: {istor_nodes}')
+        elif getattr(istor_nodes, ISTOR_NODE.STATE) != self._istate_dpath:
+            raise ValueError(f'{err_msg_base}: Installation'
+                             f' state directory mismatch: {istor_nodes}')
+
+        self._istor_nodes = istor_nodes
+        try:
+            self.save()
+        except cr_exc.RCError:
+            self._istor_nodes = None
+            raise
+
+    @property
+    def istate(self):
+        """"""
+        return self._istate
+
+    @istate.setter
+    def istate(self, istate):
+        """Set DC/OS installation state code.
+
+        :param istate: str, DC/OS installation state code
+        """
+        err_msg = f'{self.msg_src}: Set state: {istate}'
+
+        if not isinstance(istate, str):
+            raise TypeError(err_msg)
+
+        if istate not in VALID_ISTATES:
+            raise ValueError(err_msg)
+
+        istate_former = self._istate
+        self._istate = istate
+        try:
+            self.save()
+        except cr_exc.RCError:
+            self._istate = istate_former
+            raise
+
+    @property
+    def istate_dpath(self):
+        """"""
+        return self._istate_dpath

--- a/packages/winpanda/extra/src/winpanda/core/package/package.py
+++ b/packages/winpanda/extra/src/winpanda/core/package/package.py
@@ -2,11 +2,18 @@
 
 DC/OS package controller and helper type definitions.
 """
+from pathlib import Path
+
 from .manifest import PackageManifest
+from cfgm import exceptions as cfgm_exc
 from cfgm.cfgm import PkgConfManager
 from common import logger
+from common import utils as cm_utl
+from common.storage import ISTOR_NODE
+from core import exceptions as cr_exc
 from extm.extm import PkgInstExtrasManager
-from svcm.nssm import WinSvcManagerNSSM
+from svcm import exceptions as svcm_exc
+from svcm.nssm import SVC_STATUS, WinSvcManagerNSSM
 
 
 LOG = logger.get_logger(__name__)
@@ -63,3 +70,280 @@ class Package:
             self.svc_manager = None
         LOG.debug(f'{self.msg_src}: {self.manifest.pkg_id.pkg_id}:'
                   f' Service manager: {self.svc_manager}')
+
+    @property
+    def id(self):
+        """"""
+        return self.manifest.pkg_id
+
+    def handle_config_setup(self, mheading=None):
+        """Execute steps on setting up package configuration files.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+        LOG.debug(f'{mheading}: Setup configuration: ...')
+
+        try:
+            self.cfg_manager.setup_conf()
+        except cfgm_exc.PkgConfNotFoundError as e:
+            LOG.debug(f'{mheading}: Setup configuration: NOP')
+        else:
+            LOG.debug(f'{mheading}: Setup configuration: OK')
+
+    def handle_inst_extras(self, mheading=None):
+        """Process package's extra installation options.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+
+        if self.ext_manager:
+            LOG.debug(f'{mheading}: Handle extra installation options: ...')
+            self.ext_manager.handle_install_extras()
+            LOG.debug(f'{mheading}: Handle extra installation options: OK')
+        else:
+            LOG.debug(f'{mheading}: Handle extra installation options: NOP')
+
+    def handle_uninst_extras(self, mheading=None):
+        """Process package's extra uninstall options.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+
+        if self.ext_manager:
+            LOG.debug(f'{mheading}: Handle extra uninstall options: ...')
+            self.ext_manager.handle_uninstall_extras()
+            LOG.debug(f'{mheading}: Handle extra uninstall options: OK')
+        else:
+            LOG.debug(f'{mheading}: Handle extra uninstall options: NOP')
+
+    def handle_svc_setup(self, mheading=None):
+        """Execute steps on package's service setup.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+        no_svc_marker = 'service does not exist as an installed service.'
+
+        if self.svc_manager:
+            svc_name = self.svc_manager.svc_name
+            LOG.debug(f'{mheading}: Setup service: {svc_name}: ...')
+            try:
+                ret_code, stdout, stderr = self.svc_manager.status()
+            except svcm_exc.ServiceManagerCommandError as e:
+                exc_msg_line = str(e).replace('\n', '').strip()
+                LOG.debug(f'{mheading}: Setup service: {svc_name}:'
+                          f' Get initial service status: {exc_msg_line}')
+                if not exc_msg_line.endswith(no_svc_marker):
+                    err_msg = f'{mheading}: Setup service: {svc_name}:' \
+                              f' Get initial service status: {e}'
+                    raise svcm_exc.ServiceSetupError(err_msg) from e
+                # Setup a service
+                try:
+                    self.svc_manager.setup()
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = f'{mheading}: Setup service: {svc_name}: {e}'
+                    raise svcm_exc.ServiceSetupError(err_msg) from e
+            else:
+                LOG.debug(
+                    f'{mheading}: Setup service: {svc_name}: Get initial'
+                    f' service status: stdout[{stdout}] stderr[{stderr}]'
+                )
+                svc_status = str(stdout).strip().rstrip('\n')
+                # Wipe existing service
+                try:
+                    if svc_status != SVC_STATUS.STOPPED:
+                        self.svc_manager.stop()
+
+                    self.svc_manager.remove()
+                    LOG.debug(f'{mheading}: Wipe existing service:'
+                              f' {svc_name}: OK')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'{mheading}: Wipe existing service:'
+                               f' {svc_name}: {e}')
+                    raise svcm_exc.ServiceSetupError(err_msg) from e
+                # Setup a replacement service
+                try:
+                    self.svc_manager.setup()
+                    ret_code, stdout, stderr = (self.svc_manager.status())
+                    svc_status = str(stdout).strip().rstrip('\n')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'{mheading}: Setup replacement service:'
+                               f' {svc_name}: {e}')
+                    raise svcm_exc.ServiceSetupError(err_msg) from e
+                else:
+                    if svc_status != SVC_STATUS.STOPPED:
+                        err_msg = (
+                            f'{mheading}: Setup replacement service:'
+                            f' {svc_name}: Invalid status: {svc_status}'
+                        )
+                        raise svcm_exc.ServiceSetupError(err_msg)
+
+            LOG.debug(f'{mheading}: Setup service: {svc_name}: OK')
+        else:
+            LOG.debug(f'{mheading}: Setup service: NOP')
+
+    def handle_svc_wipe(self, mheading=None):
+        """Execute steps on package's service wipe off.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+        no_svc_marker = 'service does not exist as an installed service.'
+
+        if self.svc_manager:
+            svc_name = self.svc_manager.svc_name
+            LOG.debug(f'{mheading}: Wipe service: {svc_name}: ...')
+            try:
+                ret_code, stdout, stderr = self.svc_manager.status()
+            except svcm_exc.ServiceManagerCommandError as e:
+                exc_msg_line = str(e).replace('\n', '').strip()
+                LOG.debug(f'{mheading}: Wipe service: {svc_name}:'
+                          f' Get initial service status: {exc_msg_line}')
+                if not exc_msg_line.endswith(no_svc_marker):
+                    err_msg = f'{mheading}: Wipe service: {svc_name}: {e}'
+                    raise svcm_exc.ServiceWipeError(err_msg) from e
+                LOG.debug(f'{mheading}: Wipe service: NOP')
+            else:
+                LOG.debug(
+                    f'{mheading}: Wipe service: {svc_name}: Get initial'
+                    f' service status: stdout[{stdout}] stderr[{stderr}]'
+                )
+                svc_status = str(stdout).strip().rstrip('\n')
+                # Try to remove existing service
+                try:
+                    if svc_status != SVC_STATUS.STOPPED:
+                        self.svc_manager.stop()
+
+                    self.svc_manager.remove()
+                    LOG.debug(f'{mheading}: Wipe service: {svc_name}: OK')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = (f'{mheading}: Wipe existing service:'
+                               f' {svc_name}: {e}')
+                    raise svcm_exc.ServiceWipeError(err_msg) from e
+        else:
+            LOG.debug(f'{mheading}: Wipe service: NOP')
+
+    def handle_svc_start(self, mheading=None):
+        """Execute steps on package's service start.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+        no_svc_marker = 'service does not exist as an installed service.'
+        # TODO: Move stuff from the CmdStart.service_start() method here.
+        #       Overall design of this method should resemble one of the
+        #       Package.handle_svc_stop() method.
+
+    def handle_svc_stop(self, mheading=None):
+        """Execute steps on package's service stop.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+        no_svc_marker = 'service does not exist as an installed service.'
+
+        if self.svc_manager:
+            svc_name = self.svc_manager.svc_name
+            LOG.debug(f'{mheading}: Stop service: {svc_name}: ...')
+            try:
+                ret_code, stdout, stderr = self.svc_manager.status()
+            except svcm_exc.ServiceManagerCommandError as e:
+                exc_msg_line = str(e).replace('\n', '').strip()
+                LOG.debug(f'{mheading}: Stop service: {svc_name}:'
+                          f' Get initial service status: {exc_msg_line}')
+                if not exc_msg_line.endswith(no_svc_marker):
+                    err_msg = f'{mheading}: Stop service: {svc_name}: {e}'
+                    raise svcm_exc.ServiceStopError(err_msg) from e
+                LOG.debug(f'{mheading}: Stop service: NOP')
+            else:
+                LOG.debug(
+                    f'{mheading}: Stop service: {svc_name}: Get initial'
+                    f' service status: stdout[{stdout}] stderr[{stderr}]'
+                )
+                svc_status = str(stdout).strip().rstrip('\n')
+                # Stop existing service
+                try:
+                    if svc_status != SVC_STATUS.STOPPED:
+                        self.svc_manager.stop()
+
+                    LOG.debug(f'{mheading}: Stop service: {svc_name}: OK')
+                except svcm_exc.ServiceManagerCommandError as e:
+                    err_msg = f'{mheading}: Stop service: {svc_name}: {e}'
+                    raise svcm_exc.ServiceStopError(err_msg) from e
+        else:
+            LOG.debug(f'{mheading}: Stop service: NOP')
+
+    def handle_vardata_wipe(self, mheading=None):
+        """Execute steps on wiping of package's variable data.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+
+        work_dpath = getattr(self.manifest.istor_nodes, ISTOR_NODE.WORK)
+        run_dpath = getattr(self.manifest.istor_nodes, ISTOR_NODE.RUN)
+
+        for host_dpath in work_dpath, run_dpath:
+            dpath = host_dpath.joinpath(self.id.pkg_name)
+            try:
+                cm_utl.rmdir(str(dpath), recursive=True)
+                dpath.mkdir(parents=True, exist_ok=True)
+                LOG.debug(f'{mheading}: Wipe variable data: {dpath}: OK')
+            except (OSError, RuntimeError) as e:
+                err_msg = (f'{mheading}: Wipe variable data: {dpath}:'
+                           f' {type(e).__name__}: {e}')
+                raise cr_exc.RCError(err_msg) from e
+
+    def save_manifest(self, mheading=None, dpath=None):
+        """Save package's manifest to filesystem.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        :param dpath:    pathlib.Path, absolute path to the host directory
+                         where to save to
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+
+        try:
+            dpath.mkdir(parents=True, exist_ok=True)
+            self.manifest.save(dpath)
+        except (OSError, RuntimeError, cr_exc.RCError) as e:
+            err_msg = f'{mheading}: Register package: {self.id}: {e}'
+            raise cr_exc.RCError(err_msg) from e
+
+    def delete_manifest(self, mheading=None, dpath=None):
+        """Delete package's manifest from filesystem.
+
+        :param mheading: str, descriptive heading to be added to error/log
+                         messages
+        :param dpath:    pathlib.Path, absolute path to the host directory
+                         where to delete from
+        """
+        mhd_base = f'{self.msg_src}: {self.id.pkg_name}'
+        mheading = f'{mheading}: {mhd_base}' if mheading else mhd_base
+
+        try:
+            self.manifest.delete(dpath)
+        except (OSError, RuntimeError, cr_exc.RCError) as e:
+            err_msg = f'{mheading}: Deregister package: {self.id}: {e}'
+            raise cr_exc.RCError(err_msg) from e

--- a/packages/winpanda/extra/src/winpanda/svcm/exceptions.py
+++ b/packages/winpanda/extra/src/winpanda/svcm/exceptions.py
@@ -45,6 +45,16 @@ class ServiceSetupError(ServiceError):
     pass
 
 
+class ServiceWipeError(ServiceError):
+    """Service wipe off error."""
+    pass
+
+
+class ServiceStopError(ServiceError):
+    """Service stop error."""
+    pass
+
+
 class ServiceTransientError(ServiceError):
     """Service intermittent error."""
     pass


### PR DESCRIPTION
1) add configuration manager type for the "upgrade" command (CmdConfigUpgrade)
2) add command manager type for the "upgrade" command (CmdUpgrade)
3) add DC/OS installation state manager type (InstallationState)
4) add support for DC/OS installation state recognition/handling to the "setup" command manager (CmdSetup)
5) fix issue of mishandling DC/OS installation root directory in the DC/OS installation storage manager (InstallationStorage)
6) move package specific functionality from command manager classes (CmdSetup, CmdUpgrade) to the package manager class (Package) for better code reuse
7) add TODO sections to guide further codebase improvements

  - [D2IQ-64317](https://jira.mesosphere.com/browse/D2IQ-64317) Winpanda App: Implement the "Upgrade" command
