### PR TITLE
CLOUD_FORMATION: Add Admin Router gRPC port

### DIFF
--- a/gen/aws/templates/advanced/advanced-master.json
+++ b/gen/aws/templates/advanced/advanced-master.json
@@ -296,6 +296,12 @@
             "InstanceProtocol" : "TCP"
           },
           {
+            "LoadBalancerPort" : "12379",
+            "Protocol" : "TCP",
+            "InstancePort" : "12379",
+            "InstanceProtocol" : "TCP"
+          },
+          {
             "LoadBalancerPort" : "8080",
             "Protocol" : "HTTP",
             "InstancePort" : "8080",
@@ -326,6 +332,12 @@
             "LoadBalancerPort" : "443",
             "Protocol" : "TCP",
             "InstancePort" : "443",
+            "InstanceProtocol" : "TCP"
+          },
+          {
+            "LoadBalancerPort" : "12379",
+            "Protocol" : "TCP",
+            "InstancePort" : "12379",
             "InstanceProtocol" : "TCP"
           }],
         "HealthCheck" : {

--- a/gen/aws/templates/advanced/infra.json
+++ b/gen/aws/templates/advanced/infra.json
@@ -59,6 +59,11 @@
           "FromPort" : "443",
           "ToPort" : "443",
           "CidrIp" : { "Ref" : "AdminLocation" }
+          }, {
+          "IpProtocol" : "tcp",
+          "FromPort" : "12379",
+          "ToPort" : "12379",
+          "CidrIp" : { "Ref" : "AdminLocation" }
         } ]
       }
     },
@@ -85,6 +90,7 @@
           { "IpProtocol" : "tcp", "FromPort" : "5050", "ToPort" : "5050", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "80", "ToPort" : "80", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "443", "ToPort" : "443", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
+          { "IpProtocol" : "tcp", "FromPort" : "12379", "ToPort" : "12379", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "8080", "ToPort" : "8080", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "8181", "ToPort" : "8181", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "2181", "ToPort" : "2181", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} }

--- a/gen/aws/templates/cloudformation.json
+++ b/gen/aws/templates/cloudformation.json
@@ -350,6 +350,11 @@
           "FromPort" : "443",
           "ToPort" : "443",
           "CidrIp" : { "Ref" : "AdminLocation" }
+        }, {
+          "IpProtocol" : "tcp",
+          "FromPort" : "12379",
+          "ToPort" : "12379",
+          "CidrIp" : { "Ref" : "AdminLocation" }
         } ]
       }
     },
@@ -581,6 +586,7 @@
           { "IpProtocol" : "tcp", "FromPort" : "5050", "ToPort" : "5050", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "80", "ToPort" : "80", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "443", "ToPort" : "443", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
+          { "IpProtocol" : "tcp", "FromPort" : "12379", "ToPort" : "12379", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "8080", "ToPort" : "8080", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "8181", "ToPort" : "8181", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} },
           { "IpProtocol" : "tcp", "FromPort" : "2181", "ToPort" : "2181", "SourceSecurityGroupId" : { "Ref" : "LbSecurityGroup"} }
@@ -642,6 +648,12 @@
             "InstanceProtocol" : "TCP"
           },
           {
+            "LoadBalancerPort" : "12379",
+            "Protocol" : "TCP",
+            "InstancePort" : "12379",
+            "InstanceProtocol" : "TCP"
+          },
+          {
             "LoadBalancerPort" : "8080",
             "Protocol" : "HTTP",
             "InstancePort" : "8080",
@@ -673,6 +685,12 @@
             "LoadBalancerPort" : "443",
             "Protocol" : "TCP",
             "InstancePort" : "443",
+            "InstanceProtocol" : "TCP"
+          },
+          {
+            "LoadBalancerPort" : "12379",
+            "Protocol" : "TCP",
+            "InstancePort" : "12379",
             "InstanceProtocol" : "TCP"
           }],
         "HealthCheck" : {


### PR DESCRIPTION
## High-level description

This PR adds support for newly added Admin Router's gRPC port.


## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-62476) Adjust cloud formation templates and Terraform modules to open AR's new gRPC port 


