### PR TITLE
gen: check spartan addresses are not in resolvers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,3 +38,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Updated Exhibitor to version running atop [Jetty 9.4.30](https://github.com/dcos/exhibitor/commit/e6e232e1)
 
 * Ensure Docker network for Calico is eventually created correctly following failures. (D2IQ-70674)
+
+* Check that `spartan` ips (`198.51.100.1-3`) are not listed as upstream resolvers. (COPS-4616)

--- a/gen/calc.py
+++ b/gen/calc.py
@@ -488,6 +488,15 @@ def validate_master_list(master_list):
 
 
 def validate_resolvers(resolvers):
+    resolvers_list = validate_json_list(resolvers)
+    check_duplicates(resolvers_list)
+
+    resolvers_set = set(r.split(':')[0] for r in resolvers_list)
+    spartan_resolvers = ('198.51.100.1', '198.51.100.2', '198.51.100.3')
+    intersection = resolvers_set & set(spartan_resolvers)
+    assert not intersection, 'Spartan addresses found in `resolvers`: {}'.format(
+        ', '.join(r for r in spartan_resolvers if r in intersection))
+
     return validate_ip_port_list(resolvers)
 
 

--- a/gen/tests/test_config.py
+++ b/gen/tests/test_config.py
@@ -27,21 +27,30 @@ def test_invalid_enable_mesos_input_plugin():
         err_msg)
 
 
-def test_invalid_ports():
-    test_bad_range = '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:65536"]'
-    range_err_msg = "Must be between 1 and 65535 inclusive"
-    test_bad_value = '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:abc"]'
-    value_err_msg = "Must be an integer but got a str: abc"
+def test_resolvers():
+    validate_error(
+        {'resolvers': '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:65536"]'},
+        'resolvers',
+        "Must be between 1 and 65535 inclusive")
 
     validate_error(
-        {'resolvers': test_bad_range},
+        {'resolvers': '["52.37.192.49", "52.37.181.230:53", "52.37.163.105:abc"]'},
         'resolvers',
-        range_err_msg)
+        "Must be an integer but got a str: abc")
 
     validate_error(
-        {'resolvers': test_bad_value},
+        {'resolvers': '["52.37.192.49", "198.51.100.1:53"]'},
         'resolvers',
-        value_err_msg)
+        'Spartan addresses found in `resolvers`: 198.51.100.1')
+
+    validate_error(
+        {'resolvers': '["198.51.100.2", "52.37.192.49:53", "198.51.100.3:53"]'},
+        'resolvers',
+        'Spartan addresses found in `resolvers`: 198.51.100.2, 198.51.100.3')
+
+    validate_success(
+        {'resolvers': '["8.8.8.8", "1.1.1.1:5353"]'},
+    )
 
 
 def test_dns_bind_ip_blacklist():


### PR DESCRIPTION
## High-level description

Setting the spartan addresses (`198.51.100.1-3`) in the resolvers list
will lead to resolution failures as spartan will end up querying itself
in an infinate loop. Check that they are not in the list at install
time.

## Corresponding DC/OS tickets (required)

  - [COPS-4616](https://jira.d2iq.com/browse/COPS-4616) Installer should make sure Spartan IP's are not set as the 'resolvers'
