### PR TITLE
Bump Bouncer dependencies in DC/OS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,3 +32,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Updated OpenResty to 1.15.8.4. (DCOS_OSS-5967)
 
 * Update Telegraf configuration to reduce errors, vary requests to reduce load, sample less frequently. (COPS-5629)
+
+* Update Bouncer dependencies. (D2IQ-54115, D2IQ-62221)

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -29,48 +29,48 @@
     },
     "python-mimeparse": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/p/python-mimeparse/python-mimeparse-0.1.4.tar.gz",
-      "sha1": "bebc26249214c66f8c65e904e8eede8453eb4840"
+      "url": "https://files.pythonhosted.org/packages/0f/40/ac5f9e44a55b678c3cd881b4c3376e5b002677dbeab6fb3a50bac5d50d29/python-mimeparse-1.6.0.tar.gz",
+      "sha1": "675c262a74635f5e5326bb2dd1834f97c826ffa6"
     },
     "psycopg2": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/c0/07/93573b97ed61b6fb907c8439bf58f09957564cf7c39612cef36c547e68c6/psycopg2-2.7.6.1.tar.gz",
-      "sha1": "45e359fb2999c9608fea7832cb37a623151274e4"
+      "url": "https://files.pythonhosted.org/packages/a8/8f/1c5690eebf148d1d1554fc00ccf9101e134636553dbb75bdfef4f85d7647/psycopg2-2.8.5.tar.gz",
+      "sha1": "0be58e88301f7d17c1415e11ce804815ad8fe284"
     },
     "sqlalchemy": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/0c/7d/769c5fc22c0cdefd097b91cc525b6d8c88bf2afd8b0315b1e7ca088956b4/SQLAlchemy-1.2.15.tar.gz",
-      "sha1": "dd645321a887703b9be08434a73abb4041ae220f"
+      "url": "https://files.pythonhosted.org/packages/f9/67/d07cf7ac7e6dd0bc55ba62816753f86d7c558107104ca915e730c9ec2512/SQLAlchemy-1.2.19.tar.gz",
+      "sha1": "c4fe4338dc014618f21a71f30bb57eadd2c36313"
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/7b/2e/7b7634446fcbb37f666a708c366337482d13ffc259e96b2fff93b28a8e24/SQLAlchemy-Utils-0.33.9.tar.gz",
-      "sha1": "e3667b224797eb341f66539448c311629e1f8861"
+      "url": "https://files.pythonhosted.org/packages/bf/7e/3211ad9b3983b216d1b1863fd7734f80bacd1a62a5de8ff6844fb5ed1498/SQLAlchemy-Utils-0.35.0.tar.gz",
+      "sha1": "d48dd695b9d92233510c3c1499e85b912fd94240"
     },
     "mako": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/eb/f3/67579bb486517c0d49547f9697e36582cd19dafb5df9e687ed8e22de57fa/Mako-1.0.7.tar.gz",
-      "sha1": "bf0c1f4cdfca4dd37bc0c9f83e984a0558268b42"
+      "url": "https://files.pythonhosted.org/packages/72/89/402d2b4589e120ca76a6aed8fee906a0f5ae204b50e455edd36eda6e778d/Mako-1.1.3.tar.gz",
+      "sha1": "098f90baefe938434e426b8682cdfb89fa223eba"
     },
     "python-editor": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/65/1e/adf6e000ea5dc909aa420352d6ba37f16434c8a3c2fa030445411a1ed545/python-editor-1.0.3.tar.gz",
-      "sha1": "018e3c55a09ce6ac6531e9337bfa29a252aacdc2"
+      "url": "https://files.pythonhosted.org/packages/0a/85/78f4a216d28343a67b7397c99825cff336330893f00601443f7c7b2f2234/python-editor-1.0.4.tar.gz",
+      "sha1": "14a22b55e60e94f22de690d32ba9787ec998d779"
     },
     "pyasn1": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/10/46/059775dc8e50f722d205452bced4b3cc965d27e8c3389156acd3b1123ae3/pyasn1-0.4.4.tar.gz",
-      "sha1": "10f67e61e30c064301c826c6e5e461ff7bf5827d"
+      "url": "https://files.pythonhosted.org/packages/a4/db/fffec68299e6d7bad3d504147f9094830b704527a7fc098b721d38cc7fa7/pyasn1-0.4.8.tar.gz",
+      "sha1": "e0fa19f8fda46a1fa2253477499b116b33f67175"
     },
     "alembic": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/1c/65/b8e4f5b2f345bb13b5e0a3fddd892b0b3f0e8ad4880e954fdc6a50d00d84/alembic-1.0.5.tar.gz",
