### PR TITLE
Introduce Makefile in test_util directory to exercise integration tests for Windows

### DIFF
--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -1,0 +1,70 @@
+SHELL := /bin/bash -euo pipefail
+
+export AWS_REGION ?= us-west-2
+export TF_VAR_custom_dcos_download_path_win ?= https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh
+export TF_VAR_variant ?= open
+export OUTPUT_FILE ?= /dev/stdout
+
+.DEFAULT_GOAL := test
+
+.PHONY: maws
+maws:
+	$(eval $(shell maws login "eng-devprod"))
+
+.PHONY: get-terraform
+get-terraform:
+	rm -rf ./terraform_0.11.14_linux_amd64.zip
+	wget https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
+	unzip ./terraform*.zip
+	chmod +x terraform
+
+# TODO (dcos-team): This should not be required Open DC/OS
+.PHONY: dcos-set-license
+dcos-set-license:
+	@echo ${DCOS_LICENSE_CONTENTS} > license.txt
+
+.PHONY: terraform-init
+terraform-init:  get-terraform dcos-set-license
+	./terraform init --upgrade
+
+.PHONY: ssh-agent
+ssh-agent:
+	if [ -z "$$SSH_AUTH_SOCK" ] ; then \
+	  eval $$(ssh-agent -s); \
+	fi
+
+.PHONY: ssh-keygen-add
+ssh-keygen-add: ssh-agent
+	ssh-keygen -t rsa -b 2048 -f ./tf-dcos-rsa.pem -q -N ""; \
+	ssh-add ./tf-dcos-rsa.pem;
+
+.PHONY: test
+test: terraform-init ssh-keygen-add
+	./terraform apply -auto-approve
+
+.PHONY: output
+output:
+	./terraform output > ${OUTPUT_FILE}
+
+.PHONY: destroy
+destroy:
+	./terraform destroy
+
+.PHONY: clean
+clean:
+	rm -rf ./terraform
+	rm -rf ./.terraform/
+	rm -rf ./inventory
+	rm -rf ./terraform.tfstate
+	rm -rf ./terraform.tfstate.backup
+	rm -rf ./terraform_0.11.14_linux_amd64.zip
+	rm -rf ./*.pem
+	rm -rf ./*.pub
+	rm -rf ./license.txt
+
+
+.PHONY: experiment
+experiment:
+	for number in 1 2 3 4 ; do \
+		echo "make experiment..."; \
+	done

--- a/test_util/README.md
+++ b/test_util/README.md
@@ -24,7 +24,7 @@ terraform apply
 
 to start a cluster.
 
-Once Terraform finished you can setup the CLI with `dcos cluster setup $(terraform output masters_dns_name) --insecure`.
+Once Terraform finished you can setup the CLI with `dcos cluster setup $(terraform output dcos_ui) --insecure`.
 
 Do not forget to destroy the cluster again with `terraform destroy`.
 
@@ -47,3 +47,18 @@ Windows agents defaults to zero and can be set via `TF_VAR_windowsagent_num`.
 By default instances will be destroyed by CloudCleaner to change expiration set `TF_VAR_expiration=8h` and `TF_VAR_owner=$USER`.
 
 If you want to launch the master build with Windows agents simply call `terraform apply -var-file=windows.tfvars`.
+
+### Username and Password
+
+username: demo-super
+password: deleteme
+
+### Environment Variables
+
+The following enviroment variables can be overriden to customize the clluster setup
+
+* AWS_REGION
+* TF_VAR_custom_dcos_download_path_win
+* TF_VAR_variant
+* OUTPUT_FILE
+

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -14,7 +14,7 @@ variable "custom_dcos_download_path_win" {
 
 variable "variant" {
   type = "string"
-  default = "ee"
+  default = "open"
 }
 
 variable "owner" {
@@ -24,7 +24,7 @@ variable "owner" {
 
 variable "expiration" {
     type = "string"
-    default = "2h"
+    default = "1h"
 }
 
 variable "windowsagent_num" {
@@ -38,8 +38,14 @@ data "http" "whatismyip" {
   url = "http://whatismyip.akamai.com/"
 }
 
+resource "random_string" "password" {
+  length = 6
+  special = true
+  override_special = "-"
+}
+
 locals {
-  cluster_name = "generic-dcos-ee-demo"
+  cluster_name = "generic-dcos-it-${random_string.password.result}"
 }
 
 module "dcos" {
@@ -56,7 +62,7 @@ module "dcos" {
   }
 
   cluster_name        = "${local.cluster_name}"
-  ssh_public_key_file = "~/.ssh/id_rsa.pub"
+  ssh_public_key_file = "./tf-dcos-rsa.pem.pub"
   admin_ips           = ["${data.http.whatismyip.body}/32"]
 
   num_masters        = "1"
@@ -68,7 +74,7 @@ module "dcos" {
 
   dcos_variant              = "${var.variant}"
   dcos_version              = "2.1.0-beta1"
-  dcos_license_key_contents = "${file("~/license.txt")}"
+  dcos_license_key_contents = "${file("./license.txt")}"
   ansible_bundled_container = "mesosphere/dcos-ansible-bundle:windows-beta-support"
 
   custom_dcos_download_path = "${var.custom_dcos_download_path}"


### PR DESCRIPTION
* D2IQ-65138  - Enable CI for Windows Tests on Open 

We are going to enable CI for windows tests on Open DC/OS via Makefile.

---

This introduces testing based on a checkined `main.tf` and with Makefile.

The pipeline here setups only these.

* Introduces steps for `make test`
* Setups a CI pipeline for [Open DC/OS](https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcOs_Open_Test_IntegrationTest_WindowsIntegrationTEsts&branch_DcOs_Open_Test_IntegrationTest=pull%2F6965&tab=buildTypeStatusDiv) and [Enterprise DC/OS](https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcOs_Enterprise_Test_Inte_WindowsIntegrationTest&branch_DcOs_Enterprise_Test_Inte=pull%2F7471&tab=buildTypeStatusDiv)
* This will start reporting status to the Open and Enterprise PRs.
* Same `makefile` is used for both Open DC/OS and Enterprise DC/OS
* The variables used in the `Makefile` can be overridden by environment variables.

*status report*

![image](https://user-images.githubusercontent.com/332330/76267670-c3b73880-6228-11ea-8fed-9cf7a1024351.png)

---

**NOTE** - This does not bring in tests yet. The test exercise should be added by **dcos-windows** team.


