### PR TITLE
[2.2] Restart Docker only if restart file exists

### DIFF
--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -1,20 +1,20 @@
 {
-  "docker": "calico/node:v3.16.4-1-g1c131e1",
+  "docker": "calico/node:v3.15.3-1-g5c57019",
   "sources": {
     "calico": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-amd64",
-      "sha1": "1579ebf178f72292a1bc8fab0d74a88ab0921084"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-amd64",
+      "sha1": "59326f0e046bebe0c5d97ff0b4513aeb22940d41"
     },
     "calico-ipam": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-ipam-amd64",
-      "sha1": "7eeaf366c30c279c4688a220083cb5f123616042"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-ipam-amd64",
+      "sha1": "8d5aec77c38c211f682bb63b0e3c7d90b80fbbb6"
     },
     "calicoctl": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/calicoctl/releases/download/3.16.4/calicoctl-linux-amd64",
-      "sha1": "8734244e7549354d19617975413f143e36bf48bb"
+      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.15.3/calicoctl-linux-amd64",
+      "sha1": "7a0345d7a83aef8635a3de529bd8c40b8bf877a3"
     },
     "calico-libnetwork-plugin": {
       "kind": "url",

--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -1,19 +1,19 @@
 {
-  "docker": "calico/node:v3.14.0",
+  "docker": "calico/node:v3.16.4-1-g1c131e1",
   "sources": {
     "calico": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-amd64",
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-amd64",
       "sha1": "1579ebf178f72292a1bc8fab0d74a88ab0921084"
     },
     "calico-ipam": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-ipam-amd64",
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-ipam-amd64",
       "sha1": "7eeaf366c30c279c4688a220083cb5f123616042"
     },
     "calicoctl": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.14.0/calicoctl-linux-amd64",
+      "url": "https://github.com/projectcalico/calicoctl/releases/download/3.16.4/calicoctl-linux-amd64",
       "sha1": "8734244e7549354d19617975413f143e36bf48bb"
     },
     "calico-libnetwork-plugin": {

--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -1,20 +1,20 @@
 {
-  "docker": "calico/node:v3.15.3-1-g5c57019",
+  "docker": "calico/node:v3.16.4-1-g1c131e1",
   "sources": {
     "calico": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-amd64",
-      "sha1": "59326f0e046bebe0c5d97ff0b4513aeb22940d41"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-amd64",
+      "sha1": "1579ebf178f72292a1bc8fab0d74a88ab0921084"
     },
     "calico-ipam": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-ipam-amd64",
-      "sha1": "8d5aec77c38c211f682bb63b0e3c7d90b80fbbb6"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/3.16.4/calico-ipam-amd64",
+      "sha1": "7eeaf366c30c279c4688a220083cb5f123616042"
     },
     "calicoctl": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.15.3/calicoctl-linux-amd64",
-      "sha1": "7a0345d7a83aef8635a3de529bd8c40b8bf877a3"
+      "url": "https://github.com/projectcalico/calicoctl/releases/download/3.16.4/calicoctl-linux-amd64",
+      "sha1": "8734244e7549354d19617975413f143e36bf48bb"
     },
     "calico-libnetwork-plugin": {
       "kind": "url",

--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -308,10 +308,9 @@ def config_docker_cluster_store():
     updated_contents = json.dumps(dockerd_config, indent='\t').encode('ascii')
     if updated_contents == existing_contents:
         print('Docker daemon configuration has expected contents')
-        return
-
-    print("Writing updated Docker daemon configuration to {!r}".format(DOCKERD_CONFIG_FILE))
-    write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
+    else:
+        print("Writing updated Docker daemon configuration to {!r}".format(DOCKERD_CONFIG_FILE))
+        write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
 
     if os.path.exists(DOCKER_RESTART_FILE):
         # Force a Docker restart by stopping the daemon.  The reload code will

--- a/packages/calico/extra/create-calico-docker-network.py
+++ b/packages/calico/extra/create-calico-docker-network.py
@@ -35,6 +35,7 @@ from kazoo.security import make_digest_acl
 
 DOCKER_BIN = "/usr/bin/docker"
 DOCKERD_CONFIG_FILE = "/etc/docker/daemon.json"
+DOCKER_RESTART_FILE = '/run/dcos/calico-docker-restart'
 CALICO_DOCKER_NETWORK_NAME = "calico"
 CLUSTER_STORE_DOCKER_INFO_PREFIX = "Cluster Store"
 ETCD_ENDPOINTS_ENV_KEY = "ETCD_ENDPOINTS"
@@ -192,14 +193,14 @@ def reload_docker_daemon():
         with open(docker_pid_file, "r") as f:
             docker_pid = int(f.read())
         try:
-            print("Reloading found docker daemon with pid={}".format(docker_pid))
+            print("Attempting reload for docker daemon with pid={}".format(docker_pid))
             os.kill(docker_pid, signal.SIGHUP)
             return
         except OSError:
             # The pid is stale, Docker is not running. Start it now.
             traceback.print_exc(limit=1)
 
-    print("Unable to reload daemon, going to restart it instead")
+    print("Unable to reload daemon, restart it instead")
     # If the Docker service starts before we setup the certificates, the unit
     # may have entered failed state with an exhausted StartLimit.  Reset the
     # limits and then restart. See https://jira.d2iq.com/browse/D2IQ-72103
@@ -264,16 +265,10 @@ def config_docker_cluster_store():
                     "Cannot load Docker daemon configuration {!r}: {}".format(DOCKERD_CONFIG_FILE, str(e))
                 ) from e
         mode = stat.S_IMODE(os.stat(DOCKERD_CONFIG_FILE)[stat.ST_MODE])
