### PR TITLE
[2.1] Static clusters only require ZooKeeper quorum for bootstrap to proceed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,14 +3,17 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 2.1.1 (in development)
 
-* Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
-
 
 ### Security updates
 
 
 ### Notable changes
 
+* Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
+
+* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available. 
+  Previously, all ZooKeeper nodes needed to be available.
+  On clusters with dynamic master lists, all ZooKeeper nodes must still be available. (D2IQ-4248)
 
 ### Fixed and improved
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -229,6 +229,11 @@ def dcos_etcd(b, opts):
     b.zk.ensure_path("/etcd/nodes")
 
 
+@check_root
+def dcos_cluster_id(b, opts):
+    b.cluster_id()
+
+
 def noop(b, opts):
     return
 
@@ -258,6 +263,7 @@ bootstrappers = {
     'dcos-telegraf-master': dcos_telegraf_master,
     'dcos-telegraf-agent': dcos_telegraf_agent,
     'dcos-ui-update-service': noop,
+    'dcos-cluster-id': dcos_cluster_id,  # used for testing
 }
 
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -293,6 +293,11 @@ def main():
 
 
 def get_zookeeper_address_agent():
+    # The environment variables `MASTER_SOURCE` and `EXHIBITOR_ADDRESS` are set
+    # for `dcos-net`.  These values allow agents to contact ZooKeeper before
+    # the DNS that resolves `.zk` addresses is available.
+    #
+    # Agent services other than `dcos-net` wait for the DNS to be working.
     if os.getenv('MASTER_SOURCE') == 'master_list':
         # dcos-net agents with static master list
         with (utils.dcos_etc_path / 'master_list').open() as f:

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -54,11 +54,12 @@ def try_shortcut():
         log.info('Process no longer running (couldn\'t read the cmdline at: %s)', zk_pid)
         return False
 
-    log.info('PID %s has command line %s', zk_pid, cmd_line)
-
     if len(cmd_line) < 3:
         log.info("Command line too short to be zookeeper started by exhibitor")
         return False
+
+    # Only show first and last command arguments, to avoid logging sensitive info
+    log.info('PID %s has command line %s ... %s', zk_pid, cmd_line[0], cmd_line[-1])
 
     if cmd_line[-1] != b'/var/lib/dcos/exhibitor/conf/zoo.cfg' \
             or cmd_line[0] != b'/opt/mesosphere/active/java/usr/java/bin/java':
@@ -109,10 +110,19 @@ def wait(master_count_filename):
     log.info(
         "Serving hosts: `%s`, leader: `%s`", ','.join(serving), ','.join(leaders))
 
-    if len(serving) != cluster_size or len(leaders) != 1:
-        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders'
-        log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
-        sys.exit(1)
+    if utils.is_static_cluster():
+        # For static clusters, wait for a ZooKeeper quorum to be ready.
+        quorum = cluster_size // 2 + 1
+        if len(leaders) != 1 or len(serving) < quorum:
+            msg_fmt = 'Require {}+ servers and 1 leader, have {} servers and {} leaders'
+            log.error(msg_fmt.format(quorum, len(serving), len(leaders)))
+            sys.exit(1)
+    else:
+        # For other clusters, wait for all ZooKeeper nodes to be ready.
+        if len(leaders) != 1 or len(serving) != cluster_size:
+            msg_fmt = 'Require {} servers and 1 leader, have {} servers and {} leaders'
+            log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+            sys.exit(1)
 
     # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
     # there is a restart we can come up quickly without requiring a new zookeeper quorum.

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -84,8 +84,6 @@ def wait(master_count_filename):
     cluster_size = int(utils.read_file_text(master_count_filename))
     log.info('Expected cluster size: {}'.format(cluster_size))
 
-    log.info('Waiting for ZooKeeper cluster to stabilize')
-
     try:
         response = requests.get(EXHIBITOR_STATUS_URL)
     except requests.exceptions.ConnectionError as ex:

--- a/packages/bootstrap/extra/dcos_internal_utils/utils.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/utils.py
@@ -7,6 +7,9 @@ import stat
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Dict
+
+import yaml
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +19,24 @@ dcos_run_path = Path('/run/dcos')
 tmp_path = Path('/tmp')
 
 dcos_etc_path = install_path / 'etc'
+
+
+def get_user_config() -> Dict[str, str]:
+    """
+    Returns the contents of the cluster `config.yaml` file as a dictionary.
+    """
+    path = dcos_etc_path / 'user.config.yaml'
+    with path.open() as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def is_static_cluster() -> bool:
+    """
+    Returns True if this cluster has a static master list.
+    """
+    user_config = get_user_config()
+    return user_config['master_discovery'] == 'static'
 
 
 # Derived from pkgpanda/util.py#L257-L262

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -2,8 +2,9 @@ from setuptools import setup
 
 requires = [
     'cryptography',
-    'pyjwt',
     'kazoo',
+    'PyJWT',
+    'PyYAML',
     'requests',
 ]
 

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -5,14 +5,17 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Callable, Tuple
+from typing import Callable, Generator, Tuple
 
 import cryptography.hazmat.backends
 import jwt
 import pytest
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
 
 
 cryptography_default_backend = cryptography.hazmat.backends.default_backend()
