### PR TITLE
[master] Bump Mesos to nightly master beaf0cd

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
-* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/12e5e870c38681bfc0455960f89a41127dac3daf/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/beaf0cd844f3658bfccb86049f7181036b0e6ae4/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/packages/mesos-modules/windows.buildinfo.json
+++ b/packages/mesos-modules/windows.buildinfo.json
@@ -8,13 +8,13 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "54227a33b68d83b97ef1a7c14283351d45322317",
+      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
       "ref_origin": "master"
     },
     "mesos-modules": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules",
-      "ref": "6231ccf068c247064d1915298070d84885678351",
+      "ref": "4ba1e573ec4a80ec1d5514d54d5cc9529e5e1d98",
       "ref_origin": "master"
     }
   },

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,13 +10,13 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "12e5e870c38681bfc0455960f89a41127dac3daf",
+      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
       "ref_origin": "master"
     },
     "mesos-modules": {
       "kind": "git",
       "git": "https://github.com/dcos/dcos-mesos-modules.git",
-      "ref": "6231ccf068c247064d1915298070d84885678351",
+      "ref": "4ba1e573ec4a80ec1d5514d54d5cc9529e5e1d98",
       "ref_origin": "master"
     }
   },

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -3,7 +3,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "12e5e870c38681bfc0455960f89a41127dac3daf",
+      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
       "ref_origin": "master"
     },
     "openssl": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/12e5e870c38681bfc0455960f89a41127dac3daf...beaf0cd844f3658bfccb86049f7181036b0e6ae4
    https://github.com/dcos/dcos-mesos-modules/compare/6231ccf068c247064d1915298070d84885678351...4ba1e573ec4a80ec1d5514d54d5cc9529e5e1d98
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
