### PR TITLE
[2.1] Run `bootstrap calico-felix` before `libnetwork-plugin`

### DIFF
--- a/config/dcos-release.config.yaml
+++ b/config/dcos-release.config.yaml
@@ -4,12 +4,6 @@ storage:
     bucket: downloads.dcos.io
     object_prefix: dcos
     download_url: https://downloads.dcos.io/dcos/
-  azure:
-    kind: azure_block_blob
-    account_name: $AZURE_PROD_STORAGE_ACCOUNT
-    account_key: $AZURE_PROD_STORAGE_ACCESS_KEY
-    container: dcos
-    download_url: https://dcosio.azureedge.net/dcos/
 testing:
   aws:
     kind: aws_s3

--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -98,6 +98,11 @@ def dcos_calico_felix(b, opts):
 
 
 @check_root
+def dcos_calico_libnetwork(b, opts):
+    b.cluster_id()
+
+
+@check_root
 def dcos_signal(b, opts):
     b.cluster_id()
 
@@ -242,6 +247,7 @@ bootstrappers = {
     'dcos-adminrouter': dcos_adminrouter,
     'dcos-bouncer': dcos_bouncer,
     'dcos-calico-felix': dcos_calico_felix,
+    'dcos-calico-libnetwork': dcos_calico_libnetwork,
     'dcos-etcd': dcos_etcd,
     'dcos-signal': dcos_signal,
     'dcos-diagnostics-master': noop,

--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -7,7 +7,7 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node.env
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node-datastore.env
 # Ensure correct certs are in place for create-calico-docker-network.py
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-felix
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-libnetwork
 ExecStart=/opt/mesosphere/bin/start-calico-libnetwork-plugin.sh
 ExecStartPost=/opt/mesosphere/bin/create-calico-docker-network.py
 TimeoutStartSec=180s

--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -6,6 +6,8 @@ Environment=CALICO_LIBNETWORK_LABEL_ENDPOINTS=true
 EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node.env
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node-datastore.env
+# Ensure correct certs are in place for create-calico-docker-network.py
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-felix
 ExecStart=/opt/mesosphere/bin/start-calico-libnetwork-plugin.sh
 ExecStartPost=/opt/mesosphere/bin/create-calico-docker-network.py
 TimeoutStartSec=180s


### PR DESCRIPTION
## High-level description

Back-port of #7581, #7617 (to resolve a flake introduced by #7581), and #7613 (to fix CI)

Changes to Calico configuration to ensure that bootstrap files are run before Docker libnetwork plugin, and that it is reset when certificates are updated.

## Corresponding DC/OS tickets (required)

  - [D2IQ-71077](https://jira.d2iq.com/browse/D2IQ-71077) Fix Calico / etcd certificate propagation
  - [D2IQ-71567](https://jira.d2iq.com/browse/D2IQ-71567) TestReplaceCert test_ee_systemd_units_are_healthy assert unhealthy_nodes == 0 fails
  - [D2IQ-71632](https://jira.d2iq.com/browse/D2IQ-71632) binascii.Error: Incorrect padding during DC/OS build
