### PR TITLE
Update Python security libraries

### DIFF
--- a/packages/dcos-integration-test/requirements.txt
+++ b/packages/dcos-integration-test/requirements.txt
@@ -1,5 +1,5 @@
 click==7.0
-cryptography==2.7
+cryptography==3.2.1
 pyjwt==1.7.1
 pytest==4.4.0
 PyYAML==4.2b4

--- a/packages/python-certifi/buildinfo.json
+++ b/packages/python-certifi/buildinfo.json
@@ -2,7 +2,7 @@
   "requires": ["python"],
   "single_source": {
     "kind": "url",
-    "url": "https://files.pythonhosted.org/packages/5e/c4/6c4fe722df5343c33226f0b4e0bb042e4dc13483228b4718baf286f86d87/certifi-2020.6.20-py2.py3-none-any.whl",
-    "sha1": "f37eb16dd168e81f95c31495516aa948e7b846ee"
+    "url": "https://files.pythonhosted.org/packages/c1/6f/3d85f0850962279a7e4c622695d7b3171e95ac65308a57d3b29738b27149/certifi-2020.11.8-py2.py3-none-any.whl",
+    "sha1": "40bc8ec02f344f99fa1f8cbdc77dec867c1762db"
   }
 }

--- a/packages/python-cryptography/build
+++ b/packages/python-cryptography/build
@@ -5,10 +5,6 @@ mkdir -p "$LIB_INSTALL_DIR"
 
 export PKG_CONFIG_PATH=/opt/mesosphere/lib/pkgconfig
 
-for package in asn1crypto; do
-  pip3 install --no-deps --no-index --prefix=$PKG_PATH /pkg/src/$package/*.whl
-done
-
 for package in cffi cryptography; do
   pip3 install --no-deps --install-option="--prefix=$PKG_PATH" --root=/ /pkg/src/$package/
 done

--- a/packages/python-cryptography/buildinfo.json
+++ b/packages/python-cryptography/buildinfo.json
@@ -3,18 +3,13 @@
   "sources": {
     "cryptography": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/56/3b/78c6816918fdf2405d62c98e48589112669f36711e50158a0c15d804c30d/cryptography-2.9.2.tar.gz",
-      "sha1": "af16e069cad7d36442f8481542de51f87c3c7708"
-    },
-    "asn1crypto": {
-      "kind": "url",
-      "url": "https://files.pythonhosted.org/packages/e9/51/1db4a60049fb7390959be586b6eb743098e6cea3f6b2d3ed9e17fec62ba2/asn1crypto-1.3.0-py2.py3-none-any.whl",
-      "sha1": "072fabec7abe3acf53e935d6d5a965a6b81d3b87"
+      "url": "https://files.pythonhosted.org/packages/94/5c/42de91c7fbdb817b2d9a4e64b067946eb38a4eb36c1a09c96c87a0f86a82/cryptography-3.2.1.tar.gz",
+      "sha1": "20708a4955dcf7e2bb53d05418273d2bc0f80ab4"
     },
     "cffi": {
       "kind": "url_extract",
-      "url": "https://files.pythonhosted.org/packages/54/1d/15eae71ab444bd88a1d69f19592dcf32b9e3166ecf427dd9243ef0d3b7bc/cffi-1.14.1.tar.gz",
-      "sha1": "7b067fdb46d184f6bfdadc11732df6f0340e553d"
+      "url": "https://files.pythonhosted.org/packages/cb/ae/380e33d621ae301770358eb11a896a34c34f30db188847a561e8e39ee866/cffi-1.14.3.tar.gz",
+      "sha1": "7199374653c1927e8d3c523b6498b149acdb6f7e"
     }
   }
 }

--- a/test-e2e/requirements.txt
+++ b/test-e2e/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/dcos/dcos-e2e.git@2020.05.26.0
 attrs==19.1.0
-cryptography==2.7
+cryptography==3.2.1
 docker==4.0.2
 etcd3==0.11.1
 jwt==0.5.4

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ deps =
   webtest
   webtest-aiohttp==1.1.0
   schema
-  cryptography==2.5
+  cryptography==3.2.1
 # Hack to stop pytest from collecting test-e2e tests.
 # Simpler ways of achieving this would not work.
 # https://stackoverflow.com/a/37493203


### PR DESCRIPTION
## High-level description

Bump Python security libraries, particularly `cryptography` to fix CVE-2020-25659


## Corresponding DC/OS tickets (required)

  - [D2IQ-73273](https://jira.d2iq.com/browse/D2IQ-73273) Update Python cryptography library to 3.2+


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [D2IQ-ID](https://jira.mesosphere.com/browse/D2IQ-<number>) JIRA title / short description.
