### PR TITLE
Ic/fix etcd init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
-
 * Storing etcd initial state on `/var/lib/dcos` instead of `/run/dcos` [COPS-6183](https://jira.d2iq.com/browse/COPS-6183)
 * Updated DC/OS UI to [v5.0.41](https://github.com/dcos/dcos-ui/releases/tag/v5.0.41).
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
-* * Updated DC/OS UI to [v5.0.41](https://github.com/dcos/dcos-ui/releases/tag/v5.0.41).
 
 * Storing etcd initial state on `/var/lib/dcos` instead of `/run/dcos` [COPS-6183](https://jira.d2iq.com/browse/COPS-6183)
 * Updated DC/OS UI to [v5.0.41](https://github.com/dcos/dcos-ui/releases/tag/v5.0.41).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,3 +12,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### Fixed and improved
 
 * * Updated DC/OS UI to [v5.0.41](https://github.com/dcos/dcos-ui/releases/tag/v5.0.41).
+
+* Storing etcd initial state on `/var/lib/dcos` instead of `/run/dcos` [COPS-6183](https://jira.d2iq.com/browse/COPS-6183)

--- a/packages/adminrouter/extra/src/includes/server/common.conf
+++ b/packages/adminrouter/extra/src/includes/server/common.conf
@@ -23,4 +23,7 @@ location /nginx/metrics {
 location /dcos-metadata/dcos-version.json {
     # Allow non-authed access for the UI.
     alias /opt/mesosphere/active/dcos-metadata/etc/dcos-version.json;
+    # Indicate that dcos-version.json must not be cached.
+    # E.g. to have the UI report the correct version after a SOAK-update.
+    add_header Cache-Control no-cache;
 }

--- a/packages/etcd/extra/etcd_discovery/etcd_discovery.py
+++ b/packages/etcd/extra/etcd_discovery/etcd_discovery.py
@@ -316,12 +316,12 @@ def parse_cmdline() -> argparse.Namespace:
     parser_joincluster.add_argument(
         '--cluster-nodes-file',
         action='store',
-        default='/var/lib/dcos/etcd/dcos/etcd/initial-nodes',
+        default='/var/lib/dcos/etcd/initial-nodes',
         help='file where initial cluster nodes should be saved')
     parser_joincluster.add_argument(
         '--cluster-state-file',
         action='store',
-        default='/var/lib/dcos/etcd/dcos/etcd/initial-state',
+        default='/var/lib/dcos/etcd/initial-state',
         help='file where initial cluster state should be saved')
     parser_joincluster.add_argument('--etcd-data-dir',
                                     action='store',
@@ -390,10 +390,10 @@ def join_cluster(args: argparse.Namespace) -> None:
     # Check if etcd is up and running already. If so - we can skip quering ZK,
     # as etcd is able to get the list of peers directly from the shared
     # storage.
-    if os.path.isdir(args.etcd_data_dir):
+    if os.path.isdir(args.etcd_data_dir) and os.path.exists(args.cluster_nodes_file):
         log.info(
-            "directory `%s` already exists, etcd seems to be already initialized",
-            args.etcd_data_dir)
+            "directory `%s` and initial nodes file `%s` already exists, etcd seems to be already initialized",
+            args.etcd_data_dir, args.cluster_nodes_file)
         return
 
     # Determine our internal IP.

--- a/packages/etcd/extra/etcd_discovery/etcd_discovery.py
+++ b/packages/etcd/extra/etcd_discovery/etcd_discovery.py
@@ -316,12 +316,12 @@ def parse_cmdline() -> argparse.Namespace:
     parser_joincluster.add_argument(
         '--cluster-nodes-file',
         action='store',
-        default='/run/dcos/etcd/initial-nodes',
+        default='/var/lib/dcos/etcd/dcos/etcd/initial-nodes',
         help='file where initial cluster nodes should be saved')
     parser_joincluster.add_argument(
         '--cluster-state-file',
         action='store',
-        default='/run/dcos/etcd/initial-state',
+        default='/var/lib/dcos/etcd/dcos/etcd/initial-state',
         help='file where initial cluster state should be saved')
     parser_joincluster.add_argument('--etcd-data-dir',
                                     action='store',

--- a/packages/etcd/extra/etcdctl/dcos_etcdctl.py
+++ b/packages/etcd/extra/etcdctl/dcos_etcdctl.py
@@ -16,8 +16,8 @@ import requests
 
 
 ETCD_DATA_DIR = "/var/lib/dcos/etcd/default.etcd"
-CLUSTER_NODES_PATH = "/run/dcos/etcd/initial-nodes"
-CLUSTER_STATE_PATH = "/run/dcos/etcd/initial-state"
+CLUSTER_NODES_PATH = "/var/lib/dcos/etcd/initial-nodes"
+CLUSTER_STATE_PATH = "/var/lib/dcos/etcd/initial-state"
 
 
 def run_command(cmd: str,

--- a/packages/etcd/extra/systemd/dcos-etcd.service
+++ b/packages/etcd/extra/systemd/dcos-etcd.service
@@ -23,7 +23,7 @@ ExecStartPre=/bin/chown -R dcos_etcd /run/dcos/etcd/
 ExecStartPre=/opt/mesosphere/active/etcd/bin/etcd_discovery.py \
     --zk-addr 127.0.0.1:2181 \
     join-cluster \
-        --cluster-nodes-file /run/dcos/etcd/initial-nodes \
-        --cluster-state-file /run/dcos/etcd/initial-state \
+        --cluster-nodes-file /var/lib/dcos/etcd/initial-nodes \
+        --cluster-state-file /var/lib/dcos/etcd/initial-state \
         --etcd-data-dir /var/lib/dcos/etcd/default.etcd/
 ExecStart=/opt/mesosphere/active/etcd/bin/etcd.sh

--- a/packages/etcd/extra/systemd/etcd.sh
+++ b/packages/etcd/extra/systemd/etcd.sh
@@ -3,8 +3,8 @@
 set -xe
 
 IP_PRIVATE=`/opt/mesosphere/bin/detect_ip`
-CLUSTER_NODES=`cat /run/dcos/etcd/initial-nodes`
-CLUSTER_STATE=`cat /run/dcos/etcd/initial-state`
+CLUSTER_NODES=`cat /var/lib/dcos/etcd/initial-nodes`
+CLUSTER_STATE=`cat /var/lib/dcos/etcd/initial-state`
 
 GOMAXPROCS=$(nproc)
 


### PR DESCRIPTION
## High-level description

This commit ensures that etcd initial state file is persisted across cluster reboots. 


## Corresponding DC/OS tickets (required)

  - [COPS-6183](https://jira.d2iq.com/browse/COPS-6183) 2.1 beta - etcd cluster fails and cannot restart if you reboot a master node

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
