### PR TITLE
Update to Calico 3.15

### DIFF
--- a/packages/calico/buildinfo.json
+++ b/packages/calico/buildinfo.json
@@ -1,20 +1,20 @@
 {
-  "docker": "calico/node:v3.14.0",
+  "docker": "calico/node:v3.15.3-1-g5c57019",
   "sources": {
     "calico": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-amd64",
-      "sha1": "1579ebf178f72292a1bc8fab0d74a88ab0921084"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-amd64",
+      "sha1": "59326f0e046bebe0c5d97ff0b4513aeb22940d41"
     },
     "calico-ipam": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.14.0/calico-ipam-amd64",
-      "sha1": "7eeaf366c30c279c4688a220083cb5f123616042"
+      "url": "https://github.com/projectcalico/cni-plugin/releases/download/v3.15.3/calico-ipam-amd64",
+      "sha1": "8d5aec77c38c211f682bb63b0e3c7d90b80fbbb6"
     },
     "calicoctl": {
       "kind": "url",
-      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.14.0/calicoctl-linux-amd64",
-      "sha1": "8734244e7549354d19617975413f143e36bf48bb"
+      "url": "https://github.com/projectcalico/calicoctl/releases/download/v3.15.3/calicoctl-linux-amd64",
+      "sha1": "7a0345d7a83aef8635a3de529bd8c40b8bf877a3"
     },
     "calico-libnetwork-plugin": {
       "kind": "url",


### PR DESCRIPTION

## High-level description

Update Calico builder to 3.15. The Calico 3.14 image no longer works because the CentOS 8.1.1911 repo is no longer available. Calico 3.16 does not work because `microdnf` is not available on the image.

## Corresponding DC/OS tickets (required)

  - [D2IQ-72821](https://jira.d2iq.com/browse/D2IQ-72821) Calico fails to build centos/8.1.1911 repo unavailable


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
