### PR TITLE
Bump Metronome to 0.6.42

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,10 +113,5 @@ instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` cons
 #### Update Metronome to 0.6.41
 
 * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
-    * Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
 
-* Update Metronome to 0.6.42
-
-    * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
-
-    * Metronome jobs can configure networks they join (MARATHON-8727)
+* Metronome jobs networking is now configurable (MARATHON-8727)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,3 +113,10 @@ instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` cons
 #### Update Metronome to 0.6.41
 
 * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+    * Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
+
+* Update Metronome to 0.6.42
+
+    * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+
+    * Metronome jobs can configure networks they join (MARATHON-8727)

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.41-a4d46e8/metronome-0.6.41-a4d46e8.tgz",
-    "sha1": "4fc9132224fc0be639dff1903ce4f8eee9340180"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.42-b46cd62/metronome-0.6.42-b46cd62.tgz",
+    "sha1": "4873200d416141f34a56703c7267982c8d6ddeaa"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.42; add networking support to Metronome.

## Corresponding DC/OS tickets (required)

  - [MARATHON-8727](https://jira.mesosphere.com/browse/MARATHON-8727)

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [a4d46e8..b46cd62](https://github.com/dcos/metronome/compare/a4d46e8...b46cd62)

