### PR TITLE
Removed unrelated changelog entries from changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,26 +95,3 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Adjust dcos-net (l4lb) to allow for graceful shutdown of connections by changing the VIP backend weight to `0`
   when tasks are unhealthy or enter the `TASK_KILLING` state instead of removing them. (D2IQ-61077)
-
-#### Update Marathon to 1.10.6
-
-* Marathon updated to 1.9.136
-
-* /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
-
-* Marathon launched too many tasks. (DCOS_OSS-5679)
-
-* Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
-
-* With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
-instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
-
-* Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
-
-* A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
-
-#### Update Metronome to 0.6.41
-
-* There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
-
-* Metronome jobs networking is now configurable (MARATHON-8727)


### PR DESCRIPTION
Marathon and Metronome changes were listed that were released in 2.0.0; they don't need to be mentioned for 2.1.0 because they are not new changes.
