### PR TITLE
[2.1] Remove `os:linux` attribute from public agents

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1438,7 +1438,7 @@ package:
     content: |
       MESOS_RESOURCES=[{"name":"ports","type":"RANGES","ranges": {"range": [{"begin": 1, "end": 21},{"begin": 23, "end": 5050},{"begin": 5052, "end": 32000}]}}]
       MESOS_DEFAULT_ROLE=slave_public
-      MESOS_ATTRIBUTES=public_ip:true;os:linux
+      MESOS_ATTRIBUTES=public_ip:true
   - path: /etc/mesos-executor-environment.json
     content: |
       {


### PR DESCRIPTION
## High-level description

Back-port of #7322 to 2.1

The `os:linux` attribute should not be visible on DC/OS agents. Private agents have had this removed, but public agents still have it.


## Corresponding DC/OS tickets (required)

  - [D2IQ-69018](https://jira.d2iq.com/browse/D2IQ-69018) os:linux attribute still exposed on public agents


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-68446](https://jira.d2iq.com/browse/D2IQ-68446) Remove the os:linux attribute from mesos agents
