### PR TITLE
2.0: Metronome bump to 0.6.41

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update OpenSSL to 1.1.1d. (D2IQ-65604)
 
+* Update Metronome to 0.6.41
+
+    * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+
 ## DC/OS 2.0.2 (2020-01-17)
 
 * Updated DC/OS UI to [master+v2.154.16](https://github.com/dcos/dcos-ui/releases/tag/master+v2.154.16).
@@ -173,3 +177,4 @@ The Marathon option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES` has been deprecat
 * Fix preflight docker version check failing for docker 1.19. (DCOS-56831)
 
 * DC/OS Net: wait till agents become active before fanning out Mesos tasks. (DCOS_OSS-5463)
+* Update OpenSSL to 1.1.1d. (D2IQ-65604)

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["java", "exhibitor"],
+  "requires": [
+    "java",
+    "exhibitor"
+  ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.33-b28106a/metronome-0.6.33-b28106a.tgz",
-    "sha1": "9359a5a5e0ff0e123f4e460beb5c5f7c9e30f806"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.41-a4d46e8/metronome-0.6.41-a4d46e8.tgz",
+    "sha1": "4fc9132224fc0be639dff1903ce4f8eee9340180"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.41

## Corresponding DC/OS tickets (required)

  - [MARATHON-8730](https://jira.mesosphere.com/browse/MARATHON-8730)
  - [MARATHON-8709](https://jira.mesosphere.com/browse/MARATHON-8709)

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [b28106a..a4d46e8](https://github.com/dcos/metronome/compare/b28106a...a4d46e8)
