### PR TITLE
Switched ref_origin for Mesos to 1.11.x and for mesos-modules to 2.2.

### DIFF
--- a/packages/mesos-modules/buildinfo.json
+++ b/packages/mesos-modules/buildinfo.json
@@ -7,6 +7,6 @@
     "kind": "git",
     "git": "https://github.com/dcos/dcos-mesos-modules.git",
     "ref": "edc45dc57664ba87d15eef44f35288a4837d3799",
-    "ref_origin": "master"
+    "ref_origin": "2.2"
   }
 }

--- a/packages/mesos/buildinfo.json
+++ b/packages/mesos/buildinfo.json
@@ -10,7 +10,7 @@
     "kind": "git",
     "git": "https://github.com/apache/mesos",
     "ref": "d4678d33b223fec5d48007f8246f1ed1cda5e90d",
-    "ref_origin": "master"
+    "ref_origin": "1.11.x"
   },
   "environment": {
     "JAVA_LIBRARY_PATH": "/opt/mesosphere/lib",


### PR DESCRIPTION
## High-level description

This changes ref_origins (no SHA bump!) of Mesos and modules in preparation for DCOS 2.2 branchoff.


## Corresponding DC/OS tickets (required)

  - [D2IQ-72537](https://jira.d2iq.com/browse/D2IQ-72537) Mesos and modules branchoff in DCOS 2.2