### PR TITLE
[1.13] Bump Marathon to 1.8.245

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,19 +16,22 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Avoid timeouts in CockroachDB unit start. (D2IQ-69871)
 
+#### Update Marathon to 1.8.245
+
+* Allow migrations to re-run by default (MARATHON-8762)
 
 ## DC/OS 1.13.10 (2020-08-26)
 
 ### Security updates
 
-* Updated CockroachDB Python package to 0.3.5. (D2IQ-62221) 
+* Updated CockroachDB Python package to 0.3.5. (D2IQ-62221)
 
 ### Notable changes
 
-* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available. 
+* Starting services on clusters with static masters now only requires a majority of ZooKeeper nodes to be available.
   Previously, all ZooKeeper nodes needed to be available.
   On clusters with dynamic master lists, all ZooKeeper nodes must still be available. (D2IQ-4248)
-  
+
 ### Fixed and improved
 
 * Removed trailing newline from ZooKeeper log messages. (D2IQ-68394)

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,7 +4,7 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.244-248803b19/marathon-1.8.244-248803b19.tgz",
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.8.245-842a0b9e7/marathon-1.8.245-842a0b9e7.tgz",
     "sha1": "96cb0106a962e5e83d5f855b6eb2ee7205b19e3f"
   },
   "username": "dcos_marathon",


### PR DESCRIPTION
## High-level description

Bump Marathon to 1.8.245

## Corresponding DC/OS tickets (required)

* https://jira.d2iq.com/browse/MARATHON-8762
* https://jira.d2iq.com/browse/COPS-5897
