### PR TITLE
Bump Marathon to 1.10.17

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos/dcos/wiki/CHANGES.md-guidelines). Thank you!
 
 
-## DC/OS 2.1.0-beta2 (in development)
+## DC/OS 2.1.0-beta4 (in development)
 
 
 ### What's new
@@ -52,7 +52,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update logrotate to 3.14.0 (DCOS_OSS-5947)
 
-#### Update Marathon to 1.10.6
+#### Update Marathon to 1.10.17
 
 * Adds support for Mesos Resource Limits (D2IQ-61131) (D2IQ-61130)
 * Removes `revive_offers_for_new_apps` option.
@@ -96,26 +96,3 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Adjust dcos-net (l4lb) to allow for graceful shutdown of connections by changing the VIP backend weight to `0`
   when tasks are unhealthy or enter the `TASK_KILLING` state instead of removing them. (D2IQ-61077)
 * Set "os:linux" attribute for the Linux agents. (D2IQ-67223)
-
-#### Update Marathon to 1.10.6
-
-* Marathon updated to 1.9.136
-
-* /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
-
-* Marathon launched too many tasks. (DCOS_OSS-5679)
-
-* Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
-
-* With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
-instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
-
-* Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
-
-* A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
-
-#### Update Metronome to 0.6.41
-
-* There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
-
-* Metronome jobs networking is now configurable (MARATHON-8727)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,10 +52,30 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Update logrotate to 3.14.0 (DCOS_OSS-5947)
 
-#### Update Marathon to 1.10.17
+#### Update Marathon to [1.10.17](https://github.com/mesosphere/marathon/blob/v1.10.17/changelog.md)
 
 * Adds support for Mesos Resource Limits (D2IQ-61131) (D2IQ-61130)
+
 * Removes `revive_offers_for_new_apps` option.
+
+* /v2/tasks plaintext output in Marathon 1.5 returned container network endpoints in an unusable way (MARATHON-8721)
+
+* Marathon launched too many tasks. (DCOS_OSS-5679)
+
+* Marathon used to omit pod status report with tasks in `TASK_UNKOWN` state. (MARATHON-8710)
+
+* With UnreachableStrategy, setting `expungeAfterSeconds` and `inactiveAfterSeconds` to the same value will cause the
+instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` constraints. (MARATHON-8719)
+
+* Marathon was checking authorization for unrelated apps when performing a kill-and-scale operations; this has been resolved. (MARATHON-8731)
+
+* A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
+
+#### Update Metronome to [0.6.42](https://github.com/dcos/metronome/blob/4e1eac1c4d6c97296332f9664ba4269a15336ed8/changelog.md)
+
+* There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+
+* Metronome jobs networking is now configurable (MARATHON-8727)
 
 ### Breaking changes
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.6-4303d3859/marathon-1.10.6-4303d3859.tgz",
-    "sha1": "f29d66d7fc702a34f07a53f8cff55e4b7e02e9f6"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.17-c427ce965/marathon-1.10.17-c427ce965.tgz",
+    "sha1": "9e6113f95ee786ee6ee3633b72fff6c4b9708a8e"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.10.17; fix important bug where apps are not restart in response to resourceLimits. 


## Corresponding DC/OS tickets (required)

JIRA Issues:
  - [MARATHON-8744](https://jira.mesosphere.com/browse/MARATHON-8744) - Restart tasks when updating only resourceLimits
  - [D2IQ-67033](https://jira.mesosphere.com/browse/D2IQ-67033) - Show error message when string other than "undefined" passed to resourceLimits, rather than 500 error
  - [MARATHON-8743](https://jira.mesosphere.com/browse/MARATHON-8743) - improve logic for restarting healthCheckActor if the update stream closes.

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [4303d3859..c427ce965](https://github.com/mesosphere/marathon/compare/4303d3859...c427ce965)