### PR TITLE
[2.0] Print more info on test_metrics failure

### DIFF
--- a/config/dcos-release.config.yaml
+++ b/config/dcos-release.config.yaml
@@ -4,12 +4,6 @@ storage:
     bucket: downloads.dcos.io
     object_prefix: dcos
     download_url: https://downloads.dcos.io/dcos/
-  azure:
-    kind: azure_block_blob
-    account_name: $AZURE_PROD_STORAGE_ACCOUNT
-    account_key: $AZURE_PROD_STORAGE_ACCESS_KEY
-    container: dcos
-    download_url: https://dcosio.azureedge.net/dcos/
 testing:
   aws:
     kind: aws_s3

--- a/packages/dcos-integration-test/extra/test_metrics.py
+++ b/packages/dcos-integration-test/extra/test_metrics.py
@@ -2,6 +2,7 @@ import contextlib
 import copy
 import logging
 import re
+import sys
 import uuid
 
 import pytest
@@ -463,6 +464,12 @@ def check_statsd_app_metrics(dcos_api_session, marathon_app, node, expected_metr
                         assert sample[2] == val
                         if len(expected_copy) == 0:
                             return
+            sys.stderr.write(
+                "%r\n%r\n" % (
+                    expected_metrics,
+                    expected_copy,
+                )
+            )
             raise Exception('Expected statsd metrics not found')
         check_statsd_metrics()
 


### PR DESCRIPTION
## High-level description

Display any difference between the expected and retrieved metrics, to help diagnose flaky test


## Corresponding DC/OS tickets (required)

  - [D2IQ-68640](https://jira.d2iq.com/browse/D2IQ-68640) test_metrics.test_metrics_agent_statsd Expected statsd metrics not found
  - [D2IQ-71632](https://jira.d2iq.com/browse/D2IQ-71632) binascii.Error: Incorrect padding during DC/OS build

