### PR TITLE
Fix test_composition for Windows.

### DIFF
--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -191,7 +191,6 @@ def test_systemd_units_are_healthy(dcos_api_session) -> None:
         'WinRM',
         'adminrouter',
         'dcos-diagnostics',
-        'docker',
         'mesos-agent',
         'telegraf',
     }

--- a/packages/dcos-integration-test/extra/test_composition.py
+++ b/packages/dcos-integration-test/extra/test_composition.py
@@ -96,7 +96,7 @@ def test_if_all_exhibitors_are_in_sync(dcos_api_session):
 
 @pytest.mark.supportedwindows
 def test_mesos_agent_role_assignment(dcos_api_session):
-    state_endpoint = '/state.json'
+    state_endpoint = '/state'
     for agent in dcos_api_session.public_slaves:
         r = dcos_api_session.get(state_endpoint, host=agent, port=5051)
         assert r.json()['flags']['default_role'] == 'slave_public'


### PR DESCRIPTION
## High-level description

* `state.json` was removed from Mesos.
* `docker` is not part of the Windows units status.

## Corresponding DC/OS tickets (required)

  - [D2IQ-65706](https://jira.d2iq.com/browse/D2IQ-65706) Fix test_composition for Windows.