### PR TITLE
Enable test_metrics on Windows.

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -46,6 +46,7 @@ def test_metrics_ping(dcos_api_session):
         assert response.json()['ok'], 'Status code: {}, Content {}'.format(response.status_code, response.content)
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agents_prom(dcos_api_session):
     """Telegraf Prometheus endpoint is reachable on master and agents."""
     nodes = get_master_and_agents(dcos_api_session)
@@ -68,6 +69,7 @@ def get_metrics_prom(dcos_api_session, node):
     return response
 
 
+@pytest.mark.supportedwindows
 def test_metrics_procstat(dcos_api_session):
     """Assert that procstat metrics are present on master and agent nodes."""
     nodes = get_master_and_agents(dcos_api_session)
@@ -84,6 +86,7 @@ def test_metrics_procstat(dcos_api_session):
         check_procstat_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agents_mesos(dcos_api_session):
     """Assert that mesos metrics on agents are present."""
     nodes = get_agents(dcos_api_session)
@@ -100,6 +103,7 @@ def test_metrics_agents_mesos(dcos_api_session):
         check_mesos_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_mesos(dcos_api_session):
     """Assert that mesos metrics on master are present."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -113,6 +117,7 @@ def test_metrics_master_mesos(dcos_api_session):
     check_mesos_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agents_mesos_overlay(dcos_api_session):
     """Assert that mesos agent overlay module metrics on master and agents are present."""
 
@@ -130,6 +135,7 @@ def test_metrics_agents_mesos_overlay(dcos_api_session):
         _check_mesos_overlay_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_mesos_overlay(dcos_api_session):
     """Assert that mesos overlay module metrics on master are present."""
 
@@ -145,6 +151,7 @@ def test_metrics_master_mesos_overlay(dcos_api_session):
     _check_mesos_overlay_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_zookeeper(dcos_api_session):
     """Assert that ZooKeeper metrics on master are present."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -159,6 +166,7 @@ def test_metrics_master_zookeeper(dcos_api_session):
     check_zookeeper_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_cockroachdb(dcos_api_session):
     """Assert that CockroachDB metrics on master are present."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -173,6 +181,7 @@ def test_metrics_master_cockroachdb(dcos_api_session):
     check_cockroachdb_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_calico(dcos_api_session):
     """Assert that DC/OS Calico metrics on master are present."""
 
@@ -188,6 +197,7 @@ def test_metrics_master_calico(dcos_api_session):
     _check_calico_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agents_calico(dcos_api_session):
     """Assert that DC/OS Calico metrics on agents are present."""
 
@@ -205,6 +215,7 @@ def test_metrics_agents_calico(dcos_api_session):
         _check_calico_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_adminrouter_nginx_vts(dcos_api_session):
     """Assert that Admin Router Nginx VTS metrics on master are present."""
     @retrying.retry(
@@ -222,6 +233,7 @@ def test_metrics_master_adminrouter_nginx_vts(dcos_api_session):
     check_adminrouter_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_exhibitor_status(dcos_api_session):
     """Assert that Exhibitor status metrics on master are present."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -257,6 +269,7 @@ def _nginx_vts_measurement_basename(name: str) -> str:
     return '_'.join(name.split('_')[:3])
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session):
     """
     nginx_vts_*_request_seconds* metrics are not present.
@@ -287,6 +300,9 @@ def test_metrics_master_adminrouter_nginx_drop_requests_seconds(dcos_api_session
     check_adminrouter_metrics()
 
 
+# TODO: D2IQ-65403 - muted Windows tests requiring investigation
+@pytest.mark.supportedwindows
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-65403")
 def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(dcos_api_session):
     """
     nginx_vts_*_request_seconds* metrics are not present.
@@ -323,6 +339,7 @@ def test_metrics_agent_adminrouter_nginx_drop_requests_seconds(dcos_api_session)
         check_adminrouter_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     """Assert that processed Admin Router metrics on master are present."""
     node = dcos_api_session.masters[0]
