### PR TITLE
Bump Mesos for the CSI external volume support

### DIFF
--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "c78dc333fc893a43d40dc33299a61987198a6ea9",
+    "ref": "a16f3439dca13982bb4a2b9190c24aaf4eb73b0e",
     "ref_origin": "master"
   },
   "environment": {


### PR DESCRIPTION
## High-level description

Bump Mesos for the CSI external volume support

## Corresponding DC/OS tickets (required)

  - [D2IQ-71267](https://jira.d2iq.com/browse/D2IQ-71267) Bump Mesos in DC/OS for the statically provisioned CSI volumes support
