### PR TITLE
Bump Marathon to 1.10.26

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated Exhibitor to version running atop [Jetty 9.4.30](https://github.com/dcos/exhibitor/commit/e6e232e1)
 
+#### Bump Marathon to 1.10.26
+
+* Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks (MARATHON-8758)
+
 ## DC/OS 2.1.0 (2020-06-09)
 
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.17-c427ce965/marathon-1.10.17-c427ce965.tgz",
-    "sha1": "9e6113f95ee786ee6ee3633b72fff6c4b9708a8e"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.26-0513cddca/marathon-1.10.26-0513cddca.tgz",
+    "sha1": "157700fb745d0836b6aa528c30b1237e3c300ebb"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [MARATHON-8758](https://jira.mesosphere.com/browse/MARATHON-8758) Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks 

## Related tickets (optional)
