### PR TITLE
Upgrade to JDK 8u265b01

### DIFF
--- a/packages/java/build
+++ b/packages/java/build
@@ -18,11 +18,11 @@ ln -s "$PKG_PATH/usr/java/bin/keytool" "$PKG_PATH/bin/keytool"
 # When updating Java, please change the following comment and check. If you need
 # to downgrade from this version, please highlight the change on DC/OS channels.
 
-# The OpenJDK 8 tarball hosted at https://downloads.mesosphere.com/java/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz
+# The OpenJDK 8 tarball hosted at https://downloads.mesosphere.com/java/
 # was originally downloaded from
-# https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u232-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz
+# https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/
 
-expected='openjdk version "1.8.0_232"'
+expected='openjdk version "1.8.0_265"'
 version=$("$PKG_PATH/bin/java" -version 2>&1 | grep 'openjdk version')
 if [ "$version" != "$expected" ]
 then

--- a/packages/java/buildinfo.json
+++ b/packages/java/buildinfo.json
@@ -2,8 +2,8 @@
   "sources" : {
     "java": {
       "kind": "url_extract",
-      "url": "https://downloads.mesosphere.com/java/OpenJDK8U-jdk_x64_linux_hotspot_8u232b09.tar.gz",
-      "sha1": "e2d1a6e27e6f2929dcf2d78fa790c808edaa3601"
+      "url": "https://downloads.mesosphere.com/java/OpenJDK8U-jdk_x64_linux_hotspot_8u265b01.tar.gz",
+      "sha1": "62046ecb28fccb372d8b6bddd0de1754bbdcaf58"
     }
   },
   "environment": {


### PR DESCRIPTION

## High-level description

Update JDK to most recent 8u265b01. This includes a fix for large open file limits: https://bugs.openjdk.java.net/browse/JDK-8236662


## Corresponding DC/OS tickets (required)

  - [D2IQ-70809](https://jira.d2iq.com/browse/D2IQ-70809) Restrict systemd file descriptors for java.
  - [COPS-6422](https://jira.d2iq.com/browse/COPS-6422) DC/OS installation crashes on flatcar linux due to LimitNoFile
