### PR TITLE
Bump Metronome to 0.6.44

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos/dcos/wiki/CHANGES.md-guidelines). Thank you!
 
 
-## DC/OS 2.1.0-beta2 (in development)
+## DC/OS 2.1.0-beta4 (in development)
 
 
 ### What's new
@@ -114,8 +114,10 @@ instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` cons
 
 * A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
 
-#### Update Metronome to 0.6.41
+#### Update Metronome to 0.6.44
 
 * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
 
 * Metronome jobs networking is now configurable (MARATHON-8727)
+
+* A bug was fixed in which Metronome failed to see jobs from a prior version of Metronome (MARATHON-8746)

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.42-b46cd62/metronome-0.6.42-b46cd62.tgz",
-    "sha1": "4873200d416141f34a56703c7267982c8d6ddeaa"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.44-f89f00d/metronome-0.6.44-f89f00d.tgz",
+    "sha1": "be86404db870a6b4deca34cfc53716ad881c768a"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.44

## Corresponding DC/OS tickets (required)

  - [MARATHON-8746](https://jira.mesosphere.com/browse/MARATHON-8746) - A bug was fixed in which Metronome failed to see jobs from a prior version of Metronome 

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [b46cd62..f89f00d](https://github.com/dcos/metronome/compare/b46cd62...f89f00d)