### PR TITLE
[1.13] Bump Mesos to nightly 1.8.x d160015

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 ## DC/OS 1.13.11 (in development)
 
+* Updated to Mesos [1.8.2-dev](https://github.com/apache/mesos/blob/d160015e544082ff310a7e4d2e94e3c4eae9499b/CHANGELOG)
+
 ### Security updates
 
 

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -9,7 +9,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/apache/mesos",
-    "ref": "f8b8f1e9c0fbf0a3ee769eebcebf0b4e98e0bfa6",
+    "ref": "d160015e544082ff310a7e4d2e94e3c4eae9499b",
     "ref_origin": "1.8.x"
   },
   "environment": {


### PR DESCRIPTION

## High-level description

This is a routine bump to the latest Mesos and mesos-modules.

## Related JIRA Issues

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] Read the [DC/OS contributing guidelines](https://github.com/dcos/dcos/blob/master/contributing.md)
  - [x] Followed relevant code rules [Rules for Packages and Systemd](https://github.com/dcos/dcos/tree/master/docs)

## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [x] Changelog:
    https://github.com/apache/mesos/compare/f8b8f1e9c0fbf0a3ee769eebcebf0b4e98e0bfa6...d160015e544082ff310a7e4d2e94e3c4eae9499b
    
    
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
