### PR TITLE
Fix `test_dcos_diagnotics` for Windows.

### DIFF
--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -582,7 +582,7 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
             unit_ids = [unit['id'] for unit in health_report['units']]
             if 'WinRM' in unit_ids:
                 unit_output = get_file_content(agent_folder + 'C:\\d2iq\\dcos\\var\\log\\mesos\\mesos-agent.log', z)
-                verify_unit_response(unit_output, 100)
+                verify_unit_response(unit_output, 20)
 
                 verify_archived_items(agent_folder, archived_items, expected_windows_agent_files)
             else:

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -579,8 +579,8 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
             assert health_report['ip'] == slave_ip
 
             # Decide if we have a Windows or Linux agent based on the health report.
-            assert 'units' in health_report
-            if 'WinRM' in health_report['units']:
+            unit_ids = [unit['id'] for unit in health_report['units']]
+            if 'WinRM' in unit_ids:
                 unit_output = get_file_content(agent_folder + 'C:\d2iq\dcos\var\log\mesos\mesos-agent.log', z)
                 verify_unit_response(unit_output, 100)
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -482,7 +482,7 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
         '5051-system_stats_json.json',
         '5051-flags.json',
         '5051-metrics_snapshot.json',
-        'dcos-diagnostics-health.json'
+        'dcos-diagnostics-health.json',
         'C:\\d2iq\\dcos\\var\log\\adminrouter\\adminrouter-nssm.log',
         'C:\\d2iq\\dcos\\var\log\\telegraf\\telegraf.log',
         'C:\\d2iq\\dcos\\var\log\dcos-diagnostics\\dcos-diagnostics.log',

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -270,7 +270,7 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
             dcos_api_session.health.get('/units/mesos-agent/nodes', node=master))
         windows_agent_nodes = get_nodes_from_response(windows_agent_nodes_response)
 
-        assert (agent_nodes + windows_agent_nodes) == dcos_api_session.slaves
+        assert set(agent_nodes + windows_agent_nodes) == set(dcos_api_session.slaves)
 
 
 def test_dcos_diagnostics_units_unit_nodes_node(dcos_api_session):

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -470,6 +470,26 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
         'binsh_-c_cat proc`systemctl show dcos-mesos-slave.service -p MainPID| cut -d\'=\' -f2`environ.output'
     ] + expected_agent_common_files + expected_common_files
 
+    # for Windows host
+    expected_windows_agent_files = [
+        '5051 - __processes__.json',
+        '5051 - state.json',
+        '5051 - containers.json',
+        '5051 - system_stats_json.json',
+        '5051 - flags.json',
+        '5051 - metrics_snapshot.json',
+        'dcos - diagnostics - health.json'
+        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-nssm.log',
+        'C:\d2iq\dcos\\var\log\\telegraf\\telegraf.log',
+        'C:\d2iq\dcos\\var\log\dcos-diagnostics\dcos-diagnostics.log',
+        'C:\d2iq\dcos\\var\log\winpanda\winpanda.log',
+        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-access.log' ,
+        'C:\d2iq\dcos\\var\log\dcos_install.log',
+        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-error.log',
+        'C:\d2iq\dcos\\var\log\mesos\mesos-agent.log'
+    ]
+
+
     # for public agent host
     expected_public_agent_files = [
         'dcos-mesos-slave-public.service',
@@ -561,7 +581,7 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
                 unit_output = get_file_content(agent_folder + 'C:\d2iq\dcos\var\log\mesos\mesos-agent.log', z)
                 verify_unit_response(unit_output, 100)
 
-                verify_archived_items(agent_folder, archived_items, expected_agent_files)
+                verify_archived_items(agent_folder, archived_items, expected_windows_agent_files)
             else:
                 # make sure systemd unit output is correct and does not contain error message
                 unit_output = get_file_content(agent_folder + 'dcos-mesos-slave.service', z)

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -476,21 +476,21 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
 
     # for Windows host
     expected_windows_agent_files = [
-        '5051 - __processes__.json',
-        '5051 - state.json',
-        '5051 - containers.json',
-        '5051 - system_stats_json.json',
-        '5051 - flags.json',
-        '5051 - metrics_snapshot.json',
-        'dcos - diagnostics - health.json'
-        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-nssm.log',
-        'C:\d2iq\dcos\\var\log\\telegraf\\telegraf.log',
-        'C:\d2iq\dcos\\var\log\dcos-diagnostics\dcos-diagnostics.log',
-        'C:\d2iq\dcos\\var\log\winpanda\winpanda.log',
-        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-access.log',
-        'C:\d2iq\dcos\\var\log\dcos_install.log',
-        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-error.log',
-        'C:\d2iq\dcos\\var\log\mesos\mesos-agent.log'
+        '5051-__processes__.json',
+        '5051-state.json',
+        '5051-containers.json',
+        '5051-system_stats_json.json',
+        '5051-flags.json',
+        '5051-metrics_snapshot.json',
+        'dcos-diagnostics-health.json'
+        'C:\\d2iq\\dcos\\var\log\\adminrouter\\adminrouter-nssm.log',
+        'C:\\d2iq\\dcos\\var\log\\telegraf\\telegraf.log',
+        'C:\\d2iq\\dcos\\var\log\dcos-diagnostics\\dcos-diagnostics.log',
+        'C:\\d2iq\\dcos\\var\\log\\winpanda\\winpanda.log',
+        'C:\\d2iq\\dcos\\var\\log\\adminrouter\\adminrouter-access.log',
+        'C:\\d2iq\\dcos\\var\\log\dcos_install.log',
+        'C:\\d2iq\\dcos\\var\\log\\adminrouter\\adminrouter-error.log',
+        'C:\\d2iq\\dcos\\var\\log\\mesos\\mesos-agent.log'
     ]
 
     # for public agent host

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -555,11 +555,19 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
             assert 'ip' in health_report
             assert health_report['ip'] == slave_ip
 
-            # make sure systemd unit output is correct and does not contain error message
-            unit_output = get_file_content(agent_folder + 'dcos-mesos-slave.service', z)
-            verify_unit_response(unit_output, 100)
+            # Decide if we have a Windows or Linux agent based on the health report.
+            assert 'units' in health_report
+            if 'WinRM' in health_report['units']:
+                unit_output = get_file_content(agent_folder + 'C:\d2iq\dcos\var\log\mesos\mesos-agent.log', z)
+                verify_unit_response(unit_output, 100)
 
-            verify_archived_items(agent_folder, archived_items, expected_agent_files)
+                verify_archived_items(agent_folder, archived_items, expected_agent_files)
+            else:
+                # make sure systemd unit output is correct and does not contain error message
+                unit_output = get_file_content(agent_folder + 'dcos-mesos-slave.service', z)
+                verify_unit_response(unit_output, 100)
+
+                verify_archived_items(agent_folder, archived_items, expected_agent_files)
 
         # make sure all required log files for public agent node are in place.
         for public_slave_ip in dcos_api_session.public_slaves:

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -266,9 +266,13 @@ def test_dcos_diagnostics_units_unit_nodes(dcos_api_session):
             dcos_api_session.health.get('/units/dcos-mesos-slave.service/nodes', node=master))
         agent_nodes = get_nodes_from_response(agent_nodes_response)
 
