### PR TITLE
For Admin Router pin `setuptools<50`

### DIFF
--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -80,7 +80,7 @@ RUN set -ex \
 RUN python3 -m pip install --upgrade 'virtualenv<20'
 RUN set -ex \
     && virtualenv --no-site-packages $VENV_DIR \
-    && ${VENV_DIR}/bin/pip install --upgrade setuptools pip
+    && ${VENV_DIR}/bin/pip install --upgrade "setuptools<50" pip
 
 ENV PATH ${VENV_DIR}/bin:$PATH
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,11 @@ testpaths =
   release
   test_util
 
+# Workaround for change in setuptools 50 - see https://jira.d2iq.com/browse/D2IQ-71457
+[testenv]
+setenv =
+  SETUPTOOLS_USE_DISTUTILS = stdlib
+
 [testenv:py35-syntax]
 platform=linux|darwin
 passenv =


### PR DESCRIPTION
## High-level description

Pin `setuptools<50` as changes in new version break CI


## Corresponding DC/OS tickets (required)


  - [D2IQ-71457](https://jira.mesosphere.com/browse/D2IQ-71457) continuous-integration/jenkins SystemError: Parent module setuptools

