### PR TITLE
Run `bootstrap calico-felix` before `libnetwork-plugin`

### DIFF
--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -6,6 +6,8 @@ Environment=CALICO_LIBNETWORK_LABEL_ENDPOINTS=true
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node.env
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node-datastore.env
+# Ensure correct certs are in place for create-calico-docker-network.py
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-felix
 ExecStart=/opt/mesosphere/bin/start-calico-libnetwork-plugin.sh
 ExecStartPost=/opt/mesosphere/bin/create-calico-docker-network.py
 TimeoutStartSec=180s

--- a/test-e2e/test_external_calicoctl.py
+++ b/test-e2e/test_external_calicoctl.py
@@ -60,9 +60,8 @@ def calicoctl(tmpdir_factory: TempdirFactory) -> Callable[[List[str],
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
-        '!packages/{adminrouter,bouncer,etcd,openssl}/**',
+        'packages/*/**',
+        '!packages/{adminrouter,bouncer,calico,etcd,openssl}/**',
         '!packages/python*/**',
         # All e2e tests safe except this test
         'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),


### PR DESCRIPTION

## High-level description

Changes to Calico configuration to ensure that bootstrap files are run before Docker libnetwork plugin, and that it is reset when certificates are updated.

## Corresponding DC/OS tickets (required)

  - [D2IQ-71077](https://jira.d2iq.com/browse/D2IQ-71077) Fix Calico / etcd certificate propagation
