### PR TITLE
NetworkManager ignores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,3 +55,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Stop all services at once during upgrade. (COPS-6512)
 
 * Sequence service start-up to avoid timeouts in CockroachDB unit start. (D2IQ-62292)
+
+* dcos-net now configures NetworkManager ignores for its interfaces (COPS-6519)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -109,6 +109,13 @@ package:
 
       [Link]
       Unmanaged=yes
+  - path: /etc/dcos-net.conf
+    content: |
+      [main]
+      plugins=keyfile
+
+      [keyfile]
+      unmanaged-devices=interface-name:docker*;interface-name:m-*;interface-name:d-*;interface-name:vtep*;interface-name:spartan;interface-name:minuteman;
   - path: /etc/dcos_net
     content: |
       DCOS_NET_WATCHDOG={{ dcos_net_watchdog }}

--- a/packages/dcos-net/extra/dcos-net.service
+++ b/packages/dcos-net/extra/dcos-net.service
@@ -22,6 +22,7 @@ ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py mkdi
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py mkdir -p /var/lib/dcos/navstar/lashup
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py modprobe dummy
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py networkd add /opt/mesosphere/etc/dcos.network
+ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py networkmanager add /opt/mesosphere/etc/dcos-net.conf
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link add minuteman type dummy
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link set minuteman up
 ExecStartPre=/opt/mesosphere/active/dcos-net/dcos-net/bin/dcos-net-setup.py ip link add spartan type dummy


### PR DESCRIPTION
## High-level description

Adds an ignore device file for NetworkManager similar to how we do for systemd-networkd. It appears that in RHEL 7.8 sometimes NetworkManager starts after dcos-net and that ends up wiping out the 2nd and 3rd ip (198.51.100.2-3) on the spartan device. 


## Corresponding DC/OS tickets (required)

  - [COPS-6519](https://jira.d2iq.com/browse/COPS-6519) dcos-net not always able to set all Spartan IP addresses after node reboot
