### PR TITLE
[master] Bump Mesos to nightly master 2bf7f5d

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 2.2.0-dev (in development)
 
-* Updated to Mesos [1.11.0-dev](https://github.com/apache/mesos/blob/c78dc333fc893a43d40dc33299a61987198a6ea9/CHANGELOG)
+* Updated to Mesos [1.11.0-dev](https://github.com/apache/mesos/blob/2bf7f5d8dcb359845a663a011a941809ffc2366d/CHANGELOG)
 
 * Update to Fluentbit [1.4.6](https://docs.fluentbit.io/manual/installation/upgrade-notes)
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "a16f3439dca13982bb4a2b9190c24aaf4eb73b0e",
+    "ref": "2bf7f5d8dcb359845a663a011a941809ffc2366d",
     "ref_origin": "master"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/a16f3439dca13982bb4a2b9190c24aaf4eb73b0e...2bf7f5d8dcb359845a663a011a941809ffc2366d
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
