### PR TITLE
Use retry on test_dcos_cni_l4lb as from centos 7.6 first call will fail

### DIFF
--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -753,6 +753,7 @@ def test_l4lb(dcos_api_session: DcosApiSession) -> None:
             app.purge(dcos_api_session)
 
 
+@retrying.retry(wait_fixed=5000, stop_max_attempt_number=3)
 def test_dcos_cni_l4lb(dcos_api_session: DcosApiSession) -> Any:
     '''
     This tests the `dcos - l4lb` CNI plugins:

--- a/packages/dcos-integration-test/extra/test_networking.py
+++ b/packages/dcos-integration-test/extra/test_networking.py
@@ -219,7 +219,8 @@ def lb_enabled() -> Any:
 
 @retrying.retry(wait_fixed=2000,
                 stop_max_delay=5 * 60 * 1000,
-                retry_on_result=lambda ret: ret is None)
+                retry_on_result=lambda ret: ret is None,
+                retry_on_exception=lambda e: isinstance(e, Exception))
 def ensure_routable(cmd: str, host: str, port: str, json_output: bool = True) -> Any:
     proxy_uri = 'http://{}:{}/run_cmd'.format(host, port)
     log.info('Sending {} data: {}'.format(proxy_uri, cmd))
@@ -753,7 +754,6 @@ def test_l4lb(dcos_api_session: DcosApiSession) -> None:
             app.purge(dcos_api_session)
 
 
-@retrying.retry(wait_fixed=5000, stop_max_attempt_number=3)
 def test_dcos_cni_l4lb(dcos_api_session: DcosApiSession) -> Any:
     '''
     This tests the `dcos - l4lb` CNI plugins:


### PR DESCRIPTION
## High-level description

D2IQ-43857 is mentioning that this feature doesn't work at all. The truth is that only the first call fails. Doing a second call to the same address works fine. With that in mind this PR adds retry logic to `test_dcos_cni_l4lb` so this test no longer fails on centos >= 7.6


## Corresponding DC/OS tickets (required)

  - [D2IQ-43857](https://jira.d2iq.com/browse/D2IQ-43857) test_dcos_cni_l4lb fails for 1.12.0-rc3 & 1.11.6 on RHEL 7.5

