### PR TITLE
[1.13] Static clusters only require ZooKeeper quorum for bootstrap to proceed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Notable changes
 
+* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available. 
+  Previously, all ZooKeeper nodes needed to be available.
+  On clusters with dynamic master lists, all ZooKeeper nodes must still be available. (D2IQ-4248)
+  
 ### Fixed and improved
 
 * Removed trailing newline from ZooKeeper log messages. (D2IQ-68394)
@@ -13,6 +17,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Fix incorrect ownership after migration of `/run/dcos/telegraf/dcos_statsd/containers`. (D2IQ-69295)
 
 * Update Telegraf configuration to reduce errors, vary requests to reduce load, sample less frequently. (COPS-5629)
+
 
 #### Update Metronome to 0.6.48
 

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -241,6 +241,11 @@ def dcos_cockroach_config_change(b, opts):
     _create_private_directory(path=cockroach_tmpdir, owner=user)
 
 
+@check_root
+def dcos_cluster_id(b, opts):
+    b.cluster_id()
+
+
 def noop(b, opts):
     return
 
@@ -269,6 +274,7 @@ bootstrappers = {
     'dcos-telegraf-master': dcos_telegraf_master,
     'dcos-telegraf-agent': dcos_telegraf_agent,
     'dcos-ui-update-service': noop,
+    'dcos-cluster-id': dcos_cluster_id,  # used for testing
 }
 
 

--- a/packages/bootstrap/extra/dcos_internal_utils/utils.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/utils.py
@@ -8,8 +8,9 @@ import shutil
 import subprocess
 import sys
 
-import gen
+import yaml
 
+import gen
 from pkgpanda.util import is_windows
 
 
@@ -17,6 +18,24 @@ if not is_windows:
     assert 'fcntl' in sys.modules
 
 log = logging.getLogger(__name__)
+
+
+def get_user_config():
+    """
+    Returns the contents of the cluster `config.yaml` file as a dictionary.
+    """
+    path = '/opt/mesosphere/etc/user.config.yaml'
+    with open(path) as f:
+        config = yaml.safe_load(f)
+    return config
+
+
+def is_static_cluster():
+    """
+    Returns True if this cluster has a static master list.
+    """
+    user_config = get_user_config()
+    return user_config['master_discovery'] == 'static'
 
 
 def read_file_line(filename):

--- a/packages/bootstrap/extra/setup.py
+++ b/packages/bootstrap/extra/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 
 requires = [
     'kazoo',
+    'PyYAML',
     'requests',
 ]
 

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -4,10 +4,13 @@ Surrogate conftest.py contents loaded by the conftest.py file.
 import logging
 import os
 from pathlib import Path
+from typing import Generator
 
 import pytest
-
+from _pytest.fixtures import SubRequest
+from cluster_helpers import wait_for_dcos_oss
 from dcos_e2e.backends import Docker
+from dcos_e2e.cluster import Cluster
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -48,3 +51,30 @@ def log_dir() -> Path:
     Return the path to a directory which logs should be stored in.
     """
     return Path(os.environ['DCOS_E2E_LOG_DIR'])
+
+
+@pytest.fixture
+def three_master_cluster(
+    artifact_path: Path,
+    docker_backend: Docker,
+    request: SubRequest,
+    log_dir: Path,
+) -> Generator[Cluster, None, None]:
+    """Spin up a highly-available DC/OS cluster with three master nodes."""
+    with Cluster(
+        cluster_backend=docker_backend,
+        masters=3,
+        agents=0,
+        public_agents=0,
+    ) as cluster:
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config=cluster.base_config,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+        yield cluster

--- a/test-e2e/test_exhibitor_quorum.py
+++ b/test-e2e/test_exhibitor_quorum.py
@@ -1,0 +1,69 @@
+"""
+Tests for Exhibitor quorum
+"""
+from pathlib import Path
+
+import requests
+import retrying
+from _pytest.fixtures import SubRequest
+from dcos_e2e.cluster import Cluster
+from dcos_e2e.node import Node, Output
+
+
+@retrying.retry(wait_fixed=2500, stop_max_delay=120000)
+def wait_for_zookeeper_serving(master: Node, count: int) -> None:
+    """
+    Check that ZooKeeper has `count` serving nodes.
+    """
+    url = 'http://{}:8181/exhibitor/v1/cluster/status'.format(master.public_ip_address)
+    r = requests.get(url)
+    r.raise_for_status()
+    nodes = r.json()
+    print(nodes)
+    assert len([node for node in nodes if node['description'] == 'serving']) == count
+
+
+class TestExhibitorQuorum:
+
+    def test_restart_with_missing_master(
+        self,
+        three_master_cluster: Cluster,
+        tmp_path: Path,
+        request: SubRequest,
+        log_dir: Path,
+    ) -> None:
+        """
+        Bootstrap on a static master cluster can complete when ZooKeeper
+        has an available quorum.
+        """
+        masters = iter(three_master_cluster.masters)
+
+        master = next(masters)
+        wait_for_zookeeper_serving(master, 3)
+
+        # Shutdown ZooKeeper on one master
+        master.run(
+            ['systemctl', 'stop', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Select another master
+        master = next(masters)
+
+        # Restart ZooKeeper on this master to prevent the bootstrap shortcut being triggered
+        master.run(
+            ['systemctl', 'restart', 'dcos-exhibitor'],
+            output=Output.LOG_AND_CAPTURE,
+        )
+
+        # Wait till we have a healthy 2-node ZooKeeper quorum
+        wait_for_zookeeper_serving(master, 2)
+
+        # Check that bootstrap works - `dcos-cluster-id` checks the cluster id,
+        # which demonstrates that consensus checking is working
+        master.run(
+            [
+                '/opt/mesosphere/bin/dcos-shell', '/opt/mesosphere/bin/bootstrap', 'dcos-cluster-id'
+            ],
+            output=Output.LOG_AND_CAPTURE,
+        )

--- a/test-e2e/test_groups.yaml
+++ b/test-e2e/test_groups.yaml
@@ -55,3 +55,4 @@ groups:
         - test_service_account.py
         - test_master_node_replacement.py
         - test_zookeeper_backup.py
+        - test_exhibitor_quorum.py


### PR DESCRIPTION
## High-level description

Back-port of #7427

This change allows service bootstrap to proceed without all ZooKeeper nodes available, where there is no chance of ZooKeeper being started in standalone mode (in static clusters).


## Corresponding DC/OS tickets (required)

  - [D2IQ-4248](https://jira.d2iq.com/browse/D2IQ-4248) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded
  - [COPS-1754](https://jira.d2iq.com/browse/COPS-1754) Master node should be able to rejoin the cluster after failure/restart when another master is offline or being upgraded

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
