### PR TITLE
Set dcos-diagnostics hostname.

### DIFF
--- a/packages/dcos-diagnostics/extra/dcos-diagnostics.nssm.j2
+++ b/packages/dcos-diagnostics/extra/dcos-diagnostics.nssm.j2
@@ -3,7 +3,7 @@ DisplayName = dcos-diagnostics
 Description = DC/OS Diagnostics Windows Agent: exposes component health
 Application = {{ pkg_inst_dpath }}\bin\dcos-diagnostics.exe
 AppDirectory = {{ pkg_inst_dpath }}\bin
-AppParameters = --config {{ dcos_cfg_dpath }}\dcos-diagnostics\dcos-diagnostics-config.json --role=agent daemon
+AppParameters = --config {{ dcos_cfg_dpath }}\dcos-diagnostics\dcos-diagnostics-config.json --role=agent daemon --hostname {{ local_priv_ipaddr }}
 Start = SERVICE_AUTO_START
 AppStdout = {{ pkg_log_dpath }}\dcos-diagnostics.log
 AppStderr = {{ pkg_log_dpath }}\dcos-diagnostics.log

--- a/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
+++ b/packages/dcos-integration-test/extra/test_dcos_diagnostics.py
@@ -321,7 +321,7 @@ def test_dcos_diagnostics_report(dcos_api_session):
 
 
 @pytest.mark.parametrize('use_legacy_api', [
-    pytest.param(False, marks=pytest.mark.xfail("config.getoption('--windows-only')"), reason="D2IQ-65964"),
+    pytest.param(False),
     pytest.param(True, marks=pytest.mark.xfail("config.getoption('--windows-only')"))])
 def test_dcos_diagnostics_bundle_create_download_delete(dcos_api_session, use_legacy_api):
     """


### PR DESCRIPTION
## High-level description

The hostname for dcos-diagnostics should be the IP address of the host.

## Corresponding DC/OS tickets (required)

  - [D2IQ-65964](https://jira.d2iq.com/browse/D2IQ-65964)