@@ -100,3 +103,30 @@ def jwt_token() -> Callable[[str, str, int], str]:
         ).decode('ascii')
 
     return _token
+
+
+@pytest.fixture
+def three_master_cluster(
+    artifact_path: Path,
+    docker_backend: Docker,
+    request: SubRequest,
+    log_dir: Path,
+) -> Generator[Cluster, None, None]:
+    """Spin up a highly-available DC/OS cluster with three master nodes."""
+    with Cluster(
+        cluster_backend=docker_backend,
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=cluster.base_config,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        yield cluster

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -5,13 +5,10 @@ import logging
 import uuid
 from pathlib import Path
 from shlex import split
-from typing import Generator, List, Set
+from typing import List, Set
 
 import pytest
 from _pytest.fixtures import SubRequest
-
-from cluster_helpers import wait_for_dcos_oss
-from dcos_e2e.backends import Docker
 from dcos_e2e.cluster import Cluster
 from dcos_e2e.node import Node, Output
 
@@ -39,33 +36,6 @@ def get_etcdctl_with_base_args(
 
 def get_dcos_etcdctl() -> List[str]:
     return [DCOS_SHELL_PATH, "dcos-etcdctl"]
-
-
-@pytest.fixture
-def three_master_cluster(
-    artifact_path: Path,
-    docker_backend: Docker,
-    request: SubRequest,
-    log_dir: Path,
-) -> Generator[Cluster, None, None]:
-    """Spin up a highly-available DC/OS cluster with three master nodes."""
-    with Cluster(
-        cluster_backend=docker_backend,
-        masters=3,
-        agents=0,
-        public_agents=0,
-    ) as cluster:
-        cluster.install_dcos_from_path(
-            dcos_installer=artifact_path,
-            dcos_config=cluster.base_config,
-            ip_detect_path=docker_backend.ip_detect_path,
-        )
-        wait_for_dcos_oss(
-            cluster=cluster,
-            request=request,
-            log_dir=log_dir,
-        )
-        yield cluster
 
 
 def _do_backup(master: Node, backup_local_path: Path) -> None:

--- a/test-e2e/test_exhibitor_quorum.py
+++ b/test-e2e/test_exhibitor_quorum.py
@@ -1,0 +1,69 @@
+"""
+Tests for Exhibitor quorum
+"""
+from pathlib import Path
+
+import requests
+import retrying
+from _pytest.fixtures import SubRequest
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Node, Output
+
+
+@retrying.retry(wait_fixed=2500, stop_max_delay=120000)
+def wait_for_zookeeper_serving(master: Node, count: int) -> None:
+    """
+    Check that ZooKeeper has `count` serving nodes.
+    """
+    url = 'http://{}:8181/exhibitor/v1/cluster/status'.format(master.public_ip_address)
+    r = requests.get(url)
+    r.raise_for_status()
+    nodes = r.json()
+    print(nodes)
+    assert len([node for node in nodes if node['description'] == 'serving']) == count
+
+
+class TestExhibitorQuorum:
+
+    def test_restart_with_missing_master(
+        self,
+        three_master_cluster: Cluster,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        Bootstrap on a static master cluster can complete when ZooKeeper
+        has an available quorum.
+        """
+        masters = iter(three_master_cluster.masters)
+
+        master = next(masters)
+        wait_for_zookeeper_serving(master, 3)
+
+        # Shutdown ZooKeeper on one master
+        master.run(
+            ['systemctl', 'stop', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Select another master
+        master = next(masters)
+
+        # Restart ZooKeeper on this master to prevent the bootstrap shortcut being triggered
+        master.run(
+            ['systemctl', 'restart', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Wait till we have a healthy 2-node ZooKeeper quorum
+        wait_for_zookeeper_serving(master, 2)
+
+        # Check that bootstrap works - `dcos-cluster-id` checks the cluster id,
+        # which demonstrates that consensus checking is working
+        master.run(
+            [
+                '/opt/mesosphere/bin/dcos-shell', '/opt/mesosphere/bin/bootstrap', 'dcos-cluster-id'
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -59,3 +59,4 @@ groups:
         - test_calico_networking.py
         - test_adminrouter_grpc.py
         - test_external_calicoctl.py
+        - test_exhibitor_quorum.py


### PR DESCRIPTION
## High-level description

Back-port of #7427

This change allows service bootstrap to proceed without all ZooKeeper nodes available, where there is no chance of ZooKeeper being started in standalone mode (in static clusters).


## Corresponding DC/OS tickets (required)

  - [D2IQ-4248](https://jira.d2iq.com/browse/D2IQ-4248) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded
  - [COPS-1754](https://jira.d2iq.com/browse/COPS-1754) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
