### PR TITLE
Turn on `enable_docker_gc` for on-prem by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,3 +47,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Check that `spartan` ips (`198.51.100.1-3`) are not listed as upstream resolvers. (COPS-4616)
 
 * Log diff to resolv.conf in addition to the new contents. (COPS-6411)
+
+* Turn on `enable_docker_gc` for on-prem by default. (COPS-5520)

--- a/gen/build_deploy/bash.py
+++ b/gen/build_deploy/bash.py
@@ -85,7 +85,7 @@ onprem_source = Source(entry={
         'ip_detect_filename': 'genconf/ip-detect',
         'ip6_detect_filename': '',
         'bootstrap_id': lambda: calculate_environment_variable('BOOTSTRAP_ID'),
-        'enable_docker_gc': 'false'
+        'enable_docker_gc': 'true'
     },
     'must': {
         'provider': 'onprem',


### PR DESCRIPTION
## High-level description

Turn on `enable_docker_gc` for on-prem by default.

## Corresponding DC/OS tickets (required)

  - [D2IQ-71626](https://jira.d2iq.com/browse/D2IQ-71626) Turn on enable_docker_gc by default for all types of DC/OS installations