### PR TITLE
[1.13] Wait on ZooKeeper instead of Exhibitor during bootstrap

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/exhibitor.py
@@ -1,82 +1,55 @@
 import logging
 import os
+import re
+import socket
 import sys
 
 import requests
 
 from dcos_internal_utils import utils
-from pkgpanda.util import load_string, write_string
 
 log = logging.getLogger(__name__)
 
 
 EXHIBITOR_STATUS_URL = 'http://127.0.0.1:8181/exhibitor/v1/cluster/status'
 
-zk_pid_path = "/var/lib/dcos/exhibitor/zk.pid"
-stash_zk_pid_stat_mtime_path = "/var/lib/dcos/bootstrap/exhibitor_pid_stat"
+
+_zk_mode_pat = re.compile(br'^Mode: (.*)$', re.MULTILINE)
+ZK_MODE_LATENT = 'latent'
+ZK_MODE_STANDALONE = 'standalone'
+ZK_MODE_FOLLOWER = 'follower'
+ZK_MODE_LEADER = 'leader'
+
+zk_mode_map = {
+    b'standalone': ZK_MODE_STANDALONE,
+    b'follower': ZK_MODE_FOLLOWER,
+    b'leader': ZK_MODE_LEADER
+}
 
 
-def get_zk_pid_mtime():
-    try:
-        return os.stat(zk_pid_path).st_mtime_ns
-    except FileNotFoundError:
-        log.error("ZK pid file `%s` does not exist.", zk_pid_path)
-        return None
-
-
-def get_zk_pid():
-    return load_string(zk_pid_path)
-
-
-def try_shortcut():
-    try:
-        # pid stat file exists, read the value out of it
-        stashed_pid_stat = int(load_string(stash_zk_pid_stat_mtime_path))
-    except FileNotFoundError:
-        log.info('No zk.pid last mtime found at %s', stash_zk_pid_stat_mtime_path)
-        return False
-
-    # Make sure that the pid hasn't been written anew
-    cur_pid_stat = get_zk_pid_mtime()
-
-    if cur_pid_stat is None:
-        return False
-
-    if stashed_pid_stat != cur_pid_stat:
-        return False
-
-    # Check that the PID has a zk running at it currently.
-    zk_pid = get_zk_pid()
-    cmdline_path = '/proc/{}/cmdline'.format(zk_pid)
-    try:
-        # Custom because the command line is ascii with `\x00` as separator.
-        with open(cmdline_path, 'rb') as f:
-            cmd_line = f.read().split(b'\x00')[:-1]
-    except FileNotFoundError:
-        log.info('Process no longer running (couldn\'t read the cmdline at: %s)', zk_pid)
-        return False
-
-    log.info('PID %s has command line %s', zk_pid, cmd_line)
-
-    if len(cmd_line) < 3:
-        log.info("Command line too short to be zookeeper started by exhibitor")
-        return False
-
-    if cmd_line[-1] != b'/var/lib/dcos/exhibitor/conf/zoo.cfg' \
-            or cmd_line[0] != b'/opt/mesosphere/active/java/usr/java/bin/java':
-        log.info("command line doesn't start with java and end with zookeeper.cfg")
-        return False
-
-    log.info("PID file hasn't been modified. ZK still seems to be at that PID.")
-    return True
+def get_zookeeper_mode():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        server_address = ('127.0.0.1', 2181)
+        sock.connect(server_address)
+        sock.sendall(b'srvr\n')
+        response = b''
+        buf = sock.recv(512)
+        while buf != b'':
+            response += buf
+            buf = sock.recv(512)
+    match = _zk_mode_pat.search(response)
+    if match:
+        mode = match.group(1)
+        result = zk_mode_map.get(mode)
+        if result is None:
+            raise KeyError('Unexpected mode: {} in {}'.format(mode, response))
+        return result
+    if response.strip() == b'This ZooKeeper instance is not currently serving requests':
+        return ZK_MODE_LATENT
+    raise RuntimeError('Unexpected response: {}'.format(response))
 
 
 def wait(master_count_filename):
-    if try_shortcut():
-        log.info("Shortcut succeeeded, assuming local zk is in good config state, not waiting for quorum.")
-        return
-    log.info('Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize')
-
     if not os.path.exists(master_count_filename):
         log.info("master_count file doesn't exist when it should. Hard failing.")
         sys.exit(1)
@@ -86,14 +59,31 @@ def wait(master_count_filename):
 
     log.info('Waiting for ZooKeeper cluster to stabilize')
     try:
+        zk_mode = get_zookeeper_mode()
+    except ConnectionRefusedError:
+        log.error('ZooKeeper not running')
+        sys.exit(1)
+
+    if cluster_size == 1:
+        desired_modes = {ZK_MODE_STANDALONE}
+    else:
+        desired_modes = {ZK_MODE_FOLLOWER, ZK_MODE_LEADER}
+    if zk_mode not in desired_modes:
+        log.error('ZooKeeper not in correct mode: %s', zk_mode)
+        sys.exit(1)
+
+    log.info('ZooKeeper OK: %s', zk_mode)
+
+    # Check Exhibitor, but do not fail if it is shows unexpected results
+    try:
         response = requests.get(EXHIBITOR_STATUS_URL)
     except requests.exceptions.ConnectionError as ex:
         log.error('Could not connect to exhibitor: {}'.format(ex))
-        sys.exit(1)
+        return
     if response.status_code != 200:
         log.error('Could not get exhibitor status: {}, Status code: {}'.format(
             EXHIBITOR_STATUS_URL, response.status_code))
-        sys.exit(1)
+        return
 
     data = response.json()
 
@@ -114,17 +104,12 @@ def wait(master_count_filename):
         if len(leaders) != 1 or len(serving) < quorum:
             msg_fmt = 'Require {}+ servers and 1 leader, have {} servers and {} leaders'
             log.error(msg_fmt.format(quorum, len(serving), len(leaders)))
-            sys.exit(1)
+            return
     else:
         # For other clusters, wait for all ZooKeeper nodes to be ready.
         if len(leaders) != 1 or len(serving) != cluster_size:
             msg_fmt = 'Require {} servers and 1 leader, have {} servers and {} leaders'
             log.error(msg_fmt.format(cluster_size, len(serving), len(leaders)))
-            sys.exit(1)
+            return
 
-    # Local Zookeeper is up. Config should be stable, local zookeeper happy. Stash the PID so if
-    # there is a restart we can come up quickly without requiring a new zookeeper quorum.
-    zk_pid_mtime = get_zk_pid_mtime()
-    if zk_pid_mtime is not None:
-        log.info('Stashing zk.pid mtime %s to %s', zk_pid_mtime, stash_zk_pid_stat_mtime_path)
-        write_string(stash_zk_pid_stat_mtime_path, str(zk_pid_mtime))
+    log.info('Exhibitor OK')


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Wait for ZooKeeper to enter a suitable mode for the cluster, rather than waiting for Exhibitor.

## Corresponding DC/OS tickets (required)

  - [D2IQ-70393](https://jira.d2iq.com/browse/D2IQ-70393) Wait for ZooKeeper instead of Exhibitor in bootstrap


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
