### PR TITLE
Bump mesos-modules to master edc45dc57664ba87d15eef44f35288a4837d3799.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -6,7 +6,7 @@
   "single_source": {
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
-    "ref": "00e67b4e355485effbef07f29d4d8d2fbb019cac",
+    "ref": "edc45dc57664ba87d15eef44f35288a4837d3799",
     "ref_origin": "master"
   }
 }


### PR DESCRIPTION
## High-level description

Bump mesos-modules to master edc45dc57664ba87d15eef44f35288a4837d3799.

## Corresponding DC/OS tickets (required)

  - [D2IQ-71789](https://jira.d2iq.com/browse/D2IQ-71789) Mesos module in DC/OS failed to build