### PR TITLE
[2.1] Remove vestigial GUI installer port from installer

### DIFF
--- a/gen/build_deploy/bash/dcos_generate_config.sh.in
+++ b/gen/build_deploy/bash/dcos_generate_config.sh.in
@@ -45,15 +45,14 @@ DCOS_BOOTSTRAP_CA=dcos-bootstrap-ca
 # kill any existing dcos-boostrap-ca processes before running genconf
 kill $(pidof $DCOS_BOOTSTRAP_CA || true) 2>/dev/null || true
 
-PORT=${{PORT:-9000}}
 DCOS_INSTALLER_DAEMONIZE=${{DCOS_INSTALLER_DAEMONIZE:-false}}
 DCOS_INSTALLER_CONTAINER_NAME=${{DCOS_INSTALLER_CONTAINER_NAME:-{genconf_tar}}}
 
 if [ "$DCOS_INSTALLER_DAEMONIZE" == "true" ]; then
-    docker run --name=$DCOS_INSTALLER_CONTAINER_NAME -d -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
+    docker run --name=$DCOS_INSTALLER_CONTAINER_NAME -d -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
 else
     trap 'docker kill {genconf_tar}' HUP QUIT INT TERM
-    docker run --rm --name=$DCOS_INSTALLER_CONTAINER_NAME -i -p $PORT:9000 -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
+    docker run --rm --name=$DCOS_INSTALLER_CONTAINER_NAME -i -v $(pwd)/genconf/:/genconf {docker_image_name} "$@"
 fi
 
 if [ -d genconf/ca ]; then


### PR DESCRIPTION
## High-level description

Back-port of #7394 

The installer maps port 9000 (or $PORT) on the host to the container, where the GUI installer used to listen before DC/OS 1.12.

The port is now unused, and can occasionally cause problems since, even though unused, the port must be available on the bootstrap host.


## Corresponding DC/OS tickets (required)

  - [D2IQ-66022](https://jira.d2iq.com/browse/D2IQ-66022) test-e2e/test_external_cert.py: bind: address already in use
  - [D2IQ-67994](https://jira.d2iq.com/browse/D2IQ-67994) TestCertUpdate is flaky
  - [D2IQ-61304](https://jira.d2iq.com/browse/D2IQ-61304) docker driver failed programming external connectivity on endpoint: address already in use
  - [D2IQ-7844](https://jira.d2iq.com/browse/D2IQ-7844) CLI Installer binds on :9000?



