### PR TITLE
Backup and restore etcd

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1922,6 +1922,10 @@ package:
               },
               {
                   "Command": ["df"]
+              },
+              {
+                  "Command": ["/opt/mesosphere/bin/dcos-shell", "dcos-etcdctl", "diagnostic"],
+                  "Role": ["master"]
               }
           ]
         }

--- a/packages/etcd/README.md
+++ b/packages/etcd/README.md
@@ -1,0 +1,55 @@
+## etcd backup and restore
+
+This section describes the process of backing up and restoring the state of etcd running inside a DC/OS cluster.
+
+The etcd cluster is possible to recover from temporary failures and tolerates up to (N-1)/2 permanent failures for a cluster with N members. Howerever, the following scenarios, the operator is recommended to backup and restore etcd data:
+- to recover from a disastrous failure to return a cluster to a healthy state
+- to perform maintenance operations, such as an upgrade or downgrade
+
+As only etcd v3 keys require to be stored persistently in DC/OS, only v3 keys are backed up through snapshot and restored in the following process.
+
+## Backing up an etcd cluster
+
+etcd cluster achieves reliable distributed coordination and hence key/value data consistency among all etcd instances, etcd instances on all masters are capable of providing all the key/value data in the current state. As we expose the etcd instance from the Mesos leader node outside to the internal and external clients, it's reasonable to backup the etcd data on the leader node of the DC/OS cluster.
+
+#### Prerequisites
+
+- Make sure there is enough disk space available to temporarily store the etcd backup on a particular master node.
+- Any shell commands must be issued as a privileged Linux user.
+
+1. log into the leader node and backup etcd via the following provided script.
+
+`/opt/mesosphere/bin/dcos-shell dcos-etcdctl backup <backup-tar-archive-path>`
+
+2. Download the created etcd backup tar archive from this leader node to a safe location outside of the DC/OS cluster.
+
+3. Remove the etcd backup tar archive from the leader node.
+
+## Restoring an etcd cluster 
+
+The operator is supposed to execute all the following steps on all master nodes.
+
+1. Copy the previously created single etcd backup tar archive to every master node’s file system.
+
+2. Stop the etcd instances on all master nodes via the systemd unit.
+
+`systemctl stop dcos-etcd`
+
+3. Initiate the restore procedure via the provided DC/OS etcd restore script.
+
+`/opt/mesosphere/bin/dcos-shell dcos-etcdctl restore <backup-tar-archive-path>`
+
+4. Start the previously stopped etcd instances.
+
+`systemctl start dcos-etcd`
+
+5. Check the etcd cluster status.
+
+Until now, the etcd cluster is expected to be recovered from the backup file.
+
+`/opt/mesosphere/bin/dcos-shell dcos-etcdctl diagnostic`
+
+The above command typically presents the results of etcdctl command [`endpoint health`](https://github.com/etcd-io/etcd/tree/master/etcdctl#endpoint-health) and [`member list -w json`](https://github.com/etcd-io/etcd/tree/master/etcdctl#member-list) for now, and a healthy etcd cluster should meet the following requirement given the output of the above commands on all master nodes:
+
+- `endpoint health` checks the healthiness of on the current etcd instance, which should meet `healthy` 
+- `member list -w json` returns the cluster members, which should return all etcd instances

--- a/packages/etcd/README.md
+++ b/packages/etcd/README.md
@@ -2,11 +2,13 @@
 
 This section describes the process of backing up and restoring the state of etcd running inside a DC/OS cluster.
 
-The etcd cluster is possible to recover from temporary failures and tolerates up to (N-1)/2 permanent failures for a cluster with N members. Howerever, the following scenarios, the operator is recommended to backup and restore etcd data:
+The etcd cluster is possible to recover from temporary failures and tolerates up to (N-1)/2 permanent failures for a cluster with N members. However, the following scenarios, the operator is recommended to backup and restore etcd data:
 - to recover from a disastrous failure to return a cluster to a healthy state
 - to perform maintenance operations, such as an upgrade or downgrade
 
 As only etcd v3 keys require to be stored persistently in DC/OS, only v3 keys are backed up through snapshot and restored in the following process.
+
+NOTE: As etcd relies on ZooKeeper in DC/OS, the operator MUST maintain etcd while ZooKeepr functions normally.
 
 ## Backing up an etcd cluster
 

--- a/packages/etcd/build
+++ b/packages/etcd/build
@@ -15,6 +15,8 @@ install -m 755 /pkg/extra/etcd_discovery/etcd_discovery.py $PKG_PATH/bin/
 # Copy the launch script to the package bin directory.
 install -m 755 /pkg/extra/systemd/etcd.sh $PKG_PATH/bin/etcd.sh
 
+install -m 755 /pkg/extra/etcdctl/dcos_etcdctl.py $PKG_PATH/bin/dcos-etcdctl
+
 # Auto-start the dcos-etcd service on the masters.
 mkdir -p "$PKG_PATH/dcos.target.wants_master"
 cp /pkg/extra/systemd/dcos-etcd.service "$PKG_PATH/dcos.target.wants_master/dcos-etcd.service"

--- a/packages/etcd/extra/etcdctl/dcos_etcdctl.py
+++ b/packages/etcd/extra/etcdctl/dcos_etcdctl.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from argparse import ArgumentTypeError
+from pathlib import Path
+
+import requests
+
+
+ETCD_DATA_DIR = "/var/lib/dcos/etcd/default.etcd"
+
+
+def run_command(cmd: str,
+                verbose: bool = False,
+                env: dict={}) -> subprocess.CompletedProcess:
+    """ Run a command in a subprocess.
+
+    Args:
+        verbose: Show the output.
+
+    Raises:
+        subprocess.CalledProcessError: The given cmd exits with a non-0 exit
+                                       code.
+    """
+    stdout = None if verbose else subprocess.PIPE
+    stderr = None if verbose else subprocess.STDOUT
+    p = subprocess.run(
+        args=shlex.split(cmd),
+        stdout=stdout,
+        stderr=stderr,
+        encoding='utf-8',
+        check=True,
+        env=env,
+    )
+    return p
+
+
+def detect_ip():
+    cmd = '/opt/mesosphere/bin/detect_ip'
+    ret = run_command(cmd)
+    machine_ip = ret.stdout.strip()
+    return machine_ip
+
+
+def non_existing_file_path_existing_parent_dir(value: str) -> Path:
+    """Validate a path does not exist but its parent directory tree exists."""
+    path = Path(value)
+    if path.exists():
+        raise ArgumentTypeError('{} already exists'.format(path))
+    if not Path(path.parent).exists():
+        raise ArgumentTypeError(
+            '{} parent directory does not exist'.format(path))
+    return path.absolute()
+
+
+def existing_file_path(value: str) -> Path:
+    """Validate that the value is a file existing on the file system."""
+    path = Path(value)
+    if not path.exists():
+        raise argparse.ArgumentTypeError('{} does not exist'.format(path))
+    if not path.is_file():
+        raise argparse.ArgumentTypeError('{} is not a file'.format(path))
+    return path.absolute()
+
+
+class EtcdExecutorCommon():
+
+    def __init__(self):
+        self.etcdctl_path = "/opt/mesosphere/bin/etcdctl"
+        self.private_ip = detect_ip()
+        self.master_ip = "master.dcos.thisdcos.directory"
+
+    def log_cmd_result(self, cmd: str, p: subprocess.CompletedProcess) -> None:
+        def _sanitize_output(output):
+            if output is None:
+                return output
+            return output.strip()
+
+        print(
+            "cmd `{}`, exit status: `{}`, stdout: `{}`, stderr: `{}`\n".format(
+                cmd, p.returncode, _sanitize_output(p.stdout),
+                _sanitize_output(p.stderr)))
+
+    def get_endpoint(self, scheme, user_master_endpoint) -> str:
+        endpoint_ip = self.private_ip
+        if user_master_endpoint:
+            endpoint_ip = self.master_ip
+        endpoint = "{}://{}:2379".format(self.scheme, endpoint_ip)
+        return endpoint
+
+
+class EtcdExecutorSecure(EtcdExecutorCommon):
+
+    def __init__(self) -> None:
+        super(EtcdExecutorSecure, self).__init__()
+        self.ca_cert_file = "/run/dcos/pki/CA/ca-bundle.crt"
+        self.cert_file = "/run/dcos/pki/tls/certs/etcd-client-root.crt"
+        self.key_file = "/run/dcos/pki/tls/private/etcd-client-root.key"
+        self.scheme = "https"
+
+    def execute(
+            self,
+            args: str,
+            user_master_endpoint: bool=True,
+            use_v3: bool = False,
+    ) -> subprocess.CompletedProcess:
+        cmd = self.etcdctl_path
+        endpoint = self.get_endpoint(self.scheme, user_master_endpoint)
+        cmd = "{} --endpoints={}".format(cmd, endpoint)
+        cmd = "{} --cacert={} --cert={} --key={}".format(
+            cmd, self.ca_cert_file, self.cert_file, self.key_file)
+        cmd = "{} {}".format(cmd, args)
+        env = {} if not use_v3 else {"ETCDCTL_API": "3"}
+        result = run_command(cmd, env=env)
+
+        self.log_cmd_result(args, result)
+
+        return result
+
+
+class EtcdExecutorInsecure(EtcdExecutorCommon):
+    def __init__(self) -> None:
+        super(EtcdExecutorInsecure, self).__init__()
+        self.scheme = "http"
+
+    def execute(
+            self,
+            args: str,
+            user_master_endpoint: bool=True,
+            use_v3: bool = False,
+    ) -> subprocess.CompletedProcess:
+        cmd = self.etcdctl_path
+        endpoint = self.get_endpoint(self.scheme, user_master_endpoint)
+        cmd = "{} --endpoints={}".format(cmd, endpoint)
+        cmd = "{} {}".format(cmd, args)
+        env = {} if not use_v3 else {"ETCDCTL_API": "3"}
+        result = run_command(cmd, env=env)
+        self.log_cmd_result(args, result)
+
+        return result
+
+
+class EtcdCmdBase():
+
+    def __init__(self) -> None:
+        self.executor = EtcdExecutorInsecure()
+        if self.is_dcos_ee():
+            self.executor = EtcdExecutorSecure()
+
+    def is_dcos_ee(self) -> bool:
+        # This is the expanded DC/OS configuration JSON document w/o sensitive
+        # values. Read it, parse it.
+        dcos_cfg_path = '/opt/mesosphere/etc/expanded.config.json'
+        with open(dcos_cfg_path, 'rb') as f:
+            dcos_config = json.loads(f.read().decode('utf-8'))
+        dcos_variant = dcos_config.get("dcos_variant")
+        return True if dcos_variant == "enterprise" else False
+
+    def execute_etcdctl(
+            self,
+            args: str,
+            user_master_endpoint: bool=True,
+            use_v3: bool = False,
+    ) -> subprocess.CompletedProcess:
+        return self.executor.execute(args, user_master_endpoint, use_v3)
+
+
+class EtcdBackupAndRestore(EtcdCmdBase):
+    """backup and restore V3 key data of etcd."""
+
+    SNAPSHOT_NAME = "etcd_snapshot.db"
+
+    def __init__(self) -> None:
+        super(EtcdBackupAndRestore, self).__init__()
+        self.supported_cmd = ["backup", "restore"]
+        self.scheme = "https" if self.is_dcos_ee() else "http"
+
+    def backup(self) -> None:
+        parser = argparse.ArgumentParser(
+            usage='{} backup [-h] backup_path'.format(sys.argv[0]),
+            description='Create a backup of the etcd instance running on this '
+                        'DC/OS master node.')
+        parser.add_argument(
+            'backup_path',
+            type=non_existing_file_path_existing_parent_dir,
+            help='File path that the gzipped etcd backup tar archive '
+                 'will be written to',
+        )
+        args = parser.parse_args(sys.argv[2:])
+        print("Backing up etcd into {}".format(args.backup_path))
+        with tempfile.TemporaryDirectory(suffix="-back-etcd") as tmp_dir:
+            snapshot_file = os.path.join(tmp_dir, self.SNAPSHOT_NAME)
+            self.execute_etcdctl("snapshot save {}".format(snapshot_file))
+            with tarfile.open(name=args.backup_path, mode='x:gz') as tar:
+                tar.add(name=snapshot_file, arcname=self.SNAPSHOT_NAME)
+        print("etcd snaptshot is archieved under {}".format(args.backup_path))
+
+    def restore(self) -> None:
+        """ restore etcd cluster from backup file
+
+        all etcd cluster members are required to be restored through the backup
+        snapshot, that means etcd restore command should be executed on all
+        masters.
+
+        a command example of restoring a etcd node:
+        ETCDCTL_API=3 etcdctl snapshot restore snapshot.db \
+          --name m1 \
+          --data-dir= /path/to/store_data \
+          --initial-cluster m1=http://host1:2380,m2=http://host2:2380,m3=http://host3:2380 \
+          --initial-cluster-token etcd-dcos \
+          --initial-advertise-peer-urls http://host1:2380
+
+        reference: https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/recovery.md # NOQA
+        """
+
+        def _get_master_ips():
+            """ returns IP addresses of master nodes """
+            master_ip_url = "http://127.0.0.1:8123/v1/hosts/master.mesos"
+            resp = requests.get(master_ip_url, timeout=10)
+            if resp.status_code != 200:
+                resp.raise_for_status()
+
+            host_ip_list = resp.json()
+            master_ips = [host_ip["ip"] for host_ip in host_ip_list]
+            return master_ips
+
+        parser = argparse.ArgumentParser(
+            description='restore etcd cluster from an archieved file')
+        parser.add_argument(
+            'backup_path',
+            type=existing_file_path,
+            help='File path to the gzipped ZooKeeper backup tar archive to '
+                 'restore from.',
+        )
+        args = parser.parse_args(sys.argv[2:])
+
+        # remove the data directory if exists
+        try:
+            shutil.rmtree(ETCD_DATA_DIR)
+            print("The original data path {} is removed".format(ETCD_DATA_DIR))
+        except FileNotFoundError:
+            pass
+
+        # Restoring will overwrite some snapshot metadata, like member ID and
+        # cluster ID, to form a new cluster from the snapshot.
+        # Here we initialize a standalone cluster, and new members will be
+        # added to a cluster during dcos-etcd starting up by `join_cluster`
+        # in `etcd_discovery.py`
+        with tempfile.TemporaryDirectory(suffix="-restore-etcd") as tmp_dir:
+            with tarfile.open(name=str(args.backup_path), mode='r:gz') as tar:
+                tar.extractall(path=tmp_dir)
+                snatshot_db_path = os.path.join(tmp_dir, self.SNAPSHOT_NAME)
+                # the items in initial-advertise-peer-urls must be included in
+                # initial-cluster items
+                private_ip = detect_ip()
+                master_ips = _get_master_ips()
+                initial_cluster_items = [
+                    "etcd-{}={}://{}:2380".format(
+                        master_ip, self.scheme, master_ip)
+                    for master_ip in master_ips]
+                initial_cluster = ",".join(initial_cluster_items)
+                advertise_peer_urls = "{}://{}:2380".format(
+                    self.scheme, private_ip)
+                restore_cmd = (
+                    "snapshot restore {} "
+                    "--name etcd-{} "
+                    "--data-dir {} "
+                    "--initial-cluster {} "
+                    "--initial-advertise-peer-urls {} "
+                    "--initial-cluster-token etcd-dcos".format(
+                        snatshot_db_path,
+                        private_ip,
+                        ETCD_DATA_DIR,
+                        initial_cluster,
+                        advertise_peer_urls,
+                    ))
+                self.execute_etcdctl(restore_cmd)
+
+                chown_cmd = "/usr/bin/chown -R dcos_etcd:dcos_etcd {}".format(
+                    ETCD_DATA_DIR)
+                run_command(chown_cmd)
+
+        print('Local etcd instance restored successfully')
+
+
+class EtcdDiagnostic(EtcdCmdBase):
+    """Returns the status of etcd cluster and local node
+
+    Diagnostic command prints health status of both the current instance and
+    the cluster-wide with local instance as the endpoint.
+    This command is recommended to be executed on every node running etcd in
+    the quorum.
+    """
+
+    def __init__(self) -> None:
+        super(EtcdDiagnostic, self).__init__()
+        self.supported_cmd = ["diagnostic"]
+        self.check_cmd_list = self.check_commands()
+
+    @classmethod
+    def check_commands(cls) -> None:
+        # check the status of the current etcd instance
+        endpoint_check_cmd = "endpoint health"
+        # local endpoint is used for returning the etcd members, this is useful
+        # to detect the split-brain of a cluster
+        member_list_cmd = "member list -w json"
+
+        return [endpoint_check_cmd, member_list_cmd]
+
+    def diagnostic(self) -> None:
+        for cmd in self.check_cmd_list:
+            self.execute_etcdctl(cmd, user_master_endpoint=False)
+
+
+class DCOSEtcdCli():
+
+    def __init__(self) -> None:
+        self.cmd_func_map = {}
+
+    def register_cmd(self, cmd_object: EtcdCmdBase):
+        for supported_cmd in cmd_object.supported_cmd:
+            self.cmd_func_map[supported_cmd] = getattr(cmd_object,
+                                                       supported_cmd)
+
+    def execute(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            'command',
+            type=str,
+            choices=self.cmd_func_map.keys(),
+            help='CLI commands available',
+        )
+        args = parser.parse_args(sys.argv[1:2])
+        self.cmd_func_map[args.command]()
+
+
+if __name__ == '__main__':
+    try:
+        etcd_cli = DCOSEtcdCli()
+        etcd_cli.register_cmd(EtcdBackupAndRestore())
+        etcd_cli.register_cmd(EtcdDiagnostic())
+        etcd_cli.execute()
+    except subprocess.CalledProcessError as exc:
+        if exc.output:
+            sys.stdout.buffer.write(str.encode(exc.output))
+        sys.exit(exc.returncode)

--- a/packages/exhibitor/extra/dcos_zk_backup.py
+++ b/packages/exhibitor/extra/dcos_zk_backup.py
@@ -377,5 +377,5 @@ if __name__ == '__main__':
         DCOSZooKeeperCli()
     except subprocess.CalledProcessError as exc:
         if exc.output:
-            sys.stdout.buffer.write(exc.output)
+            sys.stdout.buffer.write(str.encode(exc.output))
         sys.exit(exc.returncode)

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -111,15 +111,7 @@ def get_etcdctl_with_base_args(
 )-> List[str]:
     """Returns args including etcd endpoint and certificates if necessary."""
     args = [ETCDCTL_PATH]
-    if is_dcos_ee():
-        args += ["--endpoints=https://{}:2379".format(endpoint_ip)]
-        args += [
-            "--cert=/run/dcos/pki/tls/certs/etcd-client-{}.crt".format(cert_type),
-            "--key=/run/dcos/pki/tls/private/etcd-client-{}.key".format(cert_type),
-            "--cacert={}".format(cert_type),
-        ]
-    else:
-        args += ["--endpoints=http://{}".format(endpoint_ip)]
+    args += ["--endpoints=http://{}:2379".format(endpoint_ip)]
 
     return args
 

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -4,6 +4,7 @@ Tests for the etcd backup/restore via `dcos-etcdctl`.
 import logging
 import uuid
 from pathlib import Path
+from shlex import split
 from typing import Generator, List, Set
 
 import pytest
@@ -110,12 +111,15 @@ def _do_restore(all_masters: Set[Node], backup_local_path: Path) -> None:
             output=Output.LOG_AND_CAPTURE,
         )
 
