### PR TITLE
D2IQ-62589: Add calico-libnetwork documentation

### DIFF
--- a/packages/calico/README.md
+++ b/packages/calico/README.md
@@ -16,14 +16,16 @@ This package provides DC/OS Calico component to support Calico networking contai
 
 ## DC/OS Calico component
 
-DC/OS Calico component integrates the [Calico networking](https://www.projectcalico.org) into DC/OS, by providing Calico CNI plugin for Mesos Universal Container Runtime, besides, the calico control panel will provide the functionality of network policy for DC/OS workloads.
+DC/OS Calico component integrates the [Calico networking](https://www.projectcalico.org) into DC/OS, by providing the Calico CNI plugin for Mesos Universal Container Runtime and the Calico libnetwork plugin for Docker Engine. In addition, the calico control panel will provide the functionality of configuring the network policy for DC/OS workloads.
 
 ### DC/OS Calico services
 
 DC/OS Calico integrates Calico into DC/OS for managing container networking and network security, three services are introduced:
-- dcos-calico-bird.service: A BGP client that exchanges routing information between hosts for Calico. [source](https://github.com/projectcalico/bird)
-- dcos-calico-confd.service: The confd templating engine monitors etcd datastores and generating and reloading bird configuration dynamically. [source](https://github.com/projectcalico/node)
-- dcos-calico-felix.service: the control panel for Calico networking to program routes and ACL's for containers. [source](https://github.com/projectcalico/node)
+
+* `dcos-calico-bird.service`: A BGP client that exchanges routing information between hosts for Calico. [(source)](https://github.com/projectcalico/bird)
+* `dcos-calico-confd.service`: The confd templating engine monitors etcd datastores and generating and reloading bird configuration dynamically. [(source)](https://github.com/projectcalico/node)
+* `dcos-calico-felix.service`: the control panel for Calico networking to program routes and ACL's for containers. [(source)](https://github.com/projectcalico/node)
+* `dcos-calico-libntwork-plugin.service`: the network plugin for Docker that provides Calico networking to the Docker Engine. [(source)](https://github.com/projectcalico/libnetwork-plugin)
 
 ## Configuration Reference(Networking)
 
@@ -108,16 +110,49 @@ For a more detailed description of the Calico profile, please read [here](https:
 
 ## Example
 
-### Calico networking containers
+### Calico Networking (Universal Container Runtime)
 
-To use Calico networking containers, you only have to specify the network name as `calico`, and the following example shows the Marathon application definition of Calico networking containers supported by Mesos UCR.
-a Marathon application with Calcico networking supported by Mesos UCR:
-```
+To use Calico networking containers, you only have to specify the network name as `calico`.
+
+The following marathon app definition example will launch a container using the _Mesos UCR engine_ and plug it to the `calico` network:
+
+```json
 {
   "id": "/calico-ucr",
   "instances": 1,
   "container": {
     "type": "MESOS",
+    "volumes": [],
+    "docker": {
+      "image": "mesosphere/id-server:2.1.0"
+    },
+    "portMappings": []
+  },
+  "cpus": 0.1,
+  "mem": 128,
+  "requirePorts": false,
+  "networks": [
+    {
+      "mode": "container",
+      "name": "calico"
+    }
+  ],
+  "healthChecks": [],
+  "fetch": [],
+  "constraints": []
+}
+```
+
+### Calico Networking (Docker Engine)
+
+Like with the previous example, the following marathon app definition will launch a container using the _Docker Engine_ and plug it to the `calico` network:
+
+```json
+{
+  "id": "/calico-docker",
+  "instances": 1,
+  "container": {
+    "type": "DOCKER",
     "volumes": [],
     "docker": {
       "image": "mesosphere/id-server:2.1.0"

--- a/packages/calico/README.md
+++ b/packages/calico/README.md
@@ -2,9 +2,9 @@
 
 This package provides DC/OS Calico component to support Calico networking containers and network policy in DC/OS.
 
-## system requirements
+## 1. System Requirements
 
-### Network requirements
+### 1.1. Network requirements
 
 | Port | DC/OS Component | systemd Unit             | Source       | Destination  | Description                                                                                                                         |
 |------|-----------------|--------------------------|--------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------|
@@ -14,11 +14,11 @@ This package provides DC/OS Calico component to support Calico networking contai
 | 64000 | Calico          | dcos-calico-felix.service | agent/master | agent/master | (Configurable) calico VXLAN networking can be configurable by calico_vxlan_port, by default, this shares the same value with dcos overlay vxlan port  |
 | 62091 | Calico          | dcos-calico-felix.service | agent/master | agent/master | TCP port that the Prometheus metrics server should bind to                                                                   |
 
-## DC/OS Calico component
+## 2. DC/OS Calico components
 
 DC/OS Calico component integrates the [Calico networking](https://www.projectcalico.org) into DC/OS, by providing the Calico CNI plugin for Mesos Universal Container Runtime and the Calico libnetwork plugin for Docker Engine. In addition, the calico control panel will provide the functionality of configuring the network policy for DC/OS workloads.
 
-### DC/OS Calico services
+### 2.1. DC/OS Calico services
 
 DC/OS Calico integrates Calico into DC/OS for managing container networking and network security, three services are introduced:
 
@@ -27,7 +27,7 @@ DC/OS Calico integrates Calico into DC/OS for managing container networking and 
 * `dcos-calico-felix.service`: the control panel for Calico networking to program routes and ACL's for containers. [(source)](https://github.com/projectcalico/node)
 * `dcos-calico-libntwork-plugin.service`: the network plugin for Docker that provides Calico networking to the Docker Engine. [(source)](https://github.com/projectcalico/libnetwork-plugin)
 
-## Configuration Reference(Networking)
+## 3. DC/OS Configuration Reference (Networking)
 
 | Parameter            | Description                                                                                                                        |
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,78 +39,9 @@ DC/OS Calico integrates Calico into DC/OS for managing container networking and 
 | calico_vxlan_mtu     | The MTU to set on the Calico VXLAN tunnel device. This configuration works when calico_vxlan_enabled is set to be true. Please refer to [this](https://docs.projectcalico.org/v3.8/networking/mtu) for a suitable MTU configuration [Default: 1410]    |
 | calico_veth_mtu     | The MTU to set on the veth pair devices, e.g. both the container interface and host-end interface. Please refer to [this](https://docs.projectcalico.org/v3.8/networking/mtu) for a suitable MTU configuration [Default: 1410]    |
 
-## Network Policy
+## 4. Application Example
 
-Network policy provides the ability to control network traffic by an ordered set of rules applied to the endpoints specified by a label selector, please refer [here](https://docs.projectcalico.org/v3.8/reference/resources/networkpolicy) for a detailed explanation of policy rule definitions and label selector syntax.
-
-In DC/OS, Calico network policy is exposed directly to the operators, so that the operator can manage their traffic control according to different scenarios.
-
-limitations on network policy we have in DC/OS:
-- Calico network policy is a namespaced resource, but for now, we support only `default` namespace in DC/OS, and all the namespaced Calico resources should be defined under `default` namespace.
-- Calico network policy takes effect only on Calico networking containers, which means labels set on non-Calico networking containers like `hostnetwork`, `dcos` and `bridge` will not count in Calico network policy.
-- Labels work for network policy MUST be set in NetworkInfo.Labels in Mesos, and for Marathon, they should be in networks.Labels, for example:
-```
-{
-  "id": "/client",
-  "instances": 1,
-  "container": {
-    "type": "MESOS",
-    "volumes": [],
-    "docker": {
-      "image": "mesosphere/id-server:2.1.0"
-    },
-    "portMappings": []
-  },
-  "cpus": 0.1,
-  "mem": 128,
-  "requirePorts": false,
-  "networks": [
-    {
-      "mode": "container",
-      "name": "calico",
-      "labels": {
-        "role": "client"
-      }
-    }
-  ],
-  "healthChecks": [],
-  "fetch": [],
-  "constraints": []
-}
-```
-
-### default profile
-
-Calico Profile groups endpoints which inherit labels defined in the profile, for example, each namespace has one corresponding profile to granting labels to Pods in the namespace. Calico profile supports policy rules for traffic control but is deprecated in favor of much more flexible NetworkPolicy and GlobalNetworkPolicy resources.
-
-In our case, all Calico networking containers will be assigned with a default profile with the same name as CNI network, `calico` by default, and this profile allows **only** requests from one Calico container network to another one,  which means L4LB and L7 proxy requests in which the source IP address is NATed to that of tunnel interfaces generated by Calico, and finally will be dropped. This profile can found in the following YAML definition.
-```yaml
-apiVersion: projectcalico.org/v3
-kind: Profile
-metadata:
-  creationTimestamp: 2019-12-23T04:16:55Z
-  name: calico
-  resourceVersion: "75"
-  uid: 0e105ecb-253b-11ea-9e52-065b6833052c
-spec:
-  egress:
-  - action: Allow
-    destination: {}
-    source: {}
-  ingress:
-  - action: Allow
-    destination: {}
-    source:
-      selector: has(calico)
-  labelsToApply:
-    calico: ""
-```
-To resolve this problem, calico profile `calico` is initialized by default by `dcos-calico-felix`, and allows all traffic into and out of Calico networking containers, and `calico` is the only profile supported for now and shared across all Calico networking containers.
-For a more detailed description of the Calico profile, please read [here](https://docs.projectcalico.org/v3.8/reference/resources/profile).
-
-## Example
-
-### Calico Networking (Universal Container Runtime)
+### 4.1. Calico Networking (Universal Container Runtime)
 
 To use Calico networking containers, you only have to specify the network name as `calico`.
 
@@ -143,7 +74,7 @@ The following marathon app definition example will launch a container using the 
 }
 ```
 
-### Calico Networking (Docker Engine)
+### 4.2. Calico Networking (Docker Engine)
 
 Like with the previous example, the following marathon app definition will launch a container using the _Docker Engine_ and plug it to the `calico` network:
 
@@ -176,9 +107,73 @@ Like with the previous example, the following marathon app definition will launc
 
 TODO: Or you could create a Calico networking Service through DC/OS web interface, tracked in [DCOS-62535](https://jira.mesosphere.com/browse/DCOS-62535)
 
-### Network policy examples
+## 5. Administration Topics
 
-In the following business isolation example,  we have three application definitions as shown below, and both bookstore-frontend and bookstore-server are labeled with `"biz_type": "bookstore"`, while fruitstore-frontend is labeled with `"biz_type": "fruitstore"`. Here we will create a network policy to deny the requests from fruitstore-frontend to bookstore-server while allow requests from bookstore-frontend to bookstore-server.
+### 5.1. Network Policies
+
+Network policy provides the ability to control network traffic by an ordered set of rules applied to the endpoints specified by a label selector, please refer [here](https://docs.projectcalico.org/v3.8/reference/resources/networkpolicy) for a detailed explanation of policy rule definitions and label selector syntax.
+
+In DC/OS, Calico network policy is exposed directly to the operators, so that the operator can manage their traffic control according to different scenarios.
+
+limitations on network policy we have in DC/OS:
+
+* Calico network policy is a namespaced resource, but for now, we support only `default` namespace in DC/OS, and all the namespaced Calico resources should be defined under `default` namespace.
+* Calico network policy takes effect only on Calico networking containers, which means labels set on non-Calico networking containers like `hostnetwork`, `dcos` and `bridge` will not count in Calico network policy.
+* Labels work for network policy MUST be set in `NetworkInfo.Labels` in Mesos, and for Marathon, they should be in `networks.[].labels`, for example:
+
+```js
+{
+  "id": "/client",
+  "instances": 1,
+   ...
+  "networks": [
+    {
+      "mode": "container",
+      "name": "calico",
+      "labels": {
+        "role": "client"
+      }
+    }
+  ],
+  ...
+}
+```
+
+### 5.2. Default profile
+
+Calico Profile groups endpoints which inherit labels defined in the profile, for example, each namespace has one corresponding profile to granting labels to Pods in the namespace. Calico profile supports policy rules for traffic control but is deprecated in favor of much more flexible NetworkPolicy and GlobalNetworkPolicy resources.
+
+In our case, all Calico networking containers will be assigned with a default profile with the same name as CNI network, `calico` by default, and this profile allows **only** requests from one Calico container network to another one,  which means L4LB and L7 proxy requests in which the source IP address is NATed to that of tunnel interfaces generated by Calico, and finally will be dropped. This profile can found in the following YAML definition.
+
+```yaml
+apiVersion: projectcalico.org/v3
+kind: Profile
+metadata:
+  creationTimestamp: 2019-12-23T04:16:55Z
+  name: calico
+  resourceVersion: "75"
+  uid: 0e105ecb-253b-11ea-9e52-065b6833052c
+spec:
+  egress:
+  - action: Allow
+    destination: {}
+    source: {}
+  ingress:
+  - action: Allow
+    destination: {}
+    source:
+      selector: has(calico)
+  labelsToApply:
+    calico: ""
+```
+
+To resolve this problem, calico profile `calico` is initialized by default by `dcos-calico-felix`, and allows all traffic into and out of Calico networking containers, and `calico` is the only profile supported for now and shared across all Calico networking containers.
+For a more detailed description of the Calico profile, please read [here](https://docs.projectcalico.org/v3.8/reference/resources/profile).
+
+### 5.3. Network policy examples
+
+In the following business isolation example, we have three application definitions as shown below, and both bookstore-frontend and bookstore-server are labeled with `"biz_type": "bookstore"`, while fruitstore-frontend is labeled with `"biz_type": "fruitstore"`. Here we will create a network policy to deny the requests from fruitstore-frontend to bookstore-server while allow requests from bookstore-frontend to bookstore-server.
+
 ```
 +----------------------+      +------------------------+
 |                      |      |                        |
@@ -196,10 +191,11 @@ In the following business isolation example,  we have three application definiti
              +------------------------+
 ```
 
-#### Launch Marathon applications
+#### 5.3.1. Launch Marathon applications
 
 The Marathon application definition of bookstore-frontend with policy label `"biz_type": "bookstore"`:
-```
+
+```json
 {
   "id": "/bookstore-frontend",
   "instances": 1,
@@ -230,7 +226,7 @@ The Marathon application definition of bookstore-frontend with policy label `"bi
 ```
 The Marathon application definition of bookstore-server with policy label `"biz_type": "bookstore"` and `"role": "server"`, available on port 80:
 
-```
+```json
 {
   "id": "/bookstore-server",
   "instances": 1,
@@ -261,7 +257,8 @@ The Marathon application definition of bookstore-server with policy label `"biz_
 }
 ```
 The Marathon application definition of fruitstore-frontend with policy label `"biz_type": "fruitstore"`:
-```
+
+```json
 {
   "id": "/fruitstore-frontend",
   "instances": 1,
@@ -290,7 +287,9 @@ The Marathon application definition of fruitstore-frontend with policy label `"b
   "constraints": []
 }
 ```
+
 Lauch the above three Marathon applications by executing `dcos marathon app add ${app_definition_yaml_file}`, and we will then obtain three running Marathon applications as show below:
+
 ```
 $ dcos task list
          NAME              HOST      USER     STATE                                         ID                                                    AGENT ID                  REGION  ZONE
@@ -299,7 +298,7 @@ $ dcos task list
   bookstore-frontend   172.16.2.233  root  TASK_RUNNING  bookstore-frontend.instance-79853919-2a47-11ea-91b3-66db602e14f5._app.1   0a1399a2-fe1f-4613-a618-f45159e12f2a-S0  N/A     N/A
 ```
 
-#### Test the connectivity between the frontends and the server
+#### 5.3.2. Test the connectivity between the frontends and the server
 
 Before applying network policy, the requests from bookstore-frontend and fruitstore-frontend to bookstore-server are successful, here we expect the FQDN `bookstore-server.marathon.containerip.dcos.thisdcos.directory` to return the bookstore-server container IP address:
 ```
@@ -310,7 +309,7 @@ $ dcos task exec bookstore-frontend wget -qO- bookstore-server.marathon.containe
 hubfeu2yculh%
 ```
 
-#### Apply network policy
+#### 5.3.3. Apply network policy
 
 This network policy takes effect on bookstore-server and allows requests from applications with label `biz_type` set as `bookstore` while rejects those from applications with label `biz_type` set as `fruitstore`:
 ```
@@ -347,15 +346,14 @@ Request from bookstore-frontend is successful as expected:
 $ dcos task exec bookstore-frontend wget -qO- bookstore-server.marathon.containerip.dcos.thisdcos.directory:80/id
 hubfeu2yculh%
 ```
+
 Request from fruitstore-frontend is timed out for packets are dropped.
 ```
 $ dcos task exec fruitstore-frontend wget -qO- --timeout=5 bookstore-server.marathon.containerip.dcos.thisdcos.directory:80/id
 wget: can't connect to remote host (192.168.219.133): Connection timed out
 ```
 
-## Administration
-
-### Adding network profiles
+### 5.4. Adding network profiles
 
 In most of the use cases a single calico profile is enough. However if for any reason more networks needs to be created, you should be aware of some corner cases.
 
@@ -402,6 +400,6 @@ That said, to add a network profile, you should:
       <network-name> 
   ```
 
-## Troubleshoot
+## 6. Troubleshooting
 
 Diagnostic info including Calico resources, components logs, and BGP peer status are collected in DC/OS node diagnostic bundle to debug Calico networking issues, please execute  `dcos node diagnostic create` to create a diagnostic bundle, and download the diagnostic bundle by executing `dcos node diagnostic download <diagnostic-bundle-name>`.

--- a/packages/calico/README.md
+++ b/packages/calico/README.md
@@ -2,6 +2,29 @@
 
 This package provides DC/OS Calico component to support Calico networking containers and network policy in DC/OS.
 
+<!-- MarkdownTOC -->
+
+* [1. System Requirements](#1-system-requirements)
+  - [1.1. Network requirements](#11-network-requirements)
+* [2. DC/OS Calico components](#2-dcos-calico-components)
+  - [2.1. DC/OS Calico services](#21-dcos-calico-services)
+* [3. DC/OS Configuration Reference \(Networking\)](#3-dcos-configuration-reference-networking)
+* [4. Application Example](#4-application-example)
+  - [4.1. Calico Networking \(Universal Container Runtime\)](#41-calico-networking-universal-container-runtime)
+  - [4.2. Calico Networking \(Docker Engine\)](#42-calico-networking-docker-engine)
+* [5. Administration Topics](#5-administration-topics)
+  - [5.1. Network Policies](#51-network-policies)
+  - [5.2. Default profile](#52-default-profile)
+  - [5.3. Network policy examples](#53-network-policy-examples)
+    * [5.3.1. Launch Marathon applications](#531-launch-marathon-applications)
+    * [5.3.2. Test the connectivity between the frontends and the server](#532-test-the-connectivity-between-the-frontends-and-the-server)
+    * [5.3.3. Apply network policy](#533-apply-network-policy)
+  - [5.4. Adding network profiles](#54-adding-network-profiles)
+* [6. Troubleshooting](#6-troubleshooting)
+* [7. Development](#7-development)
+
+<!-- /MarkdownTOC -->
+
 ## 1. System Requirements
 
 ### 1.1. Network requirements


### PR DESCRIPTION
## High-level description

Adding documentation regarding the `calico-libnetwork-plugin` support on DC/OS.

## Corresponding DC/OS tickets (required)

  - [D2IQ-62589](https://jira.d2iq.com/browse/D2IQ-62589) add doc for for calico libnetwork


## Related tickets (optional)

_(none)_

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] ~Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)~
  - [ ] ~Included a test which will fail if code is reverted but test is not. If there is no test please explain.~
  - [ ] ~Test Results: [link to CI job test results for component]~
  - [ ] ~Code Coverage (if available): [link to code coverage report]~
 