### PR TITLE
Bump Marathon to 1.10.26

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,76 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
 
 * Remove DC/OS Signal [D2IQ-69818](https://jira.d2iq.com/browse/D2IQ-69818)
+* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available. 
+  Previously, all ZooKeeper nodes needed to be available.
+  On clusters with dynamic master lists, all ZooKeeper nodes must still be available. (D2IQ-4248)
+
+### Fixed and improved
+
+* Fix incorrect ownership after migration of `/run/dcos/telegraf/dcos_statsd/containers`. (D2IQ-69295)
+
+* Fix to allow spaces in services endpoint URI's. (DCOS_OSS-5967)
+
+* Update Telegraf configuration to reduce errors, vary requests to reduce load, sample less frequently. (COPS-5629)
+
+* Display user email address in UI when logging in using external provider. (D2IQ-70199)
+
+* Updated DC/OS UI to [v5.1.7](https://github.com/dcos/dcos-ui/releases/tag/v5.1.7).
+
+* Removed Exhibitor snapshot cleanup and now rely on ZooKeeper autopurge. (D2IQ-68109)
+
+* Updated CockroachDB Python package to 0.3.5. (D2IQ-62221)
+
+* Wait on ZooKeeper instead of Exhibitor during bootstrap. (D2IQ-70393)
+
+
+* Updated Exhibitor to version running atop [Jetty 9.4.30](https://github.com/dcos/exhibitor/commit/e6e232e1)
+
+#### Bump Marathon to 1.10.26
+
+* Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks (MARATHON-8758)
+
+## DC/OS 2.1.0 (2020-06-09)
+
+
+### What's new
+
+* Upgrade coreOS AMIs (D2IQ-64271)
+
+* Added a new configuration option `mesos_http_executors_domain_sockets`, which will cause the mesos-agent to use
+  domain sockets when communicating with executors. While this change should not have any visible impact on users
+  in itself, it does enable administrators to write firewall rules blocking unauthorized access to the agent port
+  5051 since access to this will not be required anymore for executors to work.
+
+* Switched from Oracle Java 8 to OpenJDK 8 (DCOS-54902)
+
+* Updated DC/OS UI to [v5.0.52](https://github.com/dcos/dcos-ui/releases/tag/v5.0.52).
+
+* The configuration option `MARATHON_ACCEPTED_RESOURCE_ROLES_DEFAULT_BEHAVIOR` replaces the config option `MARATHON_DEFAULT_ACCEPTED_RESOURCE_ROLES`. Please see the Marathon [command-line flag documentation](https://github.com/mesosphere/marathon/blob/master/docs/docs/command-line-flags.md) for a description of the flag.
+
+* Updated to Mesos [1.10.0-dev](https://github.com/apache/mesos/blob/1ff2fcd90eabd98786531748869b8596120f7dfe/CHANGELOG)
+
+* Mesos overlay networking: support dropping agents from the state. (DCOS_OSS-5536)
+
+* Update CNI to 0.7.6
+
+* Updated to Boost 1.65.0 (DCOS_OSS-5555)
+
+* Admin Router: Accept nil task list from Marathon when updating cache. (DCOS_OSS-5541)
+
+* Marathon pod instances are now included in the DC/OS diagnostic bundle (DCOS_OSS-5616)
+
+* Replace [docker-gc](https://github.com/spotify/docker-gc) with `docker system prune`. (DCOS_OSS-5441)
+
+* Port the Mesos Fluent Bit container logger module to Windows. (DCOS-58622)
+
+* Port the Mesos open source metrics module to Windows. (DCOS-58008)
+
+* Add etcd into DC/OS. (DCOS-59004)
+
+* Add etcd metrics into the DC/OS Telegraf Pipeline. (D2IQ-61004)
+
+* Update libpq to 9.6.15 (DCOS-59145)
 
 
 ### Security updates

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.17-c427ce965/marathon-1.10.17-c427ce965.tgz",
-    "sha1": "9e6113f95ee786ee6ee3633b72fff6c4b9708a8e"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.26-0513cddca/marathon-1.10.26-0513cddca.tgz",
+    "sha1": "157700fb745d0836b6aa528c30b1237e3c300ebb"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [MARATHON-8758](https://jira.mesosphere.com/browse/MARATHON-8758) Fix a regression where Marathon would sometimes fail to replace lost unreachable tasks 

## Related tickets (optional)

- [COPS-6329](https://jira.d2iq.com/browse/COPS-6329)