-        # Docker reload only works to update `cluster-store` related options on
-        # their initial creation.  Subsequent changes require a restart to take
-        # effect.  We attempt to identify whether Docker was previously
-        # configured so we can reload if possible and restart only if required.
-        restart_required = 'cluster-store' in dockerd_config
     else:
         existing_contents = None
         dockerd_config = {}
         mode = 0o644
-        restart_required = False
         print('Creating Docker daemon configuration {!r}'.format(DOCKERD_CONFIG_FILE))
 
     p = exec_cmd("/opt/mesosphere/bin/detect_ip", check=True)
@@ -318,8 +313,11 @@ def config_docker_cluster_store():
     print("Writing updated Docker daemon configuration to {!r}".format(DOCKERD_CONFIG_FILE))
     write_file_bytes(DOCKERD_CONFIG_FILE, updated_contents, mode)
 
-    if restart_required:
+    if os.path.exists(DOCKER_RESTART_FILE):
+        # Force a Docker restart by stopping the daemon.  The reload code will
+        # then start the daemon rather than reloading the configuration.
         exec_cmd("systemctl stop docker")
+        os.unlink(DOCKER_RESTART_FILE)
     reload_docker_daemon()
 
     # Wait until daemon is reloaded and the configuration applied

--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DC/OS Calico Node: Docker libnetwork plugin for Calico in DC/OS
 ConditionPathExists=/opt/mesosphere/etc/calico/calico_enabled
+Before=dcos-calico-felix.service
 
 [Service]
 Environment=CALICO_LIBNETWORK_LABEL_ENDPOINTS=true


### PR DESCRIPTION
## High-level description

Only restart Docker if a restart file exists. This allows bootstrap to determine when a restart is necessary while keeping the certificate name the same.

To get this to build, also had to resolve a problem with Calico's build container due to the current image being deprecated (D2IQ-72821).

## Corresponding DC/OS tickets (required)

  - [D2IQ-72821](https://jira.d2iq.com/browse/D2IQ-72821) Calico fails to build centos/8.1.1911 repo unavailable


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
