### PR TITLE
add cache-header for dcos-version.json

### DIFF
--- a/packages/adminrouter/extra/src/includes/server/common.conf
+++ b/packages/adminrouter/extra/src/includes/server/common.conf
@@ -23,4 +23,7 @@ location /nginx/metrics {
 location /dcos-metadata/dcos-version.json {
     # Allow non-authed access for the UI.
     alias /opt/mesosphere/active/dcos-metadata/etc/dcos-version.json;
+    # Indicate that dcos-version.json must not be cached.
+    # E.g. to have the UI report the correct version after a SOAK-update.
+    add_header Cache-Control no-cache;
 }


### PR DESCRIPTION
as during a SOAK update the UI did not consistently report the correct
version of the cluster, we now let the UI know, that it must always
revalidate `dcos-version.json`.
