### PR TITLE
Use cached repo for ZooKeeper

### DIFF
--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,7 +9,7 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "https://www-us.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz",
+      "url": "https://downloads.mesosphere.com/zookeeper/zookeeper-3.4.14.tar.gz",
       "sha1": "285a0c85112d9f99d42cbbf8fb750c9aa5474716"
     },
     "log4j": {


### PR DESCRIPTION

## High-level description

Use cached version of ZooKeeper, since original site has stopped hosting


## Corresponding DC/OS tickets (required)

  - [D2IQ-72462](https://jira.d2iq.com/browse/D2IQ-72462) Build DC/OS Uncached Master Failing on missing Zookeeper download


