### PR TITLE
Make Mesos Agent waits for Telegraf

### DIFF
--- a/packages/mesos/extra/dcos-mesos-slave-public.service
+++ b/packages/mesos/extra/dcos-mesos-slave-public.service
@@ -20,6 +20,7 @@ EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave-public
 EnvironmentFile=-/etc/mesosphere/mesos/agent-public.env
 ExecStartPre=/bin/ping -c1 ready.spartan
+ExecStartPre=/bin/bash -c 'test -S /run/dcos/telegraf/dcos_statsd.sock'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave-public
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/opt/mesosphere/bin/upgrade_cni.py /var/lib/cni/networks /var/run/dcos/cni/networks /opt/mesosphere/etc/dcos-cni-networks

--- a/packages/mesos/extra/dcos-mesos-slave.service
+++ b/packages/mesos/extra/dcos-mesos-slave.service
@@ -20,6 +20,7 @@ EnvironmentFile=-/var/lib/dcos/mesos-resources
 EnvironmentFile=-/run/dcos/etc/mesos-slave
 EnvironmentFile=-/etc/mesosphere/mesos/agent.env
 ExecStartPre=/bin/ping -c1 ready.spartan
+ExecStartPre=/bin/bash -c 'test -S /run/dcos/telegraf/dcos_statsd.sock'
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-mesos-slave
 ExecStartPre=/opt/mesosphere/bin/make_disk_resources.py /var/lib/dcos/mesos-resources
 ExecStartPre=/opt/mesosphere/bin/upgrade_cni.py /var/lib/cni/networks /var/run/dcos/cni/networks /opt/mesosphere/etc/dcos-cni-networks


### PR DESCRIPTION
Mesos Agent tasks requires telegraf so Mesos should wait for telegraf
socket to appear.

Refs:  https://github.com/dcos/dcos/pull/7473#discussion_r468721781
Fixes: https://jira.d2iq.com/browse/COPS-6355

<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
