### PR TITLE
Remove Storing artifacts in Azure Cloud.

### DIFF
--- a/config/dcos-release.config.yaml
+++ b/config/dcos-release.config.yaml
@@ -4,12 +4,6 @@ storage:
     bucket: downloads.dcos.io
     object_prefix: dcos
     download_url: https://downloads.dcos.io/dcos/
-  azure:
-    kind: azure_block_blob
-    account_name: $AZURE_PROD_STORAGE_ACCOUNT
-    account_key: $AZURE_PROD_STORAGE_ACCESS_KEY
-    container: dcos
-    download_url: https://dcosio.azureedge.net/dcos/
 testing:
   aws:
     kind: aws_s3


### PR DESCRIPTION
## Corresponding DC/OS tickets (required)

  -https://jira.d2iq.com/browse/D2IQ-71632 indicates the credentials of Azure have changed.

I also realized that we don't use Azure URLs for releases.   So, we either fix with updated credentials or if this PR succeeds we can remove storing of artifacts in the azure cloud.