### PR TITLE
[master] Bump Mesos to nightly master e6b15b1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
-* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/beaf0cd844f3658bfccb86049f7181036b0e6ae4/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/e6b15b1e968649c794d67bb97961e8f0216e2ed8/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/packages/mesos-modules/windows.buildinfo.json
+++ b/packages/mesos-modules/windows.buildinfo.json
@@ -8,7 +8,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
+      "ref": "e6b15b1e968649c794d67bb97961e8f0216e2ed8",
       "ref_origin": "master"
     },
     "mesos-modules": {

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,7 +10,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
+      "ref": "e6b15b1e968649c794d67bb97961e8f0216e2ed8",
       "ref_origin": "master"
     },
     "mesos-modules": {

--- a/packages/mesos/windows.buildinfo.json
+++ b/packages/mesos/windows.buildinfo.json
@@ -3,7 +3,7 @@
     "mesos": {
       "kind": "git",
       "git": "https://github.com/apache/mesos",
-      "ref": "beaf0cd844f3658bfccb86049f7181036b0e6ae4",
+      "ref": "e6b15b1e968649c794d67bb97961e8f0216e2ed8",
       "ref_origin": "master"
     },
     "openssl": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/beaf0cd844f3658bfccb86049f7181036b0e6ae4...e6b15b1e968649c794d67bb97961e8f0216e2ed8
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
