### PR TITLE
Make telegraf wait for network

### DIFF
--- a/packages/telegraf/extra/dcos-telegraf.service
+++ b/packages/telegraf/extra/dcos-telegraf.service
@@ -16,5 +16,6 @@ EnvironmentFile=/opt/mesosphere/etc/telegraf.env
 
 LimitNOFILE=16384
 
+ExecStartPre=/bin/ping -c1 leader.mesos
 ExecStartPre=/opt/mesosphere/bin/bootstrap ${SERVICE}
 ExecStart=/opt/mesosphere/bin/start_telegraf.sh --config ${TELEGRAF_CONFIG_FILE} --config-directory ${TELEGRAF_CONFIG_DIR},${TELEGRAF_USER_CONFIG_DIR}


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Currently Mesos (and other components) does network check before starting bootstrap.
Let's introduce the same check to start telegraph at the same time as Mesos and
do not allow any retries or timeouts in bootstrap phase.

```python
# Start Telegraf
30.333688 [INFO] Clearing proxy environment variables
30.334119 [INFO] Setting ENABLE_CHECK_TIME to true
30.337367 Checking whether time is synchronized using the kernel adjtimex API.
30.337512 Time can be synchronized via most popular mechanisms (ntpd, chrony, systemd-timesyncd, etc.)
30.337662 Time is in sync!
30.338111 [INFO] No zk.pid last mtime found at /var/lib/dcos/bootstrap/exhibitor_pid_stat
30.338261 [INFO] Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize
30.338411 [INFO] master_count file doesn't exist, not waiting
30.338567 [INFO] Make sure directory exists: /run/dcos/etc
⋮
30.341205 [INFO] Make sure directory exists: /run/dcos/pki/cockroach
30.341343 [INFO] Using agent credentials for Zookeeper
# First failure 
# maybe we should fail fast here 
# but we need to support networking services with bootstrap as well
30.341649 [WARNING] Cannot resolve leader.mesos: [Errno -2] Name or service not known
# Crash
45.33918 Traceback (most recent call last):
45.339324 File "/opt/mesosphere/bin/bootstrap", line 83, in <module>
45.33947 main()
45.339625 File "/opt/mesosphere/bin/bootstrap", line 62, in main
45.339767 bootstrapper = bootstrap.Bootstrapper(opts)
45.339908 File "/opt/mesosphere/lib/python3.6/site-packages/dcos_internal_utils/bootstrap.py", line 114, in __init__
45.340047 zk.start()
45.340187 File "/opt/mesosphere/lib/python3.6/site-packages/kazoo/client.py", line 567, in start
45.340333 raise self.handler.timeout_exception("Connection time-out")
45.340471 kazoo.handlers.threading.KazooTimeoutError: Connection time-out
# Restart
50.885349 [INFO] Clearing proxy environment variables
50.885855 [INFO] Setting ENABLE_CHECK_TIME to true
50.886815 Checking whether time is synchronized using the kernel adjtimex API.
50.886966 Time can be synchronized via most popular mechanisms (ntpd, chrony, systemd-timesyncd, etc.)
50.887123 Time is in sync!
50.887681 [INFO] No zk.pid last mtime found at /var/lib/dcos/bootstrap/exhibitor_pid_stat
50.88784  [INFO] Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize
50.887981 [INFO] master_count file doesn't exist, not waiting
50.88812  [INFO] Make sure directory exists: /run/dcos/etc
⋮
50.891345 [INFO] Make sure directory exists: /run/dcos/pki/cockroach
50.89148  [INFO] Using agent credentials for Zookeeper
50.894087 [INFO] Connecting to <IP>:2181
50.895884 [INFO] Zookeeper connection established, state: CONNECTED
50.896467 [INFO] bootstrapping dcos-telegraf-agent
```

```python
# Start Mesos
30.002078 ping: ready.spartan: Name or service not known
# Second try after 5s
35.207628 PING ready.spartan (127.0.0.1) 56(84) bytes of data.
35.207772 64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.022 ms
35.207904 --- ready.spartan ping statistics ---
35.208026 1 packets transmitted, 1 received, 0% packet loss, time 0ms
35.208154 rtt min/avg/max/mdev = 0.022/0.022/0.022/0.000 ms
35.559687 [INFO] Clearing proxy environment variables
35.559828 [INFO] Setting ENABLE_CHECK_TIME to true
35.560349 Checking whether time is synchronized using the kernel adjtimex API.
35.56049  Time can be synchronized via most popular mechanisms (ntpd, chrony, systemd-timesyncd, etc.)
35.560644 Time is in sync!
35.561125 [INFO] No zk.pid last mtime found at /var/lib/dcos/bootstrap/exhibitor_pid_stat
35.561274 [INFO] Shortcut failed, waiting for exhibitor to bring up zookeeper and stabilize
35.561413 [INFO] master_count file doesn't exist, not waiting
35.561563 [INFO] Make sure directory exists: /run/dcos/etc
⋮
35.564209 [INFO] Make sure directory exists: /run/dcos/pki/cockroach
35.564358 [INFO] Using agent credentials for Zookeeper
35.565362 [INFO] Connecting to <IP>:2181
35.568417 [INFO] Zookeeper connection established, state: CONNECTED
35.569898 [INFO] bootstrapping dcos-mesos-slave
```

After reading logs we can find that Telegraf starts bootstrap script and it takes 15s to fail due to networking issues.
Mesos starts at the same time but first it fails because network is not ready yet, and restarts after 5s finishing 
bootstrap procedure without any issues and starts before Telegraf. 

Probably the root cause is in bootstrap script but in many other packages we used workaround of pinging mesos.leader
to check is network is ready. I think it's fine to do it in one more time.

Another option could be to move `ping` into well named script e.g. `check_network` but then this PR will be much bigger.

Refs: https://github.com/dcos/dcos/blame/master/packages/mesos/extra/dcos-mesos-slave.service#L22

See: 

* https://github.com/dcos/dcos/search?q=ExecStartPre%3D%2Fbin%2Fping+-c1&unscoped_q=ExecStartPre%3D%2Fbin%2Fping+-c1
* 8c253c55718c6a2f658e92ce72b1bfa5d7496233
* https://github.com/dcos/dcos/pull/662/


## Corresponding DC/OS tickets (required)

  - [https://jira.d2iq.com/browse/COPS-6355](https://jira.d2iq.com/browse/COPS-6355) Tasks don't start until the Telegraf creates /run/dcos/telegraf/dcos_statsd.sock


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
