### PR TITLE
Use latest Exhibitor master

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -1,10 +1,10 @@
 {
-  "requires": ["java", "python-requests"],
+  "requires": ["java"],
   "sources": {
     "exhibitor": {
       "kind": "git",
       "git": "https://github.com/dcos/exhibitor.git",
-      "ref": "4965c0c9e3e2150dd5bd5af44d55204bb605a5ba",
+      "ref": "6b0d5d951196e383d0852068ad565fc4da56631a",
       "ref_origin": "master"
     },
     "zookeeper": {


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This was intended to be the PR that fixed an Exhibitor problem, but it now synchronizes DC/OS `master` with the current Exhibitor `master` so that we're starting with latest versions of both.

Remove `python-requests` dependency, as the code that used it no longer exists in the package: https://github.com/dcos/dcos/commit/c3012f9f331fe06ff1ab038293d4cad2212354f2

## Corresponding DC/OS tickets (required)


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-68109](https://jira.d2iq.com/browse/D2IQ-68109) COPS-6111: Regression: Exhibitor writing JNA files to /tmp again