### PR TITLE
2.0: Bump Marathon to 1.9.136

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,19 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update OpenSSL to 1.1.1d. (D2IQ-65604)
 
+* Marathon updated to 1.9.136
+
+    * /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
+
+    * Marathon launched too many tasks. (DCOS_OSS-5679)
+
+    * Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
+
+    * With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
+      instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
+
+    * Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
+
 ## DC/OS 2.0.2 (2020-01-17)
 
 * Updated DC/OS UI to [master+v2.154.16](https://github.com/dcos/dcos-ui/releases/tag/master+v2.154.16).

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.124-e04033c6f/marathon-1.9.124-e04033c6f.tgz",
-    "sha1": "5b8933377a6b34b2dee2d692b0b9dc7eb33cd62d"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.136-c0e59f4ca/marathon-1.9.136-c0e59f4ca.tgz",
+    "sha1": "ec826e2923b857c34361edeff59747a4a180dfff"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.9.136

## Corresponding DC/OS tickets (required)


JIRA Issues:

  -  [MARATHON-8731](https://jira.mesosphere.com/browse/MARATHON-8731) - Marathon checks validation for unrelated apps when performing a kill operations
  - [MARATHON-8716](https://jira.mesosphere.com/browse/MARATHON-8716) - Too many instances of deploying application killed after leader re-election
  - [MARATHON-8721](https://jira.mesosphere.com/browse/MARATHON-8721) - /v2/tasks plaintext output in Marathon 1.5 and later returns container network endpoints in an unusable way

## Related tickets (optional)

  - [MARATHON-8725](https://jira.mesosphere.com/browse/MARATHON-8725)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [e04033c6f..c0e59f4ca](https://github.com/mesosphere/marathon/compare/e04033c6f...c0e59f4ca)
