### PR TITLE
Fix tox failure by pinning pytest dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'docopt',
         'passlib',
         'py',
-        'pytest',
+        'pytest==5.4.3',
         'pyyaml',
         'responses',
         'requests==2.20.1',

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         'docopt',
         'passlib',
         'py',
-        'pytest==5.4.3',
+        'pytest<6.0.0',
         'pyyaml',
         'responses',
         'requests==2.20.1',


### PR DESCRIPTION
## High-level description

Just released version of pytest 6.0.0 causes tox to failure.

This has been resolved by pytest https://github.com/pytest-dev/pytest/pull/7565, however, as we wait for update, we could approach the problem at our end by pinning pytest to previous stable version.


## Corresponding DC/OS tickets (required)

  - [D2IQ-70503](https://jira.d2iq.com/browse/D2IQ-70503) Pin pytest to fix tox failures in DC/OS
