### PR TITLE
Bump Metronome to 0.6.48

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,14 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * DC/OS no longer increases the rate limit for journald logging.  Scale testing demonstrated that raising the limit overloads journald, causing problems for other components that see delayed or lost logs or, worse, hang until log buffers are read. The default of 10000 messages per 30 seconds appears to distinguish well between busy components and excessively verbose components. (DCOS-53763)
 
+#### Update Metronome to 0.6.48
+
+* Fix an issue in Metronome where it became unresponsive when lots of pending jobs existed during boot. (DCOS_OSS-5965)
+
+* There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
+
+* Metronome jobs networking is now configurable (MARATHON-8727)
+
 ### Security updates
 
 * Update to OpenSSL 1.0.2u. (D2IQ-66526)

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -1,9 +1,12 @@
 {
-  "requires": ["java", "exhibitor"],
+  "requires": [
+    "java",
+    "exhibitor"
+  ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.33-b28106a/metronome-0.6.33-b28106a.tgz",
-    "sha1": "9359a5a5e0ff0e123f4e460beb5c5f7c9e30f806"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.48-2f1b92e/metronome-0.6.48-2f1b92e.tgz",
+    "sha1": "49fe71c39b952472069868ef0e35a9ffdf240895"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.48

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5965](https://jira.mesosphere.com/browse/DCOS_OSS-5965) - Metronome becomes unresponsive after launching due to a race between JobRunExecutorActor instance loading and InstanceTracker responding
  - [MARATHON-8746](https://jira.mesosphere.com/browse/MARATHON-8746) - fix regression introduced with the resolution of MARATHON-8709 
  - [MARATHON-8727](https://jira.mesosphere.com/browse/MARATHON-8727) - Allow Metronome jobs to join container networks
  - [MARATHON-8730](https://jira.mesosphere.com/browse/MARATHON-8730) - Metronome: JsonSchema validation for JobSpec id is inefficient
  - [MARATHON-8709](https://jira.mesosphere.com/browse/MARATHON-8709) - Remove Twitter-Libs dependency from Metronome

## Related tickets (optional)
