### PR TITLE
Select Windows tests

### DIFF
--- a/packages/dcos-integration-test/extra/conftest.py
+++ b/packages/dcos-integration-test/extra/conftest.py
@@ -79,6 +79,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line('markers', 'first: run test before all not marked first')
     config.addinivalue_line('markers', 'last: run test after all not marked last')
+    config.addinivalue_line('markers', 'supportedwindows: run tests that support Windows agents.')
+    config.addinivalue_line('markers', 'supportedwindowsonly: run only Windows specific tests.')
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -104,6 +104,7 @@ def test_mesos_agent_role_assignment(dcos_api_session):
         assert r.json()['flags']['default_role'] == '*'
 
 
+@pytest.mark.supportedwindows
 def test_systemd_units_are_healthy(dcos_api_session) -> None:
     """
     Test that the system is healthy at the arbitrary point in time

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -105,6 +105,7 @@ def test_mesos_agent_role_assignment(dcos_api_session):
 
 
 @pytest.mark.supportedwindows
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64752")
 def test_systemd_units_are_healthy(dcos_api_session) -> None:
     """
     Test that the system is healthy at the arbitrary point in time

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -156,6 +156,7 @@ def test_dcos_diagnostics_nodes_node_units_unit(dcos_api_session):
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_units(dcos_api_session):
     """
     test a list of collected units, endpoint /system/health/v1/units

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -19,8 +19,9 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 # another minute to allow for check-time to settle. See: DCOS_OSS-988
 LATENCY = 120
 
+pytestmark = [pytest.mark.supportedwindows]
 
-@pytest.mark.supportedwindows
+
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_health(dcos_api_session):
     """
@@ -86,7 +87,6 @@ def test_dcos_diagnostics_health(dcos_api_session):
             assert response[required_field], '{} cannot be empty'.format(required_field)
 
 
-@pytest.mark.supportedwindows
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_nodes(dcos_api_session):
     """
@@ -105,7 +105,6 @@ def test_dcos_diagnostics_nodes(dcos_api_session):
         validate_node(response['nodes'])
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_nodes_node(dcos_api_session):
     """
     test a specific node enpoint /system/health/v1/nodes/<node>
@@ -120,7 +119,6 @@ def test_dcos_diagnostics_nodes_node(dcos_api_session):
             validate_node([node_response])
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
     """
     test a list of units from a specific node, endpoint /system/health/v1/nodes/<node>/units
@@ -138,7 +136,6 @@ def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
             validate_units(units_response['units'])
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_nodes_node_units_unit(dcos_api_session):
     """
     test a specific unit for a specific node, endpoint /system/health/v1/nodes/<node>/units/<unit>
@@ -155,7 +152,6 @@ def test_dcos_diagnostics_nodes_node_units_unit(dcos_api_session):
                     check_json(dcos_api_session.health.get('/nodes/{}/units/{}'.format(node, unit_id), node=master)))
 
 
-@pytest.mark.supportedwindows
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_dcos_diagnostics_units(dcos_api_session):
     """
@@ -185,7 +181,6 @@ def test_dcos_diagnostics_units(dcos_api_session):
                                                 'puller, missing: {}'.format(diff))
 
 
-@pytest.mark.supportedwindows
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
 def test_systemd_units_health(dcos_api_session):
     """
@@ -217,7 +212,6 @@ def test_systemd_units_health(dcos_api_session):
         raise AssertionError('\n'.join(unhealthy_output))
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_units_unit(dcos_api_session):
     """
     test a unit response in a right format, endpoint: /system/health/v1/units/<unit>
@@ -274,7 +268,6 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
         assert len(agent_nodes) == len(dcos_api_session.slaves), '{} != {}'.format(agent_nodes, dcos_api_session.slaves)
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
     """
     test a specific node for a specific unit, endpoint /system/health/v1/units/<unit>/nodes/<node>
@@ -305,7 +298,6 @@ def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):
                 assert node_response['help'], 'help field cannot be empty'
 
 
-@pytest.mark.supportedwindows
 def test_dcos_diagnostics_report(dcos_api_session):
     """
     test dcos-diagnostics report endpoint /system/health/v1/report

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -88,6 +88,7 @@ def test_dcos_diagnostics_health(dcos_api_session):
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_nodes(dcos_api_session):
     """
     test a list of nodes with statuses endpoint /system/health/v1/nodes
