### PR TITLE
Enable Telegraf test on Windows.

### DIFF
--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -91,7 +91,6 @@ def test_metrics_procstat(dcos_api_session):
 
 
 @pytest.mark.supportedwindows
-@pytest.mark.xfail("config.getoption('--windows-only')", reason="D2IQ-66230: Telegraf cannot authorize with Mesos")
 def test_metrics_agents_mesos(dcos_api_session):
     """Assert that mesos metrics on agents are present."""
     nodes = get_agents(dcos_api_session)


### PR DESCRIPTION
## High-level description

* Fixing Strict mode on Windows so that telegraph can authenticate with Mesos.


## Corresponding DC/OS tickets (required)

  - [D2IQ-66230](https://jira.d2iq.com/browse/D2IQ-66230) Telegraf cannot auth with Mesos