### PR TITLE
docs: fix simple typo, thsrough -> through

### DIFF
--- a/test-e2e/test_etcd_backup.py
+++ b/test-e2e/test_etcd_backup.py
@@ -86,7 +86,7 @@ def _do_restore(all_masters: Set[Node], backup_local_path: Path) -> None:
 
 
 class EtcdClient():
-    """Communicates with etcd thsrough CLI on master nodes."""
+    """Communicates with etcd through CLI on master nodes."""
 
     def __init__(self, all_masters: Set[Node]) -> None:
         self.masters = all_masters


### PR DESCRIPTION
There is a small typo in test-e2e/test_etcd_backup.py.

Should read `through` rather than `thsrough`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md