### PR TITLE
Ic/fix etcd upgrade

### DIFF
--- a/packages/etcd/extra/etcd_discovery/etcd_discovery.py
+++ b/packages/etcd/extra/etcd_discovery/etcd_discovery.py
@@ -515,7 +515,9 @@ def join_cluster(args: argparse.Namespace) -> None:
             contender_id=LOCK_CONTENDER_ID,
             timeout=ZK_LOCK_TIMEOUT,
     ):
-        nodes = get_registered_nodes(zk=zk, zk_path=ZK_NODES_PATH)
+        nodes = get_registered_nodes(zk=zk,
+                                     zk_path=ZK_NODES_PATH,
+                                     reconcile_timeout=ZK_NODE_RECONCILIATION_TIMEOUT)
 
         # The order of nodes is important - the first node to register
         # becomes the `designated node` that will initialize cluster, all
@@ -852,7 +854,9 @@ def leave_cluster(args: argparse.Namespace) -> None:
                                   zk_path=ZK_NODES_PATH,
                                   ip=args.node_ip)
 
-        nodes = get_registered_nodes(zk=zk, zk_path=ZK_NODES_PATH)
+        nodes = get_registered_nodes(zk=zk,
+                                 zk_path=ZK_NODES_PATH,
+                                 reconcile_timeout=ZK_NODE_RECONCILIATION_TIMEOUT)
 
         if nodes:
             # There is already at least one etcd node which we should join

--- a/packages/etcd/extra/etcd_discovery/etcd_discovery.py
+++ b/packages/etcd/extra/etcd_discovery/etcd_discovery.py
@@ -165,10 +165,13 @@ def zk_lock(zk: KazooClient, lock_path: str, contender_id: str,
         raise e
     else:
         log.info("ZooKeeper lock acquired.")
-    yield
-    log.info("Releasing ZooKeeper lock")
-    lock.release()
-    log.info("ZooKeeper lock released.")
+    try:
+        yield
+    finally:
+        # Always unlock, even if we hit an exception
+        log.info("Releasing ZooKeeper lock")
+        lock.release()
+        log.info("ZooKeeper lock released.")
 
 
 def get_registered_nodes(zk: KazooClient, zk_path: str) -> List[str]:

--- a/packages/etcd/extra/etcd_discovery/etcd_discovery.py
+++ b/packages/etcd/extra/etcd_discovery/etcd_discovery.py
@@ -418,16 +418,16 @@ def parse_cmdline() -> argparse.Namespace:
     parser_joincluster.add_argument(
         '--cluster-nodes-file',
         action='store',
-        default='/var/lib/dcos/etcd/initial-nodes',
+        default='/run/dcos/etcd/initial-nodes',
         help='file where initial cluster nodes should be saved')
     parser_joincluster.add_argument(
         '--cluster-state-file',
         action='store',
-        default='/var/lib/dcos/etcd/initial-state',
+        default='/run/dcos/etcd/initial-state',
         help='file where initial cluster state should be saved')
     parser_joincluster.add_argument('--etcd-data-dir',
                                     action='store',
-                                    default='/var/lib/dcos/etcd/default.etcd/',
+                                    default='/run/dcos/etcd/default.etcd/',
                                     help="etcd's data directory location")
 
     parser_leavecluster = subparsers.add_parser('leave-cluster')

--- a/packages/etcd/extra/etcdctl/dcos_etcdctl.py
+++ b/packages/etcd/extra/etcdctl/dcos_etcdctl.py
@@ -16,8 +16,8 @@ import requests
 
 
 ETCD_DATA_DIR = "/var/lib/dcos/etcd/default.etcd"
-CLUSTER_NODES_PATH = "/var/lib/dcos/etcd/initial-nodes"
-CLUSTER_STATE_PATH = "/var/lib/dcos/etcd/initial-state"
+CLUSTER_NODES_PATH = "/run/dcos/etcd/initial-nodes"
+CLUSTER_STATE_PATH = "/run/dcos/etcd/initial-state"
 
 
 def run_command(cmd: str,

--- a/packages/etcd/extra/systemd/dcos-etcd.service
+++ b/packages/etcd/extra/systemd/dcos-etcd.service
@@ -23,7 +23,7 @@ ExecStartPre=/bin/chown -R dcos_etcd /run/dcos/etcd/
 ExecStartPre=/opt/mesosphere/active/etcd/bin/etcd_discovery.py \
     --zk-addr 127.0.0.1:2181 \
     join-cluster \
-        --cluster-nodes-file /var/lib/dcos/etcd/initial-nodes \
-        --cluster-state-file /var/lib/dcos/etcd/initial-state \
+        --cluster-nodes-file /run/dcos/etcd/initial-nodes \
+        --cluster-state-file /run/dcos/etcd/initial-state \
         --etcd-data-dir /var/lib/dcos/etcd/default.etcd/
 ExecStart=/opt/mesosphere/active/etcd/bin/etcd.sh

--- a/packages/etcd/extra/systemd/etcd.sh
+++ b/packages/etcd/extra/systemd/etcd.sh
@@ -3,8 +3,8 @@
 set -xe
 
 IP_PRIVATE=`/opt/mesosphere/bin/detect_ip`
-CLUSTER_NODES=`cat /var/lib/dcos/etcd/initial-nodes`
-CLUSTER_STATE=`cat /var/lib/dcos/etcd/initial-state`
+CLUSTER_NODES=`cat /run/dcos/etcd/initial-nodes`
+CLUSTER_STATE=`cat /run/dcos/etcd/initial-state`
 
 GOMAXPROCS=$(nproc)
 


### PR DESCRIPTION
## High-level description

This fixes a potential issue when upgrading  `etcd` after the https://github.com/dcos/dcos/pull/7313#issue-423136936 fix was landed.

In detail:
* With the current implementation it is critical that `etcd` is bootstrapped with the smallest possible quorum. Failing to do so (eg. when restarting the 51% of the cluster masters) will lead to `etcd` crash-looping.
* The bootstrap sequence is performed by locking a ZK key where we hold the cluster nodes and progressively adding nodes in the quorum.

This works fine on the initial boot, but after upgrades, or after fatal cluster failures, the `etcd` service could be deadlocked. To mitigate this, this PR:

* Adds a reconciliation phase when the `etcd` service is started, allowing it to shrink the persisted quorum on ZK only to reachable nodes.
* Adds a "grace period" of 1h during which reconciliation is not occurring, allowing the cluster to reach an eventual stability when booting.
* Rolls back the filesystem changes of https://github.com/dcos/dcos/pull/7313#issue-423136936 in order for the quorum reconciliation to be performed on every boot. 
* Adds some boy-scout clean-up by ensuring the ZK clock is *always* released, even when exceptions occur on the lock code.

Ps. I have manually tested this on SOAK, however please do review it cautiously!


## Corresponding DC/OS tickets (required)

  - [D2IQ-69069](https://jira.d2iq.com/browse/D2IQ-69069) etcd failed to upgrade on clusters with COPS-6183 fix

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
