### PR TITLE
[Windows Upgrade] Hotfix: added backward compatibility of new DC/OS Linux installer with upgrade func vs old Ansible Windows BETA container

### DIFF
--- a/build_genconf_windows.ps1
+++ b/build_genconf_windows.ps1
@@ -29,6 +29,13 @@ $source = "http://www.7-zip.org/a/7z1900-x64.exe";
 $destination = "$($artifact_storage)\prerequisites\zip\7z-x64.exe";
 Invoke-WebRequest $source -OutFile $destination
 
+# Copying dcos_install.ps1 to cache location for further packing:
+$srcfilePath = "$($gen_powershell_dir)\dcos_install.ps1.in";
+$dstfilePath = "$($gen_powershell_dir)\dcos_install.ps1";
+(Get-Content $srcfilePath).Replace("[Parameter(Mandatory=`$false)] [string] `$bootstrap_url = '{{ bootstrap_url }}'", "[Parameter(Mandatory=`$true)] [string] `$bootstrap_url") | Set-Content $dstfilePath;
+(Get-Content $dstfilePath).Replace("[Parameter(Mandatory=`$false)] [string] `$masters = '{{ master_list }}'", "[Parameter(Mandatory=`$true)] [string] `$masters") | Set-Content $dstfilePath;
+Copy-Item -Path $dstfilePath "$artifact_storage\prerequisites\dcos_install.ps1" -Force -ErrorAction SilentlyContinue;
+
 # Creating prerequisites.zip:
 Compress-Archive -Path "$artifact_storage\prerequisites\zip\*" -destinationpath "$artifact_storage\prerequisites\prerequisites.zip" -Force;
 Remove-Item -Recurse -Path "$artifact_storage\prerequisites\zip" -Force;

--- a/gen/build_deploy/powershell.py
+++ b/gen/build_deploy/powershell.py
@@ -21,7 +21,7 @@ def generate(gen_out, output_dir):
 def make_powershell(gen_out, output_dir):
     """Build powershell deployment script and store this at Bootstrap serve"""
 
-    output_dir = output_dir + '/windows/prerequisites/'
+    output_dir = output_dir + '/windows/'
     pkgpanda.util.make_directory(output_dir)
 
     bootstrap_url = gen_out.arguments['bootstrap_url']


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

There is issue in broken compatibility of old Ansible container "mesosphere/dcos-ansible-bundle:windows-beta-support" with recent (new) changes to DC/OS installer(s) - another word move of dcos_install.ps1 from DC/OS Windows installer to DC/OS Linux installer.
There is a task under Bootstrap role called "Unpack Windows installer packages" in Ansible. How does it work - if dcos_install.ps1 missing on file system, then Ansible unpacks Windows installer. Otherwise skip the task. Another word - the dcos_install.ps1 used as trigger to run the task. And now this file is unpacked earlier by DC/OS Linux installer.

To resolve the issue unpack of dcos_install.ps1 by DC/OS Windows Installer and DC/OS Linux Installer proposed to  different locations:
Windows' one -  to windows/prerequisites/dcos_install.ps1 
Linux's one - to windows/dcos_install.ps1 

Therefore if user has old Windows BETA Ansible container, Windows's one used. If Windows GA Ansible container used - a Linux's one used and it 

## Corresponding DC/OS tickets (required)

  - [D2IQ-61891](https://jira.mesosphere.com/browse/D2IQ-61891) EPIC : Support Windows Node Update

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
