### PR TITLE
1.13: Bump Marathon to 1.8.242

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* Marathon updated to 1.8.242
+
+    * Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
+
 ### Security updates
 
 * Update to OpenSSL 1.0.2u. (D2IQ-66526)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.239-a6095a83d/marathon-1.8.239-a6095a83d.tgz",
-    "sha1": "0ef14c134b08e4ad891206ee0e4c5e5a3a4e47c0"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.242-ee9086220/marathon-1.8.242-ee9086220.tgz",
+    "sha1": "c0b40df19b9fd8af1accafbba0409bbe5703cced"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.8.242

## Corresponding DC/OS tickets (required)

  - Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved.  [MARATHON-8741](https://jira.mesosphere.com/browse/MARATHON-8741)

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [a6095a83d..ee9086220](https://github.com/mesosphere/marathon/compare/a6095a83d...ee9086220)
