### PR TITLE
Stop all services at once during upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,3 +51,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Turn on `enable_docker_gc` for on-prem by default. (COPS-5520)
 
 * Marathon apps have support for CSI volumes. (MARATHON-8765)
+
+* Stop all services at once during upgrade. (COPS-6512)

--- a/pkgpanda/__init__.py
+++ b/pkgpanda/__init__.py
@@ -80,22 +80,21 @@ class Systemd:
         if not os.path.exists(self.__unit_directory):
             log.warning("Do not stop services. %s does not exist", self.__unit_directory)
             return
-        for name in os.listdir(self.__unit_directory):
-            # Skip directories
-            if os.path.isdir(os.path.join(self.__unit_directory, name)):
-                continue
-            try:
-                cmd = ["systemctl", "stop", name]
-                if not self.__block:
-                    cmd.append("--no-block")
-                check_call(cmd)
-            except CalledProcessError as ex:
-                # If the service doesn't exist, don't error. This happens when a
-                # bootstrap tarball has just been extracted but nothing started
-                # yet during first activation.
-                log.warning(ex)
-                if ex.returncode != 5:
-                    raise
+        names = list(filter(
+            lambda n: os.path.isfile(os.path.join(self.__unit_directory, n)),
+            os.listdir(self.__unit_directory)))
+        try:
+            cmd = ["systemctl", "stop"] + names
+            if not self.__block:
+                cmd.append("--no-block")
+            check_call(cmd)
+        except CalledProcessError as ex:
+            # If the service doesn't exist, don't error. This happens when a
+            # bootstrap tarball has just been extracted but nothing started
+            # yet during first activation.
+            log.warning(ex)
+            if ex.returncode != 5:
+                raise
 
     def remove_staged_unit_files(self):
         """Remove staged unit files created by Systemd.stage_new_units()."""


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Currently we stop servies one by one. This may lead to a situation when we stop service before we stop it's socket activator. So if any packet gets sent to that socket, the service will be activated. To prevent this we need to stop all services in a single command.

## Corresponding DC/OS tickets (required)

  - [COPS-6512](https://jira.d2iq.com/browse/COPS-6512) [DC/OS] [1.13.9]dcos-telegraf.socket  down after a patch


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
