### PR TITLE
[2.1] Minimize Docker daemon configuration changes, set Calico timeouts more consistently

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,8 +36,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Wait on ZooKeeper instead of Exhibitor during bootstrap. (D2IQ-70393)
 
-
 * Updated Exhibitor to version running atop [Jetty 9.4.30](https://github.com/dcos/exhibitor/commit/e6e232e1)
+
+* Ensure Docker network for Calico is eventually created correctly following failures. (D2IQ-70674)
+
 
 ## DC/OS 2.1.0 (2020-06-09)
 

--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -9,9 +9,12 @@ import os
 import shlex
 import signal
 import socket
+import stat
 import subprocess
 import sys
+import tempfile
 import time
+from collections import OrderedDict
 
 from contextlib import contextmanager
 from typing import Generator
@@ -215,21 +218,55 @@ def is_docker_cluster_store_configured():
     return False
 
 
-def config_docker_cluster_store():
-    if is_docker_cluster_store_configured():
-        print("Docker cluster store has already been configured")
-        return
+def write_file_bytes(filename, data, mode):
+    """
+    Set the contents of file to a byte string.
 
-    # load previous daemon configuration (if any)
-    dockerd_config = {}
+    The code ensures an atomic write by creating a temporary file and then
+    moving that temporary file to the given ``filename``. This prevents race
+    conditions such as the file being read by another process after it is
+    created but not yet written to.
+
+    It also prevents an invalid file being created if the `write` fails (e.g.
+    because of low disk space).
+
+    The new file is created with permissions `mode`.
+    """
+    prefix = os.path.basename(filename)
+    tmp_file_dir = os.path.dirname(os.path.realpath(filename))
+    fd, temporary_filename = tempfile.mkstemp(prefix=prefix, dir=tmp_file_dir)
+    # On Linux `mkstemp` initially creates file with permissions 0o600
+    try:
+        try:
+            os.write(fd, data)
+        finally:
+            os.close(fd)
+        os.chmod(temporary_filename, stat.S_IMODE(mode))
+        os.replace(temporary_filename, filename)
+    except Exception:
+        os.remove(temporary_filename)
+        raise
+
+
+def config_docker_cluster_store():
+    # load any previous daemon configuration
     if os.path.exists(DOCKERD_CONFIG_FILE):
-        with open(DOCKERD_CONFIG_FILE, "r") as f:
+        with open(DOCKERD_CONFIG_FILE, "rb") as f:
             try:
-                dockerd_config = json.loads(f.read())
-                print("Loaded previous `docker.json` contents")
+                existing_contents = f.read()
+                # Load config with an OrderedDict to minimize changes to an existing file
+                dockerd_config = json.loads(existing_contents, object_pairs_hook=OrderedDict)
+                print('Checking existing Docker daemon configuration {!r}'.format(DOCKERD_CONFIG_FILE))
             except Exception as e:
-                raise Exception("Error: cannot load {}: {}".format(
-                    DOCKERD_CONFIG_FILE, str(e)))
+                raise RuntimeError(
+                    "Cannot load Docker daemon configuration {!r}: {}".format(DOCKERD_CONFIG_FILE, str(e))
+                ) from e
+        mode = stat.S_IMODE(os.stat(DOCKERD_CONFIG_FILE)[stat.ST_MODE])
+    else:
+        existing_contents = None
+        dockerd_config = {}
+        mode = 0o644
+        print('Creating Docker daemon configuration {!r}'.format(DOCKERD_CONFIG_FILE))
 
     # cluster-store related options can take effect by reloading docker without
     # requiring to restart docker daemon process, according to
@@ -264,13 +301,18 @@ def config_docker_cluster_store():
             "kv.certfile": env_key_file_map[ETCD_CERT_FILE_ENV_KEY],
             "kv.keyfile": env_key_file_map[ETCD_KEY_FILE_ENV_KEY],
         }
-        dockerd_config.update(
-            {"cluster-store-opts": cluster_store_opts})
+        dockerd_config["cluster-store-opts"] = cluster_store_opts
+    else:
+        # Remove any previously configured key options
+        dockerd_config.pop("cluster-store-opts", None)
 
-    print("Writing updated docker daemon configuration to {}".format(
-        DOCKERD_CONFIG_FILE))
-    with open(DOCKERD_CONFIG_FILE, "w") as f:
-        json.dump(dockerd_config, f)
+    updated_contents = json.dumps(dockerd_config, indent='\t').encode('ascii')
+    if updated_contents == existing_contents:
+        print('Docker daemon configuration has expected contents')
+        return
+
+    print("Writing updated Docker daemon configuration to {!r}".format(DOCKERD_CONFIG_FILE))
+    write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
 
     # gracefully reload the docker daemon
     reload_docker_daemon()
@@ -286,7 +328,7 @@ def config_docker_cluster_store():
             raise Exception("Cluster store not configured")
         return True
 
-    return _wait_docker_cluster_store_config()
+    _wait_docker_cluster_store_config()
 
 
 def is_docker_calico_network_available(retries: int = 5) -> bool:
@@ -318,7 +360,7 @@ def is_docker_calico_network_available(retries: int = 5) -> bool:
 
 def create_calico_docker_network():
     # Avoid race conditions by obtaining a cluster-wide exclusive lock
-    # (using zookeeper) and letting only on agent executing the logic.
+    # (using zookeeper) and letting only one agent execute the logic.
     zk = zk_connect()
     with zk_cluster_lock(zk, "mutex"):
         net_wait_delay = 5
