### PR TITLE
Restart Docker variation 2

### DIFF
--- a/packages/calico/extra/dcos-calico-libnetwork-plugin.service
+++ b/packages/calico/extra/dcos-calico-libnetwork-plugin.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DC/OS Calico Node: Docker libnetwork plugin for Calico in DC/OS
 ConditionPathExists=/opt/mesosphere/etc/calico/calico_enabled
+After=dcos-calico-felix.service
 
 [Service]
 Environment=CALICO_LIBNETWORK_LABEL_ENDPOINTS=true


### PR DESCRIPTION
## High-level description

Only restart Docker if a restart file exists. This allows bootstrap to determine when a restart is necessary while keeping the certificate name the same.

This variation orders Felix startup before libnetwork startup, which allows both to use the same certificate.

## Corresponding DC/OS tickets (required)

  - [D2IQ-72846](https://jira.d2iq.com/browse/D2IQ-72846) upgrade from 2.1.{0,1} to 2.2.0 stops workloads 
  - [D2IQ-72784](https://jira.d2iq.com/browse/D2IQ-72784) Cosmos bootstrap 400 errors

## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
