### PR TITLE
Enable `volume/csi` isolator by default in DC/OS

### DIFF
--- a/gen/calc.py
+++ b/gen/calc.py
@@ -542,8 +542,8 @@ def calculate_adminrouter_auth_enabled(oauth_enabled):
 
 def calculate_mesos_isolation(enable_gpu_isolation, mesos_seccomp_enabled):
     isolators = ('cgroups/all,disk/du,network/cni,filesystem/linux,docker/runtime,docker/volume,'
-                 'volume/sandbox_path,volume/secret,posix/rlimits,namespaces/pid,namespaces/ipc,'
-                 'linux/capabilities,com_mesosphere_dcos_MetricsIsolatorModule')
+                 'volume/sandbox_path,volume/secret,volume/csi,posix/rlimits,namespaces/pid,'
+                 'namespaces/ipc,linux/capabilities,com_mesosphere_dcos_MetricsIsolatorModule')
     if enable_gpu_isolation == 'true':
         isolators += ',gpu/nvidia'
     if mesos_seccomp_enabled == 'true':

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1400,6 +1400,7 @@ package:
 {% case "false" %}
       MESOS_NETWORK_CNI_PLUGINS_DIR=/opt/mesosphere/active/cni/:/opt/mesosphere/active/dcos-cni/:/opt/mesosphere/active/mesos/libexec/mesos
 {% endswitch %}
+      MESOS_CSI_PLUGIN_CONFIG_DIR=/opt/mesosphere/etc/dcos/storage/csi
       MESOS_RECONFIGURATION_POLICY=additive
       MESOS_RECOVERY_TIMEOUT={{ mesos_recovery_timeout }}
       MESOS_SECCOMP_CONFIG_DIR=/opt/mesosphere/etc/dcos/mesos/seccomp


### PR DESCRIPTION
## High-level description

Enable `volume/csi` isolator by default in DC/OS.

## Corresponding DC/OS tickets (required)

  - [D2IQ-71295](https://jira.d2iq.com/browse/D2IQ-71295) Enable the `volume/csi` isolator by default in DC/OS