### PR TITLE
 [2.0] Update Bouncer dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Security updates
 
+* Updated CockroachDB Python package to 0.3.5. (D2IQ-62221) 
+
 ### Notable changes
 
 ### Fixed and improved

--- a/packages/bouncer-deps/buildinfo.json
+++ b/packages/bouncer-deps/buildinfo.json
@@ -29,23 +29,23 @@
     },
     "python-mimeparse": {
       "kind": "url_extract",
-      "url": "https://pypi.python.org/packages/source/p/python-mimeparse/python-mimeparse-0.1.4.tar.gz",
-      "sha1": "bebc26249214c66f8c65e904e8eede8453eb4840"
+      "url": "https://files.pythonhosted.org/packages/0f/40/ac5f9e44a55b678c3cd881b4c3376e5b002677dbeab6fb3a50bac5d50d29/python-mimeparse-1.6.0.tar.gz",
+      "sha1": "675c262a74635f5e5326bb2dd1834f97c826ffa6"
     },
     "psycopg2": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/c0/07/93573b97ed61b6fb907c8439bf58f09957564cf7c39612cef36c547e68c6/psycopg2-2.7.6.1.tar.gz",
-      "sha1": "45e359fb2999c9608fea7832cb37a623151274e4"
+      "url": "https://files.pythonhosted.org/packages/a8/8f/1c5690eebf148d1d1554fc00ccf9101e134636553dbb75bdfef4f85d7647/psycopg2-2.8.5.tar.gz",
+      "sha1": "0be58e88301f7d17c1415e11ce804815ad8fe284"
     },
     "sqlalchemy": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/0c/7d/769c5fc22c0cdefd097b91cc525b6d8c88bf2afd8b0315b1e7ca088956b4/SQLAlchemy-1.2.15.tar.gz",
-      "sha1": "dd645321a887703b9be08434a73abb4041ae220f"
+      "url": "https://files.pythonhosted.org/packages/f9/67/d07cf7ac7e6dd0bc55ba62816753f86d7c558107104ca915e730c9ec2512/SQLAlchemy-1.2.19.tar.gz",
+      "sha1": "c4fe4338dc014618f21a71f30bb57eadd2c36313"
     },
     "sqlalchemy-utils": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/7b/2e/7b7634446fcbb37f666a708c366337482d13ffc259e96b2fff93b28a8e24/SQLAlchemy-Utils-0.33.9.tar.gz",
-      "sha1": "e3667b224797eb341f66539448c311629e1f8861"
+      "url": "https://files.pythonhosted.org/packages/bf/7e/3211ad9b3983b216d1b1863fd7734f80bacd1a62a5de8ff6844fb5ed1498/SQLAlchemy-Utils-0.35.0.tar.gz",
+      "sha1": "d48dd695b9d92233510c3c1499e85b912fd94240"
     },
     "mako": {
       "kind": "url_extract",
@@ -59,18 +59,18 @@
     },
     "pyasn1": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/10/46/059775dc8e50f722d205452bced4b3cc965d27e8c3389156acd3b1123ae3/pyasn1-0.4.4.tar.gz",
-      "sha1": "10f67e61e30c064301c826c6e5e461ff7bf5827d"
+      "url": "https://files.pythonhosted.org/packages/a4/db/fffec68299e6d7bad3d504147f9094830b704527a7fc098b721d38cc7fa7/pyasn1-0.4.8.tar.gz",
+      "sha1": "e0fa19f8fda46a1fa2253477499b116b33f67175"
     },
     "alembic": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/1c/65/b8e4f5b2f345bb13b5e0a3fddd892b0b3f0e8ad4880e954fdc6a50d00d84/alembic-1.0.5.tar.gz",
-      "sha1": "2eee5fa2bd3ea7c526950e827824397acb24a531"
+      "url": "https://files.pythonhosted.org/packages/60/1e/cabc75a189de0fbb2841d0975243e59bde8b7822bacbb95008ac6fe9ad47/alembic-1.4.2.tar.gz",
+      "sha1": "8967b6c2297d01372c2b10ccdaa1a2bf4d1ee523"
     },
     "cockroachdb-python": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/1c/7d/063bd5cc3ffe13561ded9eddbe736d795e984a7a9dfe5d0eca0986134f6e/cockroachdb-0.2.1.tar.gz",
-      "sha1": "af40b0e6e0b9b141f6faf28bcb96b10add941886"
+      "url": "https://files.pythonhosted.org/packages/34/6c/5abe785470ec6f208d3cc38f8baa7a148b734c91978938d647d4f69a85f4/cockroachdb-0.3.5.tar.gz",
+      "sha1": "e64b0dae7283a809ea75f4b200fad2120dced390"
     }
   },
   "username": "dcos_bouncer",


### PR DESCRIPTION

## High-level description

Upgrade CockroachDB and other dependencies for Bouncer. This back-port is more limited than the changes to `master` in #7507.


## Corresponding DC/OS tickets (required)

  - [D2IQ-62221](https://jira.d2iq.com/browse/D2IQ-62221) Update cockroachdb Python package to 0.3.2+
