### PR TITLE
Bump Marathon to 1.11 snapshot build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,3 +49,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Log diff to resolv.conf in addition to the new contents. (COPS-6411)
 
 * Turn on `enable_docker_gc` for on-prem by default. (COPS-5520)
+
+* Marathon apps have support for CSI volumes. (MARATHON-8765)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.10.17-c427ce965/marathon-1.10.17-c427ce965.tgz",
-    "sha1": "9e6113f95ee786ee6ee3633b72fff6c4b9708a8e"
+    "url": "https://downloads.mesosphere.io/marathon/builds/1.11.12-30444c7d2/marathon-1.11.12-30444c7d2.tgz",
+    "sha1": "313b4f2ba57dbbf4d3fc3bb5ba9f8ab494798933"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

Include Marathon 1.11 (snapshot version) with support for CSI


## Corresponding DC/OS tickets (required)

  - [MARATHON-8765](https://jira.d2iq.com/browse/MARATHON-8765) CSI Support in Marathon
