### PR TITLE
Run integration tests with TeamCity output.

### DIFF
--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -48,7 +48,7 @@ test: cluster.json
 		SLAVE_HOSTS=$(shell jq '.private_agent_ips.value' $<) \
 		PUBLIC_AGENTS_PRIVATE_IPS=$(shell jq '.public_agent_ips.value' $<) \
 		PUBLIC_SLAVE_HOSTS=$(shell jq '.public_agent_ips.value' $<) \
-		dcos-shell pytest --full-trace --log-level=DEBUG --windows-only"
+		dcos-shell pytest --teamcity --log-level=DEBUG --windows-only"
 
 .PHONY: ssh 
 ssh: cluster.json

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -11,6 +11,11 @@ export TF_VAR_custom_dcos_download_path ?= https://downloads.dcos.io/dcos/testin
 export TF_VAR_custom_dcos_download_path_win ?= https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh
 export TF_VAR_variant ?= open
 
+DCOS_USER_PASSWORD_ENV=""
+ifneq ($(TF_VAR_variant), open)
+DCOS_USER_PASSWORD_ENV="DCOS_LOGIN_UNAME='demo-super' DCOS_LOGIN_UNAME='deleteme'"
+endif
+
 SSH_KEY ?= ./tf-dcos-rsa.pem
 
 ifndef DCOS_LICENSE_CONTENTS 
@@ -48,7 +53,7 @@ test: cluster.json
 		SLAVE_HOSTS=$(shell jq '.private_agent_ips.value' $<) \
 		PUBLIC_AGENTS_PRIVATE_IPS=$(shell jq '.public_agent_ips.value' $<) \
 		PUBLIC_SLAVE_HOSTS=$(shell jq '.public_agent_ips.value' $<) \
-	        @if [ "$(TF_VAR_variant)" != "open" ]; then DCOS_LOGIN_UNAME="demo-super" DCOS_LOGIN_UNAME="deleteme"; fi; \
+		$(DCOS_USER_PASSWORD_ENV) \
 		dcos-shell pytest -vv --teamcity --log-level=DEBUG --windows-only"
 
 .PHONY: ssh 

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -11,9 +11,8 @@ export TF_VAR_custom_dcos_download_path ?= https://downloads.dcos.io/dcos/testin
 export TF_VAR_custom_dcos_download_path_win ?= https://downloads.dcos.io/dcos/testing/master/windows/dcos_generate_config_win.sh
 export TF_VAR_variant ?= open
 
-DCOS_USER_PASSWORD_ENV=""
 ifneq ($(TF_VAR_variant), open)
-DCOS_USER_PASSWORD_ENV="DCOS_LOGIN_UNAME='demo-super' DCOS_LOGIN_UNAME='deleteme'"
+	DCOS_USER_PASSWORD_ENV := DCOS_LOGIN_UNAME='demo-super' DCOS_LOGIN_UNAME='deleteme'
 endif
 
 SSH_KEY ?= ./tf-dcos-rsa.pem

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -30,16 +30,20 @@ license.txt:
 	@echo ${DCOS_LICENSE_CONTENTS} > $@
 
 .terraform: license.txt $(TERRAFORM) main.tf
+	@echo "##teamcity[blockOpened name='terraform-init' description='Terraform initialization']"
 	$(TERRAFORM) init -input=false --upgrade
+	@echo "##teamcity[blockClosed name='terraform-init']"
 
 $(SSH_KEY):
 	ssh-keygen -t rsa -b 2048 -f $@ -q -N ""
 
 cluster.json: $(SSH_KEY) .terraform
+	@echo "##teamcity[blockOpened name='terraform-apply' description='Terraform cluster creation']"
 	if [ -z "$$SSH_AUTH_SOCK" ]; then eval $$(ssh-agent -s); fi; \
 	ssh-add "$(SSH_KEY)"; \
 	$(TERRAFORM) apply -auto-approve -input=false -var ssh_public_key_file="$(SSH_KEY).pub" -var windowsagent_num=1
 	$(TERRAFORM) output -json > $@.work
+	@echo "##teamcity[blockClosed name='terraform-apply']"
 	mv $@.work $@
 
 .PHONY: test
@@ -62,8 +66,10 @@ ssh: cluster.json
 
 .PHONY: destroy
 destroy: cluster.json
