### PR TITLE
etcd: disable etcd when calico is disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Please follow the [`CHANGES.md` modification guidelines](https://github.com/dcos
 
 * Fixed dcos-net startup script to configure network ignore file for on-prem (D2IQ-73113).
 
+* etcd is now disabled when calico is disabled via `calico_enable` (D2IQ-73299).
+
 #### Update Marathon to 1.11.24
 
 * Don't respect instances that are about to be restarted in placement constraints. (MARATHON-8771)

--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -1740,6 +1740,20 @@ package:
               }
           ],
           "LocalFiles": [
+{% switch calico_enabled %}
+{% case "true" %}
+              {
+                  "Location": "/var/lib/dcos/etcd/initial-state",
+                  "Role": ["master"],
+                  "Optional": true
+              },
+              {
+                  "Location": "/var/lib/dcos/etcd/initial-nodes",
+                  "Role": ["master"],
+                  "Optional": true
+              },
+{% case "false" %}
+{% endswitch %}
               {
                   "Location": "/opt/mesosphere/active.buildinfo.full.json"
               },
@@ -1813,16 +1827,6 @@ package:
               },
               {
                   "Location": "/var/log/mesos-state.tar.gz",
-                  "Role": ["master"],
-                  "Optional": true
-              },
-              {
-                  "Location": "/var/lib/dcos/etcd/initial-state",
-                  "Role": ["master"],
-                  "Optional": true
-              },
-              {
-                  "Location": "/var/lib/dcos/etcd/initial-nodes",
                   "Role": ["master"],
                   "Optional": true
               }
@@ -1917,6 +1921,10 @@ package:
                   "Command": ["/opt/mesosphere/bin/calicoctl", "get", "globalNetworkPolicy", "-o", "yaml"],
                   "Role": ["master"]
               },
+              {
+                  "Command": ["/opt/mesosphere/bin/dcos-shell", "dcos-etcdctl", "diagnostic"],
+                  "Role": ["master"]
+              },
 {% case "false" %}
 {% endswitch %}
               {
@@ -1949,10 +1957,6 @@ package:
               },
               {
                   "Command": ["df"]
-              },
-              {
-                  "Command": ["/opt/mesosphere/bin/dcos-shell", "dcos-etcdctl", "diagnostic"],
-                  "Role": ["master"]
               }
           ]
         }
@@ -2243,6 +2247,19 @@ package:
   - path: /etc_master/adminrouter-grpc-proxy-port.conf
     content: |
       listen {{ adminrouter_grpc_proxy_port }} http2;
+  - path: /etc_master/adminrouter-grpc-proxy-etcd.conf
+{% switch calico_enabled %}
+{% case "true" %}
+    content: |
+      location / {
+        access_by_lua_block {
+          auth.access_grpc_etcd_endpoint();
+        }
+        grpc_pass grpc://127.0.0.1:2379;
+      }
+{% case "false" %}
+    content: ""
+{% endswitch %}
   - path: /etc/adminrouter-tls-master.conf
     content: |
       # Ref: https://github.com/cloudflare/sslconfig/blob/master/conf
@@ -2634,6 +2651,8 @@ package:
         # insecure_skip_verify = true
         [inputs.zookeeper.tags]
           dcos-component-name = "ZooKeeper"
+{% switch calico_enabled %}
+{% case "true" %}
       # Reads metrics from etcd's prometheus client
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.
@@ -2648,6 +2667,8 @@ package:
         # insecure_skip_verify = true
         [inputs.prometheus.tags]
           dcos-component-name = "etcd"
+{% case "false" %}
+{% endswitch %}
       # Reads metrics from CockroachDB's prometheus client
       [[inputs.prometheus]]
         ## An array of urls to scrape metrics from.

--- a/packages/adminrouter/docker/Dockerfile
+++ b/packages/adminrouter/docker/Dockerfile
@@ -149,6 +149,7 @@ COPY adminrouter-redirect-http-https.conf \
      adminrouter-tls-master.conf \
      adminrouter-ui-security.conf \
      adminrouter-grpc-proxy-port.conf \
+     adminrouter-grpc-proxy-etcd.conf \
         /opt/mesosphere/etc/
 
 # The `ca.crt` file is copied into two places due to the fact that

--- a/packages/adminrouter/docker/adminrouter-grpc-proxy-etcd.conf
+++ b/packages/adminrouter/docker/adminrouter-grpc-proxy-etcd.conf
@@ -1,0 +1,6 @@
+location / {
+  access_by_lua_block {
+    auth.access_grpc_etcd_endpoint();
+  }
+  grpc_pass grpc://127.0.0.1:2379;
+}

--- a/packages/adminrouter/extra/src/nginx.master.conf
+++ b/packages/adminrouter/extra/src/nginx.master.conf
@@ -47,15 +47,7 @@ http {
         #
         # I am not sure though if we really need all of these though.
 
-        # NOTE(prozlach) Different services can then have their own location
-        # blocks with their own package names for gRPC services.
-        location / {
-            access_by_lua_block {
-                auth.access_grpc_etcd_endpoint();
-            }
-
-            grpc_pass grpc://127.0.0.1:2379;
-       }
+        include /opt/mesosphere/etc/adminrouter-grpc-proxy-etcd.conf;
     }
 
 }

--- a/packages/etcd/extra/systemd/dcos-etcd.service
+++ b/packages/etcd/extra/systemd/dcos-etcd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=etcd: Distributed K/V storage
 Documentation=https://docs.d2iq.com
+ConditionPathExists=/opt/mesosphere/etc/calico/calico_enabled
 
 [Service]
 Type=notify

--- a/test-e2e/test_calico_networking.py
+++ b/test-e2e/test_calico_networking.py
@@ -85,6 +85,7 @@ def calico_ipip_cluster(docker_backend: Docker, artifact_path: Path,
         # All packages safe except named packages
         'packages/**',
         '!packages/*treeinfo.json',
+        '!packages/etcd/**',
         '!packages/calico/**',
         '!packages/python*/**',
         # All e2e tests safe except this test
@@ -117,7 +118,8 @@ def test_calico_disabled(docker_backend: Docker, artifact_path: Path,
         )
 
         calico_units = ["dcos-calico-felix", "dcos-calico-bird",
-                        "dcos-calico-confd", "dcos-calico-libnetwork-plugin"]
+                        "dcos-calico-confd", "dcos-calico-libnetwork-plugin",
+                        "dcos-etcd"]
         for node in cluster.masters | cluster.agents | cluster.public_agents:
             for unit_name in calico_units:
                 assert_system_unit_state(node, unit_name, active=False)


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

When calico is disabled, we should also disable etcd.


## Corresponding DC/OS tickets (required)

  - [D2IQ-73299](https://jira.d2iq.com/browse/D2IQ-73299) Disable etcd with calico