### PR TITLE
[1.13] Use any Python 3 in build scripts

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -38,7 +38,7 @@ EOF
 fi
 
 # Create a Python virtual environment to install the DC/OS tools to.
-python3.5 -m venv /tmp/dcos_build_venv
+python3 -m venv /tmp/dcos_build_venv
 . /tmp/dcos_build_venv/bin/activate
 
 # Install the DC/OS tools

--- a/build_teamcity
+++ b/build_teamcity
@@ -56,7 +56,7 @@ _scope_opened "setup"
 export PYTHONUNBUFFERED="notemtpy"
 
 # enable pkgpanda virtualenv *ALWAYS COPY* otherwise the TC cleanup will traverse and corrupt system python
-python3.5 -m venv --clear --copies build/env
+python3 -m venv --clear --copies build/env
 . build/env/bin/activate
 
 : ${TEAMCITY_BRANCH?"TEAMCITY_BRANCH must be set (determines the tag and testing/ channel)"}


### PR DESCRIPTION
## High-level description

The DC/OS build step in CI gets allocated to some nodes with Python 3.5 and some with Python 3.6. Modify the build scripts to use any Python 3 for the build, not just 3.5

This was added to #7534 (2.1) and #7535 (2.0) in order to get them to build.


## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
