### PR TITLE
2.1: Bump Metronome to 0.6.48

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,7 +71,9 @@ instance to be expunged immediately; this helps with `GROUP_BY` or `UNIQUE` cons
 
 * A race condition would cause Marathon to fail to start properly. (MARATHON-8741)
 
-#### Update Metronome to [0.6.42](https://github.com/dcos/metronome/blob/4e1eac1c4d6c97296332f9664ba4269a15336ed8/changelog.md)
+#### Update Metronome to [0.6.48](https://github.com/dcos/metronome/blob/b1ac8790de6ad89e5dbb15ed096fac759ff88a0e/changelog.md)
+
+* Fix an issue in Metronome where it became unresponsive when lots of pending jobs existed during boot. (DCOS_OSS-5965)
 
 * There was a case where regex validation of project ids was ineffecient for certain inputs. The regex has been optimized. (MARATHON-8730)
 

--- a/packages/metronome/buildinfo.json
+++ b/packages/metronome/buildinfo.json
@@ -5,8 +5,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.44-f89f00d/metronome-0.6.44-f89f00d.tgz",
-    "sha1": "be86404db870a6b4deca34cfc53716ad881c768a"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/metronome/builds/0.6.48-2f1b92e/metronome-0.6.48-2f1b92e.tgz",
+    "sha1": "49fe71c39b952472069868ef0e35a9ffdf240895"
   },
   "username": "dcos_metronome",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Bump Metronome to 0.6.48

## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5965](https://jira.mesosphere.com/browse/DCOS_OSS-5965) - Metronome becomes unresponsive after launching due to a race between JobRunExecutorActor instance loading and InstanceTracker responding

## Related tickets (optional)
