### PR TITLE
Add logging to etcd put command in e2e tests

### DIFF
--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -102,7 +102,7 @@ class EtcdClient():
         master = list(self.masters)[0]
         etcdctl_with_args = get_etcdctl_with_base_args(endpoint_ip=MASTER_DNS)
         etcdctl_with_args += ["put", key, value]
-        master.run(args=etcdctl_with_args)
+        master.run(args=etcdctl_with_args, output=Output.LOG_AND_CAPTURE)
 
     def get_key_from_node(
             self,


### PR DESCRIPTION

## High-level description

Currently, we don't capture the stdout / stderr of the Docker command used by the client put command in `test_snapshot_backup_and_restore`. This makes it very difficult to debug failures here.


## Corresponding DC/OS tickets (required)

  - [D2IQ-70431](https://jira.d2iq.com/browse/D2IQ-70431) test_snapshot_backup_and_restore etcd_client.put(test_key, test_val) CalledProcessError


