### PR TITLE
[1.13] Update urllib to fix build problem

### DIFF
--- a/packages/adminrouter/docker/requirements-tests.txt
+++ b/packages/adminrouter/docker/requirements-tests.txt
@@ -15,4 +15,4 @@ pytest-pythonpath==0.7.1
 pytest-repeat==0.4.1
 pytest-timeout==1.2.0
 pytest==3.2.1
-requests==2.20.1
+requests==2.22.0

--- a/packages/exhibitor/buildinfo.json
+++ b/packages/exhibitor/buildinfo.json
@@ -9,7 +9,7 @@
     },
     "zookeeper": {
       "kind": "url_extract",
-      "url": "https://www-us.apache.org/dist/zookeeper/zookeeper-3.4.14/zookeeper-3.4.14.tar.gz",
+      "url": "https://downloads.mesosphere.com/zookeeper/zookeeper-3.4.14.tar.gz",
       "sha1": "285a0c85112d9f99d42cbbf8fb750c9aa5474716"
     },
     "log4j": {

--- a/packages/python-requests/buildinfo.json
+++ b/packages/python-requests/buildinfo.json
@@ -3,13 +3,13 @@
   "sources": {
     "requests": {
       "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/ff/17/5cbb026005115301a8fb2f9b0e3e8d32313142fe8b617070e7baad20554f/requests-2.20.1-py2.py3-none-any.whl",
-      "sha1": "a38551c5a3baa3bfdaa89edb5f0f3e15b298ee6a"
+      "url": "https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl",
+      "sha1": "e1fc28120002395fe1f2da9aacea4e15a449d9ee"
     },
     "urllib3": {
       "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/df/1c/59cca3abf96f991f2ec3131a4ffe72ae3d9ea1f5894abe8a9c5e3c77cfee/urllib3-1.24.2-py2.py3-none-any.whl",
-      "sha1": "02e44dd64ebeb41ca01e1943c8c3e581c6547380"
+      "url": "https://files.pythonhosted.org/packages/9f/f0/a391d1463ebb1b233795cabfc0ef38d3db4442339de68f847026199e69d7/urllib3-1.25.10-py2.py3-none-any.whl",
+      "sha1": "4b768a05e3c46a01e84e79da651b7ebde990dcf4"
     },
     "chardet": {
       "kind": "url",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         'coloredlogs',
         'Flask',
         'flask-compress',
-        'urllib3==1.24.2',
+        'urllib3==1.25.10',
         'chardet',
         'PyJWT',
         # Pins taken from 'azure==2.0.0rc4'
@@ -79,7 +79,7 @@ setup(
         'pytest<6.0.0',
         'pyyaml',
         'responses',
-        'requests==2.20.1',
+        'requests==2.22.0',
         'retrying',
         'schema',
         'wheel==0.33.1',


### PR DESCRIPTION
## High-level description

Pin the version of `requests` and `urllib` to allow CI to pass. Get ZooKeeper from our own repo


## Corresponding DC/OS tickets (required)

  - [D2IQ-ID](https://jira.d2iq.com/browse/D2IQ-ID) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
