### PR TITLE
calico: fix build

### DIFF
--- a/packages/calico/build
+++ b/packages/calico/build
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -x
 
+# NOTE(jkoelker) fix repo location since centos decided to move urls
+sed -i 's,mirror.centos.org/centos,vault.centos.org,' /etc/yum.repos.d/centos.repo
+
 # calico container is missing 'envsubst'
 microdnf install -y gettext tar
 


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Fixes the repo in the "build" container to the new centos vault url.


## Corresponding DC/OS tickets (required)

  - [D2IQ-72821](https://jira.d2iq.com/browse/D2IQ-72821) Calico fails to build centos/8.1.1911 repo unavailable
