### PR TITLE
Bump marathon with flake fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,7 +52,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Calico network: When using the Universal Runtime Engine, the contents of the `DCOS_SPACE`  network label will be compressed to `<7-char hash>...<last 53 chars>` if it is longer than 63 characters. (D2IQ-62219)
 
-#### Update Marathon to 1.10.5
+#### Update Marathon to 1.10.6
 
 * Adds support for Mesos Resource Limits (D2IQ-61131) (D2IQ-61130)
 * Removes `revive_offers_for_new_apps` option.
@@ -89,18 +89,23 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update OpenSSL to 1.1.1d. (D2IQ-65604)
 
+#### Update Marathon to 1.10.6
+
 * Marathon updated to 1.9.136
 
-    * /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
+* /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
 
-    * Marathon launched too many tasks. (DCOS_OSS-5679)
+* Marathon launched too many tasks. (DCOS_OSS-5679)
 
-    * Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
+* Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
 
-    * With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
-      instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
+* With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
+instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
 
-    * Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
-* Update Metronome to 0.6.41
+* Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
 
-    * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+* A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
+
+#### Update Metronome to 0.6.41
+
+* There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.5-6f2a6aec4/marathon-1.10.5-6f2a6aec4.tgz",
-    "sha1": "bb8bdc4583e2841d291a2f0d44bbccdba28a1b11"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.6-4303d3859/marathon-1.10.6-4303d3859.tgz",
+    "sha1": "f29d66d7fc702a34f07a53f8cff55e4b7e02e9f6"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.10.6, fixing a critical issue that would cause Marathon to sometimes fail to start.


## Corresponding DC/OS tickets (required)

  - [MARATHON-8741](https://jira.d2iq.com/browse/MARATHON-8741) LaunchQueueActor receives command to load instances before leader election occurs

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [6f2a6aec4..4303d3859](https://github.com/mesosphere/marathon/compare/6f2a6aec4...4303d3859)