### PR TITLE
Fix wrong ns when empty RESOLVERS env

### DIFF
--- a/packages/dcos-net/extra/gen_resolvconf.py
+++ b/packages/dcos-net/extra/gen_resolvconf.py
@@ -73,6 +73,8 @@ else:
 
     # Resolvconf does not support custom ports, skip if not default
     for ns in os.environ['RESOLVERS'].split(','):
+        if len(ns.strip()) == 0:
+            continue
         ip, separator, port = ns.rpartition(':')
         if not separator:
             fallback_servers.append(ns)


### PR DESCRIPTION
## High-level description

When RESOLVERS environment is empty and dcos-net service is down, generates a error configuration file.

The content  like this:
```
# Generated by gen_resolvconf.py. Do not edit.
# Change configuration options by changing DC/OS cluster configuration.
# This file must be overwritten regularly for proper cluster operation around
# master failure.

options timeout:1
options attempts:3

nameserver 
```

Because the namerserver is exists but ip is empty,  then the host dns resolve all failed.

## Corresponding DC/OS tickets (required)

  - [D2IQ-5997](https://jira.d2iq.com/browse/D2IQ-5997) JIRA title / short description.


