### PR TITLE
[2.1] Timeout CockroachDB configuration in post-start step

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,6 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Updated to Mesos [1.10.1-dev](https://github.com/apache/mesos/blob/3ca3879d52ea0f9bff05443d331d63105b2cc4db/CHANGELOG)
 
-* Reset Docker start limit if it fails during reboot. (D2IQ-72103)
-
 ### Security updates
 
 
@@ -21,6 +19,10 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 * Allow disabling Calico overlay by setting `calico_enabled` to `false`. (COPS-6451)
 
 * Stop all services at once during upgrade. (COPS-6512)
+
+* Reset Docker start limit if it fails during reboot. (D2IQ-72103)
+
+* Avoid timeouts in CockroachDB unit start. (D2IQ-69871)
 
 ## DC/OS 2.1.1
 

--- a/packages/bouncer/extra/dcos-bouncer.service
+++ b/packages/bouncer/extra/dcos-bouncer.service
@@ -1,5 +1,8 @@
 [Unit]
-Description=DC/OS Identity and Access Manager (Bouncer): offers login methods and user management
+Description=DC/OS Identity and Access Manager (Bouncer)
+Documentation=https://docs.d2iq.com/mesosphere/dcos/
+# Wait for CockroachDB to be available
+After=dcos-cockroach.service
 
 [Service]
 Type=simple

--- a/packages/cockroach/extra/dcos-cockroach.service
+++ b/packages/cockroach/extra/dcos-cockroach.service
@@ -1,9 +1,11 @@
 [Unit]
-Description=CockroachDB: Database for the DC/OS IAM
-Documentation=https://docs.mesosphere.com
+Description=DC/OS CockroachDB Database
+Documentation=https://docs.d2iq.com/mesosphere/dcos/
+# Wait for ZooKeeper to be available
+After=dcos-exhibitor.service
 
 [Service]
-Type=simple
+Type=notify
 PermissionsStartOnly=True
 User=dcos_cockroach
 Restart=always
@@ -21,10 +23,9 @@ ExecStartPre=/bin/chown -R dcos_cockroach /run/dcos/cockroach
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach
 ExecStartPre=/opt/mesosphere/active/cockroach/bin/register.py
 ExecStart=/opt/mesosphere/active/cockroach/bin/cockroach.sh
-ExecStartPost=-/bin/sleep 15
-ExecStartPost=-/opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
+ExecStartPost=-timeout 30 /opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
 PIDFile=/run/dcos/cockroach/cockroach.pid
-TimeoutStartSec=60s
+TimeoutStartSec=90s
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/cockroach/extra/dcos-cockroach.service
+++ b/packages/cockroach/extra/dcos-cockroach.service
@@ -23,7 +23,7 @@ ExecStartPre=/bin/chown -R dcos_cockroach /run/dcos/cockroach
 ExecStartPre=/opt/mesosphere/bin/bootstrap dcos-cockroach
 ExecStartPre=/opt/mesosphere/active/cockroach/bin/register.py
 ExecStart=/opt/mesosphere/active/cockroach/bin/cockroach.sh
-ExecStartPost=-timeout 30 /opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
+ExecStartPost=-/usr/bin/timeout 30 /opt/mesosphere/active/cockroach/bin/cockroachdb-change-config.py
 PIDFile=/run/dcos/cockroach/cockroach.pid
 TimeoutStartSec=90s
 

--- a/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
+++ b/packages/cockroach/extra/dcos-cockroachdb-config-change.timer
@@ -3,6 +3,5 @@ Description=CockroachDB Set Configuration Timer: Timer to periodically set the C
 Documentation=https://docs.mesosphere.com
 
 [Timer]
-OnBootSec=5sec
 OnStartupSec=5min
 OnUnitActiveSec=10min


### PR DESCRIPTION

## High-level description

This change prevents a timeout in the CockroachDB systemd ExecStartPost commands from terminating CockroachDB.

This is a simpler version of #7648 - not as complete a solution, but fewer changes to the existing release.


## Corresponding DC/OS tickets (required)

  - [D2IQ-69871](https://jira.d2iq.com/browse/D2IQ-69871) Set cockroach change config to timeout if connection to CDB cannot be made
  - [D2IQ-62292](https://jira.d2iq.com/browse/D2IQ-62292) Remove possibility of timeouts in systemd ExecStartPost
  - [D2IQ-51276](https://jira.d2iq.com/browse/D2IQ-51276) Consoldiate CA bootstrap? (CA bootstrap does not retry or fail on Docker reload failure)

## Related tickets (optional)
- https://jira.d2iq.com/browse/COPS-5601
- https://jira.d2iq.com/browse/COPS-5795
- https://jira.d2iq.com/browse/COPS-6063