### PR TITLE
Bumped mesos to 1.10.x d4afcd10b6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
 
-* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/8682b5ddf8b773beffe8bf0428c9350d6ae59412/CHANGELOG)
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/d4afcd10b6535d91c5a6a544aed2f09af6201b46/CHANGELOG)
 
 * Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,8 +9,8 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "8682b5ddf8b773beffe8bf0428c9350d6ae59412",
-    "ref_origin": "master"
+    "ref": "d4afcd10b6535d91c5a6a544aed2f09af6201b46",
+    "ref_origin": "1.10.x"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description

This changes ref_origin in `mesos` pachake to 1.10.x  Mesos branch and bumps Mesos.


## Corresponding DC/OS tickets (required)

  - [D2IQ-68266](https://jira.d2iq.com/browse/D2IQ-68266) Make DCOS 2.1 branch use corresponding branches of mesos/modules.