### PR TITLE
Upgrade to ZooKeeper 3.5.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Upgraded to CockroachDB 19.1 (D2IQ-69872)
 
+* Upgraded to ZooKeeper 3.5.8 (D2IQ-70462)
 
 ### Fixed and improved
 

--- a/packages/exhibitor/build
+++ b/packages/exhibitor/build
@@ -1,11 +1,21 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
 
+set -x
+
 # Zookeeper
 
 mkdir -p "$PKG_PATH/usr"
 cp -rp "/pkg/src/zookeeper" "$PKG_PATH/usr"
 rm -rf "$PKG_PATH/usr/zookeeper/"{src,docs,contrib}
+
+# Note(JP): the ZK 3.4 binary distribution had the zookeeper-3.4.x.jar
+# file placed in the root of the archive, whereas the 3.5 binary
+# distribution has this file in the lib/ directory in the archive.
+# Exhibitor seems to expect the former, though, otherwise erroring
+# out with ` java.io.IOException: Could not find zookeeper.* jar`.
+# Create a symbolic link for Exhibitor to be able to discover the file.
+ln -s "$PKG_PATH/usr/zookeeper/lib/zookeeper-3*.jar" "$PKG_PATH/usr/zookeeper"
 
 mkdir -p "$PKG_PATH/bin"
 ln -s "$PKG_PATH/usr/zookeeper/bin/zkCli.sh" "$PKG_PATH/bin/zkCli.sh"
@@ -49,7 +59,7 @@ envsubst '$PKG_PATH' < /pkg/extra/bootstrap_exhibitor_tls.py > "$exhibitor_tls_b
 chmod +x "$exhibitor_tls_bootsrapper"
 
 
-mkdir -p "$PKG_PATH/usr/zookeeper/build/lib/"
+mkdir -p "$PKG_PATH/usr/zookeeper/lib/"
 cp /pkg/src/log4j/log4j-systemd-journal-appender-1.3.2.jar "$PKG_PATH/usr/zookeeper/lib/"
 # DCOS-308: Renaming "jna-4.2.2" to "log4j-jna-4.2.2.jar" will
 # make sure that Exhibitor will include JNA library to cleanupInstance ZK

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,8 +9,8 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "https://www-us.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz",
-      "sha1": "285a0c85112d9f99d42cbbf8fb750c9aa5474716"
+      "url": "https://downloads.apache.org/zookeeper/zookeeper-3.5.8/apache-zookeeper-3.5.8-bin.tar.gz",
+      "sha1": "1953bdd512bafc69740b474ae41a07c550c408bb"
     },
     "log4j": {
         "kind": "url",

--- a/packages/exhibitor/extra/start_exhibitor.py
+++ b/packages/exhibitor/extra/start_exhibitor.py
@@ -111,7 +111,7 @@ backup-max-store-ms=21600000
 connect-port=2888
 observer-threshold=0
 election-port=3888
-zoo-cfg-extra=tickTime\\=2000&initLimit\\=10&syncLimit\\=5&quorumListenOnAllIPs\\=true&maxClientCnxns\\=0&autopurge.purgeInterval\\=1
+zoo-cfg-extra=clientPortAddress\\=0.0.0.0&admin.serverAddress\\=127.0.0.1&admin.serverPort\\=8182&4lw.commands.whitelist\\=*&tickTime\\=2000&initLimit\\=10&syncLimit\\=5&quorumListenOnAllIPs\\=true&maxClientCnxns\\=0&autopurge.purgeInterval\\=1
 auto-manage-instances-settling-period-ms=0
 auto-manage-instances=1
 auto-manage-instances-fixed-ensemble-size={zookeeper_cluster_size}


### PR DESCRIPTION


## High-level description

Upgrade from ZooKeeper 3.4 to 3.5.

Initial changes derived from #5878


## Corresponding DC/OS tickets (required)

  - [D2IQ-70462](https://jira.d2iq.com/browse/D2IQ-70462) Upgrade DC/OS ZooKeeper to 3.5
  - [DCOS_OSS-5277](https://jira.d2iq.com/browse/DCOS_OSS-5277) Explore switching to ZooKeeper 3.5.x for DC/OS 1.14


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
