### PR TITLE
Pin mypy for integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ testpaths =
 setenv =
   SETUPTOOLS_USE_DISTUTILS = stdlib
 
-[testenv:py35-syntax]
+[testenv:py3-syntax]
 platform=linux|darwin
 passenv =
     TEAMCITY_VERSION
@@ -38,7 +38,7 @@ commands =
   flake8 --verbose
 
 
-[testenv:py35-unittests]
+[testenv:py3-unittests]
 platform=linux|darwin
 # See the following link for AWS_* environment variables:
 # http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials
@@ -75,7 +75,7 @@ commands=
 # pkgpanda build tests are kept separate from the rest because they take a while
 # (lots of calls to docker). They also currently assume that they're run with a
 # specific working directory (something that should be fixed).
-[testenv:py35-pkgpanda-build]
+[testenv:py3-pkgpanda-build]
 platform=linux|darwin
 passenv =
   TEAMCITY_VERSION
@@ -89,7 +89,7 @@ commands=
   pytest --basetemp={envtmpdir} --junitxml=junit-{envname}.xml {posargs} build_integration_test.py
 
 
-[testenv:py35-bootstrap]
+[testenv:py3-bootstrap]
 platform=linux|darwin
 passenv =
   TEAMCITY_VERSION
@@ -108,6 +108,7 @@ commands=
   mypy ./test-e2e
   mypy ./packages/cockroach/extra
   mypy ./packages/exhibitor/extra/dcos_zk_backup.py
+  mypy packages/dcos-integration-test/extra/
 
 [testenv:collect-integration-tests]
 platform=linux|darwin
@@ -115,9 +116,3 @@ basepython=python3.5
 deps= -rpackages/dcos-integration-test/requirements.txt
 commands=
   py.test --xfailflake-report --collect-only packages/dcos-integration-test/extra/
-
-[testenv:integration-test-mypy]
-deps=
-    mypy
-commands =
-    mypy packages/dcos-integration-test/extra/


### PR DESCRIPTION


## High-level description

Pin mypy for integration tests, to prevent stricter checks failing after mypy 0.790 was released. Also run other tests with any Python 3, not just unsupported 3.5


## Corresponding DC/OS tickets (required)

  - [D2IQ-72431](https://jira.d2iq.com/browse/D2IQ-72431) mypy failure following upgrade


