### PR TITLE
Run a separate bootstrap for Calico libnetwork

### DIFF
--- a/packages/bootstrap/extra/dcos_internal_utils/cli.py
+++ b/packages/bootstrap/extra/dcos_internal_utils/cli.py
@@ -97,6 +97,11 @@ def dcos_calico_felix(b, opts):
     b.cluster_id()
 
 
+@check_root
+def dcos_calico_libnetwork(b, opts):
+    b.cluster_id()
+
+
 def migrate_containers(legacy_containers_dir: Path, new_containers_dir: Path) -> bool:
     if not legacy_containers_dir.exists():
         log.info(
@@ -237,6 +242,7 @@ bootstrappers = {
     'dcos-adminrouter': dcos_adminrouter,
     'dcos-bouncer': dcos_bouncer,
     'dcos-calico-felix': dcos_calico_felix,
+    'dcos-calico-libnetwork': dcos_calico_libnetwork,
     'dcos-etcd': dcos_etcd,
     'dcos-diagnostics-master': noop,
     'dcos-diagnostics-agent': noop,

--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -318,7 +318,7 @@ def config_docker_cluster_store():
     write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
 
     if restart_required:
-        exec_cmd("systemctl start docker")
+        exec_cmd("systemctl restart docker")
     else:
         reload_docker_daemon()
 

--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -263,16 +263,18 @@ def config_docker_cluster_store():
                     "Cannot load Docker daemon configuration {!r}: {}".format(DOCKERD_CONFIG_FILE, str(e))
                 ) from e
         mode = stat.S_IMODE(os.stat(DOCKERD_CONFIG_FILE)[stat.ST_MODE])
+        # Docker reload only works to update `cluster-store` related options on
+        # their initial creation.  Subsequent changes require a restart to take
+        # effect.  We attempt to identify whether Docker was previously
+        # configured so we can reload if possible and restart only if required.
+        restart_required = 'cluster-store' in dockerd_config
     else:
         existing_contents = None
         dockerd_config = {}
         mode = 0o644
+        restart_required = False
         print('Creating Docker daemon configuration {!r}'.format(DOCKERD_CONFIG_FILE))
 
-    # cluster-store related options can take effect by reloading docker without
-    # requiring to restart docker daemon process, according to
-    # https://docs.docker.com/engine/reference/commandline/dockerd/#miscellaneous-options # NOQA
-    # cluster-advertise is required to make cluster-store take effect
     p = exec_cmd("/opt/mesosphere/bin/detect_ip", check=True)
     private_node_ip = p.stdout.strip()
     dockerd_config.update({
@@ -315,8 +317,10 @@ def config_docker_cluster_store():
     print("Writing updated Docker daemon configuration to {!r}".format(DOCKERD_CONFIG_FILE))
     write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
 
-    # gracefully reload the docker daemon
-    reload_docker_daemon()
+    if restart_required:
+        exec_cmd("systemctl start docker")
+    else:
+        reload_docker_daemon()
 
     # Wait until daemon is reloaded and the configuration applied
     @retrying.retry(

--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -8,7 +8,7 @@ EnvironmentFile=/opt/mesosphere/environment
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node.env
 EnvironmentFile=/opt/mesosphere/etc/calico/calico-node-datastore.env
 # Ensure correct certs are in place for create-calico-docker-network.py
-ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-felix
+ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-calico-libnetwork
 ExecStart=/opt/mesosphere/bin/start-calico-libnetwork-plugin.sh
 ExecStartPost=/opt/mesosphere/bin/create-calico-docker-network.py
 TimeoutStartSec=180s


### PR DESCRIPTION
## High-level description

To avoid conflicts in Enterprise bootstrap steps, run a separate bootstrap for the Calico libnetwork bootstrap process.

This is used to generate different client certificates for libnetwork, and avoid errors during startup. If any libnetwork config changes, reload or restart Docker to ensure it takes effect.


## Corresponding DC/OS tickets (required)

  - [D2IQ-71567](https://jira.d2iq.com/browse/D2IQ-71567) TestReplaceCert test_ee_systemd_units_are_healthy assert unhealthy_nodes == 0 fails


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
