### PR TITLE
e2e: only run calico disabled when calico modified

### DIFF
--- a/test-e2e/test_calico_networking.py
+++ b/test-e2e/test_calico_networking.py
@@ -37,37 +37,6 @@ def assert_system_unit_state(node: Node, unit_name: str, active: bool = True) ->
         assert "ConditionResult=no" in unit_properties
 
 
-def test_calico_disabled(docker_backend: Docker, artifact_path: Path,
-                         request: SubRequest, log_dir: Path) -> None:
-    with Cluster(
-            cluster_backend=docker_backend,
-            masters=1,
-            agents=1,
-            public_agents=1,
-    ) as cluster:
-        config = {"calico_enabled": "false"}
-        cluster.install_dcos_from_path(
-            dcos_installer=artifact_path,
-            dcos_config={
-                **cluster.base_config,
-                **config,
-            },
-            output=Output.LOG_AND_CAPTURE,
-            ip_detect_path=docker_backend.ip_detect_path,
-        )
-        wait_for_dcos_oss(
-            cluster=cluster,
-            request=request,
-            log_dir=log_dir,
-        )
-
-        calico_units = ["dcos-calico-felix", "dcos-calico-bird",
-                        "dcos-calico-confd", "dcos-calico-libnetwork-plugin"]
-        for node in cluster.masters | cluster.agents | cluster.public_agents:
-            for unit_name in calico_units:
-                assert_system_unit_state(node, unit_name, active=False)
-
-
 @pytest.fixture(scope="module")
 def calico_ipip_cluster(docker_backend: Docker, artifact_path: Path,
                         request: SubRequest, log_dir: Path) -> Iterator[Cluster]:
@@ -109,6 +78,49 @@ def calico_ipip_cluster(docker_backend: Docker, artifact_path: Path,
             cluster=cluster,
             target_dir=log_dir / artifact_dir_format(request.node.name),
         )
+
+
+@pytest.mark.skipif(
+    only_changed(E2E_SAFE_DEFAULT + [
+        # All packages safe except named packages
+        'packages/**',
+        '!packages/*treeinfo.json',
+        '!packages/calico/**',
+        '!packages/python*/**',
+        # All e2e tests safe except this test
+        'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),
+    ]),
+    reason='Only safe files modified',
+)
+def test_calico_disabled(docker_backend: Docker, artifact_path: Path,
+                         request: SubRequest, log_dir: Path) -> None:
+    with Cluster(
+            cluster_backend=docker_backend,
+            masters=1,
+            agents=1,
+            public_agents=1,
+    ) as cluster:
+        config = {"calico_enabled": "false"}
+        cluster.install_dcos_from_path(
+            dcos_installer=artifact_path,
+            dcos_config={
+                **cluster.base_config,
+                **config,
+            },
+            output=Output.LOG_AND_CAPTURE,
+            ip_detect_path=docker_backend.ip_detect_path,
+        )
+        wait_for_dcos_oss(
+            cluster=cluster,
+            request=request,
+            log_dir=log_dir,
+        )
+
+        calico_units = ["dcos-calico-felix", "dcos-calico-bird",
+                        "dcos-calico-confd", "dcos-calico-libnetwork-plugin"]
+        for node in cluster.masters | cluster.agents | cluster.public_agents:
+            for unit_name in calico_units:
+                assert_system_unit_state(node, unit_name, active=False)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Follow up to https://github.com/dcos/dcos/pull/7575 to restrict the test running to only when calico files change.


## Corresponding DC/OS tickets (required)

 - Same as #7575 

