### PR TITLE
Eliminated 15-minutes hang after completing mesos/mesos-modules cmake.

### DIFF
--- a/packages/mesos-modules/windows.build.ps1
+++ b/packages/mesos-modules/windows.build.ps1
@@ -1,3 +1,5 @@
+Set-PSDebug -Trace 1
+
 $ErrorActionPreference = "stop"
 
 $PKG_DIR = "c:\pkg"

--- a/packages/mesos-modules/windows.build.ps1
+++ b/packages/mesos-modules/windows.build.ps1
@@ -72,8 +72,13 @@ function Build-Mesos-Modules {
                 "-DBUILD_TESTING=OFF"
             ) `
             -NoNewWindow `
-            -Wait `
             -PassThru
+
+        # `Start-Process -Wait` is prone to hanging when waiting for cmake.
+	# (The particular mechanism of this is not yet known - see D2IQ-67087.)
+        # Instead, we use `Wait-Process` here and below.
+        Wait-Process -InputObject $p
+
         if ($p.ExitCode -ne 0) {
             Throw "[mesos-modules] cmake failed to generate config"
         }
@@ -87,8 +92,10 @@ function Build-Mesos-Modules {
                 "--", "-m"
             ) `
             -NoNewWindow `
-            -Wait `
             -PassThru
+
+        Wait-Process -InputObject $p
+
         if ($p.ExitCode -ne 0) {
             Throw "[mesos-modules] build failed"
         }

--- a/packages/mesos/windows.build.ps1
+++ b/packages/mesos/windows.build.ps1
@@ -1,3 +1,5 @@
+Set-PSDebug -Trace 1
+
 $ErrorActionPreference = "stop"
 
 $PKG_DIR = "c:\pkg"

--- a/packages/mesos/windows.build.ps1
+++ b/packages/mesos/windows.build.ps1
@@ -47,8 +47,13 @@ function Build-Mesos {
                 "-DBUILD_TESTING=OFF"
             ) `
             -NoNewWindow `
-            -Wait `
             -PassThru
+
+        # `Start-Process -Wait` is prone to hanging when waiting for cmake.
+	# (The particular mechanism of this is not yet known - see D2IQ-67087.)
+        # Instead, we use `Wait-Process` here and below.
+        Wait-Process -InputObject $p
+
         if ($p.ExitCode -ne 0) {
             Throw "cmake failed to generate config"
         }
@@ -63,8 +68,10 @@ function Build-Mesos {
                 "--", "-m"
             ) `
             -NoNewWindow `
-            -Wait `
             -PassThru
+
+        Wait-Process -InputObject $p
+
         if ($p.ExitCode -ne 0) {
             Throw "build failed"
         }


### PR DESCRIPTION
This speeds up mesos and mesos-modules Windows build scripts by 15 minutes each.

## Corresponding DC/OS tickets (required)

  - [D2IQ-67207](https://jira.d2iq.com/browse/D2IQ-67207) Windows builds of Mesos and mesos-modules on DCOS OSS hang for 15 munutes after cmake exit.

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from one developer on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
Once a PR has **1 approval**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