@@ -377,6 +394,7 @@ def test_metrics_master_adminrouter_nginx_vts_processor(dcos_api_session):
     check_adminrouter_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agents_adminrouter_nginx_vts(dcos_api_session):
     """Assert that Admin Router Nginx VTS metrics on agents are present."""
     nodes = get_agents(dcos_api_session)
@@ -400,6 +418,9 @@ def test_metrics_agents_adminrouter_nginx_vts(dcos_api_session):
         check_adminrouter_metrics()
 
 
+# TODO: D2IQ-65403 - muted Windows tests requiring investigation
+@pytest.mark.supportedwindows
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-65403")
 def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
     """Assert that processed Admin Router metrics on agent are present."""
     # Make request to Admin Router on every agent to ensure metrics.
@@ -449,6 +470,7 @@ def test_metrics_agent_adminrouter_nginx_vts_processor(dcos_api_session):
         check_adminrouter_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_diagnostics(dcos_api_session):
     """Assert that DC/OS Diagnostics metrics on master are present."""
     nodes = get_master_and_agents(dcos_api_session)
@@ -465,6 +487,7 @@ def test_metrics_diagnostics(dcos_api_session):
         check_diagnostics_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_fluentbit(dcos_api_session):
     """Ensure that fluent bit metrics are present on masters and agents"""
     nodes = get_master_and_agents(dcos_api_session)