@@ -345,7 +387,7 @@ def create_calico_docker_network():
         subnet = os.getenv("CALICO_IPV4POOL_CIDR")
         if not subnet:
             raise Exception(
-                "Environment varialbe CALICO_IPV4POOL_CIDR is not set")
+                "Environment variable CALICO_IPV4POOL_CIDR is not set")
 
         net_create_cmd = "{} network create --driver calico " \
             "--opt org.projectcalico.profile={} " \

--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -8,7 +8,7 @@ EnvironmentFile=/opt/mesosphere/etc/calico/calico-node.env
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node-datastore.env
 ExecStart=/opt/mesosphere/bin/start-calico-libnetwork-plugin.sh
 ExecStartPost=/opt/mesosphere/bin/create-calico-docker-network.py
-TimeoutStartSec=60s
+TimeoutStartSec=180s
 
 Restart=always
 StartLimitInterval=0

--- a/test-e2e/test_calico_networking.py
+++ b/test-e2e/test_calico_networking.py
@@ -11,7 +11,7 @@ from typing import Iterator
 import pytest
 
 from _pytest.fixtures import SubRequest
-from cluster_helpers import wait_for_dcos_oss
+from cluster_helpers import artifact_dir_format, dump_cluster_journals, wait_for_dcos_oss
 from dcos_e2e.backends import Docker
 from dcos_e2e.cluster import Cluster
 from dcos_e2e.node import Node, Output
@@ -22,7 +22,7 @@ superuser_username = str(uuid.uuid4())
 superuser_password = str(uuid.uuid4())
 
 
-def assert_system_unit_state(node: Node, unit_name: str, active: bool=True) -> None:
+def assert_system_unit_state(node: Node, unit_name: str, active: bool = True) -> None:
     result = node.run(
         args=["systemctl show {}".format(unit_name)],
         output=Output.LOG_AND_CAPTURE,
@@ -39,11 +39,14 @@ def assert_system_unit_state(node: Node, unit_name: str, active: bool=True) -> N
 @pytest.fixture(scope="module")
 def calico_ipip_cluster(docker_backend: Docker, artifact_path: Path,
                         request: SubRequest, log_dir: Path) -> Iterator[Cluster]:
+    # Create a relatively large test cluster, since we've seen problems
+    # when many agents attempt to create the Docker network. See
+    # https://jira.d2iq.com/browse/D2IQ-70674
     with Cluster(
             cluster_backend=docker_backend,
-            masters=1,
-            agents=2,
-            public_agents=1,
+            masters=3,
+            agents=8,
+            public_agents=8,
     ) as cluster:
 
         config = {
@@ -70,38 +73,43 @@ def calico_ipip_cluster(docker_backend: Docker, artifact_path: Path,
         )
         yield cluster
 
+        dump_cluster_journals(
+            cluster=cluster,
+            target_dir=log_dir / artifact_dir_format(request.node.name),
+        )
+
 
 def test_calico_ipip_container_connectivity(calico_ipip_cluster: Cluster) -> None:
 
-        environment_variables = {
-            "DCOS_LOGIN_UNAME":
-            superuser_username,
-            "DCOS_LOGIN_PW":
-            superuser_password,
-            "MASTER_PUBLIC_IP":
-            list(calico_ipip_cluster.masters)[0].public_ip_address,
-            "MASTERS_PRIVATE_IPS":
-            [node.private_ip_address for node in calico_ipip_cluster.masters],
-            "PUBLIC_AGENTS_PRIVATE_IPS":
-            [node.public_ip_address for node in calico_ipip_cluster.public_agents],
-            "PRIVATE_AGENTS_PRIVATE_IPS":
-            [node.private_ip_address for node in calico_ipip_cluster.agents],
-        }
+    environment_variables = {
+        "DCOS_LOGIN_UNAME":
+        superuser_username,
+        "DCOS_LOGIN_PW":
+        superuser_password,
+        "MASTER_PUBLIC_IP":
+        list(calico_ipip_cluster.masters)[0].public_ip_address,
+        "MASTERS_PRIVATE_IPS":
+        [node.private_ip_address for node in calico_ipip_cluster.masters],
+        "PUBLIC_AGENTS_PRIVATE_IPS":
+        [node.public_ip_address for node in calico_ipip_cluster.public_agents],
+        "PRIVATE_AGENTS_PRIVATE_IPS":
+        [node.private_ip_address for node in calico_ipip_cluster.agents],
+    }
 
-        pytest_command = [
-            "pytest",
-            "-vvv",
-            "-s",
-            "-x",
-            "test_networking.py",
-            "-k",
-            "test_calico",
-        ]
-        calico_ipip_cluster.run_with_test_environment(
-            args=pytest_command,
-            env=environment_variables,
-            output=Output.LOG_AND_CAPTURE,
-        )
+    pytest_command = [
+        "pytest",
+        "-vvv",
+        "-s",
+        "-x",
+        "test_networking.py",
+        "-k",
+        "test_calico",
+    ]
+    calico_ipip_cluster.run_with_test_environment(
+        args=pytest_command,
+        env=environment_variables,
+        output=Output.LOG_AND_CAPTURE,
+    )
 
 
 def test_calico_ipip_unit_active(calico_ipip_cluster: Cluster) -> None:


### PR DESCRIPTION
Back-port of #7526 

## High-level description

The Calico startup is relatively new, and we've seen some problems with the way timeouts are set. This PR updates the timeouts to make more sense. Also, the setup changes a Docker config file, which interferes with existing config managers. Although we can't "fix" that, we can keep the JSON in the original order to make the structure more predictable. This also ensures that updates to the network setup in future versions will be reflected in the Docker configuration.

## Corresponding DC/OS tickets (required)

  - [D2IQ-70674](https://jira.d2iq.com/browse/D2IQ-70674) packages/calico/extra/dcos-calico-libnetwork-plugin.service problems.
