### PR TITLE
[2.1] Upgrade OpenResty to fix spaces in URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Fix incorrect ownership after migration of `/run/dcos/telegraf/dcos_statsd/containers`. (D2IQ-69295)
 
+* Fix to allow spaces in services endpoint URI's. (DCOS_OSS-5967)
+
 
 ## DC/OS 2.1.0 (2020-06-09)
 

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:16.04
 
+# The version of OpenResty here is built from the branch `1.15.8.x` SHA
+# 99ec14bfb2bdd95f71f75067620927d19d3f9a80.  It is "almost 1.15.8.4"
+# since 1.15.8.4 has not been released but contains fixes that we need.
+# See https://jira.d2iq.com/browse/DCOS_OSS-5967
+
 # Let's try to limit the number of layers to minimum:
-ENV OPENRESTY_VERSION=1.15.8.3 \
-    OPENRESTY_DOWNLOAD_SHASUM=277573100c216772b45390f26f0d1c3cf50370f1 \
+ENV OPENRESTY_VERSION=1.15.8.4-99ec14b \
+    OPENRESTY_DOWNLOAD_SHASUM=acb59b0c67dbe1b3a4ab68aa9d4ea3c188ee3a61 \
     OPENRESTY_DIR=/usr/local/src/openresty \
     OPENRESTY_COMPILE_SCRIPT=/usr/local/src/build-resty.sh \
     OPENRESTY_COMPILE_OPTS="" \
@@ -18,7 +23,7 @@ ENV OPENRESTY_VERSION=1.15.8.3 \
     IAM_SHARED_SECRET_FILE_PATH=/usr/local/iam.jwt-key.shared-secret
 
 # These depend on other ENV vars, so we need a separate ENV block:
-ENV OPENRESTY_DOWNLOAD_URL=https://openresty.org/download/openresty-$OPENRESTY_VERSION.tar.gz \
+ENV OPENRESTY_DOWNLOAD_URL=https://downloads.mesosphere.com/openresty_mirror/openresty-$OPENRESTY_VERSION.tar.gz \
     AUTH_ERROR_PAGE_DIR_PATH=${AR_BIN_DIR}/nginx/conf/errorpages
 
 WORKDIR /usr/local/src/


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

OpenResty 1.15.8.3 fails to pass spaces in the `/services` endpoint. Upgrade to 1.15.8.4 which contains the fix.


## Corresponding DC/OS tickets (required)

  - [DCOS_OSS-5967](https://jira.d2iq.com/browse/DCOS_OSS-5967) Upgrade OpenResty in AdminRouter to 1.15.8.4 version


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [COPS-6166](https://jira.mesosphere.com/browse/COPS-6166) Unable to rename/delete folders in Data Science Engine UI
