### PR TITLE
[Windows Upgrade] [BugFix] D2IQ-65203: fixed way the detect script is executed

### DIFF
--- a/gen/build_deploy/powershell/dcos_install.ps1.in
+++ b/gen/build_deploy/powershell/dcos_install.ps1.in
@@ -26,7 +26,7 @@
   [Optional] DC/OS variable directory for a files created by bootstrap process, for logs stored. Default value is C:\d2iq\dcos\var
 
 .NOTES
-    Updated: 2020-01-29       Added Invoke-NativeApplication function to run native processes. Extended logging. Streamed stdout/stderr to the single log file.
+    Updated: 2020-01-29       Added Invoke-NativeApplication function to run native Windows apps. Extended logging. Streamed stdout/stderr to the single log file.
     Updated: 2020-01-17       Added LongPathsSupport function that enables support of pathes longer 256 symbols.
     Updated: 2019-11-29       Added install_dir and var_dir into path.json file for more flexible DC/OS configuration. Replaced conf dir with etc.
     Updated: 2019-11-22       Removed RunOnce.ps1 and Scheduled task logic. Fixed cluster.conf parameters. Added download of detect_ip*.ps1 scripts.
@@ -146,6 +146,8 @@ function Test-CalledFromPrompt {
 }
 
 function Invoke-NativeApplication {
+    # The helper function is used to run Native Windows apps in PS1 such as python.exe or cmd.exe. IMPORTANT, it cannot be used to run PS1 CmdLets!
+    # Source code: https://github.com/mnaoumov/Invoke-NativeApplication
     param
     (
         [ScriptBlock] $ScriptBlock,
@@ -410,7 +412,7 @@ function main($url, $masters) {
     for ($i=0; $i -lt $masterarray.length; $i++) {
         $masternodecontent += "[master-node-$($i+1)]`nPrivateIPAddr=$($masterarray[$i])`nZookeeperListenerPort=2181`n"
     }
-    $local_ip = Invoke-NativeApplication {. "$($basedir)\bin\detect_ip.ps1"}
+    $local_ip = try { . "$($basedir)\bin\detect_ip.ps1" } catch { throw "$(Get-Date -Format "yyyy-MM-dd HH:mm:ss") ERROR: Failed to execute `'$($basedir)\bin\detect_ip.ps1`' . Check script validity!" 2>&1 | Tee-Object -FilePath "$($vardir)\log\dcos_install.log" -Append; return }
     Write-Log -Level "Debug" -LogContent "Local IP: $($local_ip)"
     $content = "$($masternodecontent)`n[distribution-storage]`nRootUrl=$($url)`nPkgRepoPath=windows/packages`nPkgListPath=windows/package_lists/latest.package_list.json`nDcosClusterPkgInfoPath=cluster-package-info.json`n`n[local]`nPrivateIPAddr=$($local_ip)"
     CreateWriteFile "$($basedir)\etc" "cluster.conf" $content

--- a/gen/build_deploy/powershell/dcos_node_upgrade.ps1.in
+++ b/gen/build_deploy/powershell/dcos_node_upgrade.ps1.in
@@ -111,6 +111,8 @@ function Test-CalledFromPrompt {
 }
 
 function Invoke-NativeApplication {
+    # The helper function is used to run Native Windows apps in PS1 such as python.exe or cmd.exe. IMPORTANT, it cannot be used to run PS1 CmdLets!
+    # Source code: https://github.com/mnaoumov/Invoke-NativeApplication
     param
     (
         [ScriptBlock] $ScriptBlock,
@@ -218,7 +220,7 @@ function main($url, $masters) {
     for ($i=0; $i -lt $masterarray.length; $i++) {
         $masternodecontent += "[master-node-$($i+1)]`nPrivateIPAddr=$($masterarray[$i])`nZookeeperListenerPort=2181`n"
     }
-    $local_ip = Invoke-NativeApplication {. "$($basedir)\bin\detect_ip.ps1"}
+    $local_ip = try { . "$($basedir)\bin\detect_ip.ps1" } catch { throw "$(Get-Date -Format "yyyy-MM-dd HH:mm:ss") ERROR: Failed to execute `'$($basedir)\bin\detect_ip.ps1`' . Check script validity!" 2>&1 | Tee-Object -FilePath "$($vardir)\log\dcos_node_upgrade.log" -Append; return }
     Write-Log -Level "Debug" -LogContent "Local IP: $($local_ip)"
     $content = "$($masternodecontent)`n[distribution-storage]`nRootUrl=$($url)`nPkgRepoPath=windows/packages`nPkgListPath=windows/package_lists/latest.package_list.json`nDcosClusterPkgInfoPath=cluster-package-info.json`n`n[local]`nPrivateIPAddr=$($local_ip)"
     CreateWriteFile "$($basedir)\etc" "cluster.conf" $content


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

BugFix: currently if some NativeApplication being failed on Windows machine, and then when the detect script (cmdlet) is ran, $LASTEXITCODE of a previous Native Application (not cmdlet, but python, or an exe, or some service) being picked up instead of real exit code of cmdlet. As per official documentation $LASTEXICODE works only with external apps such as cmds, python, exe, etc, but not with Powershell cmdlets. Which is very odd limitation of PS as scripting language. 

Therefore for running the detect script only "Invoke-NativeApplication" removed as executor, new executor  suggested -  simple `try { } catch { }`  construction.

## Corresponding DC/OS tickets (required)

  - [D2IQ-65203](https://jira.d2iq.com/browse/D2IQ-65203)  upgrade_win.ps1 stops with an error


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from one developer on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
Once a PR has **1 approval**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
