### PR TITLE
Enable test_endpoints for Windows.

### DIFF
--- a/packages/dcos-integration-test/extra/test_endpoints.py
+++ b/packages/dcos-integration-test/extra/test_endpoints.py
@@ -39,7 +39,6 @@ def test_if_mesos_is_up(dcos_api_session):
 
 
 @pytest.mark.supportedwindows
-@pytest.mark.xfail("config.getoption('--windows-only')", strict=True, reason="D2IQ-64754")
 def test_if_all_mesos_slaves_have_registered(dcos_api_session):
     r = dcos_api_session.get('/mesos/master/slaves')
     assert r.status_code == 200


### PR DESCRIPTION
## High-level description

`test_endpoints.test_if_all_mesos_slaves_have_registered` passes as expected.
This we can remove the `xfail`.