+    # etcd instances are required to start up simultaneously to meet the
+    # requirement of peer communication when starting up
     for master in all_masters:
-        master.run(args=["systemctl", "start", "dcos-etcd"])
+        cmd_in_background = "nohup systemctl start dcos-etcd >/dev/null 2>&1 &"
+        master.run(args=split(cmd_in_background), shell=True)
 
 
 class EtcdClient():
-    """Communicates with etcd through CLI on master nodes."""
+    """Communicates with etcd thsrough CLI on master nodes."""
 
     def __init__(self, all_masters: Set[Node]) -> None:
         self.masters = all_masters

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -183,13 +183,13 @@ class TestEtcdBackup:
         # Restore etcd from backup on all master nodes.
         _do_restore(three_master_cluster.masters, backup_local_path)
 
-        # assert all etcd containers
-        for master in three_master_cluster.masters:
-            assert etcd_client.get_key_from_node(test_key, master) == test_val
-
         # Assert DC/OS is intact.
         wait_for_dcos_oss(
             cluster=three_master_cluster,
             request=request,
             log_dir=log_dir,
         )
+
+        # assert all etcd containers
+        for master in three_master_cluster.masters:
+            assert etcd_client.get_key_from_node(test_key, master) == test_val

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -1,0 +1,207 @@
+"""
+Tests for the Etcd backup/restore via `dcos-etcdctl`.
+"""
+
+import logging
+import subprocess
+import uuid
+from pathlib import Path
+from typing import List, Set
+
+import pytest
+from _pytest.fixtures import SubRequest
+
+from cluster_helpers import wait_for_dcos_oss
+from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Node, Output
+from dcos_test_utils.etcd import is_enterprise
+
+
+LOGGER = logging.getLogger(__name__)
+
+LOCAL_ETCD_ENDPOINT = "127.0.0.1:2379"
+
+
+@pytest.fixture
+def three_master_cluster(
+    artifact_path: Path,
+    docker_backend: Docker,
+    request: SubRequest,
+    log_dir: Path,
+) -> Cluster:
+    """Spin up a highly-available DC/OS cluster with three master nodes."""
+    with Cluster(
+        cluster_backend=docker_backend,
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=cluster.base_config,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        yield cluster
+
+
+def _do_backup(master: Node, backup_local_path: Path) -> None:
+
+    backup_name = backup_local_path.name
+    # This must be an existing directory on the remote server.
+    backup_remote_path = Path('/etc/') / backup_name
+    master.run(
+        args=[
+            '/opt/mesosphere/bin/dcos-shell',
+            'dcos-etcdctl',
+            get_etcd_base_args(),
+            'backup',
+            str(backup_remote_path),
+        ],
+        output=Output.LOG_AND_CAPTURE,
+    )
+
+    master.run(args=['systemctl', 'stop', 'dcos-etcd'])
+
+    master.download_file(
+        remote_path=backup_remote_path,
+        local_path=backup_local_path,
+    )
+
+    master.run(args=['rm', str(backup_remote_path)])
+
+
+def _do_restore(all_masters: Set[Node], backup_local_path: Path) -> None:
+    backup_name = backup_local_path.name
+    backup_remote_path = Path('/etc/') / backup_name
+
+    for master in all_masters:
+        master.send_file(
+            local_path=backup_local_path,
+            remote_path=backup_remote_path,
+        )
+
+    for master in all_masters:
+        master.run(
+            args=[
+                '/opt/mesosphere/bin/dcos-shell',
+                'dcos-etcdctl',
+                get_etcd_base_args(),
+                'restore', str(backup_remote_path),
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+    for master in all_masters:
+        master.run(args=['systemctl', 'start', 'dcos-etcd'])
+
+
+def get_etcd_base_args(
+    self,
+    cert_type: str="root",
+    endpoint: str=LOCAL_ETCD_ENDPOINT,
+)-> List[str]:
+    """Returns args including etcd endpoint and certificates if necessary"""
+    args = []
+    if is_enterprise():
+        args += ["--endpoints=https://{}".format(endpoint)]
+        args += [
+            "--cert=/run/dcos/pki/tls/certs/etcd-client-{}.crt".format(cert_type),
+            "--key=/run/dcos/pki/tls/private/etcd-client-{}.key".format(cert_type),
+            "--cacert={}".format(cert_type),
+        ]
+    else:
+        args += ["--endpoints=http://{}".format(endpoint)]
+
+    return args
+
+
+class EtcdClient():
+    """Interacts etcd through CLI on master nodes."""
+    def __init__(self, all_masters: Set[Node]) -> None:
+        self.masters = all_masters
+
+    def put(self, key: str, value: str) -> None:
+        """assigns the value to the key.
+
+        etcd is not exposed outside of the DC/OS cluster,so we have to execute
+        etcdctl inside the DC/OS cluster, on a master in our case.
+        `master.dcos.thisdcos.directory:2379` is the endpoint that etcd
+        cluster is exposed, hence we use this endpoint to set a value to a key
+        """
+        master = self.masters[0]
+        master.run(
+            args=[
+                '/opt/mesosphere/bin/dcos-shell',
+                'etcdctl',
+                get_etcd_base_args(endpoint="master.dcos.thisdcos.directory:2379"),
+                'put',
+                key,
+                value,
+            ],
+        )
+
+    def get_key_from_node(
+            self,
+            key: str,
+            master_node: Node,
+    ) -> subprocess.CompletedProcess:
+        """gets the value of the key on given master node"""
+        result = master_node.run(
+            args=[
+                '/opt/mesosphere/bin/dcos-shell',
+                'etcdctl',
+                get_etcd_base_args("{}:2379".format(master_node.private_ip_address)),
+                'get',
+                key,
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )
+        value = result.stdout.strip().decode()
+        return value
+
+
+@pytest.fixture()
+def etcd_client(three_master_cluster: Cluster):
+    etcd_client = EtcdClient(three_master_cluster)
+    return etcd_client
+
+
+class TestEtcdBackup:
+    def test_snapshot_backup_and_restore(
+        self,
+        three_master_cluster: Cluster,
+        etcd_client: EtcdClient,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+
+        test_key, test_val = "foo", "bar"
+        etcd_client.put(test_key, test_val)
+
+        random = uuid.uuid4().hex
+        backup_name = 'etcd-backup-{random}.tar.gz'.format(random=random)
+        backup_local_path = tmp_path / backup_name
+
+        # Take Etcd backup from one master node.
+        _do_backup(next(iter(three_master_cluster.masters)), backup_local_path)
+
+        # Restore ZooKeeper from backup on all master nodes.
+        _do_restore(three_master_cluster.masters, backup_local_path)
+
+        # assert all etcd containers
+        for master in three_master_cluster.masters:
+            assert etcd_client.get(test_key, master) == test_val
+
+        # Assert DC/OS is intact.
+        wait_for_dcos_oss(
+            cluster=three_master_cluster,
+            request=request,
+            log_dir=log_dir,
+        )

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -58,3 +58,4 @@ groups:
         - test_zookeeper_backup.py
         - test_calico_networking.py
         - test_adminrouter_grpc.py
+        - test_etcd_backup.py

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -52,10 +52,11 @@
 # fail.
 groups:
     group_1:
+        - test_etcd_backup.py
         - test_service_account.py
         - test_master_node_replacement.py
         - test_windows.py
         - test_zookeeper_backup.py
         - test_calico_networking.py
         - test_adminrouter_grpc.py
-        - test_etcd_backup.py
+


### PR DESCRIPTION
## High-level description

_This PR rebases https://github.com/dcos/dcos/pull/6957_

This PR introduces a utility `dcos-etcdctl` on `/opt/mesosphere` that can be used to import/export the etcd state.

## Corresponding DC/OS tickets (required)

  - [D2IQ-66110](https://jira.d2iq.com/browse/D2IQ-66110) https://jira.d2iq.com/browse/D2IQ-66110.


## Related tickets (optional)

  - [D2IQ-58912](https://jira.d2iq.com/browse/D2IQ-58912) include etcd in backup and diagnostic bundles.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from one developer on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
Once a PR has **1 approval**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
