### PR TITLE
Show installer port for debugging purposes

### DIFF
--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -49,6 +49,8 @@ PORT=${{PORT:-9000}}
 DCOS_INSTALLER_DAEMONIZE=${{DCOS_INSTALLER_DAEMONIZE:-false}}
 DCOS_INSTALLER_CONTAINER_NAME=${{DCOS_INSTALLER_CONTAINER_NAME:-{genconf_tar}}}
 
+>&2 echo "Running {docker_image_name} on port $PORT"
+
 if [ "$DCOS_INSTALLER_DAEMONIZE" == "true" ]; then
     docker run --name=$DCOS_INSTALLER_CONTAINER_NAME -d -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
 else


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

There's a rare failure mode where a Docker failure occurs during DC/OS installation. This adds an extra log line to try to isolate the problem next time it occurs.

## Corresponding DC/OS tickets (required)

  - [D2IQ-66022](https://jira.d2iq.com/browse/D2IQ-66022) test-e2e/test_external_cert.py: bind: address already in use
  - [D2IQ-67994](https://jira.d2iq.com/browse/D2IQ-67994) TestCertUpdate is flaky
  - [D2IQ-61304](https://jira.d2iq.com/browse/D2IQ-61304) docker driver failed programming external connectivity on endpoint: address already in use


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
