### PR TITLE
Note an important breaking change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update OpenResty to 1.15.8.2. (DCOS-61159)
 
+### Marathon
+
+* Marathon no longer sanitizes the field `"acceptedResourceRoles"`. The field is an array of one or two values: `*` and the service role. Previously, when an invalid value was provided, Marathon would silently drop it. Now, it returns an error. If this causes a disruption, you can re-enable this feature by adding `MARATHON_DEPRECATED_FEATURES=sanitize_accepted_resource_roles` to the file `/var/lib/dcos/marathon/environment` on all masters. You must remove this line before upgrading to DC/OS 2.2.
+
 ### Fixed and improved
 
 * Reserve all agent VTEP IPs upon recovering from replicated log. (DCOS_OSS-5626)


### PR DESCRIPTION
Marathon 1.9 deprecated the specification of invalid acceptedResourceRoles. In Marathon 1.10, we're turning it off by default. We should make this clear to users that are upgrading.