### PR TITLE
Use any Python 3 for integration test collection

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ commands=
 
 [testenv:collect-integration-tests]
 platform=linux|darwin
-basepython=python3.5
+basepython=python3
 deps= -rpackages/dcos-integration-test/requirements.txt
 commands=
   py.test --xfailflake-report --collect-only packages/dcos-integration-test/extra/


### PR DESCRIPTION
## High-level description

Don't require Python 3.5 for tox integration test collection. Use whichever Python 3 is available.

This relatively minor change was actually made to test whether tox is failing on master in CI (it's not). However, it is a useful change and as long as it tests OK, we should add it.

## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
