### PR TITLE
Removed `os:linux` agent attribute.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1378,7 +1378,6 @@ package:
       MESOS_RECONFIGURATION_POLICY=additive
       MESOS_RECOVERY_TIMEOUT={{ mesos_recovery_timeout }}
       MESOS_SECCOMP_CONFIG_DIR=/opt/mesosphere/etc/dcos/mesos/seccomp
-      MESOS_ATTRIBUTES=os:linux
 {% switch has_mesos_seccomp_profile_name %}
 {% case "true" %}
       MESOS_SECCOMP_PROFILE_NAME={{ mesos_seccomp_profile_name }}


### PR DESCRIPTION
## High-level description

This is a part of the windows cleanup that reverts adding 'os:linux` attribute to agents.

## Corresponding DC/OS tickets (required)

  - [D2IQ-68446](https://jira.d2iq.com/browse/D2IQ-68446) Remove the os:linux attribute from mesos agents.