@@ -508,6 +531,7 @@ def check_statsd_app_metrics(dcos_api_session, marathon_app, node, expected_metr
         check_statsd_metrics()
 
 
+@pytest.mark.supportedwindows
 def test_metrics_agent_statsd(dcos_api_session):
     """Assert that statsd metrics on private agent are present."""
     task_name = 'test-metrics-statsd-app'
@@ -625,6 +649,7 @@ def get_task_hostname(dcos_api_session, framework_name, task_name):
     return node
 
 
+@pytest.mark.supportedwindows
 def test_task_metrics_metadata(dcos_api_session):
     """Test that task metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()
@@ -647,6 +672,7 @@ def test_task_metrics_metadata(dcos_api_session):
         check_metrics_metadata()
 
 
+@pytest.mark.supportedwindows
 def test_executor_metrics_metadata(dcos_api_session):
     """Test that executor metrics have expected metadata/labels"""
     expanded_config = get_expanded_config()
@@ -743,6 +769,7 @@ def get_agents(dcos_api_session):
     return nodes
 
 
+@pytest.mark.supportedwindows
 def test_metrics_containers(dcos_api_session):
     """Assert that a Marathon app's container and app metrics can be retrieved."""
     @retrying.retry(wait_fixed=STD_INTERVAL, stop_max_delay=METRICS_WAITTIME)
@@ -823,6 +850,7 @@ def test_metrics_containers(dcos_api_session):
         test_containers(endpoints)
 
 
+@pytest.mark.supportedwindows
 def test_statsd_metrics_containers_app(dcos_api_session):
     """Assert that statsd app metrics appear in the v0 metrics API."""
     task_name = 'test-statsd-metrics-containers-app'
@@ -879,6 +907,7 @@ def test_statsd_metrics_containers_app(dcos_api_session):
             assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
 
 
+@pytest.mark.supportedwindows
 def test_prom_metrics_containers_app_host(dcos_api_session):
     """Assert that prometheus app metrics appear in the v0 metrics API."""
     task_name = 'test-prom-metrics-containers-app-host'
@@ -933,6 +962,7 @@ def test_prom_metrics_containers_app_host(dcos_api_session):
             assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
 
 
+@pytest.mark.supportedwindows
 def test_prom_metrics_containers_app_bridge(dcos_api_session):
     """Assert that prometheus app metrics appear in the v0 metrics API."""
     task_name = 'test-prom-metrics-containers-app-bridge'
@@ -991,6 +1021,7 @@ def test_prom_metrics_containers_app_bridge(dcos_api_session):
             assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
 
 
+@pytest.mark.supportedwindows
 def test_task_prom_metrics_not_filtered(dcos_api_session):
     """Assert that prometheus app metrics aren't filtered according to adminrouter config.
 
@@ -1060,6 +1091,7 @@ def test_task_prom_metrics_not_filtered(dcos_api_session):
             assert_app_metric_value_for_task(dcos_api_session, node, task_name, metric_name, metric_value)
 
 
+@pytest.mark.supportedwindows
 def test_metrics_containers_nan(dcos_api_session):
     """Assert that the metrics API can handle app metric gauges with NaN values."""
     task_name = 'test-metrics-containers-nan'
@@ -1215,6 +1247,9 @@ def get_metrics_for_task(dcos_api_session, node: str, task_name: str):
     )
 
 
+# TODO: D2IQ-65401 - muted Windows tests requiring investigation
+@pytest.mark.supportedwindows
+@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-65401")
 def test_standalone_container_metrics(dcos_api_session):
     """
     An operator should be able to launch a standalone container using the
@@ -1363,6 +1398,7 @@ def test_standalone_container_metrics(dcos_api_session):
         _post_agent(kill_data)
 
 
+@pytest.mark.supportedwindows
 def test_pod_application_metrics(dcos_api_session):
     """Launch a pod, wait for its containers to be added to the metrics service,
     and then verify that:


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

```python
test_metrics.py::test_metrics_ping PASSED
test_metrics.py::test_metrics_agents_prom PASSED
test_metrics.py::test_metrics_procstat PASSED
test_metrics.py::test_metrics_agents_mesos PASSED
test_metrics.py::test_metrics_master_mesos PASSED
test_metrics.py::test_metrics_agents_mesos_overlay PASSED
test_metrics.py::test_metrics_master_mesos_overlay PASSED
test_metrics.py::test_metrics_master_zookeeper PASSED
test_metrics.py::test_metrics_master_cockroachdb PASSED
test_metrics.py::test_metrics_master_calico PASSED
test_metrics.py::test_metrics_agents_calico PASSED
test_metrics.py::test_metrics_master_adminrouter_nginx_vts PASSED
test_metrics.py::test_metrics_master_exhibitor_status PASSED
test_metrics.py::test_metrics_master_adminrouter_nginx_drop_requests_seconds PASSED
test_metrics.py::test_metrics_agent_adminrouter_nginx_drop_requests_seconds XFAIL
test_metrics.py::test_metrics_master_adminrouter_nginx_vts_processor PASSED
test_metrics.py::test_metrics_agents_adminrouter_nginx_vts PASSED
test_metrics.py::test_metrics_agent_adminrouter_nginx_vts_processor XFAIL
test_metrics.py::test_metrics_diagnostics PASSED
test_metrics.py::test_metrics_fluentbit PASSED
test_metrics.py::test_metrics_agent_statsd PASSED
test_metrics.py::test_task_metrics_metadata PASSED
test_metrics.py::test_executor_metrics_metadata PASSED
test_metrics.py::test_metrics_node PASSED
test_metrics.py::test_metrics_containers PASSED
test_metrics.py::test_statsd_metrics_containers_app PASSED
test_metrics.py::test_prom_metrics_containers_app_host PASSED
test_metrics.py::test_prom_metrics_containers_app_bridge PASSED
test_metrics.py::test_task_prom_metrics_not_filtered PASSED
test_metrics.py::test_metrics_containers_nan PASSED
test_metrics.py::test_standalone_container_metrics XFAIL
test_metrics.py::test_pod_application_metrics PASSED
```


## Corresponding DC/OS tickets (required)

  - [D2IQ-64755](https://jira.d2iq.com/browse/D2IQ-64755)


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

Skip two test
* https://jira.d2iq.com/browse/D2IQ-65401
* https://jira.d2iq.com/browse/D2IQ-65403


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from one developer on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
Once a PR has **1 approval**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
