### PR TITLE
[1.13] Use ZooKeeper autopurge instead of Exhibitor periodic cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Display user email address in UI when logging in using external provider. (D2IQ-70199)
 
+* Removed Exhibitor snapshot cleanup and now rely on ZooKeeper autopurge. (D2IQ-68109)
+
 
 #### Update Metronome to 0.6.48
 

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -99,7 +99,10 @@ zookeeper-log-directory={zookeeper_log_dir}
 zookeeper-config-directory=/var/lib/dcos/exhibitor/conf
 zookeeper-pid-path=/var/lib/dcos/exhibitor/zk.pid
 log-index-directory={zookeeper_log_dir}
-cleanup-period-ms=300000
+# Exhibitor runs PurgeTxnLog every `cleanup-period-ms` ms.  With ZK 3.4+ this
+# is no longer required if `autopurge` is configured for ZK.  Setting
+# `cleanup-period-ms` to 0 prevents Exhibitor from running the purge.
+cleanup-period-ms=0
 check-ms={check_ms}
 backup-period-ms=600000
 client-port=2181
@@ -108,7 +111,7 @@ backup-max-store-ms=21600000
 connect-port=2888
 observer-threshold=0
 election-port=3888
-zoo-cfg-extra=tickTime\\=2000&initLimit\\=10&syncLimit\\=5&quorumListenOnAllIPs\\=true&maxClientCnxns\\=0&autopurge.snapRetainCount\\=5&autopurge.purgeInterval\\=6
+zoo-cfg-extra=tickTime\\=2000&initLimit\\=10&syncLimit\\=5&quorumListenOnAllIPs\\=true&maxClientCnxns\\=0&autopurge.purgeInterval\\=1
 auto-manage-instances-settling-period-ms=0
 auto-manage-instances=1
 auto-manage-instances-fixed-ensemble-size={zookeeper_cluster_size}


### PR DESCRIPTION
## High-level description

Back-port of #7314

ZooKeeper 3.4 introduced autopurge to clean up old snapshots and transaction logs. This was also one of the responsibilities handled by Exhibitor. For some time we have had ZK running autopurge every 6 hours, but also Exhibitor calling ZK purge every 5 minutes.

Exhibitor does not pass the configured JNA temporary directory through to its explicit purge, so it causes ZooKeeper to to use `/tmp` for executable files, even if it is mounted `noexec`.

This PR stops the Exhibitor purge, and changes the ZK autopurge to run every hour (the minimum). 


## Corresponding DC/OS tickets (required)

  - [D2IQ-68109](https://jira.d2iq.com/browse/D2IQ-68109) COPS-6111: Regression: Exhibitor writing JNA files to /tmp again
  - [D2IQ-68868](https://jira.d2iq.com/browse/D2IQ-68868) Back-port dropping Exhibitor purge
