### PR TITLE
Remove runtime directory since it's not necessary

### DIFF
--- a/packages/exhibitor/extra/dcos-exhibitor.service
+++ b/packages/exhibitor/extra/dcos-exhibitor.service
@@ -10,7 +10,6 @@ RestartSec=5
 LimitNOFILE=16384
 # Run in new mount namespace to create custom resolv.conf.
 MountFlags=private
-RuntimeDirectory=dcos_exhibitor
 # On some systems /tmp is mounted as noexec. Make zookeeper write its JNA
 # libraries to a path we control instead. See DCOS-11056
 Environment=JNA_TMP_DIR=/var/lib/dcos/exhibitor/tmp


### PR DESCRIPTION
>  RuntimeDirectory= is not implemented in CentOS 7's version of systemd. 
https://forums.centos.org/viewtopic.php?t=71267

<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
