### PR TITLE
[2.0] Bump Marathon to 1.9.146

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * dcos-net now configures NetworkManager ignores for its interfaces (COPS-6519)
 
-#### Update Marathon to 1.9.145
+#### Update Marathon to 1.9.146
 
 * Reject role sanitization that would result in an empty array (MARATHON-8748)
 
@@ -36,6 +36,7 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Marathon no longer logs task data, as it may contain secrets for Docker containers. (MARATHON-8774)
 
+* Don't respect instances that are about to be restarted in placement constraints. (MARATHON-8771)
 
 ## DC/OS 2.0.6 (2020-07-30)
 

--- a/packages/marathon/buildinfo.json
+++ b/packages/marathon/buildinfo.json
@@ -4,8 +4,8 @@
   ],
   "single_source": {
     "kind": "url_extract",
-    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.145-f3bbc9f36/marathon-1.9.145-f3bbc9f36.tgz",
-    "sha1": "99d7c0cbb95e6cdf3779c135bb690a8e4ac363f8"
+    "url": "https://s3.amazonaws.com/downloads.mesosphere.io/marathon/builds/1.9.146-576ae9d35/marathon-1.9.146-576ae9d35.tgz",
+    "sha1": "bd01c1273333260a36eff9f1242762ae30cffc3b"
   },
   "username": "dcos_marathon",
   "state_directory": true


### PR DESCRIPTION
## Corresponding DC/OS tickets (required)

  - [MARATHON-8771](https://jira.d2iq.com/browse/MARATHON-8771)