@@ -119,6 +120,7 @@ def test_dcos_diagnostics_nodes_node(dcos_api_session):
             validate_node([node_response])
 
 
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
     """
     test a list of units from a specific node, endpoint /system/health/v1/nodes/<node>/units
@@ -136,6 +138,7 @@ def test_dcos_diagnostics_nodes_node_units(dcos_api_session):
             validate_units(units_response['units'])
 
 
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_nodes_node_units_unit(dcos_api_session):
     """
     test a specific unit for a specific node, endpoint /system/health/v1/nodes/<node>/units/<unit>
@@ -212,6 +215,7 @@ def test_systemd_units_health(dcos_api_session):
         raise AssertionError('\n'.join(unhealthy_output))
 
 
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_units_unit(dcos_api_session):
     """
     test a unit response in a right format, endpoint: /system/health/v1/units/<unit>
@@ -225,6 +229,7 @@ def test_dcos_diagnostics_units_unit(dcos_api_session):
 
 
 @retrying.retry(wait_fixed=2000, stop_max_delay=LATENCY * 1000)
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
     """
     test a list of nodes for a specific unit, endpoint /system/health/v1/units/<unit>/nodes
@@ -312,6 +317,7 @@ def test_dcos_diagnostics_report(dcos_api_session):
 
 
 @pytest.mark.parametrize('use_legacy_api', [False, True])
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64753")
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session, use_legacy_api):
     """
     test bundle create, read, delete workflow

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -38,6 +38,7 @@ def test_if_mesos_is_up(dcos_api_session):
     assert '<title>Mesos</title>' in r.text
 
 
+@pytest.mark.supportedwindows
 def test_if_all_mesos_slaves_have_registered(dcos_api_session):
     r = dcos_api_session.get('/mesos/master/slaves')
     assert r.status_code == 200

--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -39,6 +39,7 @@ def test_if_mesos_is_up(dcos_api_session):
 
 
 @pytest.mark.supportedwindows
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64754")
 def test_if_all_mesos_slaves_have_registered(dcos_api_session):
     r = dcos_api_session.get('/mesos/master/slaves')
     assert r.status_code == 200

--- a/packages/dcos-integration-test/extra/test_rexray.py
+++ b/packages/dcos-integration-test/extra/test_rexray.py
@@ -10,7 +10,6 @@ __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
 
-@pytest.mark.supportedwindows
 def test_move_external_volume_to_new_agent(dcos_api_session):
     """Test that an external volume is successfully attached to a new agent.
 

--- a/packages/dcos-integration-test/extra/test_units.py
+++ b/packages/dcos-integration-test/extra/test_units.py
@@ -12,7 +12,6 @@ __maintainer__ = 'gpaul'
 __contact__ = 'dcos-security@mesosphere.io'
 
 
-@pytest.mark.supportedwindows
 def test_verify_units():
     """Test that all systemd units are valid."""
     def _check_units(path):

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -27,7 +27,6 @@ def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: st
 
 @pytest.mark.supportedwindows
 @pytest.mark.supportedwindowsonly
-@pytest.mark.xfail("config.getoption('--windows-only')", strict=True)
 def test_if_docker_app_can_be_deployed_windows(dcos_api_session):
     """Marathon app inside docker deployment integration test.
 

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -27,6 +27,7 @@ def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: st
 
 @pytest.mark.supportedwindows
 @pytest.mark.supportedwindowsonly
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True)
 def test_if_docker_app_can_be_deployed_windows(dcos_api_session):
     """Marathon app inside docker deployment integration test.
 

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -36,10 +36,12 @@ set via [environment variables](https://www.terraform.io/docs/configuration-0-11
 ```
 export TF_VAR_custom_dcos_download_path="https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
 export TF_VAR_custom_dcos_download_path_win="https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh"
-export TF_VAT_variant="open"
+export TF_VAR_variant="open"
 terraform init --upgrade
 terraform apply
 ```
 
 If you want to launch the build of a specific pull request simply replace `master` with `pull/<PR#>`. The number of
 Windows agents defaults to zero and can be set via `TF_VAR_windowsagent_num`.
+
+If you want to launch the master build with Windows agents simply call `terraform apply -var-file=windows.tfvars`.

--- a/test_util/windows.tfvars
+++ b/test_util/windows.tfvars
@@ -1,0 +1,4 @@
+custom_dcos_download_path = "https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
+custom_dcos_download_path_win = "https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh"
+variant="open"
+windowsagent_num="1"


### PR DESCRIPTION
## High-level description

Select all Windows tests from D2IQ-61892. We mark those as expecting to fail that have
not been fixed yet. The tests are simply run by passing `--windows-only` to `pytest`.