### PR TITLE
[master] Bump Mesos to nightly master aefa4bd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
-* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/ea670eca55af847bd7fcba1510726dd0059edf32/CHANGELOG)
-* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/ea670eca55af847bd7fcba1510726dd0059edf32/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/aefa4bdb8a111c74f1d0f7e851a486f4e2ec47e7/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/aefa4bdb8a111c74f1d0f7e851a486f4e2ec47e7/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,7 +10,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "ea670eca55af847bd7fcba1510726dd0059edf32",
+      "ref": "aefa4bdb8a111c74f1d0f7e851a486f4e2ec47e7",
       "ref_origin": "master"
     },
     "mesos-modules": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "ea670eca55af847bd7fcba1510726dd0059edf32",
+    "ref": "aefa4bdb8a111c74f1d0f7e851a486f4e2ec47e7",
     "ref_origin": "master"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/ea670eca55af847bd7fcba1510726dd0059edf32...aefa4bdb8a111c74f1d0f7e851a486f4e2ec47e7
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