-        windows_agent_nodes_response = check_json(
-            dcos_api_session.health.get('/units/mesos-agent/nodes', node=master))
-        windows_agent_nodes = get_nodes_from_response(windows_agent_nodes_response)
+        # Fetch Windows nodes if we have some.
+        if 'WinRM' in pulled_units:
+            windows_agent_nodes_response = check_json(
+                dcos_api_session.health.get('/units/mesos-agent/nodes', node=master))
+            windows_agent_nodes = get_nodes_from_response(windows_agent_nodes_response)
+        else:
+            windows_agent_nodes = list()
 
         assert set(agent_nodes + windows_agent_nodes) == set(dcos_api_session.slaves)
 

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -483,12 +483,11 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
         'C:\d2iq\dcos\\var\log\\telegraf\\telegraf.log',
         'C:\d2iq\dcos\\var\log\dcos-diagnostics\dcos-diagnostics.log',
         'C:\d2iq\dcos\\var\log\winpanda\winpanda.log',
-        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-access.log' ,
+        'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-access.log',
         'C:\d2iq\dcos\\var\log\dcos_install.log',
         'C:\d2iq\dcos\\var\log\\adminrouter\\adminrouter-error.log',
         'C:\d2iq\dcos\\var\log\mesos\mesos-agent.log'
     ]
-
 
     # for public agent host
     expected_public_agent_files = [

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -581,7 +581,7 @@ def _download_bundle_from_master(dcos_api_session, master_index, bundle, diagnos
             # Decide if we have a Windows or Linux agent based on the health report.
             unit_ids = [unit['id'] for unit in health_report['units']]
             if 'WinRM' in unit_ids:
-                unit_output = get_file_content(agent_folder + 'C:\d2iq\dcos\var\log\mesos\mesos-agent.log', z)
+                unit_output = get_file_content(agent_folder + 'C:\\d2iq\\dcos\\var\\log\\mesos\\mesos-agent.log', z)
                 verify_unit_response(unit_output, 100)
 
                 verify_archived_items(agent_folder, archived_items, expected_windows_agent_files)


### PR DESCRIPTION
## High-level description

The Mesos service unit has a different name on Windows so we query that one as well.
The expected files of the diagnostics bundle are different as well.

## Corresponding DC/OS tickets (required)

  - [D2IQ-65707](https://jira.d2iq.com/browse/D2IQ-65707)