-      "sha1": "2eee5fa2bd3ea7c526950e827824397acb24a531"
+      "url": "https://files.pythonhosted.org/packages/60/1e/cabc75a189de0fbb2841d0975243e59bde8b7822bacbb95008ac6fe9ad47/alembic-1.4.2.tar.gz",
+      "sha1": "8967b6c2297d01372c2b10ccdaa1a2bf4d1ee523"
     },
     "cockroachdb-python": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/1c/7d/063bd5cc3ffe13561ded9eddbe736d795e984a7a9dfe5d0eca0986134f6e/cockroachdb-0.2.1.tar.gz",
-      "sha1": "af40b0e6e0b9b141f6faf28bcb96b10add941886"
+      "url": "https://files.pythonhosted.org/packages/34/6c/5abe785470ec6f208d3cc38f8baa7a148b734c91978938d647d4f69a85f4/cockroachdb-0.3.5.tar.gz",
+      "sha1": "e64b0dae7283a809ea75f4b200fad2120dced390"
     }
   },
   "username": "dcos_bouncer",

--- a/packages/dcos-integration-test/extra/get_test_group.py
+++ b/packages/dcos-integration-test/extra/get_test_group.py
@@ -17,14 +17,14 @@ import click
 import yaml
 
 
-def patterns_from_group(group_name: str, test_groups_path: str='test_groups.yaml') -> List[str]:
+def patterns_from_group(group_name: str, test_groups_path: str = 'test_groups.yaml') -> List[str]:
     """
     Given a group name, return all the pytest patterns defined for that group
     in ``test_groups.yaml``.
     """
     test_group_file = Path(test_groups_path)
     test_group_file_contents = test_group_file.read_text()
-    test_groups = yaml.load(test_group_file_contents)['groups']
+    test_groups = yaml.safe_load(test_group_file_contents)['groups']
     group = test_groups[group_name]  # type: List[str]
     return group
 

--- a/packages/dcos-integration-test/extra/test_meta.py
+++ b/packages/dcos-integration-test/extra/test_meta.py
@@ -85,7 +85,7 @@ def test_test_groups() -> None:
 
     test_group_file = Path(test_groups_path)
     test_group_file_contents = test_group_file.read_text()
-    test_groups = yaml.load(test_group_file_contents)['groups']
+    test_groups = yaml.safe_load(test_group_file_contents)['groups']
     test_patterns = []
     for group in test_groups:
         test_patterns += patterns_from_group(group_name=group, test_groups_path=test_groups_path)

--- a/packages/dcos-integration-test/extra/test_misc.py
+++ b/packages/dcos-integration-test/extra/test_misc.py
@@ -14,7 +14,7 @@ __contact__ = 'dcos-cluster-ops@mesosphere.io'
 # TODO(cmaloney): Validate it contains some settings we expact.
 def test_load_user_config() -> None:
     with open('/opt/mesosphere/etc/user.config.yaml', 'r') as f:
-        user_config = yaml.load(f)
+        user_config = yaml.safe_load(f)
 
     # Calculated parameters shouldn't be in the user config
     assert 'master_quorum' not in user_config

--- a/packages/python-certifi/buildinfo.json
+++ b/packages/python-certifi/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://pypi.python.org/packages/29/9b/25ef61e948321296f029f53c9f67cc2b54e224db509eb67ce17e0df6044a/certifi-2017.11.5-py2.py3-none-any.whl",
-    "sha1": "0e09a6f85d5f93ec1012ae8de014af2fecb7e2ea"
+    "url": "https://files.pythonhosted.org/packages/5e/c4/6c4fe722df5343c33226f0b4e0bb042e4dc13483228b4718baf286f86d87/certifi-2020.6.20-py2.py3-none-any.whl",
+    "sha1": "f37eb16dd168e81f95c31495516aa948e7b846ee"
   }
 }

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -3,18 +3,18 @@
   "sources": {
     "cryptography": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/f3/39/d3904df7c56f8654691c4ae1bdb270c1c9220d6da79bd3b1fbad91afd0e1/cryptography-2.4.2.tar.gz",
-      "sha1": "dbebf76a5e10eeb3c251bd1a243e0d1dacfda765"
+      "url": "https://files.pythonhosted.org/packages/56/3b/78c6816918fdf2405d62c98e48589112669f36711e50158a0c15d804c30d/cryptography-2.9.2.tar.gz",
+      "sha1": "af16e069cad7d36442f8481542de51f87c3c7708"
     },
     "asn1crypto": {
       "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl",
-      "sha1": "fff0f73e555ae1b230a95beae1604ce3fbc22646"
+      "url": "https://files.pythonhosted.org/packages/e9/51/1db4a60049fb7390959be586b6eb743098e6cea3f6b2d3ed9e17fec62ba2/asn1crypto-1.3.0-py2.py3-none-any.whl",
+      "sha1": "072fabec7abe3acf53e935d6d5a965a6b81d3b87"
     },
     "cffi": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/e7/a7/4cd50e57cc6f436f1cc3a7e8fa700ff9b8b4d471620629074913e3735fb2/cffi-1.11.5.tar.gz",
