### PR TITLE
 Use ACL for S3 Bucket Upload and Copy Operation

### DIFF
--- a/release/storage/aws.py
+++ b/release/storage/aws.py
@@ -80,7 +80,7 @@ class S3StorageProvider(AbstractStorageProvider):
         new_object = self.get_object(destination_path)
         old_path = src_object.bucket_name + '/' + src_object.key
 
-        new_object.copy_from(CopySource=old_path)
+        new_object.copy_from(CopySource=old_path, ACL='bucket-owner-full-control')
 
     def upload(self,
                destination_path: str,
@@ -89,6 +89,7 @@ class S3StorageProvider(AbstractStorageProvider):
                no_cache: bool=False,
                content_type: Optional[str]=None):
         extra_args = {}
+        extra_args['ACL'] = 'bucket-owner-full-control'
         if no_cache:
             extra_args['CacheControl'] = 'no-cache'
         if content_type:


### PR DESCRIPTION
Fix D2IQ-70676 - AWS S3 Copy with (AccessDenied) when calling the Copy Object operation

Use ACL for S3 Bucket Upload and Copy Operation

This ACL is useful if the give permissions to S3 operations via ACL. The
x-amz- header is sent by adding this ACL to boto3 library.

There are two separate calls, upload and copy, both need to send the
ACL as indicated in the AWS Documentation.

    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#object

    When copying an object, you can preserve all metadata (default) or
    specify new metadata. However, the ACL is not preserved and is set to
    private for the user making the request. To override the default ACL
    setting, specify a new ACL when generating a copy request. For more
    information, see Using ACLs .

## Corresponding DC/OS tickets (required)

  - D2IQ-70676 - AWS S3 Copy with (AccessDenied) when calling the Copy Object operation
