### PR TITLE
Bump Metronome to 0.6.48

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Removed trailing newline from ZooKeeper log messages. (D2IQ-68394)
 
+#### Update Metronome to 0.6.48
+
+* Fix an issue in Metronome where it became unresponsive when lots of pending jobs existed during boot. (DCOS_OSS-5965)
 
 ## DC/OS 2.0.4 (2020-05-12)
 

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.44-f89f00d/metronome-0.6.44-f89f00d.tgz",
-    "sha1": "be86404db870a6b4deca34cfc53716ad881c768a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.48-2f1b92e/metronome-0.6.48-2f1b92e.tgz",
+    "sha1": "49fe71c39b952472069868ef0e35a9ffdf240895"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.48

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5965](https://jira.mesosphere.com/browse/DCOS_OSS-5965) - Metronome becomes unresponsive after launching due to a race between JobRunExecutorActor instance loading and InstanceTracker responding

## Related tickets (optional)