+	@echo "##teamcity[blockOpened name='terraform-destroy' description='Terraform cluster teardown']"
 	$(TERRAFORM) destroy -auto-approve -var ssh_public_key_file="$(SSH_KEY).pub";
 	rm cluster.json || true;
+	@echo "##teamcity[blockClosed name='terraform-destroy']"
 
 .PHONY: clean
 clean:

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -12,7 +12,7 @@ export TF_VAR_custom_dcos_download_path_win ?= https://downloads.dcos.io/dcos/te
 export TF_VAR_variant ?= open
 
 ifneq ($(TF_VAR_variant), open)
-	DCOS_USER_PASSWORD_ENV := DCOS_LOGIN_UNAME='demo-super' DCOS_LOGIN_UNAME='deleteme'
+	DCOS_USER_PASSWORD_ENV := DCOS_LOGIN_UNAME='demo-super' DCOS_LOGIN_PW='deleteme'
 endif
 
 SSH_KEY ?= ./tf-dcos-rsa.pem

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -48,7 +48,7 @@ test: cluster.json
 		SLAVE_HOSTS=$(shell jq '.private_agent_ips.value' $<) \
 		PUBLIC_AGENTS_PRIVATE_IPS=$(shell jq '.public_agent_ips.value' $<) \
 		PUBLIC_SLAVE_HOSTS=$(shell jq '.public_agent_ips.value' $<) \
-		dcos-shell pytest --teamcity --log-level=DEBUG --windows-only"
+		dcos-shell pytest -v --teamcity --log-level=DEBUG --windows-only"
 
 .PHONY: ssh 
 ssh: cluster.json

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -48,6 +48,7 @@ test: cluster.json
 		SLAVE_HOSTS=$(shell jq '.private_agent_ips.value' $<) \
 		PUBLIC_AGENTS_PRIVATE_IPS=$(shell jq '.public_agent_ips.value' $<) \
 		PUBLIC_SLAVE_HOSTS=$(shell jq '.public_agent_ips.value' $<) \
+	        @if [ "$(TF_VAR_variant)" != "open" ]; then DCOS_LOGIN_UNAME="demo-super" DCOS_LOGIN_UNAME="deleteme"; fi; \
 		dcos-shell pytest -vv --teamcity --log-level=DEBUG --windows-only"
 
 .PHONY: ssh 

--- a/test_util/Makefile
+++ b/test_util/Makefile
@@ -48,7 +48,7 @@ test: cluster.json
 		SLAVE_HOSTS=$(shell jq '.private_agent_ips.value' $<) \
 		PUBLIC_AGENTS_PRIVATE_IPS=$(shell jq '.public_agent_ips.value' $<) \
 		PUBLIC_SLAVE_HOSTS=$(shell jq '.public_agent_ips.value' $<) \
-		dcos-shell pytest -v --teamcity --log-level=DEBUG --windows-only"
+		dcos-shell pytest -vv --teamcity --log-level=DEBUG --windows-only"
 
 .PHONY: ssh 
 ssh: cluster.json

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -184,7 +184,7 @@ output "masters_private_ip" {
 
 output "private_agent_ips" {
     description = "These are the IP addresses of all private agents"
-    value       = "${join(",", module.dcos.infrastructure.private_agents.private_ips)}"
+    value       = "${join(",", concat(module.windowsagent.private_ips, module.dcos.infrastructure.private_agents.private_ips))}"
 }
 
 output "public_agent_ips" {

--- a/test_util/main.tf
+++ b/test_util/main.tf
@@ -35,7 +35,7 @@ variable "windowsagent_num" {
 
 variable "ssh_public_key_file" {
   type = "string"
-  default = "./tf-dcos-rsa.pem.pub"
+  default = "~/.ssh/id_rsa.pub"
   description = "Defines the public key to log on the cluster."
 }
 


### PR DESCRIPTION
## High-level description

* Enable TemCity CI steps in `pytest` runs.
* Set `DCOS_LOGIN_UNAME` and `DCOS_LOGIN_PW` for enterprise tests.
* Create service messages for TeamCity.
* Concat Windows and Linux agent private IPs.

## Corresponding DC/OS tickets (required)

- [D2IQ-65651](https://jira.d2iq.com/browse/D2IQ-65651) 
- [D2IQ-65649](https://jira.d2iq.com/browse/D2IQ-65649)