### PR TITLE
D2IQ-67029: Guarding against exceptions while in ZK lock

### DIFF
--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -95,10 +95,12 @@ def zk_cluster_lock(zk: KazooClient, name: str, timeout: int = 30) -> Generator:
         raise e
     else:
         print("ZooKeeper lock acquired.")
-    yield
-    print("Releasing ZooKeeper lock")
-    lock.release()
-    print("ZooKeeper lock released.")
+    try:
+        yield
+    finally:
+        print("Releasing ZooKeeper lock")
+        lock.release()
+        print("ZooKeeper lock released.")
 
 
 def zk_flag_set(zk: KazooClient, name: str, value: str):


### PR DESCRIPTION
## High-level description

Fixes a condition where the ZK lock remains acquired. This can be catastrophic since it might block the regular boot sequence of the agents, requiring a manual intervention on removal of the lock from zookeeper. 

## Corresponding DC/OS tickets (required)

  - [D2IQ-67029](https://jira.d2iq.com/browse/D2IQ-67029) Revise the way the dcos-calico-libnetwork-plugin.service acquires cluster-wide lock.


## Related tickets (optional)

_None_

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from one developer on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
Once a PR has **1 approval**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
