### PR TITLE
Update test_helpers.py

### DIFF
--- a/packages/dcos-integration-test/extra/test_helpers.py
+++ b/packages/dcos-integration-test/extra/test_helpers.py
@@ -219,7 +219,7 @@ def marathon_test_docker_app(app_name: str, constraints: Any = None) -> tuple:
                 'name': 'http'
             }],
             'docker': {
-                'image': "mcr.microsoft.com/dotnet/core/samples:aspnetapp",
+                'image': "mcr.microsoft.com/dotnet/samples:aspnetapp",
                 'forcePullImage': False,
                 'privileged': False,
             }


### PR DESCRIPTION
Update to the current .NET samples repo. The old samples repro will be deleted.

See: https://github.com/dotnet/dotnet-docker/issues/4755

FYI on other breaking changes: https://github.com/dotnet/dotnet-docker/discussions/4764