-      "sha1": "1686e6689a691414d3d22626c837adeee3996dd9"
+      "url": "https://files.pythonhosted.org/packages/54/1d/15eae71ab444bd88a1d69f19592dcf32b9e3166ecf427dd9243ef0d3b7bc/cffi-1.14.1.tar.gz",
+      "sha1": "7b067fdb46d184f6bfdadc11732df6f0340e553d"
     }
   }
 }

--- a/packages/python-future/buildinfo.json
+++ b/packages/python-future/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/f/future/future-0.15.2.tar.gz",
-      "sha1": "431bf8ff160e8e785a2f76c3e57c1b6c2b13b41a"
+      "url": "https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz",
+      "sha1": "d8c8b2d3889fc22bb38f049ed8e3dbdc35a83d6e"
   }
 }

--- a/packages/python-idna/buildinfo.json
+++ b/packages/python-idna/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://pypi.python.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl",
-    "sha1": "a75f31778ea0bbf218d7ae085f4f961d004d6ff2"
+    "url": "https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl",
+    "sha1": "999b6718b4d789d8ca0d2ddf7c07826154291825"
   }
 }

--- a/packages/python-isodate/buildinfo.json
+++ b/packages/python-isodate/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/f4/5b/fe03d46ced80639b7be9285492dc8ce069b841c0cebe5baacdd9b090b164/isodate-0.5.4.tar.gz",
-      "sha1": "40ccf07a8e46284a79cfc4d41e151f71ae63f535"
+      "url": "https://files.pythonhosted.org/packages/b1/80/fb8c13a4cd38eb5021dc3741a9e588e4d1de88d895c1910c6fc8a08b7a70/isodate-0.6.0.tar.gz",
+      "sha1": "2c69e08c9894a9cd96c627146463260f5731df62"
   }
 }

--- a/packages/python-jose/buildinfo.json
+++ b/packages/python-jose/buildinfo.json
@@ -3,18 +3,18 @@
   "sources": {
     "python-jose": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/d1/c1/ecc8b1229f0e8cdaef93da903d4495579edea529f77eb42e60908879d3b7/python-jose-3.0.1.tar.gz",
-      "sha1": "bc4aaf20a2bb797494d7e51755a8e9a22ace86d0"
+      "url": "https://files.pythonhosted.org/packages/2e/0e/29e1f5bba4e719eb09efc2b76ea46439aa2dabffa5bcd7d3fccae816d128/python-jose-3.1.0.tar.gz",
+      "sha1": "b81ce740c7ac4cc90280c0c83183f183538a4384"
     },
     "ecdsa": {
        "kind": "url_extract",
-       "url": "https://files.pythonhosted.org/packages/f9/e5/99ebb176e47f150ac115ffeda5fedb6a3dbb3c00c74a59fd84ddf12f5857/ecdsa-0.13.tar.gz",
-      "sha1": "7bcf6d1773d08bcc4bdd28cd05c545969f5aa162"
+       "url": "https://files.pythonhosted.org/packages/e3/7c/b508ade1feb47cd79222e06d85e477f5cfc4fb0455ad3c70eb6330fc49aa/ecdsa-0.15.tar.gz",
+      "sha1": "5ac84f3012d807793bcb98a8e9c86c63b9965596"
     },
     "rsa": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/cb/d0/8f99b91432a60ca4b1cd478fd0bdf28c1901c58e3a9f14f4ba3dba86b57f/rsa-4.0.tar.gz",
-      "sha1": "8a68dcee7bd2a7727c253b9ed2820cd1b5b9241a"
+      "url": "https://files.pythonhosted.org/packages/a2/d5/04b8a9719149583fec76efdff2e7a81c6e3cc34909ee818d3fbf115edc2e/rsa-4.6.tar.gz",
+      "sha1": "43335708732a72541476be1432c06f9992dc8e2d"
     }
   }
 }

