### PR TITLE
Bumping the etcd version to v3.4.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* Updated `etcd` to [v3.4.9](https://github.com/etcd-io/etcd/releases/tag/v3.4.10).
+
 * Fixing some corner-cases that could render `etcd` unable to start [D2IQ-69069](https://jira.d2iq.com/browse/D2IQ-69069)
 
 * Storing etcd initial state on `/var/lib/dcos` instead of `/run/dcos` [COPS-6183](https://jira.d2iq.com/browse/COPS-6183)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
-* Updated `etcd` to [v3.4.9](https://github.com/etcd-io/etcd/releases/tag/v3.4.10).
+* Updated `etcd` to [v3.4.9](https://github.com/etcd-io/etcd/releases/tag/v3.4.9).
 
 * Fixing some corner-cases that could render `etcd` unable to start [D2IQ-69069](https://jira.d2iq.com/browse/D2IQ-69069)
 

--- a/packages/etcd/buildinfo.json
+++ b/packages/etcd/buildinfo.json
@@ -1,8 +1,8 @@
 {
   "single_source" : {
       "kind": "url_extract",
-      "url": "https://github.com/etcd-io/etcd/releases/download/v3.4.0/etcd-v3.4.0-linux-amd64.tar.gz",
-      "sha1": "af01072da1dd5c74d83ca45fe52c304afbce15a2"
+      "url": "https://github.com/etcd-io/etcd/releases/download/v3.4.9/etcd-v3.4.9-linux-amd64.tar.gz",
+      "sha1": "3ecc9563bb3f5043ad763070b026ab1375d99175"
   },
   "username": "dcos_etcd",
   "state_directory": true


### PR DESCRIPTION
## High-level description

This commit bumps the etcd version to 3.4.9 


## Corresponding DC/OS tickets (required)

  - [COPS-6341](https://jira.d2iq.com/browse/COPS-6341) Etcd need to be upgraded to 3.4.9


## Related tickets (optional)

(None)