### PR TITLE
calico: bump version to v3.14.0

### DIFF
--- a/packages/calico/build
+++ b/packages/calico/build
@@ -2,7 +2,7 @@
 set -x
 
 # calico container is missing 'envsubst'
-apt-get update && apt-get install -y gettext-base curl
+microdnf install -y gettext tar
 
 # create a go build environment
 curl https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz | tar -zvx -C /usr/local

--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -1,20 +1,20 @@
 {
-  "docker": "calico/node:v3.8.2",
+  "docker": "calico/node:v3.14.0",
   "sources": {
     "calico": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.8.2/calico-amd64",
-      "sha1": "80de69b9cc68f0193b0d18e45fcdfa19c7a71fa9"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-amd64",
+      "sha1": "1579ebf178f72292a1bc8fab0d74a88ab0921084"
     },
     "calico-ipam": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.8.2/calico-ipam-amd64",
-      "sha1": "544d9414d1f8ed6d1c5dd2526d27275cf63ec5f7"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-ipam-amd64",
+      "sha1": "7eeaf366c30c279c4688a220083cb5f123616042"
     },
     "calicoctl": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.8.2/calicoctl-linux-amd64",
-      "sha1": "a14d747d270eecc53b8a877f7869ae3c52104de5"
+      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.14.0/calicoctl-linux-amd64",
+      "sha1": "8734244e7549354d19617975413f143e36bf48bb"
     },
     "calico-libnetwork-plugin": {
       "kind": "url",

--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -18,8 +18,8 @@
     },
     "calico-libnetwork-plugin": {
       "kind": "url",
-      "url": "https://github.com/mesosphere/libnetwork-plugin/releases/download/v1.1.3-1-d2iq/libnetwork-plugin-amd64",
-      "sha1": "f363d1d1fdacefac8d91fb4336495e5b5020920f"
+      "url": "https://github.com/mesosphere/libnetwork-plugin/releases/download/v1.1.3-2-d2iq/libnetwork-plugin-amd64",
+      "sha1": "2db71bf79ac47e7eba2a59ed81440b47defb29ce"
     }
   }
 }


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [COPS-6121](https://jira.d2iq.com/browse//COPS-6121) Beta4: Calico networking not working with Docker
  - [D2IQ-65076](https://jira.d2iq.com/browse/D2IQ-65076) Bump calico to the latest version before releasing dc/os containing it