### PR TITLE
Bump Metronome to 0.6.44

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,19 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated DC/OS UI to [v4.0.1](https://github.com/dcos/dcos-ui/releases/tag/v4.0.1).
 
+* Update Metronome to 0.6.44
+
+    * Metronome jobs can be configured to join container networks (MARATHON-8727)
+
 ### Fixed and improved
 
 * Update OpenResty to 1.15.8.3. (D2IQ-66506)
 
 * Update to OpenSSL 1.1.1g. (D2IQ-67050)
+
+* Update Metronome to 0.6.44
+
+    * A bug was introduced in Metronome for DC/OS 2.0.3 in which jobs created in previous versions of DC/OS were not seen. This has been fixed, and jobs created before 2.0.3 are visible once again. (MARATHON-8746)
 
 ## DC/OS 2.0.3 (2020-03-25)
 

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.41-a4d46e8/metronome-0.6.41-a4d46e8.tgz",
-    "sha1": "4fc9132224fc0be639dff1903ce4f8eee9340180"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.44-f89f00d/metronome-0.6.44-f89f00d.tgz",
+    "sha1": "be86404db870a6b4deca34cfc53716ad881c768a"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - A bug was introduced in Metronome for DC/OS 2.0.3 in which jobs created in previous versions of DC/OS were not seen. This has been fixed, and jobs created before 2.0.3 are visible once again.  [MARATHON-8746](https://jira.mesosphere.com/browse/MARATHON-8746)
  - Metronome jobs can be configured to join container networks - [MARATHON-8727](https://jira.mesosphere.com/browse/MARATHON-8727)

## Related tickets (optional)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Change log from the last version integrated (this should be a link to commits for easy verification and review): [a4d46e8..f89f00d](https://github.com/dcos/metronome/compare/a4d46e8...f89f00d)
