### PR TITLE
Bump Marathon to 1.8.244

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,11 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Metronome jobs networking is now configurable (MARATHON-8727)
 
+#### Update Marathon to 1.8.244
+
+* Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks (MARATHON-8758)
+
+* Improved the reliability of error handling for health check handling (MARATHON-8743)
 
 ## DC/OS 1.13.9 (2020-4-22)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.242-ee9086220/marathon-1.8.242-ee9086220.tgz",
-    "sha1": "c0b40df19b9fd8af1accafbba0409bbe5703cced"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.244-248803b19/marathon-1.8.244-248803b19.tgz",
+    "sha1": "96cb0106a962e5e83d5f855b6eb2ee7205b19e3f"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [MARATHON-8758](https://jira.mesosphere.com/browse/MARATHON-8758) Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks 
  - [MARATHON-8743](https://jira.mesosphere.com/browse/MARATHON-8743) Improved the reliability of error handling for health check handling
- [COPS-6329](https://jira.d2iq.com/browse/COPS-6329) MoM not scheduling new instances of app unless manually triggered


## Related tickets (optional)
