### PR TITLE
Enable Windows App tests.

### DIFF
--- a/packages/dcos-integration-test/extra/test_mesos.py
+++ b/packages/dcos-integration-test/extra/test_mesos.py
@@ -352,10 +352,6 @@ def test_fault_domain(dcos_api_session):
         assert 'domain' in agent, 'missing domain field for agent. {}'.format(agent)
         agent_region, agent_zone = get_region_zone(agent['domain'])
 
-        # This can be removed after https://jira.d2iq.com/browse/D2IQ-65811 is resolved
-        if agent_region.startswith('windows-'):
-            agent_region = agent_region[len('windows-'):]
-
         assert agent_region == expected_region, 'expect region {}. Got {}'.format(expected_region, agent_region)
 
         # agent_zone might be different on agents, so we just make sure it's a sane value

--- a/packages/dcos-integration-test/extra/test_windows.py
+++ b/packages/dcos-integration-test/extra/test_windows.py
@@ -11,7 +11,6 @@ __contact__ = 'orchestration-team@mesosphere.io'
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail("config.getoption('--windows-only')", reason="D2IQ-66235: Mesos is not sending offers")
 def deploy_test_app_and_check_windows(dcos_api_session, app: dict, test_uuid: str):
     """This method deploys the python test server container and then checks
     if the container is up and can accept connections.


### PR DESCRIPTION
## High-level description

The Windows app test should pass because the `windows-` fault domains have been
removed.


## Corresponding DC/OS tickets (required)

  - [D2IQ-66235](https://jira.d2iq.com/browse/D2IQ-66235)
  - [D2IQ-65808](https://jira.d2iq.com/browse/D2IQ-65808)