--- a/packages/python-jwt/buildinfo.json
+++ b/packages/python-jwt/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://files.pythonhosted.org/packages/93/d1/3378cc8184a6524dc92993090ee8b4c03847c567e298305d6cf86987e005/PyJWT-1.6.4-py2.py3-none-any.whl",
-    "sha1": "4a7a127bda251d12e10a89226a2d84bcab5f9dc4"
+    "url": "https://files.pythonhosted.org/packages/87/8b/6a9f14b5f781697e51259d81657e6048fd31a113229cf346880bb7545565/PyJWT-1.7.1-py2.py3-none-any.whl",
+    "sha1": "c279f764ba3bf3b21b29e5a12dfd2ea7dead4ab5"
   }
 }

--- a/packages/python-markupsafe/buildinfo.json
+++ b/packages/python-markupsafe/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz",
-    "sha1": "cd5c22acf6dd69046d6cb6a3920d84ea66bdf62a"
+    "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
+    "sha1": "f70e5fd3c120a1b108d4347ea1115e3962c42026"
   }
 }

--- a/packages/python-passlib/buildinfo.json
+++ b/packages/python-passlib/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://files.pythonhosted.org/packages/ee/a7/d6d238d927df355d4e4e000670342ca4705a72f0bf694027cf67d9bcf5af/passlib-1.7.1-py2.py3-none-any.whl",
-    "sha1": "bc8fca38c407eb01ee55ec199538734c1d35ff8c"
+    "url": "https://files.pythonhosted.org/packages/11/b8/e9a78f3033228013ba8564adad8d0031bf9d39ea3acc3cdb9d55fabeb4ba/passlib-1.7.2-py2.py3-none-any.whl",
+    "sha1": "223eee683f8fc446bc99429a6b1ddbe056c4ccad"
   }
 }

--- a/packages/python-pycparser/buildinfo.json
+++ b/packages/python-pycparser/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/8c/2d/aad7f16146f4197a11f8e91fb81df177adcc2073d36a17b1491fd09df6ed/pycparser-2.18.tar.gz",
-      "sha1": "1c75af69ae6273b1f1f531744f87d060965ed85d"
+      "url": "https://files.pythonhosted.org/packages/0f/86/e19659527668d70be91d0369aeaa055b4eb396b0f387a4f92293a20035bd/pycparser-2.20.tar.gz",
+      "sha1": "0ae93d89b69fab48af3a407a2f8663bcea270c3d"
   }
 }

--- a/packages/python-pyyaml/buildinfo.json
+++ b/packages/python-pyyaml/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://pypi.python.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz",
-    "sha1": "cb7fd3e58c129494ee86e41baedfec69eb7dafbe"
+    "url": "https://files.pythonhosted.org/packages/64/c2/b80047c7ac2478f9501676c988a5411ed5572f35d1beff9cae07d321512c/PyYAML-5.3.1.tar.gz",
+    "sha1": "3b20272e119990b2bbeb03815a1dd3f3e48af07e"
   }
 }

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -3,8 +3,8 @@
   "sources": {
     "requests": {
       "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/ff/17/5cbb026005115301a8fb2f9b0e3e8d32313142fe8b617070e7baad20554f/requests-2.20.1-py2.py3-none-any.whl",
-      "sha1": "a38551c5a3baa3bfdaa89edb5f0f3e15b298ee6a"
+      "url": "https://files.pythonhosted.org/packages/45/1e/0c169c6a5381e241ba7404532c16a21d86ab872c9bed8bdcd4c423954103/requests-2.24.0-py2.py3-none-any.whl",
+      "sha1": "1ee1d4eb7c910502b93f61156af26178a5e747c7"
     },
     "urllib3": {
       "kind": "url",

--- a/packages/six/buildinfo.json
+++ b/packages/six/buildinfo.json
@@ -3,8 +3,8 @@
   "sources": {
     "six": {
       "kind": "url",
-      "url": "https://pypi.python.org/packages/py2.py3/s/six/six-1.10.0-py2.py3-none-any.whl",
-      "sha1": "19df5f56abce3db94d5e0e079e54bf430fddbb02"
+      "url": "https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl",
+      "sha1": "8730d16507db66e828c696ecc7cb785e557900bb"
      }
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'pytest<6.0.0',
         'pyyaml',
         'responses',
-        'requests==2.20.1',
+        'requests==2.24.0',
         'retrying',
         'schema',
         'wheel==0.33.1',


### PR DESCRIPTION
## High-level description

Update Bouncer dependencies that are provided by DC/OS. This follows on from https://github.com/dcos/dcos/pull/7499 which only changes the dependencies in the Bouncer repo (e.g. used for testing).


## Corresponding DC/OS tickets (required)

  - [D2IQ-54115](https://jira.d2iq.com/browse/D2IQ-54115) Bump Bouncer dependencies conservatively
  - [D2IQ-62221](https://jira.d2iq.com/browse/D2IQ-62221) Update cockroachdb Python package to 0.3.2+
