### PR TITLE
[2.0] Static clusters only require ZooKeeper quorum for bootstrap to proceed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,15 +2,17 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 2.0.6 (in development)
 
-### What's new
-
-* Updated DC/OS UI to [v5.1.1](https://github.com/dcos/dcos-ui/releases/tag/v5.1.1)
-* Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
-
-
 ### Security updates
 
 ### Notable changes
+
+* Updated DC/OS UI to [v5.1.1](https://github.com/dcos/dcos-ui/releases/tag/v5.1.1)
+
+* Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
+
+* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available. 
+  Previously, all ZooKeeper nodes needed to be available.
+  On clusters with dynamic master lists, all ZooKeeper nodes must still be available. (D2IQ-4248)
 
 ### Fixed and improved
 

--- a/packages/bootstrap/buildinfo.json
+++ b/packages/bootstrap/buildinfo.json
@@ -1,6 +1,5 @@
 {
   "requires": [
-    "dcos-image",
     "python",
     "python-kazoo",
     "python-requests",

--- a/packages/bootstrap/extra/dcos_internal_utils/bootstrap.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/bootstrap.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import sys
 import uuid
 
 import kazoo.exceptions
@@ -9,10 +7,6 @@ from kazoo.retry import KazooRetry
 from kazoo.security import ACL, ANYONE_ID_UNSAFE, Permissions
 
 from dcos_internal_utils import utils
-from pkgpanda.util import is_windows
-
-if not is_windows:
-    assert 'pwd' in sys.modules
 
 log = logging.getLogger(__name__)
 
@@ -46,36 +40,21 @@ class Bootstrapper(object):
     def __exit__(self, type, value, tb):
         self.close()
 
-    def cluster_id(self, path='/var/lib/dcos/cluster-id', readonly=False):
-        dirpath = os.path.dirname(os.path.abspath(path))
-        log.info('Opening {} for locking'.format(dirpath))
-        with utils.Directory(dirpath) as d:
-            log.info('Taking exclusive lock on {}'.format(dirpath))
-            with d.lock():
-                if readonly:
-                    zkid = None
-                else:
-                    zkid = str(uuid.uuid4()).encode('ascii')
+    def cluster_id(self, path=utils.dcos_lib_path / 'cluster-id', readonly=False):
+        if readonly:
+            zkid = None
+        else:
+            zkid = str(uuid.uuid4()).encode('ascii')
+        zkid = self._consensus('/cluster-id', zkid, ANYONE_READ)
+        zkid = zkid.decode('ascii')
 
-                zkid = self._consensus('/cluster-id', zkid, ANYONE_READ)
-                zkid = zkid.decode('ascii')
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if utils.write_file_on_mismatched_content((zkid + '\n').encode('ascii'), path, utils.write_public_file):
+            log.info('Wrote cluster ID to {}'.format(path))
+        else:
+            log.info('Cluster ID in ZooKeeper and file are the same: {}'.format(zkid))
 
-                if os.path.exists(path):
-                    fileid = utils.read_file_line(path)
-                    if fileid == zkid:
-                        log.info('Cluster ID in ZooKeeper and file are the same: {}'.format(zkid))
-                        return zkid
-
-                log.info('Writing cluster ID from ZK to {} via rename'.format(path))
-
-                tmppath = path + '.tmp'
-                with open(tmppath, 'w') as f:
-                    f.write(zkid + '\n')
-                os.rename(tmppath, path)
-
-                log.info('Wrote cluster ID to {}'.format(path))
-
-                return zkid
+        return zkid
 
     def _consensus(self, path, value, acl=None):
         if value is not None:

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -5,10 +5,7 @@ import json
 import logging
 import os
 import random
-import shutil
-import stat
 import sys
-import tempfile
 from pathlib import Path
 
 import cryptography.hazmat.backends
@@ -18,7 +15,6 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt.utils import base64url_decode, bytes_to_number
 
 from dcos_internal_utils import bootstrap, exhibitor, utils
-from pkgpanda.actions import apply_service_configuration
 
 log = logging.getLogger(__name__)
 
@@ -29,9 +25,7 @@ def _known_exec_directory():
     """
     # This directory must be outside /tmp to support
     # environments where /tmp is mounted noexec.
-    known_directory = Path('/var/lib/dcos/exec')
-    known_directory.mkdir(parents=True, exist_ok=True)
-    return known_directory
+    return utils.dcos_lib_path / 'exec'
 
 
 def _create_private_directory(path, owner):
@@ -43,9 +37,9 @@ def _create_private_directory(path, owner):
         path (pathlib.Path): The path to the directory to create.
         owner (str): The owner of the directory.
     """
-    path.mkdir(exist_ok=True)
+    path.mkdir(parents=True, exist_ok=True)
+    utils.chown(path, user=owner)
     path.chmod(0o700)
-    shutil.chown(str(path), user=owner)
 
 
 def check_root(fun):
@@ -91,10 +85,11 @@ def dcos_adminrouter(b, opts):
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
-    os.makedirs('/run/dcos/dcos-adminrouter', exist_ok=True)
-    pubkey_path = '/run/dcos/dcos-adminrouter/auth-token-verification-key'
-    _write_file_bytes(pubkey_path, pubkey_pem_bytes, 0o644)
-    shutil.chown(pubkey_path, user='dcos_adminrouter')
+    rundir = utils.dcos_run_path / 'dcos-adminrouter'
+    rundir.mkdir(parents=True, exist_ok=True)
+    pubkey_path = rundir / 'auth-token-verification-key'
+    utils.write_public_file(pubkey_path, pubkey_pem_bytes)
+    utils.chown(pubkey_path, user='dcos_adminrouter')
 
 
 @check_root
@@ -145,7 +140,7 @@ def dcos_telegraf_common() -> None:
     # on creation, so separate `chmod` ensures that the permissions are
     # correct on each restart.
 
-    telegraf_run = Path('/run/dcos/telegraf')
+    telegraf_run = utils.dcos_run_path / 'telegraf'
     telegraf_run.mkdir(parents=True, exist_ok=True)
     utils.chown(telegraf_run, user='root', group='dcos_telegraf')
     telegraf_run.chmod(0o775)
@@ -195,15 +190,16 @@ def dcos_net_agent(b, opts):
 
 @check_root
 def dcos_bouncer(b, opts):
-    os.makedirs('/run/dcos/dcos-bouncer', exist_ok=True)
-    shutil.chown('/run/dcos/dcos-bouncer', user='dcos_bouncer')
-    # Permissions are restricted to the dcos_bouncer user as this directory
-    # contains sensitive data.  See
-    # https://jira.mesosphere.com/browse/DCOS-18350
-
-    # The ``bouncer_tmpdir`` directory path corresponds to the
-    # TMPDIR environment variable configured in the dcos-bouncer.service file.
     user = 'dcos_bouncer'
+
+    rundir = utils.dcos_run_path / 'dcos-bouncer'
+    _create_private_directory(path=rundir, owner=user)
+
+    # Create the `TMPDIR` used by Bouncer.  This is not `/tmp` because many
+    # systems mark `/tmp` as `noexec` but Bouncer needs to store executable
+    # FFI files.  The security provided by `noexec` applies to directories
+    # that are writable by multiple users.  This directory is writable only
+    # by the owner, and hence is secure without `noexec`.
     bouncer_tmpdir = _known_exec_directory() / user
     _create_private_directory(path=bouncer_tmpdir, owner=user)
 
@@ -225,18 +221,13 @@ def dcos_history(b, opts):
 
 @check_root
 def dcos_cockroach_config_change(b, opts):
-    # Permissions are restricted to the dcos_cockroach user in case this
-    # directory contains sensitive data - we also want to avoid the security
-    # risk of other users writing to this directory.
-    # See https://jira.mesosphere.com/browse/DCOS-18350 for a related change to
-    # dcos-bouncer.
-    #
-    # The ``dcos_cockroach`` user is the ``User`` used in the
-    # ``dcos-cockroachdb-config-change.service``
-
-    # The ``cockroach_tmpdir`` directory path corresponds to the
-    # dcos-cockroachdb-config-change.service.
     user = 'dcos_cockroach'
+
+    # Create the `TMPDIR` used by Cockroach.  This is not `/tmp` because many
+    # systems mark `/tmp` as `noexec` but Cockroach needs to store executable
+    # FFI files.  The security provided by `noexec` applies to directories
+    # that are writable by multiple users.  This directory is writable only
+    # by the owner, and hence is secure without `noexec`.
     cockroach_tmpdir = _known_exec_directory() / user
     _create_private_directory(path=cockroach_tmpdir, owner=user)
 
@@ -273,7 +264,7 @@ bootstrappers = {
 
 
 def get_roles():
-    return os.listdir('/opt/mesosphere/etc/roles')
+    return os.listdir(str(utils.dcos_etc_path / 'roles'))
 
 
 def main():
@@ -298,7 +289,7 @@ def main():
         if service not in bootstrappers:
             log.error('Unknown service: {}'.format(service))
             sys.exit(1)
-        apply_service_configuration(service)
+        utils.apply_service_configuration(service)
         log.info('bootstrapping {}'.format(service))
         bootstrappers[service](b, opts)
 
@@ -306,7 +297,7 @@ def main():
 def get_zookeeper_address_agent():
     if os.getenv('MASTER_SOURCE') == 'master_list':
         # dcos-net agents with static master list
-        with open('/opt/mesosphere/etc/master_list', 'r') as f:
+        with (utils.dcos_etc_path / 'master_list').open() as f:
             master_list = json.load(f)
         assert len(master_list) > 0
         return random.choice(master_list) + ':2181'
@@ -342,41 +333,7 @@ def parse_args():
         help='Host string passed to Kazoo client constructor.')
     parser.add_argument(
         '--master_count',
-        type=str,
-        default='/opt/mesosphere/etc/master_count',
+        type=Path,
+        default=utils.dcos_etc_path / 'master_count',
         help='File with number of master servers')
     return parser.parse_args()
-
-
-def _write_file_bytes(path, data, mode):
-    """
-    Atomically write `data` to `path` using the file permissions
-    `stat.S_IMODE(mode)`.
-
-    File consumers can rely on seeing valid file contents once they are able to
-    open the file. This is achieved by performing all relevant operations on a
-    temporary file followed by a `os.replace()` which, if successful, renames to
-    the desired path (and overwrites upon conflict) in an atomic operation (on
-    both, Windows, and Linux).
-
-    If acting on the temporary file fails (be it writing, closing, chmodding,
-    replacing) an attempt is performed to remove the temporary file; and the
-    original exception is re-raised.
-    """
-    assert isinstance(data, bytes)
-
-    basename = os.path.basename(path)
-    tmpfile_dir = os.path.dirname(os.path.realpath(path))
-
-    fd, tmpfile_path = tempfile.mkstemp(prefix=basename, dir=tmpfile_dir)
-
-    try:
-        try:
-            os.write(fd, data)
-        finally:
-            os.close(fd)
-        os.chmod(tmpfile_path, stat.S_IMODE(mode))
-        os.replace(tmpfile_path, path)
-    except Exception:
-        os.remove(tmpfile_path)
-        raise

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -295,6 +295,11 @@ def main():
 
 
 def get_zookeeper_address_agent():
+    # The environment variables `MASTER_SOURCE` and `EXHIBITOR_ADDRESS` are set
+    # for `dcos-net`.  These values allow agents to contact ZooKeeper before
+    # the DNS that resolves `.zk` addresses is available.
+    #
+    # Agent services other than `dcos-net` wait for the DNS to be working.
     if os.getenv('MASTER_SOURCE') == 'master_list':
         # dcos-net agents with static master list
         with (utils.dcos_etc_path / 'master_list').open() as f:

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -232,6 +232,11 @@ def dcos_cockroach_config_change(b, opts):
     _create_private_directory(path=cockroach_tmpdir, owner=user)
 
 
+@check_root
+def dcos_cluster_id(b, opts):
+    b.cluster_id()
+
+
 def noop(b, opts):
     return
 
@@ -260,6 +265,7 @@ bootstrappers = {
     'dcos-telegraf-master': dcos_telegraf_master,
     'dcos-telegraf-agent': dcos_telegraf_agent,
     'dcos-ui-update-service': noop,
+    'dcos-cluster-id': dcos_cluster_id,  # used for testing
 }
 
 

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -54,11 +54,12 @@ def try_shortcut():
         log.info('Process no longer running (couldn\'t read the cmdline at: %s)', zk_pid)
         return False
 
-    log.info('PID %s has command line %s', zk_pid, cmd_line)
-
     if len(cmd_line) < 3:
         log.info("Command line too short to be zookeeper started by exhibitor")
         return False
+
+    # Only show first and last command arguments, to avoid logging sensitive info
+    log.info('PID %s has command line %s ... %s', zk_pid, cmd_line[0], cmd_line[-1])
 
     if cmd_line[-1] != b'/var/lib/dcos/exhibitor/conf/zoo.cfg' \
             or cmd_line[0] != b'/opt/mesosphere/active/java/usr/java/bin/java':
@@ -109,10 +110,19 @@ def wait(master_count_filename):
     log.info(
         "Serving hosts: `%s`, leader: `%s`", ','.join(serving), ','.join(leaders))
 
-    if len(serving) != cluster_size or len(leaders) != 1:
-        msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders'
-        log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
-        sys.exit(1)
+    if utils.is_static_cluster():
+        # For static clusters, wait for a ZooKeeper quorum to be ready.
+        quorum = cluster_size // 2 + 1
+        if len(leaders) != 1 or len(serving) < quorum:
+            msg_fmt = 'Require {}+ servers and 1 leader, have {} servers and {} leaders'
+            log.error(msg_fmt.format(quorum, len(serving), len(leaders)))
+            sys.exit(1)
+    else:
+        # For other clusters, wait for all ZooKeeper nodes to be ready.
+        if len(leaders) != 1 or len(serving) != cluster_size:
+            msg_fmt = 'Require {} servers and 1 leader, have {} servers and {} leaders'
+            log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+            sys.exit(1)
 
     # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
     # there is a restart we can come up quickly without requiring a new zookeeper quorum.

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -84,8 +84,6 @@ def wait(master_count_filename):
     cluster_size = int(utils.read_file_text(master_count_filename))
     log.info('Expected cluster size: {}'.format(cluster_size))
 
-    log.info('Waiting for ZooKeeper cluster to stabilize')
-
     try:
         response = requests.get(EXHIBITOR_STATUS_URL)
     except requests.exceptions.ConnectionError as ex:

--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -1,37 +1,35 @@
 import logging
-import os
 import sys
 
 import requests
 
 from dcos_internal_utils import utils
-from pkgpanda.util import load_string, write_string
 
 log = logging.getLogger(__name__)
 
 
 EXHIBITOR_STATUS_URL = 'http://127.0.0.1:8181/exhibitor/v1/cluster/status'
 
-zk_pid_path = "/var/lib/dcos/exhibitor/zk.pid"
-stash_zk_pid_stat_mtime_path = "/var/lib/dcos/bootstrap/exhibitor_pid_stat"
+zk_pid_path = utils.dcos_lib_path / 'exhibitor' / 'zk.pid'
+stash_zk_pid_stat_mtime_path = utils.dcos_lib_path / 'bootstrap' / 'exhibitor_pid_stat'
 
 
 def get_zk_pid_mtime():
     try:
-        return os.stat(zk_pid_path).st_mtime_ns
+        return zk_pid_path.stat().st_mtime_ns
     except FileNotFoundError:
         log.error("ZK pid file `%s` does not exist.", zk_pid_path)
         return None
 
 
 def get_zk_pid():
-    return load_string(zk_pid_path)
+    return utils.read_file_text(zk_pid_path)
 
 
 def try_shortcut():
     try:
         # pid stat file exists, read the value out of it
-        stashed_pid_stat = int(load_string(stash_zk_pid_stat_mtime_path))
+        stashed_pid_stat = int(utils.read_file_bytes(stash_zk_pid_stat_mtime_path).decode('utf8'))
     except FileNotFoundError:
         log.info('No zk.pid last mtime found at %s', stash_zk_pid_stat_mtime_path)
         return False
@@ -72,24 +70,27 @@ def try_shortcut():
 
 
 def wait(master_count_filename):
+    if not master_count_filename.exists():
+        # this is an agent
+        log.info("master_count file doesn't exist, not waiting")
+        return
+
     if try_shortcut():
         log.info("Shortcut succeeeded, assuming local zk is in good config state, not waiting for quorum.")
         return
     log.info('Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize')
 
-    if not os.path.exists(master_count_filename):
-        log.info("master_count file doesn't exist when it should. Hard failing.")
-        sys.exit(1)
-
-    cluster_size = int(utils.read_file_line(master_count_filename))
+    cluster_size = int(utils.read_file_text(master_count_filename))
     log.info('Expected cluster size: {}'.format(cluster_size))
 
     log.info('Waiting for ZooKeeper cluster to stabilize')
+
     try:
         response = requests.get(EXHIBITOR_STATUS_URL)
     except requests.exceptions.ConnectionError as ex:
         log.error('Could not connect to exhibitor: {}'.format(ex))
         sys.exit(1)
+
     if response.status_code != 200:
         log.error('Could not get exhibitor status: {}, Status code: {}'.format(
             EXHIBITOR_STATUS_URL, response.status_code))
@@ -110,11 +111,12 @@ def wait(master_count_filename):
 
     if len(serving) != cluster_size or len(leaders) != 1:
         msg_fmt = 'Expected {} servers and 1 leader, got {} servers and {} leaders'
-        raise Exception(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+        log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
+        sys.exit(1)
 
     # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
     # there is a restart we can come up quickly without requiring a new zookeeper quorum.
     zk_pid_mtime = get_zk_pid_mtime()
     if zk_pid_mtime is not None:
         log.info('Stashing zk.pid mtime %s to %s', zk_pid_mtime, stash_zk_pid_stat_mtime_path)
-        write_string(stash_zk_pid_stat_mtime_path, str(zk_pid_mtime))
+        utils.write_private_file(stash_zk_pid_stat_mtime_path, str(zk_pid_mtime).encode('utf8'))

--- a/packages/bootstrap/extra/dcos_internal_utils/utils.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/utils.py
@@ -7,6 +7,9 @@ import stat
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Dict
+
+import yaml
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +19,24 @@ dcos_run_path = Path('/run/dcos')
 tmp_path = Path('/tmp')
 
 dcos_etc_path = install_path / 'etc'
+
+
+def get_user_config() -> Dict[str, str]:
+    """
+    Returns the contents of the cluster `config.yaml` file as a dictionary.
+    """
+    path = dcos_etc_path / 'user.config.yaml'
+    with path.open() as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def is_static_cluster() -> bool:
+    """
+    Returns True if this cluster has a static master list.
+    """
+    user_config = get_user_config()
+    return user_config['master_discovery'] == 'static'
 
 
 # Derived from pkgpanda/util.py#L257-L262

--- a/packages/bootstrap/extra/dcos_internal_utils/utils.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/utils.py
@@ -1,69 +1,159 @@
-try:
-    import fcntl
-except ImportError:
-    pass
+import json
 import logging
 import os
 import shutil
+import socket
+import stat
 import subprocess
-import sys
-
-import gen
-
-from pkgpanda.util import is_windows
-
-
-if not is_windows:
-    assert 'fcntl' in sys.modules
+import tempfile
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+install_path = Path('/opt/mesosphere')
+dcos_lib_path = Path('/var/lib/dcos')
+dcos_run_path = Path('/run/dcos')
+tmp_path = Path('/tmp')
 
-def read_file_line(filename):
-    with open(filename, 'r') as f:
+dcos_etc_path = install_path / 'etc'
+
+
+# Derived from pkgpanda/util.py#L257-L262
+def load_json(filepath):
+    try:
+        with filepath.open() as f:
+            return json.load(f)
+    except ValueError as ex:
+        raise ValueError("Invalid JSON in {0}: {1}".format(filepath, ex)) from ex
+
+
+def read_file_text(filepath):
+    with filepath.open() as f:
         return f.read().strip()
+
+
+def read_file_bytes(filepath):
+    with filepath.open('rb') as f:
+        return f.read()
+
+
+def write_readonly_file(filepath, data):
+    _write_file_bytes(filepath, data, 0o400)
+
+
+def write_private_file(filepath, data):
+    _write_file_bytes(filepath, data, 0o600)
+
+
+def write_public_file(filepath, data):
+    _write_file_bytes(filepath, data, 0o644)
+
+
+def _write_file_bytes(filepath, data, mode):
+    """
+    Set the contents of file to a byte string.
+
+    The code ensures an atomic write by creating a temporary file and then
+    moving that temporary file to the given ``filename``. This prevents race
+    conditions such as the file being read by another process after it is
+    created but not yet written to.
+
+    It also prevents an invalid file being created if the `write` fails (e.g.
+    because of low disk space).
+
+    On Linux the new file is created with permissions `mode`.
+
+    This function does not attempt to fsync the file to disk. fsync protects
+    files being lost following an OS crash. However, the bootstrap process is
+    always re-run before services restart. Hence, any files not persisted to
+    disk will be recreated after a crash.
+    """
+    filename = str(filepath)
+    prefix = os.path.basename(filename)
+    tmp_file_dir = os.path.dirname(os.path.realpath(filename))
+    fd, temporary_filename = tempfile.mkstemp(prefix=prefix, dir=tmp_file_dir)
+    # On Linux `mkstemp` initially creates file with permissions 0o600
+    try:
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
+        os.chmod(temporary_filename, stat.S_IMODE(mode))
+        os.replace(temporary_filename, filename)
+    except Exception:
+        os.remove(temporary_filename)
+        raise
+
+
+def write_file_on_mismatched_content(desired_content, target, write):
+    """
+    Write the contents to a new target.
+
+    The copy is atomic, ensuring that the target file never exists with
+    partial contents.  The code avoids writing the file if the contents
+    do not need to be updated.  The return value is a boolean indicating
+    whether the contents of the file changed.
+    """
+    if target.exists():
+        current_content = read_file_bytes(target)
+        if current_content == desired_content:
+            return False
+
+    write(target, desired_content)
+    return True
 
 
 def chown(path, user=None, group=None):
     shutil.chown(str(path), user, group)
 
 
+# Copied from gen/calc.py#L87-L102
+def valid_ipv4_address(ip):
+    try:
+        socket.inet_pton(socket.AF_INET, ip)
+        return True
+    except OSError:
+        return False
+    except TypeError:
+        return False
+
+
+# Copied from gen/calc.py#L87-L102
+def validate_ipv4_addresses(ips: list):
+    invalid_ips = []
+    for ip in ips:
+        if not valid_ipv4_address(ip):
+            invalid_ips.append(ip)
+    assert not invalid_ips, 'Invalid IPv4 addresses in list: {}'.format(', '.join(invalid_ips))
+
+
 def detect_ip():
-    cmd = ['/opt/mesosphere/bin/detect_ip']
+    cmd = [str(install_path / 'bin' / 'detect_ip')]
     machine_ip = subprocess.check_output(cmd, stderr=subprocess.DEVNULL).decode('ascii').strip()
-    gen.calc.validate_ipv4_addresses([machine_ip])
+    validate_ipv4_addresses([machine_ip])
     return machine_ip
 
 
-class Directory:
-    def __init__(self, path):
-        self.path = path
-
-    def __enter__(self):
-        log.info('Opening {}'.format(self.path))
-        self.fd = os.open(self.path, os.O_RDONLY)
-        log.info('Opened {} with fd {}'.format(self.path, self.fd))
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        log.info('Closing {} with fd {}'.format(self.path, self.fd))
-        os.close(self.fd)
-
-    def lock(self):
-        return Flock(self.fd, fcntl.LOCK_EX)
+DCOS_SERVICE_CONFIGURATION_FILE = "dcos-service-configuration.json"
+DCOS_SERVICE_CONFIGURATION_PATH = dcos_etc_path / DCOS_SERVICE_CONFIGURATION_FILE
+SYSCTL_SETTING_KEY = "sysctl"
 
 
-class Flock:
-    def __init__(self, fd, op):
-        (self.fd, self.op) = (fd, op)
+# Derived from pkgpanda/actions.py#L308-L327
+def _apply_sysctl(setting, service):
+    try:
+        subprocess.check_call(["sysctl", "-q", "-w", setting])
+    except subprocess.CalledProcessError:
+        log.warning("sysctl {setting} not set for {service}".format(setting=setting, service=service))
 
-    def __enter__(self):
-        log.info('Locking fd {}'.format(self.fd))
-        # If the fcntl() fails, an IOError is raised.
-        fcntl.flock(self.fd, self.op)
-        log.info('Locked fd {}'.format(self.fd))
-        return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        fcntl.flock(self.fd, fcntl.LOCK_UN)
-        log.info('Unlocked fd {}'.format(self.fd))
+def _apply_sysctl_settings(sysctl_settings, service):
+    for setting, value in sysctl_settings.get(service, {}).items():
+        _apply_sysctl("{setting}={value}".format(setting=setting, value=value), service)
+
+
+def apply_service_configuration(service):
+    if DCOS_SERVICE_CONFIGURATION_PATH.exists():
+        dcos_service_properties = load_json(DCOS_SERVICE_CONFIGURATION_PATH)
+        if SYSCTL_SETTING_KEY in dcos_service_properties:
+            _apply_sysctl_settings(dcos_service_properties[SYSCTL_SETTING_KEY], service)

--- a/packages/bootstrap/extra/pytest.ini
+++ b/packages/bootstrap/extra/pytest.ini
@@ -1,0 +1,5 @@
+# The existence of this `pytest.ini` file sets the `pytest` root
+# directory to here, which prevents `pytest` from finding the
+# `conftest.py` for `dcos-image` package from the DC/OS root directory.
+# Since `dcos-image` is not a dependency of `bootstrap`, that
+# `conftest.py` breaks these tests.

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup
 
 requires = [
+    'cryptography',
+    'pyjwt',
     'kazoo',
     'requests',
 ]

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -2,8 +2,9 @@ from setuptools import setup
 
 requires = [
     'cryptography',
-    'pyjwt',
     'kazoo',
+    'PyJWT',
+    'PyYAML',
     'requests',
 ]
 

--- a/packages/bootstrap/extra/tests/test_bootstrap.py
+++ b/packages/bootstrap/extra/tests/test_bootstrap.py
@@ -7,16 +7,11 @@ except ImportError:
 import random
 import string
 import subprocess
-import sys
 
 import pytest
 from kazoo.client import KazooClient, KazooRetry
 
 from dcos_internal_utils import bootstrap
-from pkgpanda.util import is_windows
-
-if not is_windows:
-    assert 'pwd' in sys.modules
 
 zookeeper_docker_image = 'jplock/zookeeper'
 zookeeper_docker_run_args = ['--publish=2181:2181', '--publish=2888:2888', '--publish=3888:3888']
@@ -63,17 +58,16 @@ def _check_consensus(methodname, monkeypatch, tmpdir):
 
     b = bootstrap.Bootstrapper(zk_hosts)
 
-    path = tmpdir.join('/cluster-id')
+    path = tmpdir / 'cluster-id'
     assert not path.exists()
 
     method = getattr(b, methodname)
 
-    id1 = method(str(path))
-    path.remove()
-    id2 = method(str(path))
+    id1 = method(path)
+    path.unlink()
+    id2 = method(path)
     assert id1 == id2
 
 
-@pytest.mark.skipif(is_windows, reason="test fails on Windows reason: docker file does not work on windows")
-def test_bootstrap(zk_server, monkeypatch, tmpdir):
-    _check_consensus('cluster_id', monkeypatch, tmpdir)
+def test_bootstrap(zk_server, monkeypatch, tmp_path):
+    _check_consensus('cluster_id', monkeypatch, tmp_path)

--- a/packages/bootstrap/extra/tests/test_cli.py
+++ b/packages/bootstrap/extra/tests/test_cli.py
@@ -1,0 +1,86 @@
+import pytest
+
+from dcos_internal_utils import cli
+
+
+def test_telegraf_no_legacy(tmp_path):
+    """
+    When there is no legacy directory `migrate_containers` does not
+    create a new directory and returns False.
+    """
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    assert cli.migrate_containers(src, dst) is False
+    assert not src.exists()
+    assert not dst.exists()
+
+
+def test_telegraf_migrate_empty(tmp_path):
+    """
+    When the legacy directory exists, `migrate_containers` moves the
+    directory and returns True.
+    """
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    assert cli.migrate_containers(src, dst) is True
+    assert not src.exists()
+    assert dst.exists()
+    assert not any(dst.iterdir())
+
+
+def test_telegraf_migrate_not_empty(tmp_path):
+    """
+    Migration moves legacy files.
+    """
+    file_contents = b'1234'
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    file = src / 'file'
+    file.write_bytes(file_contents)
+    assert cli.migrate_containers(src, dst) is True
+    assert not src.exists()
+    assert dst.exists()
+    file = dst / 'file'
+    assert list(dst.iterdir()) == [file]
+    assert file.read_bytes() == file_contents
+
+
+def test_telegraf_migrate_dst_exists_empty(tmp_path):
+    """
+    Migration works if the target directory exists but is empty.
+    """
+    file_contents = b'1234'
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    file = src / 'file'
+    file.write_bytes(file_contents)
+    dst.mkdir()
+    assert cli.migrate_containers(src, dst) is True
+    assert not src.exists()
+    assert dst.exists()
+    file = dst / 'file'
+    assert list(dst.iterdir()) == [file]
+    assert file.read_bytes() == file_contents
+
+
+def test_telegraf_migrate_dst_exists_not_empty(tmp_path):
+    """
+    Migration fails if the target directory contains files.
+    """
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    src_file = src / 'src_file'
+    src_file.touch()
+    dst.mkdir()
+    dst_file = dst / 'dst_file'
+    dst_file.touch()
+    with pytest.raises(RuntimeError):
+        cli.migrate_containers(src, dst)
+    assert src.exists()
+    assert src_file.exists()
+    assert dst.exists()
+    assert dst_file.exists()

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -4,10 +4,13 @@ Surrogate conftest.py contents loaded by the conftest.py file.
 import logging
 import os
 from pathlib import Path
+from typing import Generator
 
 import pytest
-
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
 from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -48,3 +51,30 @@ def log_dir() -> Path:
     Return the path to a directory which logs should be stored in.
     """
     return Path(os.environ['DCOS_E2E_LOG_DIR'])
+
+
+@pytest.fixture
+def three_master_cluster(
+    artifact_path: Path,
+    docker_backend: Docker,
+    request: SubRequest,
+    log_dir: Path,
+) -> Generator[Cluster, None, None]:
+    """Spin up a highly-available DC/OS cluster with three master nodes."""
+    with Cluster(
+        cluster_backend=docker_backend,
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=cluster.base_config,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        yield cluster

--- a/test-e2e/test_exhibitor_quorum.py
+++ b/test-e2e/test_exhibitor_quorum.py
@@ -1,0 +1,69 @@
+"""
+Tests for Exhibitor quorum
+"""
+from pathlib import Path
+
+import requests
+import retrying
+from _pytest.fixtures import SubRequest
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Node, Output
+
+
+@retrying.retry(wait_fixed=2500, stop_max_delay=120000)
+def wait_for_zookeeper_serving(master: Node, count: int) -> None:
+    """
+    Check that ZooKeeper has `count` serving nodes.
+    """
+    url = 'http://{}:8181/exhibitor/v1/cluster/status'.format(master.public_ip_address)
+    r = requests.get(url)
+    r.raise_for_status()
+    nodes = r.json()
+    print(nodes)
+    assert len([node for node in nodes if node['description'] == 'serving']) == count
+
+
+class TestExhibitorQuorum:
+
+    def test_restart_with_missing_master(
+        self,
+        three_master_cluster: Cluster,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        Bootstrap on a static master cluster can complete when ZooKeeper
+        has an available quorum.
+        """
+        masters = iter(three_master_cluster.masters)
+
+        master = next(masters)
+        wait_for_zookeeper_serving(master, 3)
+
+        # Shutdown ZooKeeper on one master
+        master.run(
+            ['systemctl', 'stop', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Select another master
+        master = next(masters)
+
+        # Restart ZooKeeper on this master to prevent the bootstrap shortcut being triggered
+        master.run(
+            ['systemctl', 'restart', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Wait till we have a healthy 2-node ZooKeeper quorum
+        wait_for_zookeeper_serving(master, 2)
+
+        # Check that bootstrap works - `dcos-cluster-id` checks the cluster id,
+        # which demonstrates that consensus checking is working
+        master.run(
+            [
+                '/opt/mesosphere/bin/dcos-shell', '/opt/mesosphere/bin/bootstrap', 'dcos-cluster-id'
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -55,3 +55,4 @@ groups:
         - test_service_account.py
         - test_master_node_replacement.py
         - test_zookeeper_backup.py
+        - test_exhibitor_quorum.py

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ passenv =
 deps =
   attrs==19.1.0
   dnspython
-  pytest==3.3.2
+  pytest==3.10.1
   pytest-catchlog==1.2.2
   PyYAML
   webtest
@@ -102,7 +102,7 @@ deps =
   attrs==19.1.0
   dnspython
   teamcity-messages
-  pytest==3.3.2
+  pytest==3.10.1
   pytest-catchlog==1.2.2
   PyYAML
   webtest
@@ -122,7 +122,7 @@ passenv =
   SSH_AUTH_SOCK
 deps =
   attrs==19.1.0
-  pytest==3.3.2
+  pytest==3.10.1
   schema
 changedir=pkgpanda/build/tests
 commands=
@@ -135,7 +135,7 @@ passenv =
   SSH_AUTH_SOCK
 deps =
   attrs==19.1.0
-  pytest==3.3.2
+  pytest==3.10.1
   schema
 changedir=pkgpanda/build/tests
 commands=
@@ -148,7 +148,7 @@ passenv =
   TEAMCITY_VERSION
 deps=
   attrs==19.1.0
-  pytest==3.3.2
+  pytest==3.10.1
 changedir=packages/bootstrap/extra
 commands=
   pip install .
@@ -160,7 +160,7 @@ passenv =
   TEAMCITY_VERSION
 deps=
   attrs==19.1.0
-  pytest==3.3.2
+  pytest==3.10.1
 changedir=packages/bootstrap/extra
 commands=
   pip install .


### PR DESCRIPTION
## High-level description

Back-port of #7427

This change allows service bootstrap to proceed without all ZooKeeper nodes available, where there is no chance of ZooKeeper being started in standalone mode (in static clusters).


## Corresponding DC/OS tickets (required)

  - [D2IQ-4248](https://jira.d2iq.com/browse/D2IQ-4248) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded
  - [COPS-1754](https://jira.d2iq.com/browse/COPS-1754) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
