### PR TITLE
Skip e2e tests on trains for safe subset of changes

### DIFF
--- a/packages/installer.treeinfo.json
+++ b/packages/installer.treeinfo.json
@@ -1,9 +1,4 @@
 {
-  "exclude": [
-    "vcredist",
-    "nssm",
-    "winpanda"
-  ],
   "core_package_list": [
     "dcos-image"
   ]

--- a/packages/treeinfo.json
+++ b/packages/treeinfo.json
@@ -1,10 +1,7 @@
 {
   "exclude": [
     "dcos-launch",
-    "dcos-metrics",
-    "vcredist",
-    "nssm",
-    "winpanda"
+    "dcos-metrics"
   ],
   "bootstrap_package_list": ["dcos-image"]
 }

--- a/test-e2e/test_adminrouter_grpc.py
+++ b/test-e2e/test_adminrouter_grpc.py
@@ -22,9 +22,8 @@ from dcos_e2e.node import Output
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
-        '!packages/{adminrouter,bootstrap,bouncer,etcd,openssl}/**',
+        'packages/*/**',
+        '!packages/{adminrouter,bootstrap,bouncer,bouncer-deps,etcd,openssl}/**',
         '!packages/python*/**',
         # All e2e tests safe except this test
         'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),

--- a/test-e2e/test_calico_networking.py
+++ b/test-e2e/test_calico_networking.py
@@ -126,8 +126,7 @@ def test_calico_disabled(docker_backend: Docker, artifact_path: Path,
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/{calico,etcd,java,marathon}/**',  # All packages safe except named packages
         '!packages/dcos-integration-test/requirements.txt',
         '!packages/dcos-integration-test/extra/{conftest,test_helpers,test_networking}.py',  # Used in test
@@ -172,8 +171,7 @@ def test_calico_ipip_container_connectivity(calico_ipip_cluster: Cluster) -> Non
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/{bootstrap,calico,etcd,openssl}/**',
         '!packages/python*/**',
         # All e2e tests safe except this test

--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -130,8 +130,7 @@ def etcd_client(static_three_master_cluster: Cluster) -> EtcdClient:
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/etcd/**',  # All packages safe except named packages
         # All e2e tests safe except this test
         'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),

--- a/test-e2e/test_service_account.py
+++ b/test-e2e/test_service_account.py
@@ -15,8 +15,7 @@ from dcos_e2e.node import Output
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/{bouncer,bouncer-deps,cockroach,flask,libpq,openssl,six}/**',
         '!packages/python*/**',
         # All e2e tests safe except this test

--- a/test-e2e/test_zookeeper_backup.py
+++ b/test-e2e/test_zookeeper_backup.py
@@ -79,8 +79,7 @@ def _zk_flag_exists(zk: KazooClient, znode: str) -> bool:
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/{exhibitor,java}/**',
         # All e2e tests safe except this test
         'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),

--- a/test-e2e/test_zookeeper_quorum.py
+++ b/test-e2e/test_zookeeper_quorum.py
@@ -50,8 +50,7 @@ def check_bootstrap(node: Node) -> None:
 @pytest.mark.skipif(
     only_changed(E2E_SAFE_DEFAULT + [
         # All packages safe except named packages
-        'packages/**',
-        '!packages/*treeinfo.json',
+        'packages/*/**',
         '!packages/{bootstrap,exhibitor,java}/**',
         # All e2e tests safe except this test
         'test-e2e/test_*', '!' + escape(trailing_path(__file__, 2)),


### PR DESCRIPTION
## High-level description

The e2e tests skipping generally identifies two sets of files:
1. files that do not contribute to the delivered artifact of DC/OS (e.g. Markdown files);
2. files that, despite contributing to the artifact, are not expected to affect the outcome of the specific e2e test.

The first subset is generally those files identified in the `E2E_SAFE_DEFAULT` variable. If a PR only changes these files, there is practically no chance that the e2e test outcomes should be affected.

This PR allows trains to skip e2e testing when only files in `E2E_SAFE_DEFAULT` are changed.

As a minor addition, I removed some defunct packages from `treeinfo.json`. This allowed me to check that the change to the `packages/**` patterns do run the tests when `treeinfo.json` changes.

## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
