### PR TITLE
Bump Marathon to 1.9.143

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,9 +24,13 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * dcos-net now configures NetworkManager ignores for its interfaces (COPS-6519)
 
-#### Update Marathon to 1.9.141
+#### Update Marathon to 1.9.143
 
 * Allow migrations to re-run by default (MARATHON-8762)
+
+* Don't show `enforceRole` for sub-groups (MARATHON-8769)
+
+* Respect `enforceRole` on `PUT /v2/groups` (MARATHON-8770)
 
 ## DC/OS 2.0.6 (2020-07-30)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,7 +4,7 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.143-ebac8cd5b/marathon-docs-1.9.143-ebac8cd5b.tgz",
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.143-ebac8cd5b/marathon-1.9.143-ebac8cd5b.tgz",
     "sha1": "52af91fbabde51394f80a0d830300b580e0cef8f"
   },
   "username": "dcos_marathon",

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,7 +4,7 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.143-ebac8cd5b/marathon-docs-1.9.143-ebac8cd5b",
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.143-ebac8cd5b/marathon-docs-1.9.143-ebac8cd5b.tgz",
     "sha1": "52af91fbabde51394f80a0d830300b580e0cef8f"
   },
   "username": "dcos_marathon",

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.141-87dfd11ba/marathon-1.9.141-87dfd11ba.tgz",
-    "sha1": "18db81ae5bdf1b8e8d68f1d97383b98c02524e07"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.143-ebac8cd5b/marathon-docs-1.9.143-ebac8cd5b",
+    "sha1": "52af91fbabde51394f80a0d830300b580e0cef8f"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [COPS-6533](https://jira.d2iq.com/browse/COPS-6533)
  - [COPS-6529](https://jira.d2iq.com/browse/COPS-6529)
  - [MARATHON-8769](https://jira.d2iq.com/browse/MARATHON-8769) - enforceRole property shows for sub-groups, creating confusion
  - [MARATHON-8770](https://jira.d2iq.com/browse/MARATHON-8770) - enforceRole behavior and setting ignored for PUT /v2/groups
