### PR TITLE
Add decorator to skip e2e tests

### DIFF
--- a/test-e2e/pytest.ini
+++ b/test-e2e/pytest.ini
@@ -1,0 +1,8 @@
+# The existence of this `pytest.ini` file sets the `pytest` root
+# directory to here, which prevents `pytest` from finding the
+# `conftest.py` for `dcos-image` package from the DC/OS root directory.
+# Since `dcos-image` is not a dependency of `test-e2e`, that
+# `conftest.py` breaks these tests.
+[pytest]
+log_cli = True
+log_cli_level = INFO

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -9,4 +9,5 @@ pytest==4.1.1
 responses==0.10.6
 requests==2.21.0
 wheel==0.33.1
+wcmatch==6.1
 teamcity-messages==1.21

--- a/test-e2e/test_e2e_module.py
+++ b/test-e2e/test_e2e_module.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 from typing import Callable, Generator, Tuple
 
-import conditional
 import cryptography.hazmat.backends
 import jwt
 import pytest
@@ -25,20 +24,12 @@ cryptography_default_backend = cryptography.hazmat.backends.default_backend()
 @pytest.fixture(scope='session', autouse=True)
 def configure_logging() -> None:
     """
-    Surpress INFO, DEBUG and NOTSET log messages from libraries that log
+    Suppress INFO, DEBUG and NOTSET log messages from libraries that log
     excessive amount of debug output that isn't useful for debugging e2e tests.
     """
     logging.getLogger('urllib3.connectionpool').setLevel(logging.WARN)
     logging.getLogger('docker').setLevel(logging.WARN)
     logging.getLogger('sarge').setLevel(logging.WARN)
-
-
-@pytest.fixture(scope='session', autouse=True)
-def log_changed_files() -> None:
-    """
-    Log files that have changed for this PR
-    """
-    conditional.log_modified_files()
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
## High-level description

Add a decorator to skip e2e tests if only safe files are modified. Only one test is decorated, until we've seen that it works for PR's, trains, and masters (it should only skip in the non-train PR).

In e2e test build log
```
[09:50:20] :	 [Step 2/3] ----------------------------- live log collection ------------------------------
[09:50:20] :	 [Step 2/3] conditional.py              31 INFO     INSTALLER_URL=https://downloads.dcos.io/dcos/testing/pull/7445/dcos_generate_config.sh
[09:50:21] :	 [Step 2/3] conditional.py              52 INFO     Remaining requests: 59
[09:50:21] :	 [Step 2/3] conditional.py              84 INFO     Merging mesosphere:jongiddy/D2IQ-70118-e2e-change-decorator into dcos:master
[09:50:21] :	 [Step 2/3] conditional.py              93 INFO     Modified files: ['test-e2e/conditional.py', 'test-e2e/pytest.ini', 'test-e2e/requirements.txt', 'test-e2e/test_e2e_module.py', 'test-e2e/test_exhibitor_quorum.py']
[09:50:21] :	 [Step 2/3] conditional.py             128 INFO     /teamcity/work/a22ac65ca925181e/test-e2e/test_exhibitor_quorum.py:31: Changed files not in safelist: ('test-e2e/conditional.py', 'test-e2e/test_exhibitor_quorum.py', 'test-e2e/pytest.ini')
[09:50:21] :	 [Step 2/3] collected 10 items
```
so test gets run this time. We'll start to see skips in other PR's once this merges.

Note, 'test-e2e/requirements.txt' and 'test-e2e/test_e2e_module.py' could affect the test outcome, so should not be in the safe list. I have added a note to the follow-up issue to fix this (see related ticket). 

## Corresponding DC/OS tickets (required)

  - [D2IQ-70118](https://jira.d2iq.com/browse/D2IQ-70118) Develop conditional skipping decorators for e2e tests


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-70203](https://jira.d2iq.com/browse/D2IQ-70203) Annotate remaining e2e tests for conditional skipping
