### PR TITLE
calico: secure the default overlay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ### Fixed and improved
 
+* The default `calico` policy is isololating ([D2IQ-71272](https://jira.d2iq.com/browse/D2IQ-71272)).
+
 * Updated `etcd` to [v3.4.9](https://github.com/etcd-io/etcd/releases/tag/v3.4.9).
 
 * Fixing some corner-cases that could render `etcd` unable to start [D2IQ-69069](https://jira.d2iq.com/browse/D2IQ-69069)

--- a/packages/calico/extra/profile.yaml
+++ b/packages/calico/extra/profile.yaml
@@ -11,6 +11,7 @@ spec:
   ingress:
   - action: Allow
     destination: {}
-    source: {}
+    source:
+      selector: has(calico)
   labelsToApply:
     calico: ""


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

The documentation states that the default calico policy is isolating. That is incorrect as it is wide open (any <-> any). Add the ingress selector to select only traffic from the overlay to isolate.


## Corresponding DC/OS tickets (required)

  - [D2IQ-71272](https://jira.d2iq.com/browse/D2IQ-71272) calico: default profile not isolating

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
