### PR TITLE
Switched dcos-mesos-modules to 2.1 branch

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -7,6 +7,6 @@
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
     "ref": "4ba1e573ec4a80ec1d5514d54d5cc9529e5e1d98",
-    "ref_origin": "master"
+    "ref_origin": "2.1"
   }
 }


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

This switches dcos-mesos-modules package to using 2.1 dcos-mesos-modules branch.
SHA is not changed.


## Corresponding DC/OS tickets (required)

  - [D2IQ-68266](https://jira.d2iq.com/browse/D2IQ-68266) Make DCOS 2.1 branch use corresponding branches of mesos/modules.

