### PR TITLE
dcos-net: fix argument order for `add_config`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,3 +12,5 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 ### Fixed and improved
 
 * Update DC/OS UI to [v6.1.16](https://github.com/dcos/dcos-ui/releases/tag/v6.1.16).
+
+* Fixed dcos-net startup script to configure network ignore file for on-prem (D2IQ-73113).

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -111,9 +111,6 @@ package:
       Unmanaged=yes
   - path: /etc/dcos-net.conf
     content: |
-      [main]
-      plugins=keyfile
-
       [keyfile]
       unmanaged-devices=interface-name:docker*;interface-name:m-*;interface-name:d-*;interface-name:vtep*;interface-name:spartan;interface-name:minuteman;
   - path: /etc/dcos_net

--- a/packages/dcos-net/extra/dcos-net-setup.py
+++ b/packages/dcos-net/extra/dcos-net-setup.py
@@ -111,7 +111,7 @@ def copy_file(src, dst) -> bool:
         return True
 
 
-def add_config(unit: str, src: str, path: str) -> int:
+def add_config(unit: str, path: str, src: str) -> int:
     # Check if the unit exists
     result = check_for_unit(unit)
     if result < 0:

--- a/packages/dcos-net/extra/dcos-net-setup.py
+++ b/packages/dcos-net/extra/dcos-net-setup.py
@@ -153,7 +153,8 @@ def add_networkd_config(src: str) -> int:
     # https://jira.mesosphere.com/browse/DCOS_OSS-1790
     # We need to mark interfaces managed by DC/OS as unmanaged when networkd is
     # enabled on coreos
-    if NETWORKD or 'coreos' in platform.release():
+    release = platform.release()
+    if NETWORKD or 'coreos' in release or 'flatcar' in release:
         return add_config('systemd-networkd.service', '/etc/systemd/network', src)
 
     return 0


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

dcos-net: fix argument order for `add_config`


## Corresponding DC/OS tickets (required)

  - [D2IQ-73113](https://jira.d2iq.com/browse/D2IQ-73113) dcos-net fails to start on RHEL/Centos 7.8 in dcos 2.2
  - [COPS-6519](https://jira.d2iq.com/browse/COPS-6519) dcos-net not always able to set all Spartan IP addresses after node reboot
